### PR TITLE
Add authority sufficiency preflight for future V13 runs

### DIFF
--- a/docs/authority_sufficiency_preflight_v0_1.md
+++ b/docs/authority_sufficiency_preflight_v0_1.md
@@ -1,0 +1,521 @@
+# Authority Sufficiency Preflight v0.1
+
+## Mandatory Stage 0 Before Bounded Autonomous Execution
+
+## Status
+
+```text
+Authority Sufficiency Preflight v0.1:
+FORWARD-ONLY V13 OPERATING PROPOSAL
+
+Stage:
+0 / PRE-EXECUTION / READ-ONLY
+
+Canonical status:
+COMPLETE ON BRANCH / PR PENDING
+
+Run authority:
+NONE
+
+Run 003:
+NOT STARTED
+
+BOAW-001:
+EXHAUSTED / UNCHANGED
+
+Run 002:
+PASS / COMPLETE / 3 OF 3 LOOPS CLOSED
+
+Current Gate:
+HOLD — REVIEW OF AUTHORITY SUFFICIENCY PREFLIGHT PR REQUIRED
+```
+
+This proposal defines authority routing before a bounded autonomous run or
+implementation loop. It does not grant authority, activate a run, authorize
+implementation, or create a new V13 Gate.
+
+## Purpose
+
+Authority sufficiency must be established before implementation begins or
+implementation credit is tested.
+
+The observed structure is:
+
+1. a high-value Aspire candidate may be correctly identified;
+2. its intended effect may require merge, default-branch presence, release,
+   deployment, repository settings, external action, or Human Seat authority;
+3. without an explicit authority check, an AI may either:
+   - create preparation and falsely count it as present movement; or
+   - silently choose an easier lower-priority internal candidate; and
+4. required authority must therefore be evaluated before implementation
+   credit, not after an artifact has been created.
+
+This is a bounded operating rule, not a general autonomy theory.
+
+## Core Rule
+
+> A candidate may enter implementation only when the authority required to make
+> its intended effect operational, verifiable, reversible, and closable is
+> already available within the approved run envelope.
+
+> Authority insufficiency is not an implementation failure and is not a
+> completed loop. It is a pre-execution routing result.
+
+Therefore:
+
+- selecting a valuable candidate does not create permission to execute it;
+- artifact creation does not compensate for missing operational authority;
+- future merge, publication, activation, or Human approval cannot be counted as
+  present Aspire movement;
+- a candidate outside current authority must not be implemented as preparation
+  and then scored as a completed `1.01`;
+- Stage 0 consumes no loop count; and
+- a loop-level authority mismatch consumes no loop count because
+  implementation has not started.
+
+## Position in the Operating Sequence
+
+Stage 0 occurs before bounded autonomous selection execution:
+
+```text
+Aspire / Roadmap
+→ Authority Sufficiency Preflight
+→ Shin approves one bounded authority envelope
+→ Loop-Level Authority Match
+→ Bounded implementation
+→ Operational effect verification
+→ Receipt
+→ Next loop or successful stop
+→ Reserved closure-only tail
+→ Authority exhausted
+```
+
+Stage 0 is read-only. A run-level result may propose an authority envelope to
+Shin, but no run begins automatically.
+
+Stage 0 adds pre-activation authority proof and pre-implementation matching. It
+does not replace or weaken any later V13 Gate, current-authority check, or
+Minimum Autonomous Loop check.
+
+## Two-Level Structure
+
+### A. Run-Level Authority Sufficiency Preflight
+
+The run-level preflight occurs before Shin activates or approves a bounded run.
+It inspects:
+
+- current canonical repository state;
+- active Aspire and priority order;
+- likely qualifying change classes;
+- actual target surfaces;
+- whether each surface requires:
+  - branch-local execution;
+  - default-branch merge;
+  - release;
+  - deployment;
+  - repository settings;
+  - permissions or secrets;
+  - external communication;
+  - payment or client handling; or
+  - Human Seat judgment;
+- rollback authority;
+- merge authority;
+- validation authority;
+- target-surface verification authority;
+- receipt authority;
+- final canonical state-sync authority;
+- a closure-only tail after the final operational loop;
+- maximum loops, branches, PRs, and correction attempts;
+- prohibited surfaces; and
+- exhaustion and re-entry conditions.
+
+The output is one bounded authority-envelope proposal for Shin.
+
+Shin approves the run envelope once. Every in-envelope loop still declares an
+authority match, but does not require repeated Shin approval.
+
+### B. Loop-Level Authority Match Declaration
+
+The loop-level declaration occurs before each implementation loop. It declares:
+
+- highest-priority grounded candidate;
+- frozen Aspire priority;
+- actual target operational surface;
+- authority required;
+- authority currently held;
+- whether operational effect can exist by loop end;
+- whether validation and rollback can be completed;
+- whether the final receipt and closure can be completed;
+- whether a Human Seat decision is required; and
+- `Authority Match: YES / NO`.
+
+`Authority Match: YES` is valid only when all required authority is currently
+held, operational effect is available by loop end, validation, rollback,
+receipt, and the closure tail are all closable or preserved, and no unresolved
+Human Seat decision remains. If any one of those conditions is not satisfied,
+the match is `NO`.
+
+If the declaration is `YES`, implementation may continue without another Shin
+approval, subject to every limit and prohibition in the approved run envelope.
+
+If the declaration is `NO`, return:
+
+```text
+Authority Match:
+NO
+
+Implementation:
+NOT STARTED
+
+Loop Count Consumed:
+0
+
+Improvement Credit:
+NOT TESTED
+
+Required Authority:
+<exact missing authority>
+
+Decision Route:
+AUTHORITY ESCALATION / STOP
+```
+
+Do not create a branch, artifact, PR, or implementation before the mismatch is
+resolved.
+
+Loop count moves from `0` at the first candidate-specific implementation
+mutation, including creation or modification of a candidate artifact. A
+mismatch detected after that boundary is not a pre-execution result and cannot
+be reclassified as `Loop Count Consumed: 0`.
+
+## Candidate Ranking Before Authority Filtering
+
+> Candidate priority must be evaluated before authority filtering.
+
+Authority filtering must not hide the highest-value grounded candidate.
+
+For every loop declaration:
+
+1. identify the highest-priority grounded candidate;
+2. disclose whether it is within the approved authority envelope; and
+3. only then determine the route.
+
+The AI must not silently replace a high-priority blocked candidate with an
+easier in-authority internal task.
+
+A lower-priority candidate may proceed without escalation only when all are
+true:
+
+- the higher-priority candidate is presently unavailable because its earliest
+  missing node is an unarrived external event or a separately reserved Human
+  decision;
+- the lower-priority action does not bypass, obscure, delay, or weaken that
+  higher-priority path;
+- the approved authority envelope permits the lower-priority class; and
+- the lower-priority action independently satisfies the `1.01` conditions.
+
+Otherwise, stop for authority escalation.
+
+## Authority Sufficiency Components
+
+Authority sufficiency is a conjunctive all-of requirement, not an additive
+score: every component below must be present, and no component compensates for
+another.
+
+```text
+Authority Sufficiency =
+Scope Authority
++ Surface Authority
++ Integration Authority
++ Verification Authority
++ Rollback Authority
++ Receipt Authority
++ Closure-Tail Authority
+```
+
+- **Scope Authority:** the change class is permitted.
+- **Surface Authority:** the actual effect-bearing surface may be changed.
+- **Integration Authority:** required merge, activation, release, or deployment
+  is authorized.
+- **Verification Authority:** the claimed effect can be checked after
+  integration.
+- **Rollback Authority:** a named, history-preserving recovery route exists.
+- **Receipt Authority:** the loop result can be durably recorded.
+- **Closure-Tail Authority:** final state synchronization remains authorized
+  after the last operational loop or an immediate-stop event.
+
+If any component is absent:
+
+```text
+Authority Sufficiency:
+INSUFFICIENT
+```
+
+No implementation begins.
+
+## Closure-Only Tail
+
+Every future bounded run envelope must reserve a non-discretionary closure-only
+tail before activation.
+
+The tail:
+
+- does not select a new candidate;
+- does not consume an operational loop;
+- cannot extend or renew the run;
+- cannot modify criteria;
+- may record only already-completed facts;
+- may synchronize only the predefined canonical state surfaces;
+- may record exhaustion, stop, rollback identity, receipts, and re-entry
+  conditions;
+- expires after successful canonical synchronization; and
+- cannot be used for Loop N+1.
+
+The run-level branch, PR, and correction maxima must either include capacity
+explicitly reserved for this tail or declare a separate tail-only allowance
+that operational loops cannot consume.
+
+A run envelope without a defined closure-only tail is:
+
+```text
+Authority Sufficiency:
+INSUFFICIENT
+
+Run Activation:
+HOLD
+```
+
+## Human Approval Model
+
+```text
+Every loop:
+AUTHORITY MATCH DECLARATION REQUIRED
+
+Every loop:
+NEW HUMAN APPROVAL NOT REQUIRED WHEN MATCH = YES
+
+Run activation:
+ONE EXPLICIT SHIN APPROVAL REQUIRED
+
+Envelope expansion:
+NEW EXPLICIT SHIN APPROVAL REQUIRED
+
+True Human Seat decision:
+RETURN TO SHIN
+
+Routine implementation and closure:
+AI-OWNED WITHIN ENVELOPE
+```
+
+Routine merge, validation, state synchronization, and cleanup must not be
+returned to Shin when they are already included in the approved envelope.
+
+## Preflight Result Classes
+
+These are authority-routing classifications. They do not create a fifth V13
+Gate.
+
+### AUTHORITY SUFFICIENT
+
+- the proposed run envelope is complete;
+- activation may be presented to Shin; and
+- no run begins automatically.
+
+V13 Gate before activation: `HOLD`.
+
+### AUTHORITY ENVELOPE REQUIRED
+
+- a valuable run is identifiable;
+- one or more required authority components are absent; and
+- the bounded missing authority is presented for Shin's decision.
+
+V13 Gate: `HOLD`.
+
+### AUTHORITY MISMATCH
+
+- an active run exists;
+- the current candidate is outside its envelope;
+- implementation does not start; and
+- the route returns to authority escalation or stop.
+
+V13 Gate: `HOLD`.
+
+### HUMAN SEAT REQUIRED
+
+- direction, risk tolerance, externalization, value judgment, or explicit human
+  consent is irreducible.
+
+V13 Gate: `HOLD`.
+
+### NO QUALIFYING RUN
+
+- no grounded bounded run justifies an authority request; and
+- the preflight stops without manufacturing a proposal.
+
+V13 Gate: `HOLD`.
+
+Prohibited or unprovable authority maps to the existing V13 Gate `BLOCK`.
+
+## Required Run-Level Output Contract
+
+```text
+Preflight:
+AUTHORITY SUFFICIENCY
+
+Canonical As-of:
+<commit>
+
+Active Aspire:
+<exact Aspire>
+
+Highest-Priority Grounded Run:
+<bounded run or none>
+
+Target Operational Surfaces:
+<surfaces>
+
+Required Authority Components:
+<list>
+
+Currently Available Authority:
+<list>
+
+Missing Authority:
+<list or none>
+
+Proposed Maximum Loops:
+<number>
+
+Proposed Maximum Active Branches:
+<number>
+
+Proposed Maximum PRs:
+<number>
+
+Correction Limit:
+<number>
+
+Permitted Change Classes:
+<list>
+
+Prohibited Change Classes:
+<list>
+
+Merge / Integration Authority:
+<exact boundary>
+
+Rollback Boundary:
+<exact boundary>
+
+Closure-Only Tail:
+<exact predefined files and authority>
+
+Closure-Tail Capacity Reservation:
+<included in maxima or separate tail-only branch / PR / correction allowance>
+
+Human Seat Returns:
+<exact conditions>
+
+Preflight Result:
+AUTHORITY SUFFICIENT /
+AUTHORITY ENVELOPE REQUIRED /
+HUMAN SEAT REQUIRED /
+NO QUALIFYING RUN
+
+V13 Gate:
+HOLD / BLOCK
+
+Activation:
+NOT STARTED
+
+Run:
+NOT STARTED
+```
+
+## Required Loop-Level Output Contract
+
+```text
+Loop:
+<number>
+
+Highest-Priority Grounded Candidate:
+<candidate>
+
+Priority:
+<number or name>
+
+Actual Target Surface:
+<surface>
+
+Required Authority:
+<list>
+
+Authority Held:
+<list>
+
+Operational Effect Available By Loop End:
+YES / NO
+
+Validation Closable:
+YES / NO
+
+Rollback Closable:
+YES / NO
+
+Receipt Closable:
+YES / NO
+
+Closure-Tail Preserved:
+YES / NO
+
+Human Seat Required:
+YES / NO
+
+Authority Match:
+YES / NO
+
+Implementation:
+MAY START / NOT STARTED
+
+Loop Count Consumed:
+0 until implementation begins
+
+Decision Route:
+CONTINUE / AUTHORITY ESCALATION / HUMAN SEAT / STOP
+```
+
+## Relationship to Prior Evidence
+
+- Stress Run 001 remains `FAIL / CLOSED`.
+- Run 002 remains `PASS / COMPLETE / 3 OF 3 LOOPS CLOSED`.
+- BOAW-001 remains `EXHAUSTED`.
+- the Post-Exhaustion Closure remains `PASS / COMPLETE`.
+- no prior score, receipt, commit, or evaluation is rewritten.
+- Stage 0 is a Forward-only extraction from the authority/effect and
+  post-exhaustion closure findings.
+- Stage 0 does not establish autonomous generalization.
+- Stage 0 does not authorize Run 003.
+
+## Boundary
+
+This proposal does not authorize:
+
+- Run 003 or another bounded run;
+- a new BOAW or BOAW-001 renewal/reactivation;
+- candidate selection, branch creation, implementation, merge, release,
+  deployment, external communication, payment, or client handling for a future
+  run;
+- runtime, automation, repository settings, permissions, or secrets;
+- Canon, paper, V7, price, outreach, README, offer, schema, example, or
+  validator changes; or
+- a rewrite of Run 001, Run 002, PR #4/#5 evidence, or PR #7–#10 receipts.
+
+The specification and its
+[manual template](../templates/v13_authority_sufficiency_preflight.md) are
+manual authority-routing surfaces only.
+
+## Completion Line
+
+Authority Sufficiency Preflight v0.1 is complete as a Stage 0 proposal when a
+future bounded run must prove its full authority envelope, including its
+closure-only tail, before implementation can begin.

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -2,6 +2,11 @@
 
 ## Signal
 
