### PR TITLE
Add dependency-free Loop Record example validator

### DIFF
--- a/scripts/validate_loop_record_examples.py
+++ b/scripts/validate_loop_record_examples.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Validate committed V13 Loop Record examples without third-party packages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_SCHEMA_KEYS = {
+    "$schema",
+    "$id",
+    "$defs",
+    "$ref",
+    "title",
+    "description",
+    "type",
+    "properties",
+    "required",
+    "additionalProperties",
+    "items",
+    "enum",
+    "minLength",
+}
+
+SUPPORTED_TYPES = {"object", "array", "string"}
+
+
+class SchemaSupportError(Exception):
+    """The repository schema uses a keyword this validator cannot enforce."""
+
+
+class RecordValidationError(Exception):
+    """A Loop Record does not conform to the supported schema."""
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RecordValidationError(f"{path}: cannot read valid JSON: {exc}") from exc
+
+
+def audit_schema(schema: Any, location: str = "#") -> None:
+    if not isinstance(schema, dict):
+        raise SchemaSupportError(f"{location}: schema node must be an object")
+
+    unsupported = sorted(set(schema) - SUPPORTED_SCHEMA_KEYS)
+    if unsupported:
+        raise SchemaSupportError(
+            f"{location}: unsupported schema keyword(s): {', '.join(unsupported)}"
+        )
+
+    schema_type = schema.get("type")
+    if schema_type is not None and schema_type not in SUPPORTED_TYPES:
+        raise SchemaSupportError(f"{location}: unsupported type: {schema_type!r}")
+
+    for metadata_key in ("$schema", "$id", "$ref", "title", "description"):
+        value = schema.get(metadata_key)
+        if value is not None and not isinstance(value, str):
+            raise SchemaSupportError(f"{location}/{metadata_key}: must be a string")
+
+    for container_key in ("properties", "$defs"):
+        container = schema.get(container_key)
+        if container is None:
+            continue
+        if not isinstance(container, dict):
+            raise SchemaSupportError(f"{location}/{container_key}: must be an object")
+        for name, child in container.items():
+            audit_schema(child, f"{location}/{container_key}/{name}")
+
+    required = schema.get("required")
+    if required is not None and (
+        not isinstance(required, list)
+        or any(not isinstance(name, str) for name in required)
+    ):
+        raise SchemaSupportError(f"{location}/required: must be an array of strings")
+
+    enum = schema.get("enum")
+    if enum is not None and not isinstance(enum, list):
+        raise SchemaSupportError(f"{location}/enum: must be an array")
+
+    min_length = schema.get("minLength")
+    if min_length is not None and (
+        not isinstance(min_length, int)
+        or isinstance(min_length, bool)
+        or min_length < 0
+    ):
+        raise SchemaSupportError(
+            f"{location}/minLength: must be a non-negative integer"
+        )
+
+    if "items" in schema:
+        audit_schema(schema["items"], f"{location}/items")
+
+    additional = schema.get("additionalProperties")
+    if additional is not None and not isinstance(additional, (bool, dict)):
+        raise SchemaSupportError(
+            f"{location}/additionalProperties: must be boolean or a schema object"
+        )
+    if isinstance(additional, dict):
+        audit_schema(additional, f"{location}/additionalProperties")
+
+
+def resolve_local_ref(root_schema: dict[str, Any], reference: str) -> dict[str, Any]:
+    if not reference.startswith("#/"):
+        raise SchemaSupportError(f"unsupported non-local $ref: {reference}")
+
+    current: Any = root_schema
+    for raw_part in reference[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or part not in current:
+            raise SchemaSupportError(f"unresolvable $ref: {reference}")
+        current = current[part]
+
+    if not isinstance(current, dict):
+        raise SchemaSupportError(f"$ref does not resolve to a schema object: {reference}")
+    return current
+
+
+def validate_instance(
+    schema: dict[str, Any],
+    instance: Any,
+    root_schema: dict[str, Any],
+    location: str = "$",
+    ref_stack: tuple[str, ...] = (),
+) -> None:
+    reference = schema.get("$ref")
+    if reference is not None:
+        if reference in ref_stack:
+            raise SchemaSupportError(f"cyclic $ref is unsupported: {reference}")
+        validate_instance(
+            resolve_local_ref(root_schema, reference),
+            instance,
+            root_schema,
+            location,
+            ref_stack + (reference,),
+        )
+
+    if "enum" in schema and instance not in schema["enum"]:
+        raise RecordValidationError(
+            f"{location}: {instance!r} is not in enum {schema['enum']!r}"
+        )
+
+    schema_type = schema.get("type")
+
+    if schema_type == "object":
+        if not isinstance(instance, dict):
+            raise RecordValidationError(f"{location}: expected object")
+
+        properties = schema.get("properties", {})
+        for name in schema.get("required", []):
+            if name not in instance:
+                raise RecordValidationError(
+                    f"{location}: missing required property {name!r}"
+                )
+
+        additional = schema.get("additionalProperties", True)
+        for name, value in instance.items():
+            if name in properties:
+                validate_instance(
+                    properties[name], value, root_schema, f"{location}.{name}", ref_stack
+                )
+            elif additional is False:
+                raise RecordValidationError(
+                    f"{location}: unexpected property {name!r}"
+                )
+            elif isinstance(additional, dict):
+                validate_instance(
+                    additional, value, root_schema, f"{location}.{name}", ref_stack
+                )
+
+    elif schema_type == "array":
+        if not isinstance(instance, list):
+            raise RecordValidationError(f"{location}: expected array")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, value in enumerate(instance):
+                validate_instance(
+                    item_schema,
+                    value,
+                    root_schema,
+                    f"{location}[{index}]",
+                    ref_stack,
+                )
+
+    elif schema_type == "string":
+        if not isinstance(instance, str):
+            raise RecordValidationError(f"{location}: expected string")
+        min_length = schema.get("minLength")
+        if min_length is not None and len(instance) < min_length:
+            raise RecordValidationError(
+                f"{location}: string length is below {min_length}"
+            )
+
+
+def validate_examples(schema_path: Path, examples_dir: Path) -> int:
+    schema = load_json(schema_path)
+    if not isinstance(schema, dict):
+        raise SchemaSupportError(f"{schema_path}: root schema must be an object")
+    audit_schema(schema)
+
+    example_paths = sorted(examples_dir.glob("*.json"))
+    if not example_paths:
+        raise RecordValidationError(f"{examples_dir}: no JSON examples found")
+
+    failures: list[str] = []
+    for example_path in example_paths:
+        try:
+            validate_instance(
+                schema,
+                load_json(example_path),
+                schema,
+                example_path.name,
+            )
+        except RecordValidationError as exc:
+            failures.append(str(exc))
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        f"PASS: {len(example_paths)}/{len(example_paths)} Loop Record examples "
+        f"validate against {schema_path}"
+    )
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate examples/*.json against the supported subset used by "
+            "schema/v13_loop_record.schema.json. Unsupported schema keywords "
+            "fail closed."
+        )
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=repo_root / "schema" / "v13_loop_record.schema.json",
+    )
+    parser.add_argument(
+        "--examples-dir",
+        type=Path,
+        default=repo_root / "examples",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return validate_examples(args.schema, args.examples_dir)
+    except (SchemaSupportError, RecordValidationError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## BOAW-001 / Run 002 / Loop 03 — CLOSED

### Primary variable

Replace repeated reconstruction of repository-specific Loop Record validation
with one dependency-free, on-demand, fail-closed command.

### Required Loop Receipt

- Authority-window ID: `BOAW-001`
- Run / loop: `Run 002 / Loop 03`
- Starting `main` SHA: `07b085390ac37655a49271e636d701fa5d18e6e7`
- Selected variable: reproducible Loop Record example validation
- Priority: `Priority 5 — internal operating-surface compounding`
- Target operational surface:
  `scripts/validate_loop_record_examples.py` on default-branch `main`
- Pre-change availability: `ABSENT` — validation required reconstruction of an
  ephemeral tailored command, and no canonical dependency-free repository
  command existed
- Post-change availability: `AVAILABLE / VERIFIED` — the exact command reruns
  successfully from remote default-branch `main`, accepts all 12 canonical
  examples, and rejects the bounded negative and unsupported-keyword probes
- Implementation commit: `76ed421d4a4b51c50623d72d3b9f37a6c828dd8a`
- PR number: `#9`
- Verified PR head: `76ed421d4a4b51c50623d72d3b9f37a6c828dd8a`
- Merge SHA: `e3f2a3ac705ab1932d94a8c4f01b4e85eeedb047`
- Final operational `main` SHA: `e3f2a3ac705ab1932d94a8c4f01b4e85eeedb047`
- Rollback SHA: `07b085390ac37655a49271e636d701fa5d18e6e7`
- Correction attempts: `0`
- Present Aspire movement: `DEMONSTRATED — CASE-BOUNDED` — the current
  canonical schema/example set now has one rerunnable dependency-free
  validation command on `main`
- Next-loop starting-condition effect: `LIGHTER` — a later schema/example
  verification no longer has to reconstruct the same validator before it can
  inspect the current canonical set
- Load-Bearing Compliance: `PASS CANDIDATE`
- Improvement Credit: `GRANTED — CASE-BOUNDED`
- Successor Transfer: `VALID TRANSFER` — the repository maintainer owns
  revalidation when the schema introduces a new keyword or the canonical
  example-set topology changes
- Unowned Successor Debt: `none observed`
- Remaining authorized loops: `0`
- Exact state:
  `LOOP 03 CLOSED / BOAW-001 EXHAUSTED / LOOP 04 BLOCK`

### Validation

- exact one-file functional scope;
- implementation blob:
  `2ddade88f7c0bce1e899b4ab2482b9fff7f81b41`;
- SHA-256:
  `02e6073766ed3f47b6ced6cabf9308572c004e82e7aa3574d521e5f041ffb89a`;
- exact corrected historical residue, 266 lines, standard library only;
- default command from post-merge `main`: `12/12` examples accepted;
- explicit schema/examples command: `12/12` accepted;
- missing nested required field rejected;
- invalid enum rejected;
- unexpected root property rejected;
- unsupported schema keyword rejected fail-closed;
- empty example set and invalid JSON rejected;
- two independent pre-merge audits returned `PASS`;
- PR was `OPEN / READY / MERGEABLE / CLEAN` at the exact verified head;
- reviews, comments, unresolved threads, and failed checks: `0`;
- `git diff --check`: PASS;
- remote-main merge parents, implementation blob, clean worktree, positive
  examples, negative probes, and fail-closed behavior verified after merge.

### Authority boundary

- Human Seat questions: `0`
- External actions beyond required branch/PR transport and merge: `0`
- CI, hook, schedule, dependency, schema/example, automatic Gate, runtime,
  service, package, plugin, README, Canon, paper, Revenue, outreach, V7, and
  public-claim surfaces changed: `0`
- PR #4 and PR #5 remain open Draft non-merge evidence and were not modified
- This receipt claims only current-schema, current-example validation under the
  supported subset. It does not claim full or future JSON Schema compatibility,
  exhaustive semantic correctness, general reliability, or proof that V13
  works.
- Three loops are now complete. BOAW-001 cannot renew, extend, reinterpret, or
  transfer itself. Further `main` write and further loop selection are
  `BLOCK` unless Shin supplies a new explicit authority.