+- 🟢 BLUE / AUTHORITY-SUFFICIENCY-PREFLIGHT-V0.1-COMPLETE-ON-BRANCH-PR-PENDING
+- 🟢 BLUE / AUTHORITY-SUFFICIENCY-MANUAL-TEMPLATE-COMPLETE-ON-BRANCH
+- 🟡 YELLOW / FUTURE-BOUNDED-AUTONOMOUS-RUNS-HOLD-STAGE-0-NOT-CANONICAL
+- 🟡 YELLOW / RUN-003-NOT-STARTED
+- 🔴 RED / STAGE-0-PROPOSAL-GRANTS-NO-RUN-AUTHORITY
 - 🟢 BLUE / BOUNDED-OPERATIONAL-AUTHORITY-WINDOW-V0.1-MERGED-CANONICAL-ON-MAIN
 - 🟢 BLUE / PR-6-MERGE-DECISION-PASS-COMPLETE
 - 🟢 BLUE / BOAW-001-ACTIVATED-FOR-RUN-002-BY-EXPLICIT-SHIN-STATEMENT
@@ -96,6 +101,64 @@
 - 🟡 YELLOW / EXTERNAL-EVIDENCE-RETURN-PASSIVE
 - 🟡 YELLOW / UNRELATED-PUBLIC-EXPOSURE-HOLD
 - 🔴 RED / BROAD-RUNTIME-AUTOMATION-BLOCK
+
+## Authority Sufficiency Preflight v0.1 — Branch Proposal
+
+The current branch-state proposal is:
+
+```text
+Authority Sufficiency Preflight v0.1:
+COMPLETE ON BRANCH / PR PENDING
+
+Manual template:
+COMPLETE ON BRANCH
+
+Future bounded autonomous runs:
+HOLD — STAGE 0 NOT YET CANONICAL
+
+Run 003:
+NOT STARTED
+
+BOAW-001:
+EXHAUSTED / UNCHANGED
+
+Run 002:
+PASS / COMPLETE / UNCHANGED
+
+Stress Run 001:
+FAIL / CLOSED / UNCHANGED
+
+PR merge:
+NOT AUTHORIZED
+
+Current Gate:
+HOLD — REVIEW OF AUTHORITY SUFFICIENCY PREFLIGHT PR REQUIRED
+
+Active Branch:
+docs/authority-sufficiency-preflight-v0-1
+
+Codex Next Authorized Action:
+none after PR creation
+```
+
+The proposal is defined in
+[Authority Sufficiency Preflight v0.1](authority_sufficiency_preflight_v0_1.md)
+and its
+[manual template](../templates/v13_authority_sufficiency_preflight.md).
+
+Stage 0 is read-only, consumes no loop, and grants no run or implementation
+authority. It ranks the highest-priority grounded candidate before authority
+filtering, requires an explicit authority match before every implementation
+loop, and requires a predefined closure-only tail before run activation.
+
+The result classes `AUTHORITY SUFFICIENT`, `AUTHORITY ENVELOPE REQUIRED`,
+`AUTHORITY MISMATCH`, `HUMAN SEAT REQUIRED`, and `NO QUALIFYING RUN` route to
+the existing V13 Gates; they do not create a fifth Gate.
+
+This branch changes no prior score, receipt, or evaluation. BOAW-001 remains
+exhausted, Run 002 remains closed, Loop 04 remains blocked, and Run 003 remains
+unstarted. Merge of the review PR would make Stage 0 canonical only; it would
+not activate or authorize a run.
 
 ## BOAW-001 Run 002 — Post-Exhaustion Closure
 

--- a/docs/loop_map.md
+++ b/docs/loop_map.md
@@ -127,6 +127,81 @@ exact statement: `I activate BOAW-001 for Run 002.`
 Shin has not issued that activation statement in this merge closure. An
 inactive BOAW has no standing authority.
 
+## Authority Sufficiency Preflight v0.1 — Stage 0 Proposal / PR Pending
+
+The preceding BOAW pre-activation block remains an unchanged historical
+snapshot; current Run 002 exhaustion and closure state is recorded below.
+
+[Authority Sufficiency Preflight v0.1](authority_sufficiency_preflight_v0_1.md)
+and its
+[manual template](../templates/v13_authority_sufficiency_preflight.md) define a
+read-only Stage 0 for future bounded autonomous runs.
+
+```text
+Authority Sufficiency Preflight v0.1:
+COMPLETE ON BRANCH / PR PENDING
+
+Manual template:
+COMPLETE ON BRANCH
+
+Future bounded autonomous runs:
+HOLD — STAGE 0 NOT YET CANONICAL
+
+Run 003:
+NOT STARTED
+
+BOAW-001:
+EXHAUSTED / UNCHANGED
+
+Run 002:
+PASS / COMPLETE / UNCHANGED
+
+Current Gate:
+HOLD — REVIEW OF AUTHORITY SUFFICIENCY PREFLIGHT PR REQUIRED
+
+Active Branch:
+docs/authority-sufficiency-preflight-v0-1
+
+Codex Next Authorized Action:
+none after PR creation
+```
+
+The Forward-only operating sequence is:
+
+```text
+Aspire / Roadmap
+→ Authority Sufficiency Preflight
+→ Shin approves one bounded authority envelope
+→ Loop-Level Authority Match
+→ Bounded implementation
+→ Operational effect verification
+→ Receipt
+→ Next loop or successful stop
+→ Reserved closure-only tail
+→ Authority exhausted
+```
+
+Stage 0 precedes autonomous selection execution and is read-only. It proposes
+an authority envelope but does not grant it, activate a run, or authorize
+implementation.
+
+Before every implementation loop, the highest-priority grounded candidate is
+named before authority filtering and receives an explicit
+`Authority Match: YES / NO`. A match of `YES` does not require fresh Shin
+approval when the loop remains inside the already approved envelope. A
+mismatch returns before branch, artifact, PR, or implementation creation and
+consumes no loop count.
+
+Every future run envelope must reserve its closure-only tail before activation.
+That tail may record completed facts and synchronize predefined canonical state
+surfaces only. It cannot select a candidate, extend or renew the run, modify
+criteria, or authorize Loop N+1.
+
+The Stage 0 result classes map to `HOLD`; prohibited or unprovable authority
+maps to `BLOCK`. They do not create a fifth V13 Gate. Stress Run 001 remains
+`FAIL / CLOSED`; Run 002 remains `PASS / COMPLETE`; BOAW-001 remains
+`EXHAUSTED`; Loop 04 remains `BLOCK`; and Run 003 remains `NOT STARTED`.
+
 ## Deviation
 
 A deviation occurs when the actual work starts moving a loop beyond its current gate.

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -8,6 +8,87 @@ Purpose:
 
 V13 LoopKit is a lightweight operating layer for AI-agent work after completion. It helps decide whether the next loop should `GO`, `HOLD`, `CAP`, or `BLOCK`.
 
+## V13 — Authority Sufficiency Preflight v0.1 Branch Proposal
+
+Date:
+`2026-07-24`
+
+Starting canonical `main`:
+`4b3b771b2d4f747c0bc6cf8e250e235bb1be7570`
+
+Execution subject:
+`Codex 13-9`
+
+Branch-state receipt:
+
+```text
+Authority Sufficiency Preflight v0.1:
+COMPLETE ON BRANCH / PR PENDING
+
+Manual template:
+COMPLETE ON BRANCH
+
+Future bounded autonomous runs:
+HOLD — STAGE 0 NOT YET CANONICAL
+
+Run 003:
+NOT STARTED
+
+BOAW-001:
+EXHAUSTED / UNCHANGED
+
+Run 002:
+PASS / COMPLETE / UNCHANGED
+
+Stress Run 001:
+FAIL / CLOSED / UNCHANGED
+
+PR merge:
+NOT AUTHORIZED
+
+Current Gate:
+HOLD — REVIEW OF AUTHORITY SUFFICIENCY PREFLIGHT PR REQUIRED
+
+Active Branch:
+docs/authority-sufficiency-preflight-v0-1
+
+Codex Next Authorized Action:
+none after PR creation
+```
+
+New branch artifacts:
+
+1. `docs/authority_sufficiency_preflight_v0_1.md`
+2. `templates/v13_authority_sufficiency_preflight.md`
+
+Forward-only integration surfaces:
+
+1. `docs/loop_map.md`
+2. `docs/current_signal.md`
+3. `handoff/current_codex_handoff.md`
+
+Stage 0 occurs before Shin activates a future bounded run. It is read-only,
+consumes no loop, proposes one complete authority envelope, ranks candidates
+before authority filtering, requires every implementation loop to declare
+`Authority Match: YES / NO`, and reserves a non-discretionary closure-only
+tail.
+
+A matched in-envelope loop does not require repeated Shin approval. A mismatch
+stops before branch, artifact, PR, or implementation creation, consumes zero
+loops, and receives no improvement credit. The closure-only tail has no
+candidate-selection, criteria-change, extension, renewal, or Loop N+1
+authority.
+
+The Stage 0 result classes map to existing V13 Gates and create no fifth Gate.
+This proposal does not establish autonomous generalization and grants no
+authority for Run 003, another BOAW, an operational loop, or PR merge.
+
+Completion Line:
+
+Authority Sufficiency Preflight v0.1は、future runの実装前にauthority envelope
+とclosure-only tailを明示するStage 0 proposalとしてbranch上で完了し、Run 003
+を開始せずnon-draft review PRで停止する。
+
 ## V13 — BOAW-001 Run 002 Post-Exhaustion Closure
 
 Date:

--- a/templates/v13_authority_sufficiency_preflight.md
+++ b/templates/v13_authority_sufficiency_preflight.md
@@ -1,0 +1,203 @@
+This template performs authority routing only.
+It does not grant authority, activate a run, or authorize implementation.
+
+# V13 Authority Sufficiency Preflight Template
+
+Use this manual template before a future bounded autonomous run and before each
+implementation loop inside an approved run envelope.
+
+Governing specification:
+[Authority Sufficiency Preflight v0.1](../docs/authority_sufficiency_preflight_v0_1.md).
+
+## 1. Run-Level Authority Sufficiency Preflight
+
+Copy and complete:
+
+```text
+Preflight:
+AUTHORITY SUFFICIENCY
+
+Canonical As-of:
+<commit>
+
+Active Aspire:
+<exact Aspire>
+
+Highest-Priority Grounded Run:
+<bounded run or none>
+
+Target Operational Surfaces:
+<surfaces>
+
+Required Authority Components:
+<list>
+
+Currently Available Authority:
+<list>
+
+Missing Authority:
+<list or none>
+
+Proposed Maximum Loops:
+<number>
+
+Proposed Maximum Active Branches:
+<number>
+
+Proposed Maximum PRs:
+<number>
+
+Correction Limit:
+<number>
+
+Permitted Change Classes:
+<list>
+
+Prohibited Change Classes:
+<list>
+
+Merge / Integration Authority:
+<exact boundary>
+
+Rollback Boundary:
+<exact boundary>
+
+Closure-Only Tail:
+<exact predefined files and authority>
+
+Closure-Tail Capacity Reservation:
+<included in maxima or separate tail-only branch / PR / correction allowance>
+
+Human Seat Returns:
+<exact conditions>
+
+Preflight Result:
+AUTHORITY SUFFICIENT /
+AUTHORITY ENVELOPE REQUIRED /
+HUMAN SEAT REQUIRED /
+NO QUALIFYING RUN
+
+V13 Gate:
+HOLD / BLOCK
+
+Activation:
+NOT STARTED
+
+Run:
+NOT STARTED
+```
+
+Run-level rules:
+
+- evaluate the highest-priority grounded run before authority filtering;
+- name every required authority component and every missing component;
+- reserve the closure-only tail before activation;
+- reserve branch, PR, and correction capacity for closure transport inside the
+  maxima or as a separate tail-only allowance;
+- return the proposed envelope to Shin for one explicit activation decision;
+- do not start the run from this template.
+
+## 2. Loop-Level Authority Match Declaration
+
+Copy and complete before implementation:
+
+```text
+Loop:
+<number>
+
+Highest-Priority Grounded Candidate:
+<candidate>
+
+Priority:
+<number or name>
+
+Actual Target Surface:
+<surface>
+
+Required Authority:
+<list>
+
+Authority Held:
+<list>
+
+Operational Effect Available By Loop End:
+YES / NO
+
+Validation Closable:
+YES / NO
+
+Rollback Closable:
+YES / NO
+
+Receipt Closable:
+YES / NO
+
+Closure-Tail Preserved:
+YES / NO
+
+Human Seat Required:
+YES / NO
+
+Authority Match:
+YES / NO
+
+Implementation:
+MAY START / NOT STARTED
+
+Loop Count Consumed:
+0 until implementation begins
+
+Decision Route:
+CONTINUE / AUTHORITY ESCALATION / HUMAN SEAT / STOP
+```
+
+Loop-level rules:
+
+- disclose the highest-priority grounded candidate before checking whether it
+  fits the envelope;
+- do not silently replace blocked high-priority work with easier internal work;
+- allow a lower-priority candidate without escalation only when the
+  higher-priority candidate's earliest missing node is an unarrived external
+  event or separately reserved Human decision, the lower-priority action does
+  not bypass, obscure, delay, or weaken that path, the envelope permits its
+  class, and it independently satisfies the `1.01` conditions;
+- `Authority Match: YES` permits continuation only inside the approved
+  envelope and does not override another Gate or Human Seat boundary;
+- require every authority component to be held, all operational-effect,
+  validation, rollback, receipt, and closure-tail declarations to be `YES`,
+  and `Human Seat Required` to be `NO` before declaring `Authority Match: YES`;
+- in-envelope loops do not require repeated Shin approval; and
+- a mismatch stops before branch, artifact, PR, or implementation creation and
+  consumes no loop.
+
+Loop count moves from `0` at the first candidate-specific implementation
+mutation, including creation or modification of a candidate artifact. A later
+mismatch cannot be reclassified as a zero-loop pre-execution result.
+
+Envelope expansion requires new explicit Shin approval. A true Human Seat
+decision returns to Shin before mutation.
+
+If the authority match is `NO`, preserve:
+
+```text
+Authority Match:
+NO
+
+Implementation:
+NOT STARTED
+
+Loop Count Consumed:
+0
+
+Improvement Credit:
+NOT TESTED
+
+Required Authority:
+<exact missing authority>
+
+Decision Route:
+AUTHORITY ESCALATION / STOP
+```
+
+The closure-only tail has no candidate-selection, criteria-change, extension,
+renewal, or Loop N+1 authority.


### PR DESCRIPTION
## Scope

- STAGE 0 PROPOSAL ONLY
- NO RUN AUTHORITY
- RUN 003 NOT STARTED
- BOAW-001 REMAINS EXHAUSTED
- RUN 001 AND RUN 002 EVIDENCE UNCHANGED
- EVERY LOOP DECLARES AUTHORITY MATCH
- IN-ENVELOPE LOOPS DO NOT REQUIRE REPEATED SHIN APPROVAL
- CLOSURE-ONLY TAIL REQUIRED
- Merge of this PR does not activate or authorize any run.

## What this proposes

Adds one read-only Authority Sufficiency Preflight before future bounded-run
activation and one Authority Match declaration before each implementation
loop. Candidate ranking occurs before authority filtering; a mismatch stops
before implementation and consumes zero loops.

## Validation

- Exactly five authorized files changed.
- Existing integration files contain Forward-only additions only.
- New specification and template links resolve; Markdown fences are balanced.
- Existing 12 Loop Record examples validate.
- `git diff --check` passes.
- Run 003 was not started and no operational loop was executed.

This is a non-draft review PR. Merge is not authorized by the creation packet.
