### PR TITLE
Add deterministic unmanaged repository scan

### DIFF
--- a/decision_os/cli.py
+++ b/decision_os/cli.py
@@ -8,11 +8,18 @@ import sys
 from typing import Any, Sequence, TextIO
 
 from .checks import evidence, inspect_repository, unknown_payload
+from .scan import failure_payload as scan_failure_payload
+from .scan import scan_repository
+from .scan_text import render_text
 
 
 EXIT_USAGE = 2
 EXIT_INTERNAL = 6
 USAGE = "decision-os check <repository>"
+SCAN_USAGE = (
+    "decision-os scan <repository> | "
+    "decision-os scan --format json|text <repository>"
+)
 
 
 def serialize(payload: dict[str, Any]) -> str:
@@ -46,15 +53,88 @@ def _failure_payload(
     )
 
 
+def _scan_format(arguments: Sequence[str]) -> str:
+    if (
+        len(arguments) >= 3
+        and arguments[0] == "scan"
+        and arguments[1] == "--format"
+        and arguments[2] == "text"
+    ):
+        return "text"
+    return "json"
+
+
+def _write_scan(
+    payload: dict[str, Any],
+    output_format: str,
+    stream: TextIO,
+) -> None:
+    if output_format == "text":
+        stream.write(render_text(payload))
+        return
+    _write(payload, stream)
+
+
+def _run_scan(arguments: Sequence[str], output: TextIO) -> int:
+    output_format = _scan_format(arguments)
+    repository: str | None = None
+    if (
+        len(arguments) == 2
+        and arguments[0] == "scan"
+        and arguments[1]
+        and not arguments[1].startswith("-")
+    ):
+        repository = arguments[1]
+        output_format = "json"
+    elif (
+        len(arguments) == 4
+        and arguments[0] == "scan"
+        and arguments[1] == "--format"
+        and arguments[2] in ("json", "text")
+        and arguments[3]
+    ):
+        output_format = arguments[2]
+        repository = arguments[3]
+
+    if repository is None:
+        payload = scan_failure_payload(
+            "scan.cli.usage",
+            {
+                "argument_count": len(arguments),
+                "usage": SCAN_USAGE,
+            },
+        )
+        _write_scan(payload, output_format, output)
+        return EXIT_USAGE
+
+    try:
+        payload, exit_code = scan_repository(Path(repository))
+    except Exception as exc:
+        payload = scan_failure_payload(
+            "scan.internal",
+            {
+                "message": "unexpected bounded scan failure",
+                "type": type(exc).__name__,
+            },
+        )
+        exit_code = EXIT_INTERNAL
+
+    _write_scan(payload, output_format, output)
+    return exit_code
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
     stdout: TextIO | None = None,
 ) -> int:
-    """Run ``decision-os check <repository>`` and emit exactly one JSON object."""
+    """Run one repository-local Decision-OS inspection command."""
 
     arguments = list(sys.argv[1:] if argv is None else argv)
     output = sys.stdout if stdout is None else stdout
+
+    if arguments and arguments[0] == "scan":
+        return _run_scan(arguments, output)
 
     if (
         len(arguments) != 2

--- a/decision_os/scan.py
+++ b/decision_os/scan.py
@@ -1,0 +1,1090 @@
+"""Bounded, read-only inspection for ordinary local Git repositories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import errno
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import subprocess
+from typing import Any, Iterable, Sequence
+from urllib.parse import urlsplit
+
+
+EXIT_OK = 0
+EXIT_NOT_GIT = 3
+EXIT_UNSTABLE = 7
+
+SCHEMA_VERSION = "decision-os.scan.v0.2"
+MAX_RESTART_FILES = 64
+MAX_FILE_BYTES = 256 * 1024
+MAX_TOTAL_BYTES = 1024 * 1024
+MAX_DIRECTORY_ENTRIES = 4096
+
+INSTRUCTION_PATHS = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+)
+RESTART_PATHS = (
+    "HANDOFF.md",
+    "CURRENT_STATE.md",
+    "docs/current_state.md",
+)
+V13_PATHS = (
+    "docs/current_signal.md",
+    "handoff/current_codex_handoff.md",
+)
+
+MARKER_LABELS = {
+    "current_identity": frozenset(("current task", "active branch")),
+    "verification": frozenset(
+        ("verification", "validation", "test receipt", "tests")
+    ),
+    "rollback": frozenset(
+        ("rollback", "rollback identity", "known-good commit")
+    ),
+    "unfinished_work": frozenset(
+        ("known gaps", "unfinished work", "missing closure")
+    ),
+    "next_action": frozenset(("next action", "next authorized action")),
+    "boundary": frozenset(("not authorized", "do not repeat", "boundary")),
+}
+
+CLAIMS_NOT_MADE = (
+    "repository_safety",
+    "task_completeness",
+    "instruction_quality",
+    "software_correctness",
+    "remote_freshness",
+    "workflow_specific_diagnosis",
+    "authority_or_gate",
+)
+
+RECOMMENDATION_NONE = "NO ADOPTION RECOMMENDATION"
+RECOMMENDATION_LITE = "LITE RESTART NOTE RECOMMENDED"
+RECOMMENDATION_HANDOFF = "HANDOFF SURFACE RECOMMENDED"
+RECOMMENDATION_FULLER = "FULLER V13 FIT CHECK MAY BE USEFUL"
+RECOMMENDATION_INSUFFICIENT = "INSUFFICIENT EVIDENCE"
+
+
+@dataclass(frozen=True)
+class GitCommandError(Exception):
+    args_used: tuple[str, ...]
+    returncode: int
+    stderr: str
+
+
+@dataclass(frozen=True)
+class _GitSnapshot:
+    root: str
+    head: str
+    branch: str | None
+    status: str
+
+
+@dataclass(frozen=True)
+class _FileObservation:
+    path: str
+    state: str
+    reason: str | None = None
+    content: str | None = None
+    size: int = 0
+
+
+class _UnstableSnapshot(Exception):
+    def __init__(self, changed: Sequence[str]) -> None:
+        super().__init__("inspection snapshot changed")
+        self.changed = tuple(changed)
+
+
+class GitReader:
+    """Run only bounded local Git reads with optional locking disabled."""
+
+    def __init__(self, target: Path) -> None:
+        self.target = target
+        self.environment = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("GIT_")
+        }
+        self.environment.update(
+            {
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_NO_LAZY_FETCH": "1",
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+                "LC_ALL": "C",
+                "LANG": "C",
+                "TZ": "UTC",
+            }
+        )
+
+    def run(
+        self, *arguments: str, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        completed = subprocess.run(
+            ("git", "-C", str(self.target), *arguments),
+            capture_output=True,
+            check=False,
+            env=self.environment,
+            encoding="utf-8",
+            errors="surrogateescape",
+            stdin=subprocess.DEVNULL,
+        )
+        if check and completed.returncode != 0:
+            raise GitCommandError(
+                tuple(arguments),
+                completed.returncode,
+                completed.stderr.strip(),
+            )
+        return completed
+
+
+def _evidence(
+    check: str, status: str, source: str, detail: Any
+) -> dict[str, Any]:
+    return {
+        "check": check,
+        "detail": detail,
+        "source": source,
+        "status": status,
+    }
+
+
+def _base_repository() -> dict[str, Any]:
+    return {
+        "ahead": None,
+        "behind": None,
+        "branch": None,
+        "change_count": None,
+        "default_ref": None,
+        "detached": None,
+        "head": None,
+        "origin": {
+            "identity": None,
+            "present": None,
+            "remote_freshness": "NOT_CHECKED",
+        },
+        "root_name": None,
+        "worktree": "UNKNOWN",
+    }
+
+
+def failure_payload(
+    check: str,
+    detail: Any,
+    *,
+    status: str = "UNKNOWN",
+    repository: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the stable scan failure schema used for bounded transport errors."""
+
+    return {
+        "claims_not_made": list(CLAIMS_NOT_MADE),
+        "command": "scan",
+        "evidence": [_evidence(check, status, "decision-os scan", detail)],
+        "mode": "UNDETERMINED",
+        "recommendation": {
+            "basis": [check],
+            "code": RECOMMENDATION_INSUFFICIENT,
+            "minimum_next_step": (
+                "Establish one stable local repository snapshot before "
+                "interpreting scan evidence."
+            ),
+        },
+        "repository": _base_repository() if repository is None else repository,
+        "route": {
+            "basis": [],
+            "code": "NONE",
+            "command": None,
+        },
+        "scan_completion": "FAILED",
+        "schema_version": SCHEMA_VERSION,
+        "unknowns": [
+            {
+                "basis": [check],
+                "code": "scan_result",
+                "reason": "The bounded local scan did not complete.",
+            }
+        ],
+    }
+
+
+def _snapshot(reader: GitReader) -> _GitSnapshot:
+    root = reader.run("rev-parse", "--show-toplevel").stdout.strip()
+    head = reader.run("rev-parse", "--verify", "HEAD").stdout.strip()
+    branch_result = reader.run(
+        "symbolic-ref", "--quiet", "--short", "HEAD", check=False
+    )
+    branch = (
+        branch_result.stdout.strip()
+        if branch_result.returncode == 0
+        else None
+    )
+    status_output = reader.run(
+        "-c",
+        "core.fsmonitor=false",
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--no-renames",
+    ).stdout
+    return _GitSnapshot(root, head, branch, status_output)
+
+
+def _changed_snapshot_fields(
+    opening: _GitSnapshot, closing: _GitSnapshot
+) -> tuple[str, ...]:
+    changed: list[str] = []
+    if opening.root != closing.root:
+        changed.append("repository_identity")
+    if opening.head != closing.head:
+        changed.append("head")
+    if opening.branch != closing.branch:
+        changed.append("branch")
+    if opening.status != closing.status:
+        changed.append("worktree")
+    return tuple(changed)
+
+
+def _sanitize_origin(raw: str | None) -> dict[str, Any]:
+    if raw is None or not raw.strip():
+        return {
+            "identity": None,
+            "present": False,
+            "remote_freshness": "NOT_CHECKED",
+        }
+
+    value = raw.strip()
+    identity = "LOCAL_PATH"
+    if "://" in value:
+        try:
+            parsed = urlsplit(value)
+            hostname = parsed.hostname
+        except ValueError:
+            hostname = None
+            parsed = None
+        if parsed is None:
+            identity = None
+        elif parsed.scheme not in ("file", "") and hostname:
+            path = parsed.path.lstrip("/")
+            identity = hostname
+            if path:
+                identity = f"{identity}/{path}"
+    else:
+        bounded_value = value.split("#", 1)[0].split("?", 1)[0]
+        scp_match = re.match(
+            r"^(?:[^@/\s]+@)?([^:/\s]+):(.+)$", bounded_value
+        )
+        if scp_match:
+            identity = f"{scp_match.group(1)}/{scp_match.group(2).lstrip('/')}"
+
+    return {
+        "identity": _safe_output_text(identity),
+        "present": True,
+        "remote_freshness": "NOT_CHECKED",
+    }
+
+
+def _safe_output_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in value
+    ):
+        return None
+    return value
+
+
+def _safe_parts(relative: str) -> tuple[str, ...]:
+    path = PurePosixPath(relative)
+    if path.is_absolute() or not path.parts:
+        raise ValueError("path is not a bounded relative path")
+    if any(part in ("", ".", "..") or "\x00" in part for part in path.parts):
+        raise ValueError("path contains an unsafe component")
+    return tuple(path.parts)
+
+
+def _directory_flags() -> int:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    return flags
+
+
+def _entry_match(directory_fd: int, expected: str) -> tuple[str, str | None]:
+    """Find one exact entry name without allowing an unbounded directory read."""
+
+    case_mismatch = False
+    try:
+        with os.scandir(directory_fd) as entries:
+            for index, entry in enumerate(entries):
+                if index >= MAX_DIRECTORY_ENTRIES:
+                    return "UNKNOWN", "directory_entry_limit"
+                if entry.name == expected:
+                    return "OBSERVED", None
+                if entry.name.casefold() == expected.casefold():
+                    case_mismatch = True
+    except OSError as exc:
+        return "UNKNOWN", f"unreadable:{type(exc).__name__}"
+    if case_mismatch:
+        return "UNKNOWN", "case_mismatch"
+    return "ABSENT", None
+
+
+def _open_parent_directory(
+    root: Path, parts: Sequence[str]
+) -> tuple[int | None, str, str | None]:
+    """Open a verified parent via descriptor-relative, no-follow traversal."""
+
+    try:
+        directory_fd = os.open(root, _directory_flags())
+    except OSError as exc:
+        return None, "UNKNOWN", f"unreadable:{type(exc).__name__}"
+
+    for component in parts[:-1]:
+        state, reason = _entry_match(directory_fd, component)
+        if state != "OBSERVED":
+            os.close(directory_fd)
+            return None, state, reason
+        try:
+            observed = os.stat(
+                component, dir_fd=directory_fd, follow_symlinks=False
+            )
+            if stat.S_ISLNK(observed.st_mode):
+                os.close(directory_fd)
+                return None, "UNKNOWN", "symlink_rejected"
+            child_fd = os.open(
+                component,
+                _directory_flags(),
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            os.close(directory_fd)
+            return None, "ABSENT", None
+        except OSError as exc:
+            os.close(directory_fd)
+            reason = (
+                "symlink_rejected"
+                if exc.errno in (errno.ELOOP, errno.ENOTDIR)
+                else f"unreadable:{type(exc).__name__}"
+            )
+            return None, "UNKNOWN", reason
+        os.close(directory_fd)
+        directory_fd = child_fd
+    return directory_fd, "OBSERVED", None
+
+
+def _observe_path(
+    root: Path,
+    relative: str,
+    *,
+    read_content: bool,
+    remaining_bytes: int = MAX_TOTAL_BYTES,
+) -> _FileObservation:
+    try:
+        parts = _safe_parts(relative)
+    except ValueError:
+        return _FileObservation(relative, "UNKNOWN", "unsafe_path")
+
+    parent_fd, parent_state, parent_reason = _open_parent_directory(root, parts)
+    if parent_fd is None:
+        return _FileObservation(relative, parent_state, parent_reason)
+    final_name = parts[-1]
+    try:
+        final_state, final_reason = _entry_match(parent_fd, final_name)
+        if final_state != "OBSERVED":
+            os.close(parent_fd)
+            return _FileObservation(relative, final_state, final_reason)
+        before = os.stat(final_name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        os.close(parent_fd)
+        return _FileObservation(relative, "ABSENT")
+    except OSError as exc:
+        os.close(parent_fd)
+        return _FileObservation(
+            relative, "UNKNOWN", f"unreadable:{type(exc).__name__}"
+        )
+    if stat.S_ISLNK(before.st_mode):
+        os.close(parent_fd)
+        return _FileObservation(relative, "UNKNOWN", "symlink_rejected")
+    if not stat.S_ISREG(before.st_mode):
+        os.close(parent_fd)
+        return _FileObservation(relative, "UNKNOWN", "not_regular_file")
+    if not read_content:
+        os.close(parent_fd)
+        return _FileObservation(relative, "OBSERVED", size=before.st_size)
+    if before.st_size > MAX_FILE_BYTES or before.st_size > remaining_bytes:
+        os.close(parent_fd)
+        return _FileObservation(relative, "UNKNOWN", "size_limit")
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(final_name, flags, dir_fd=parent_fd)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+        ):
+            raise _UnstableSnapshot((f"surface:{relative}",))
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(65536, MAX_FILE_BYTES + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > MAX_FILE_BYTES or total > remaining_bytes:
+                return _FileObservation(relative, "UNKNOWN", "size_limit")
+        after_open = os.fstat(descriptor)
+        after_path = os.stat(
+            final_name, dir_fd=parent_fd, follow_symlinks=False
+        )
+        identity_before = (
+            before.st_dev,
+            before.st_ino,
+            before.st_mode,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+        identity_open = (
+            after_open.st_dev,
+            after_open.st_ino,
+            after_open.st_mode,
+            after_open.st_size,
+            after_open.st_mtime_ns,
+        )
+        identity_path = (
+            after_path.st_dev,
+            after_path.st_ino,
+            after_path.st_mode,
+            after_path.st_size,
+            after_path.st_mtime_ns,
+        )
+        if identity_before != identity_open or identity_before != identity_path:
+            raise _UnstableSnapshot((f"surface:{relative}",))
+        data = b"".join(chunks)
+    except _UnstableSnapshot:
+        raise
+    except OSError as exc:
+        return _FileObservation(
+            relative, "UNKNOWN", f"unreadable:{type(exc).__name__}"
+        )
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+    try:
+        content = data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return _FileObservation(relative, "UNKNOWN", "invalid_utf8")
+    return _FileObservation(
+        relative, "OBSERVED", content=content, size=len(data)
+    )
+
+
+def _handoff_candidates(root: Path) -> tuple[tuple[str, ...], str | None]:
+    try:
+        parts = _safe_parts("handoff")
+    except ValueError:
+        return (), "unsafe_path"
+    parent_fd, parent_state, parent_reason = _open_parent_directory(root, parts)
+    if parent_fd is None:
+        if parent_state == "ABSENT":
+            return (), None
+        return (), parent_reason
+    state, reason = _entry_match(parent_fd, parts[-1])
+    if state != "OBSERVED":
+        os.close(parent_fd)
+        if state == "ABSENT":
+            return (), None
+        return (), reason
+    try:
+        directory_fd = os.open(
+            parts[-1],
+            _directory_flags(),
+            dir_fd=parent_fd,
+        )
+    except OSError as exc:
+        reason = (
+            "symlink_rejected"
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR)
+            else f"unreadable:{type(exc).__name__}"
+        )
+        return (), reason
+    finally:
+        os.close(parent_fd)
+    names: list[str] = []
+    try:
+        with os.scandir(directory_fd) as entries:
+            for index, entry in enumerate(entries):
+                if index >= MAX_DIRECTORY_ENTRIES:
+                    return (), "directory_entry_limit"
+                name = entry.name
+                if not name.endswith(".md"):
+                    continue
+                if any(
+                    ord(character) < 32 or ord(character) == 127
+                    for character in name
+                ):
+                    return (), "unsafe_filename"
+                if any(0xD800 <= ord(character) <= 0xDFFF for character in name):
+                    return (), "unsafe_filename"
+                names.append(name)
+                if len(names) > MAX_RESTART_FILES:
+                    return (), "candidate_limit"
+    except OSError as exc:
+        return (), f"unreadable:{type(exc).__name__}"
+    finally:
+        os.close(directory_fd)
+    names.sort(key=lambda item: item.encode("utf-8"))
+    return tuple(f"handoff/{name}" for name in names), None
+
+
+def _marker_classes(content: str) -> tuple[str, ...]:
+    labels: set[str] = set()
+    for line in content.splitlines():
+        match = re.match(
+            r"^\s*(?:[-*]\s+)?([A-Za-z][A-Za-z -]*?)\s*:",
+            line,
+        )
+        if match is None:
+            continue
+        label = " ".join(match.group(1).lower().split())
+        for marker_class, accepted in MARKER_LABELS.items():
+            if label in accepted:
+                labels.add(marker_class)
+    return tuple(name for name in MARKER_LABELS if name in labels)
+
+
+def _unknown_entry(code: str, reason: str, basis: Iterable[str]) -> dict[str, Any]:
+    return {
+        "basis": list(basis),
+        "code": code,
+        "reason": reason,
+    }
+
+
+def _recommendation(
+    *,
+    mode: str,
+    unsafe_surface: bool,
+    instruction_count: int,
+    has_restart: bool,
+    dirty: bool,
+    detached: bool,
+    non_default_ahead: bool,
+) -> tuple[str, list[str], str]:
+    if mode != "UNMANAGED_REPOSITORY":
+        return (
+            RECOMMENDATION_NONE,
+            ["v13.surface"],
+            "Run decision-os check <repository>.",
+        )
+    if unsafe_surface:
+        return (
+            RECOMMENDATION_INSUFFICIENT,
+            ["surface.unknown"],
+            (
+                "Review the unreadable or unsafe bounded evidence before "
+                "drawing an adoption conclusion."
+            ),
+        )
+    if instruction_count >= 2 and not has_restart and (
+        dirty or non_default_ahead
+    ):
+        return (
+            RECOMMENDATION_FULLER,
+            ["instructions.multiple", "active_work", "restart.absent"],
+            (
+                "Use a fit check only if repository-specific interpretation "
+                "of these bounded findings is valuable."
+            ),
+        )
+    if not has_restart and (
+        instruction_count >= 2 or non_default_ahead
+    ):
+        basis = (
+            ["instructions.multiple", "restart.absent"]
+            if instruction_count >= 2
+            else ["branch.non_default_ahead", "restart.absent"]
+        )
+        return (
+            RECOMMENDATION_HANDOFF,
+            basis,
+            (
+                "Create one stable handoff surface with current identity, "
+                "evidence, boundaries, and the next action."
+            ),
+        )
+    if not has_restart and (
+        dirty or detached or instruction_count == 1
+    ):
+        basis: list[str] = []
+        if dirty:
+            basis.append("worktree.dirty")
+        if detached:
+            basis.append("head.detached")
+        if instruction_count == 1:
+            basis.append("instructions.one")
+        basis.append("restart.absent")
+        return (
+            RECOMMENDATION_LITE,
+            basis,
+            (
+                "Create or update one restart note with the current work and "
+                "next action before the next agent session."
+            ),
+        )
+    return (
+        RECOMMENDATION_NONE,
+        [],
+        "No adoption step is recommended from this bounded evidence.",
+    )
+
+
+def scan_repository(target: Path) -> tuple[dict[str, Any], int]:
+    """Inspect one local Git repository without writing to it."""
+
+    reader = GitReader(target)
+    try:
+        opening = _snapshot(reader)
+    except GitCommandError as exc:
+        return (
+            failure_payload(
+                "git.repository",
+                {
+                    "arguments": list(exc.args_used),
+                    "message": "required local Git read failed",
+                    "returncode": exc.returncode,
+                },
+            ),
+            EXIT_NOT_GIT,
+        )
+
+    root = Path(opening.root)
+    root_name = _safe_output_text(root.name)
+    branch = _safe_output_text(opening.branch)
+    status_lines = tuple(
+        sorted(entry for entry in opening.status.split("\0") if entry)
+    )
+    origin_result = reader.run(
+        "config", "--get", "remote.origin.url", check=False
+    )
+    origin_raw = (
+        origin_result.stdout.strip()
+        if origin_result.returncode == 0
+        else None
+    )
+    origin = _sanitize_origin(origin_raw)
+
+    default_result = reader.run(
+        "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD", check=False
+    )
+    default_ref: str | None = None
+    ahead: int | None = None
+    behind: int | None = None
+    if default_result.returncode == 0:
+        full_default_ref = default_result.stdout.strip()
+        prefix = "refs/remotes/"
+        default_ref = (
+            full_default_ref[len(prefix) :]
+            if full_default_ref.startswith(prefix)
+            else full_default_ref
+        )
+        default_ref = _safe_output_text(default_ref)
+        count_result = reader.run(
+            "rev-list",
+            "--left-right",
+            "--count",
+            f"HEAD...{full_default_ref}",
+            check=False,
+        )
+        if count_result.returncode == 0:
+            counts = count_result.stdout.split()
+            if len(counts) == 2 and all(item.isdigit() for item in counts):
+                ahead, behind = (int(counts[0]), int(counts[1]))
+
+    repository = {
+        "ahead": ahead,
+        "behind": behind,
+        "branch": branch,
+        "change_count": len(status_lines),
+        "default_ref": default_ref,
+        "detached": opening.branch is None,
+        "head": opening.head,
+        "origin": origin,
+        "root_name": root_name,
+        "worktree": "DIRTY" if status_lines else "CLEAN",
+    }
+
+    evidence: list[dict[str, Any]] = [
+        _evidence(
+            "git.repository",
+            "OBSERVED" if root_name is not None else "UNKNOWN",
+            "local Git",
+            {"root_name": root_name},
+        ),
+        _evidence(
+            "git.head",
+            "OBSERVED",
+            "local Git",
+            {
+                "detached": opening.branch is None,
+                "head": opening.head,
+            },
+        ),
+        _evidence(
+            "git.branch",
+            "OBSERVED" if opening.branch is None or branch is not None else "UNKNOWN",
+            "local Git",
+            {
+                "branch": branch,
+                "detached": opening.branch is None,
+            },
+        ),
+        _evidence(
+            "git.worktree",
+            "OBSERVED",
+            "local Git",
+            {
+                "change_count": len(status_lines),
+                "state": "DIRTY" if status_lines else "CLEAN",
+            },
+        ),
+        _evidence(
+            "git.default_branch",
+            "OBSERVED" if default_ref is not None else "UNKNOWN",
+            "local Git",
+            {
+                "ahead": ahead,
+                "behind": behind,
+                "default_ref": default_ref,
+                "remote_freshness": "NOT_CHECKED",
+            },
+        ),
+        _evidence(
+            "git.origin",
+            (
+                "UNKNOWN"
+                if origin["present"] and origin["identity"] is None
+                else "OBSERVED"
+                if origin["present"]
+                else "ABSENT"
+            ),
+            "local Git config",
+            origin,
+        ),
+    ]
+
+    instruction_observations = tuple(
+        _observe_path(root, relative, read_content=False)
+        for relative in INSTRUCTION_PATHS
+    )
+    instruction_present = tuple(
+        item.path for item in instruction_observations if item.state == "OBSERVED"
+    )
+    instruction_unknown = tuple(
+        {"path": item.path, "reason": item.reason}
+        for item in instruction_observations
+        if item.state == "UNKNOWN"
+    )
+    evidence.append(
+        _evidence(
+            "instructions.surfaces",
+            (
+                "UNKNOWN"
+                if instruction_unknown
+                else "OBSERVED"
+                if instruction_present
+                else "ABSENT"
+            ),
+            "bounded path allowlist",
+            {
+                "absent": [
+                    item.path
+                    for item in instruction_observations
+                    if item.state == "ABSENT"
+                ],
+                "observed": list(instruction_present),
+                "unknown": list(instruction_unknown),
+            },
+        )
+    )
+
+    handoff_paths, handoff_directory_issue = _handoff_candidates(root)
+    restart_candidates = tuple(dict.fromkeys((*RESTART_PATHS, *handoff_paths)))
+    restart_observations: list[_FileObservation] = []
+    remaining_bytes = MAX_TOTAL_BYTES
+    for relative in restart_candidates:
+        try:
+            observation = _observe_path(
+                root,
+                relative,
+                read_content=True,
+                remaining_bytes=remaining_bytes,
+            )
+        except _UnstableSnapshot as exc:
+            return (
+                failure_payload(
+                    "scan.snapshot",
+                    {"changed": list(exc.changed)},
+                    status="CONTRADICTORY",
+                    repository=repository,
+                ),
+                EXIT_UNSTABLE,
+            )
+        restart_observations.append(observation)
+        if observation.state == "OBSERVED":
+            remaining_bytes -= observation.size
+
+    restart_present = tuple(
+        item.path for item in restart_observations if item.state == "OBSERVED"
+    )
+    restart_unknown: list[dict[str, Any]] = [
+        {"path": item.path, "reason": item.reason}
+        for item in restart_observations
+        if item.state == "UNKNOWN"
+    ]
+    if handoff_directory_issue is not None:
+        restart_unknown.append(
+            {"path": "handoff/*.md", "reason": handoff_directory_issue}
+        )
+    markers = {
+        item.path: list(_marker_classes(item.content or ""))
+        for item in restart_observations
+        if item.state == "OBSERVED"
+    }
+    bounded_restart = tuple(
+        path
+        for path, marker_classes in markers.items()
+        if "current_identity" in marker_classes
+        and "next_action" in marker_classes
+    )
+    evidence.extend(
+        (
+            _evidence(
+                "restart.surfaces",
+                (
+                    "UNKNOWN"
+                    if restart_unknown
+                    else "OBSERVED"
+                    if restart_present
+                    else "ABSENT"
+                ),
+                "bounded restart paths",
+                {
+                    "absent": [
+                        item.path
+                        for item in restart_observations
+                        if item.state == "ABSENT"
+                    ],
+                    "bounded_restart_evidence": list(bounded_restart),
+                    "observed": list(restart_present),
+                    "unknown": restart_unknown,
+                },
+            ),
+            _evidence(
+                "restart.markers",
+                (
+                    "OBSERVED"
+                    if any(markers.values())
+                    else "ABSENT"
+                    if markers
+                    else "NOT_APPLICABLE"
+                ),
+                "exact normalized field labels",
+                {
+                    "markers": markers,
+                    "semantic_quality_proven": False,
+                },
+            ),
+        )
+    )
+
+    v13_observations = tuple(
+        _observe_path(root, relative, read_content=False)
+        for relative in V13_PATHS
+    )
+    v13_present = tuple(
+        item.path for item in v13_observations if item.state == "OBSERVED"
+    )
+    v13_unknown = tuple(
+        {"path": item.path, "reason": item.reason}
+        for item in v13_observations
+        if item.state == "UNKNOWN"
+    )
+    if len(v13_present) == len(V13_PATHS) and not v13_unknown:
+        mode = "V13_MANAGED_REPOSITORY"
+    elif not v13_present and not v13_unknown:
+        mode = "UNMANAGED_REPOSITORY"
+    else:
+        mode = "UNDETERMINED"
+    route = {
+        "basis": list(v13_present)
+        + [item["path"] for item in v13_unknown],
+        "code": "RUN_V13_CHECK" if mode != "UNMANAGED_REPOSITORY" else "NONE",
+        "command": (
+            "decision-os check <repository>"
+            if mode != "UNMANAGED_REPOSITORY"
+            else None
+        ),
+    }
+    evidence.append(
+        _evidence(
+            "v13.routing",
+            (
+                "UNKNOWN"
+                if v13_unknown
+                else "OBSERVED"
+                if v13_present
+                else "NOT_APPLICABLE"
+            ),
+            "canonical V13 path allowlist",
+            {
+                "mode": mode,
+                "observed": list(v13_present),
+                "unknown": list(v13_unknown),
+            },
+        )
+    )
+
+    try:
+        closing = _snapshot(reader)
+    except GitCommandError as exc:
+        return (
+            failure_payload(
+                "git.snapshot",
+                {
+                    "arguments": list(exc.args_used),
+                    "message": "required local Git read failed",
+                    "returncode": exc.returncode,
+                },
+                repository=repository,
+            ),
+            EXIT_NOT_GIT,
+        )
+    changed = _changed_snapshot_fields(opening, closing)
+    if changed:
+        return (
+            failure_payload(
+                "scan.snapshot",
+                {"changed": list(changed)},
+                status="CONTRADICTORY",
+                repository=repository,
+            ),
+            EXIT_UNSTABLE,
+        )
+    evidence.append(
+        _evidence(
+            "scan.snapshot",
+            "OBSERVED",
+            "opening and closing local reads",
+            {"stable": True},
+        )
+    )
+
+    unsafe_surface = bool(
+        instruction_unknown or restart_unknown or v13_unknown
+    )
+    default_name = default_ref.rsplit("/", 1)[-1] if default_ref else None
+    non_default_ahead = bool(
+        branch is not None
+        and default_name is not None
+        and branch != default_name
+        and ahead is not None
+        and ahead > 0
+    )
+    recommendation_code, basis, minimum_next_step = _recommendation(
+        mode=mode,
+        unsafe_surface=unsafe_surface,
+        instruction_count=len(instruction_present),
+        has_restart=bool(bounded_restart),
+        dirty=bool(status_lines),
+        detached=opening.branch is None,
+        non_default_ahead=non_default_ahead,
+    )
+
+    unknowns = [
+        _unknown_entry(
+            "task_completion",
+            "A clean worktree or a handoff marker cannot prove task completion.",
+            ["git.worktree", "restart.markers"],
+        ),
+        _unknown_entry(
+            "instruction_quality",
+            "Instruction-surface presence does not prove instruction quality.",
+            ["instructions.surfaces"],
+        ),
+        _unknown_entry(
+            "software_correctness",
+            "Local test or verification markers do not prove software correctness.",
+            ["restart.markers"],
+        ),
+        _unknown_entry(
+            "remote_freshness",
+            "The local-only scan does not contact a remote.",
+            ["git.default_branch", "git.origin"],
+        ),
+    ]
+    if unsafe_surface:
+        unknowns.append(
+            _unknown_entry(
+                "bounded_surface",
+                "At least one bounded surface could not be inspected safely.",
+                ["surface.unknown"],
+            )
+        )
+
+    return (
+        {
+            "claims_not_made": list(CLAIMS_NOT_MADE),
+            "command": "scan",
+            "evidence": evidence,
+            "mode": mode,
+            "recommendation": {
+                "basis": basis,
+                "code": recommendation_code,
+                "minimum_next_step": minimum_next_step,
+            },
+            "repository": repository,
+            "route": route,
+            "scan_completion": "PARTIAL" if unsafe_surface else "COMPLETE",
+            "schema_version": SCHEMA_VERSION,
+            "unknowns": unknowns,
+        },
+        EXIT_OK,
+    )
+
+
+__all__ = (
+    "CLAIMS_NOT_MADE",
+    "EXIT_NOT_GIT",
+    "EXIT_OK",
+    "EXIT_UNSTABLE",
+    "GitCommandError",
+    "GitReader",
+    "SCHEMA_VERSION",
+    "failure_payload",
+    "scan_repository",
+)

--- a/decision_os/scan_text.py
+++ b/decision_os/scan_text.py
@@ -1,0 +1,326 @@
+"""Deterministic human rendering for an already-computed scan payload."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+import unicodedata
+
+
+RECOMMENDATION_NONE = "NO ADOPTION RECOMMENDATION"
+RECOMMENDATION_LITE = "LITE RESTART NOTE RECOMMENDED"
+RECOMMENDATION_HANDOFF = "HANDOFF SURFACE RECOMMENDED"
+RECOMMENDATION_FULLER = "FULLER V13 FIT CHECK MAY BE USEFUL"
+RECOMMENDATION_INSUFFICIENT = "INSUFFICIENT EVIDENCE"
+
+RECOMMENDATIONS = frozenset(
+    (
+        RECOMMENDATION_NONE,
+        RECOMMENDATION_LITE,
+        RECOMMENDATION_HANDOFF,
+        RECOMMENDATION_FULLER,
+        RECOMMENDATION_INSUFFICIENT,
+    )
+)
+
+MODES = frozenset(
+    (
+        "UNMANAGED_REPOSITORY",
+        "V13_MANAGED_REPOSITORY",
+        "UNDETERMINED",
+    )
+)
+
+UNKNOWN_MESSAGES = {
+    "task_completion": (
+        "The scan cannot establish whether the current task is complete."
+    ),
+    "instruction_quality": (
+        "Instruction-surface presence does not establish instruction quality."
+    ),
+    "software_correctness": (
+        "Local markers do not establish software correctness."
+    ),
+    "remote_freshness": (
+        "Remote freshness was not checked by this local-only scan."
+    ),
+    "bounded_surface": (
+        "At least one bounded surface could not be inspected safely."
+    ),
+    "scan_result": "The bounded local scan did not complete.",
+}
+
+MINIMUM_NEXT_STEPS = {
+    RECOMMENDATION_NONE: (
+        "No adoption step is recommended from this bounded evidence."
+    ),
+    RECOMMENDATION_LITE: (
+        "Create or update one restart note with the current work and next "
+        "action before the next agent session."
+    ),
+    RECOMMENDATION_HANDOFF: (
+        "Create one stable handoff surface with current identity, evidence, "
+        "boundaries, and the next action."
+    ),
+    RECOMMENDATION_FULLER: (
+        "Review whether the observed instruction surfaces need one shared "
+        "restart contract."
+    ),
+    RECOMMENDATION_INSUFFICIENT: (
+        "Resolve the unavailable bounded evidence, then rerun the scan."
+    ),
+}
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return value
+    return ()
+
+
+def _safe_inline(value: Any, fallback: str = "unknown") -> str:
+    if not isinstance(value, str):
+        return fallback
+    cleaned = "".join(
+        (
+            character
+            if unicodedata.category(character) not in {"Cc", "Cf", "Cs"}
+            else " "
+        )
+        for character in value
+    )
+    cleaned = " ".join(cleaned.split())
+    return cleaned or fallback
+
+
+def _safe_repository_name(value: Any) -> str:
+    name = _safe_inline(value, "unknown")
+    return name.replace("/", "_").replace("\\", "_")
+
+
+def _integer(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _count(detail: Mapping[str, Any], key: str) -> int:
+    return len(_sequence(detail.get(key)))
+
+
+def _evidence_description(
+    item: Mapping[str, Any],
+    repository: Mapping[str, Any],
+    mode: str,
+) -> str:
+    check = _safe_inline(item.get("check"), "unknown check")
+    status = _safe_inline(item.get("status"), "UNKNOWN")
+    detail = _mapping(item.get("detail"))
+
+    if check == "git.repository":
+        return (
+            "Local Git repository identity was observed."
+            if status == "OBSERVED"
+            else "Local Git repository identity was not available."
+        )
+    if check == "git.head":
+        head = _safe_inline(repository.get("head"), "unknown")
+        return f"HEAD identity is {head[:12]}."
+    if check == "git.branch":
+        if repository.get("detached") is True:
+            return "HEAD is detached."
+        branch = _safe_inline(repository.get("branch"), "unknown")
+        return f"Current branch is {branch}."
+    if check == "git.worktree":
+        state = _safe_inline(repository.get("worktree"), "UNKNOWN")
+        count = _integer(repository.get("change_count"))
+        suffix = "" if count is None else f" ({count} change entries)"
+        return f"Worktree state is {state}{suffix}."
+    if check == "git.default_branch":
+        if status != "OBSERVED":
+            return "The local default-branch relationship was not available."
+        default_ref = _safe_inline(repository.get("default_ref"), "unknown")
+        ahead = _integer(repository.get("ahead"))
+        behind = _integer(repository.get("behind"))
+        relation = (
+            "unknown"
+            if ahead is None or behind is None
+            else f"ahead {ahead}, behind {behind}"
+        )
+        return f"Local default reference is {default_ref} ({relation})."
+    if check == "git.origin":
+        if status == "OBSERVED":
+            return "A sanitized local origin identity was observed."
+        if status == "ABSENT":
+            return "No local origin was observed."
+        return "The local origin identity could not be represented safely."
+    if check == "instructions.surfaces":
+        if status == "OBSERVED":
+            count = _count(detail, "observed")
+            return f"{count} allowlisted AI instruction surfaces were observed."
+        if status == "ABSENT":
+            return "No allowlisted AI instruction surface was observed."
+        return "At least one allowlisted instruction surface was unavailable."
+    if check == "restart.surfaces":
+        if status == "OBSERVED":
+            observed = _count(detail, "observed")
+            bounded = _count(detail, "bounded_restart_evidence")
+            return (
+                f"{observed} bounded restart candidates were observed; "
+                f"{bounded} contained structural restart evidence."
+            )
+        if status == "ABSENT":
+            return "No bounded restart surface was observed."
+        return "At least one bounded restart surface was unavailable."
+    if check == "restart.markers":
+        if status == "OBSERVED":
+            return "One or more bounded restart marker classes were observed."
+        if status == "ABSENT":
+            return "No accepted restart marker class was observed."
+        return "Restart-marker inspection had no readable candidate."
+    if check == "v13.routing":
+        if mode == "V13_MANAGED_REPOSITORY":
+            return "Canonical V13 paths were observed; strict check is the route."
+        if mode == "UNDETERMINED":
+            return "V13 path state could not be classified completely."
+        return "Strict V13 state validation is not applicable to this scan."
+    if check == "scan.snapshot":
+        if status == "OBSERVED":
+            return "Opening and closing local evidence matched."
+        return "The local repository changed during inspection."
+    if check in ("cli.usage", "scan.cli.usage"):
+        return "The scan invocation did not match the documented grammar."
+    if check in ("runner.internal", "scan.internal"):
+        return "The bounded scan encountered an internal failure."
+
+    label = check.replace(".", " ")
+    return f"{label}: {status}."
+
+
+def _append_unique(target: list[str], value: str) -> None:
+    if value not in target:
+        target.append(value)
+
+
+def _grouped_evidence(
+    payload: Mapping[str, Any],
+    repository: Mapping[str, Any],
+    mode: str,
+) -> dict[str, list[str]]:
+    groups = {
+        "Observed": [],
+        "Absent": [],
+        "Not applicable": [],
+        "Unknown": [],
+    }
+    for raw_item in _sequence(payload.get("evidence")):
+        item = _mapping(raw_item)
+        status = item.get("status")
+        description = _evidence_description(item, repository, mode)
+        if status == "OBSERVED":
+            group = "Observed"
+        elif status == "ABSENT":
+            group = "Absent"
+        elif status == "NOT_APPLICABLE":
+            group = "Not applicable"
+        else:
+            group = "Unknown"
+        _append_unique(groups[group], description)
+
+    for raw_unknown in _sequence(payload.get("unknowns")):
+        unknown = _mapping(raw_unknown)
+        code = unknown.get("code")
+        if isinstance(code, str):
+            description = UNKNOWN_MESSAGES.get(
+                code,
+                f"{_safe_inline(code).replace('_', ' ')} remains unknown.",
+            )
+            _append_unique(groups["Unknown"], description)
+    return groups
+
+
+def _summary_label(completion: str, recommendation: str) -> str:
+    if completion == "FAILED":
+        return "FAILED"
+    if recommendation == RECOMMENDATION_INSUFFICIENT:
+        return "INSUFFICIENT EVIDENCE"
+    if recommendation == RECOMMENDATION_NONE:
+        return "OBSERVATIONS AVAILABLE"
+    return "REVIEW"
+
+
+def render_text(payload: Mapping[str, Any]) -> str:
+    """Render one scan payload without inspecting a repository or environment."""
+
+    completion = _safe_inline(payload.get("scan_completion"), "FAILED")
+    mode_value = payload.get("mode")
+    mode = mode_value if mode_value in MODES else "UNDETERMINED"
+
+    recommendation_object = _mapping(payload.get("recommendation"))
+    recommendation_value = recommendation_object.get("code")
+    recommendation = (
+        recommendation_value
+        if recommendation_value in RECOMMENDATIONS
+        else RECOMMENDATION_INSUFFICIENT
+    )
+
+    repository = _mapping(payload.get("repository"))
+    root_name = _safe_repository_name(repository.get("root_name"))
+    head = _safe_inline(repository.get("head"), "unknown")[:12]
+    if repository.get("detached") is True:
+        branch = "DETACHED"
+    else:
+        branch = _safe_inline(repository.get("branch"), "unknown")
+
+    if root_name == "unknown" and head == "unknown":
+        repository_line = "Repository: unavailable"
+    else:
+        repository_line = f"Repository: {root_name} @ {head} ({branch})"
+
+    lines = [
+        f"Decision-OS Scan v0.2: {_summary_label(completion, recommendation)}",
+        f"Mode: {mode}",
+        repository_line,
+        "",
+    ]
+
+    groups = _grouped_evidence(payload, repository, mode)
+    for title in ("Observed", "Absent", "Not applicable", "Unknown"):
+        lines.append(f"{title}:")
+        entries = groups[title]
+        if entries:
+            lines.extend(f"- {entry}" for entry in entries)
+        else:
+            lines.append("- none")
+        lines.append("")
+
+    route = _mapping(payload.get("route"))
+    minimum_next_step = (
+        "Run decision-os check <repository>."
+        if route.get("code") == "RUN_V13_CHECK"
+        else MINIMUM_NEXT_STEPS[recommendation]
+    )
+    lines.extend(
+        (
+            "Recommendation:",
+            recommendation,
+            "",
+            "Minimum next step:",
+            minimum_next_step,
+            "",
+            "Limits:",
+            (
+                "This scan does not establish task completion, instruction "
+                "quality, software correctness, repository safety, remote "
+                "freshness, authority, or a V13 Gate."
+            ),
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+__all__ = ("render_text",)

--- a/docs/v13_runner_v0_2.md
+++ b/docs/v13_runner_v0_2.md
@@ -1,0 +1,267 @@
+# V13 Runner v0.2 — Unmanaged Repository Scan
+
+V13 Runner v0.2 adds a repository-local, read-only discovery command for an
+ordinary Git repository that has not adopted V13:
+
+```text
+decision-os scan <repository>
+```
+
+The scan collects bounded local evidence. It does not diagnose a workflow,
+grant authority, rank values, write to the inspected repository, contact a
+remote, or replace the paid AI Agent Handoff Audit.
+
+The strict V13 validator remains:
+
+```text
+decision-os check <repository>
+```
+
+`scan` does not weaken, replace, or automatically execute `check`.
+
+## Five-Minute Local Path
+
+From this source repository:
+
+```sh
+PATH="$PWD/bin:$PATH"
+decision-os scan .
+decision-os scan --format text .
+```
+
+The equivalent module forms are:
+
+```sh
+python3 -B -m decision_os scan .
+python3 -B -m decision_os scan --format text .
+```
+
+No package installation, publication, release, LLM, network access, or global
+command registration is required.
+
+## Command and Format Contract
+
+The accepted forms are exactly:
+
+```text
+decision-os scan <repository>
+decision-os scan --format json <repository>
+decision-os scan --format text <repository>
+```
+
+JSON is the default. JSON output is one UTF-8 object followed by one line feed,
+with sorted keys, stable evidence order, and no timestamp. Text is an explicit,
+deterministic rendering of the already-built payload; it performs no second
+inspection, terminal detection, wrapping, or additional inference.
+
+The JSON schema is separate from the v0.1 `check` schema:
+
+```text
+schema_version:
+decision-os.scan.v0.2
+
+scan_completion:
+COMPLETE / PARTIAL / FAILED
+
+mode:
+UNMANAGED_REPOSITORY / V13_MANAGED_REPOSITORY / UNDETERMINED
+
+evidence.status:
+OBSERVED / ABSENT / NOT_APPLICABLE / UNKNOWN / CONTRADICTORY
+
+route.code:
+NONE / RUN_V13_CHECK
+```
+
+Top-level fields are:
+
+- `schema_version`
+- `command`
+- `scan_completion`
+- `mode`
+- `repository`
+- `evidence`
+- `unknowns`
+- `recommendation`
+- `route`
+- `claims_not_made`
+
+The report omits absolute repository paths, dirty filenames, file bodies,
+marker values, credentials, URL query/fragment data, timestamps, and opaque
+scores. A configured origin is sanitized. Remote freshness is always
+`NOT_CHECKED`.
+
+## Bounded Evidence
+
+Local Git reads report:
+
+- inspectable worktree and `HEAD`;
+- branch or detached state;
+- clean or dirty state and change count;
+- locally recorded default-ref relationship;
+- sanitized origin presence and identity;
+- opening/closing snapshot stability.
+
+The implementation disables optional Git locks, filesystem monitoring,
+terminal prompts, and lazy object fetching. Ambient `GIT_*` variables are
+removed so they cannot redirect inspection, change object/index identity, or
+write trace output. No `fetch`, `pull`, `ls-remote`, hook, network, or mutating
+Git command is run.
+
+Instruction presence is checked only at:
+
+```text
+AGENTS.md
+CLAUDE.md
+.github/copilot-instructions.md
+```
+
+Instruction content and quality are not evaluated.
+
+Restart candidates are limited to:
+
+```text
+HANDOFF.md
+CURRENT_STATE.md
+docs/current_state.md
+handoff/*.md
+```
+
+`handoff/*.md` means direct children only: no recursion, at most 64 Markdown
+candidates, and at most 4,096 directory entries inspected. Each candidate is
+limited to 256 KiB and all restart content together to 1 MiB.
+
+Descriptor-relative, no-follow traversal rejects intermediate and final
+symlinks. Exact path case is required. Unsafe, unreadable, invalid-UTF-8,
+oversized, case-mismatched, or over-limit evidence becomes `UNKNOWN`; it is
+never silently treated as absent.
+
+## Restart Markers
+
+Readable restart candidates are checked only for exact normalized field-label
+classes:
+
+| Class | Accepted labels |
+| --- | --- |
+| Current identity | `Current Task`, `Active Branch` |
+| Verification | `Verification`, `Validation`, `Test Receipt`, `Tests` |
+| Rollback | `Rollback`, `Rollback Identity`, `Known-Good Commit` |
+| Unfinished work | `Known Gaps`, `Unfinished Work`, `Missing Closure` |
+| Next action | `Next Action`, `Next Authorized Action` |
+| Boundary | `Not Authorized`, `Do Not Repeat`, `Boundary` |
+
+A file is bounded structural restart evidence only when at least one current
+identity marker and one next-action marker are present. Marker values are not
+reported or semantically judged. Marker presence does not establish truth,
+freshness, completeness, quality, successful verification, or task completion.
+
+## V13 Routing
+
+The canonical V13 paths are:
+
+```text
+docs/current_signal.md
+handoff/current_codex_handoff.md
+```
+
+If both are safely present, mode is `V13_MANAGED_REPOSITORY`. If only one is
+present or either cannot be safely established, mode is `UNDETERMINED`. Both
+modes return the literal route `decision-os check <repository>` and make no
+generic adoption recommendation. Only `check` evaluates canonical V13 state.
+
+The absence of both files selects `UNMANAGED_REPOSITORY`; their absence is not
+a failure or a claim that the repository is unsafe.
+
+## Recommendation Contract
+
+The scan returns exactly one of:
+
+```text
+NO ADOPTION RECOMMENDATION
+LITE RESTART NOTE RECOMMENDED
+HANDOFF SURFACE RECOMMENDED
+FULLER V13 FIT CHECK MAY BE USEFUL
+INSUFFICIENT EVIDENCE
+```
+
+The first matching rule applies:
+
+1. V13-managed or undetermined V13 route: no adoption recommendation; use the
+   strict `check` route.
+2. Unsafe or unreadable bounded evidence in an unmanaged repository:
+   insufficient evidence.
+3. Multiple instruction surfaces, no bounded restart evidence, and dirty or
+   locally-ahead non-default work: a fuller fit check may be useful.
+4. Multiple instruction surfaces or locally-ahead non-default work, with no
+   bounded restart evidence: a handoff surface is recommended.
+5. Dirty work, detached `HEAD`, or exactly one instruction surface, with no
+   bounded restart evidence: a lite restart note is recommended.
+6. Otherwise: no adoption recommendation.
+
+These are static generic recommendations, not V13 Gates, permissions, safety
+ratings, workflow diagnoses, or proof that adoption is required.
+
+## Exit Codes
+
+`scan` uses:
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Scan transport completed, including ordinary gaps and optional unknowns |
+| `2` | Invalid scan invocation or format |
+| `3` | Non-Git/unborn target or required local Git read failure |
+| `6` | Unexpected bounded internal failure |
+| `7` | Opening and closing evidence cannot belong to one stable snapshot |
+
+`scan` never emits the strict `check` meanings `4` or `5`. An optional missing,
+unreadable, malformed, oversized, or rejected surface returns exit `0` with a
+visible `PARTIAL` result. Missing evidence is not permission to continue.
+
+The existing `check` exit codes, fields, first-current-block rule, historical
+separation, and contradiction precedence remain unchanged.
+
+## Explicit Non-Claims
+
+The scan does not establish:
+
+- repository safety;
+- task completion;
+- instruction quality;
+- software correctness;
+- remote freshness;
+- workflow-specific causation or repeated failure;
+- Aspire, Gate, authority, or a Human value decision.
+
+A clean worktree is not task completion. A filename is not a valid handoff.
+An instruction file is not proof of instruction quality. A test marker is not
+proof that software is correct. Multiple instruction surfaces are not, by
+themselves, a contradiction.
+
+## Optional Repository-Specific Interpretation
+
+`decision-os scan` reports bounded, generic repository evidence; it does not
+provide workflow-specific diagnosis, select a custom priority fix, or give
+implementation advice. If repository-specific interpretation may be useful,
+you may
+[open the AI Agent Handoff Audit fit-check form](https://github.com/shin4141/decision-os-v13-loopkit/issues/new?template=ai_agent_handoff_audit_fit_check.md).
+The free fit check confirms only fit, bounded scope, and material availability;
+bespoke diagnosis begins only after scope confirmation and payment. Because
+the form is public, do not post credentials, secrets, private repository
+content, customer data, or confidential material.
+
+The link is documentation-only. JSON and terminal output contain no URL,
+automatic lead submission, tracking, payment flow, price, personalized sales
+pressure, or free bespoke diagnosis.
+
+## Implementation and Closure Boundary
+
+Runner v0.2 is standard-library-only and repository-local. Its bounded
+implementation surfaces are `decision_os/scan.py`,
+`decision_os/scan_text.py`, the explicit `scan` dispatch in
+`decision_os/cli.py`, v0.2-only tests/fixtures, and this document.
+
+The integration receipt is reserved for the predefined Forward-only
+closure-only tail after exact-head review and history-preserving merge. That
+tail may update only this document, `docs/current_signal.md`, and
+`handoff/current_codex_handoff.md`. Until that receipt is written, this section
+does not claim merge completion or grant additional authority.

--- a/tests/fixtures/v13_runner_v0_2/base/README.md
+++ b/tests/fixtures/v13_runner_v0_2/base/README.md
@@ -1,0 +1,3 @@
+# Unmanaged fixture
+
+This repository fixture has no AI instruction or restart surface.

--- a/tests/fixtures/v13_runner_v0_2/copilot_instruction/.github/copilot-instructions.md
+++ b/tests/fixtures/v13_runner_v0_2/copilot_instruction/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+Keep changes bounded.

--- a/tests/fixtures/v13_runner_v0_2/multiple_instructions/AGENTS.md
+++ b/tests/fixtures/v13_runner_v0_2/multiple_instructions/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+Use the repository's existing tests.

--- a/tests/fixtures/v13_runner_v0_2/multiple_instructions/CLAUDE.md
+++ b/tests/fixtures/v13_runner_v0_2/multiple_instructions/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+Preserve the current task boundary.

--- a/tests/fixtures/v13_runner_v0_2/one_instruction/AGENTS.md
+++ b/tests/fixtures/v13_runner_v0_2/one_instruction/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+Use the repository's existing tests.

--- a/tests/fixtures/v13_runner_v0_2/restart_markers/HANDOFF.md
+++ b/tests/fixtures/v13_runner_v0_2/restart_markers/HANDOFF.md
@@ -1,0 +1,19 @@
+# Handoff
+
+Active Branch:
+feature/restartable
+
+Verification:
+tests recorded
+
+Rollback Identity:
+known local commit
+
+Missing Closure:
+none stated
+
+Next Authorized Action:
+review the next bounded step
+
+Not Authorized:
+external action

--- a/tests/fixtures/v13_runner_v0_2/restart_surface/HANDOFF.md
+++ b/tests/fixtures/v13_runner_v0_2/restart_surface/HANDOFF.md
@@ -1,0 +1,3 @@
+# Handoff
+
+This file intentionally has no bounded current-identity or next-action marker.

--- a/tests/test_decision_os_scan.py
+++ b/tests/test_decision_os_scan.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import os
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.scan import (
+    EXIT_NOT_GIT,
+    EXIT_OK,
+    EXIT_UNSTABLE,
+    GitReader,
+    RECOMMENDATION_FULLER,
+    RECOMMENDATION_HANDOFF,
+    RECOMMENDATION_INSUFFICIENT,
+    RECOMMENDATION_LITE,
+    RECOMMENDATION_NONE,
+    _snapshot,
+    scan_repository,
+)
+from decision_os import scan as scan_module
+from tests.test_decision_os_checks import (
+    create_repository as create_v13_repository,
+    run_git,
+    tree_digest,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "v13_runner_v0_2"
+
+
+def apply_overlay(repository: Path, name: str) -> None:
+    shutil.copytree(FIXTURES / name, repository, dirs_exist_ok=True)
+
+
+def create_unmanaged_repository(
+    parent: Path, *overlays: str, push: bool = True
+) -> Path:
+    repository = parent / "target"
+    remote = parent / "remote.git"
+    repository.mkdir()
+    run_git(repository, "init", "-b", "main")
+    apply_overlay(repository, "base")
+    for overlay in overlays:
+        apply_overlay(repository, overlay)
+    run_git(repository, "add", ".")
+    run_git(
+        repository,
+        "-c",
+        "user.name=V13 Runner Test",
+        "-c",
+        "user.email=runner@example.invalid",
+        "commit",
+        "-m",
+        "fixture",
+    )
+    if push:
+        run_git(parent, "init", "--bare", str(remote))
+        run_git(repository, "remote", "add", "origin", str(remote))
+        run_git(repository, "push", "-u", "origin", "main")
+        run_git(remote, "symbolic-ref", "HEAD", "refs/heads/main")
+        run_git(
+            repository,
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+        )
+    return repository
+
+
+def recommendation(payload: dict[str, object]) -> str:
+    value = payload["recommendation"]
+    if not isinstance(value, dict):
+        raise AssertionError("recommendation is not an object")
+    code = value["code"]
+    if not isinstance(code, str):
+        raise AssertionError("recommendation code is not text")
+    return code
+
+
+def evidence_item(
+    payload: dict[str, object], check: str
+) -> dict[str, object]:
+    items = payload["evidence"]
+    if not isinstance(items, list):
+        raise AssertionError("evidence is not an array")
+    return next(item for item in items if item["check"] == check)
+
+
+class UnmanagedRepositoryScanTest(unittest.TestCase):
+    def test_clean_repository_has_no_adoption_recommendation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("decision-os.scan.v0.2", payload["schema_version"])
+            self.assertEqual("COMPLETE", payload["scan_completion"])
+            self.assertEqual("UNMANAGED_REPOSITORY", payload["mode"])
+            self.assertEqual(RECOMMENDATION_NONE, recommendation(payload))
+            self.assertEqual("NONE", payload["route"]["code"])
+            self.assertEqual("CLEAN", payload["repository"]["worktree"])
+            self.assertEqual(0, payload["repository"]["change_count"])
+            self.assertNotIn(str(repository), repr(payload))
+
+    def test_one_instruction_recommends_lite_restart_note(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "one_instruction"
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(RECOMMENDATION_LITE, recommendation(payload))
+            instruction = evidence_item(payload, "instructions.surfaces")
+            self.assertEqual("OBSERVED", instruction["status"])
+            self.assertEqual(
+                ["AGENTS.md"], instruction["detail"]["observed"]
+            )
+
+    def test_multiple_instructions_recommend_handoff_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "multiple_instructions"
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(RECOMMENDATION_HANDOFF, recommendation(payload))
+
+    def test_multiple_instructions_and_active_work_use_fuller_fit_route(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "multiple_instructions"
+            )
+            (repository / "work.txt").write_text("uncommitted\n", encoding="utf-8")
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(RECOMMENDATION_FULLER, recommendation(payload))
+
+    def test_structural_restart_evidence_suppresses_adoption_recommendation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "one_instruction", "restart_markers"
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(RECOMMENDATION_NONE, recommendation(payload))
+            restart = evidence_item(payload, "restart.surfaces")
+            self.assertEqual(
+                ["HANDOFF.md"],
+                restart["detail"]["bounded_restart_evidence"],
+            )
+            marker = evidence_item(payload, "restart.markers")
+            self.assertIn(
+                "current_identity", marker["detail"]["markers"]["HANDOFF.md"]
+            )
+            self.assertIn(
+                "next_action", marker["detail"]["markers"]["HANDOFF.md"]
+            )
+            self.assertFalse(marker["detail"]["semantic_quality_proven"])
+
+    def test_filename_only_restart_surface_does_not_prove_restartability(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "one_instruction", "restart_surface"
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(RECOMMENDATION_LITE, recommendation(payload))
+            restart = evidence_item(payload, "restart.surfaces")
+            self.assertEqual(
+                [], restart["detail"]["bounded_restart_evidence"]
+            )
+            marker = evidence_item(payload, "restart.markers")
+            self.assertEqual("ABSENT", marker["status"])
+
+    def test_dirty_and_detached_states_are_evidence_not_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            (repository / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+            dirty_payload, dirty_exit = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, dirty_exit)
+            self.assertEqual(RECOMMENDATION_LITE, recommendation(dirty_payload))
+            run_git(repository, "add", "dirty.txt")
+            run_git(
+                repository,
+                "-c",
+                "user.name=V13 Runner Test",
+                "-c",
+                "user.email=runner@example.invalid",
+                "commit",
+                "-m",
+                "detach fixture",
+            )
+            run_git(repository, "checkout", "--detach", "HEAD")
+
+            detached_payload, detached_exit = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, detached_exit)
+            self.assertEqual(
+                RECOMMENDATION_LITE, recommendation(detached_payload)
+            )
+            self.assertTrue(detached_payload["repository"]["detached"])
+
+    def test_non_default_ahead_work_recommends_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            run_git(repository, "switch", "-c", "feature/local")
+            (repository / "feature.txt").write_text("feature\n", encoding="utf-8")
+            run_git(repository, "add", "feature.txt")
+            run_git(
+                repository,
+                "-c",
+                "user.name=V13 Runner Test",
+                "-c",
+                "user.email=runner@example.invalid",
+                "commit",
+                "-m",
+                "local feature",
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(RECOMMENDATION_HANDOFF, recommendation(payload))
+            self.assertEqual(1, payload["repository"]["ahead"])
+            self.assertEqual(0, payload["repository"]["behind"])
+
+    def test_invalid_utf8_is_partial_unknown_not_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "restart_surface"
+            )
+            (repository / "HANDOFF.md").write_bytes(b"\xff\xfe")
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("PARTIAL", payload["scan_completion"])
+            self.assertEqual(
+                RECOMMENDATION_INSUFFICIENT, recommendation(payload)
+            )
+            restart = evidence_item(payload, "restart.surfaces")
+            self.assertEqual("UNKNOWN", restart["status"])
+            self.assertEqual(
+                "invalid_utf8", restart["detail"]["unknown"][0]["reason"]
+            )
+
+    def test_symlinked_surface_is_not_followed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_unmanaged_repository(parent)
+            sentinel = parent / "outside.md"
+            sentinel.write_text(
+                "Active Branch:\noutside\n\nNext Action:\nnever read\n",
+                encoding="utf-8",
+            )
+            handoff = repository / "HANDOFF.md"
+            handoff.symlink_to(sentinel)
+            before = sentinel.read_bytes()
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("PARTIAL", payload["scan_completion"])
+            self.assertEqual(
+                RECOMMENDATION_INSUFFICIENT, recommendation(payload)
+            )
+            self.assertEqual(before, sentinel.read_bytes())
+            restart = evidence_item(payload, "restart.surfaces")
+            self.assertEqual(
+                "symlink_rejected", restart["detail"]["unknown"][0]["reason"]
+            )
+
+    def test_symlinked_handoff_directory_is_not_traversed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_unmanaged_repository(parent)
+            outside = parent / "outside"
+            outside.mkdir()
+            (outside / "state.md").write_text(
+                "Active Branch:\noutside\n\nNext Action:\nnever read\n",
+                encoding="utf-8",
+            )
+            (repository / "handoff").symlink_to(outside, target_is_directory=True)
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("PARTIAL", payload["scan_completion"])
+            self.assertEqual(
+                RECOMMENDATION_NONE, recommendation(payload)
+            )
+            self.assertEqual("UNDETERMINED", payload["mode"])
+            self.assertEqual("RUN_V13_CHECK", payload["route"]["code"])
+            restart = evidence_item(payload, "restart.surfaces")
+            reasons = {
+                item["reason"] for item in restart["detail"]["unknown"]
+            }
+            self.assertIn("symlink_rejected", reasons)
+
+    def test_v13_repository_routes_to_check_without_weak_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_v13_repository(
+                Path(directory), "complete"
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("V13_MANAGED_REPOSITORY", payload["mode"])
+            self.assertEqual(RECOMMENDATION_NONE, recommendation(payload))
+            self.assertEqual("RUN_V13_CHECK", payload["route"]["code"])
+            self.assertEqual(
+                "decision-os check <repository>",
+                payload["route"]["command"],
+            )
+
+    def test_partial_v13_surface_is_undetermined_and_routes_to_check(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            current_signal = repository / "docs" / "current_signal.md"
+            current_signal.parent.mkdir()
+            current_signal.write_text("# current\n", encoding="utf-8")
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("UNDETERMINED", payload["mode"])
+            self.assertEqual("RUN_V13_CHECK", payload["route"]["code"])
+            self.assertEqual(RECOMMENDATION_NONE, recommendation(payload))
+
+    def test_origin_identity_does_not_emit_credentials_or_local_path(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            run_git(
+                repository,
+                "remote",
+                "set-url",
+                "origin",
+                "https://user:secret@example.test/owner/repo.git?token=x#frag",
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            identity = payload["repository"]["origin"]["identity"]
+            self.assertEqual("example.test/owner/repo.git", identity)
+            self.assertNotIn("secret", repr(payload))
+            self.assertNotIn("token", repr(payload))
+
+            run_git(
+                repository,
+                "remote",
+                "set-url",
+                "origin",
+                "git@example.test:owner/repo.git?token=x#frag",
+            )
+            scp_payload, scp_exit = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, scp_exit)
+            self.assertEqual(
+                "example.test/owner/repo.git",
+                scp_payload["repository"]["origin"]["identity"],
+            )
+            self.assertNotIn("token", repr(scp_payload))
+
+    def test_malformed_origin_is_bounded_unknown_not_internal_failure(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            run_git(
+                repository,
+                "remote",
+                "set-url",
+                "origin",
+                "https://[malformed/repo",
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertIsNone(payload["repository"]["origin"]["identity"])
+            origin = evidence_item(payload, "git.origin")
+            self.assertEqual("UNKNOWN", origin["status"])
+
+    def test_exact_allowlist_does_not_accept_case_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            (repository / "agents.md").write_text(
+                "# lower-case only\n", encoding="utf-8"
+            )
+            run_git(repository, "add", "agents.md")
+            run_git(
+                repository,
+                "-c",
+                "user.name=V13 Runner Test",
+                "-c",
+                "user.email=runner@example.invalid",
+                "commit",
+                "-m",
+                "case fixture",
+            )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            instruction = evidence_item(payload, "instructions.surfaces")
+            self.assertNotIn("AGENTS.md", instruction["detail"]["observed"])
+
+    def test_handoff_candidate_enumeration_stops_at_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            handoff = repository / "handoff"
+            handoff.mkdir()
+            for index in range(65):
+                (handoff / f"{index:02d}.md").write_text(
+                    "Active Branch:\nfixture\n\nNext Action:\nfixture\n",
+                    encoding="utf-8",
+                )
+
+            payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("PARTIAL", payload["scan_completion"])
+            restart = evidence_item(payload, "restart.surfaces")
+            self.assertEqual([], restart["detail"]["observed"])
+            self.assertIn(
+                {
+                    "path": "handoff/*.md",
+                    "reason": "candidate_limit",
+                },
+                restart["detail"]["unknown"],
+            )
+
+    def test_intermediate_directory_swap_cannot_escape_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_unmanaged_repository(parent)
+            docs = repository / "docs"
+            docs.mkdir()
+            (docs / "current_state.md").write_text(
+                "Active Branch:\ninside\n\nNext Action:\ninside\n",
+                encoding="utf-8",
+            )
+            run_git(repository, "add", "docs/current_state.md")
+            run_git(
+                repository,
+                "-c",
+                "user.name=V13 Runner Test",
+                "-c",
+                "user.email=runner@example.invalid",
+                "commit",
+                "-m",
+                "safe state",
+            )
+            outside = parent / "outside"
+            outside.mkdir()
+            sentinel = outside / "current_state.md"
+            sentinel.write_text(
+                "Active Branch:\nsecret\n\nNext Action:\nsecret\n",
+                encoding="utf-8",
+            )
+            real_match = scan_module._entry_match
+            swapped = False
+
+            def swap_after_match(
+                directory_fd: int, expected: str
+            ) -> tuple[str, str | None]:
+                nonlocal swapped
+                result = real_match(directory_fd, expected)
+                if expected == "docs" and result[0] == "OBSERVED" and not swapped:
+                    docs.rename(repository / "docs-original")
+                    (repository / "docs").symlink_to(
+                        outside, target_is_directory=True
+                    )
+                    swapped = True
+                return result
+
+            with patch(
+                "decision_os.scan._entry_match",
+                side_effect=swap_after_match,
+            ):
+                payload, exit_code = scan_repository(repository)
+
+            self.assertTrue(swapped)
+            self.assertEqual(EXIT_UNSTABLE, exit_code)
+            self.assertNotIn("secret", repr(payload))
+            self.assertEqual(
+                b"Active Branch:\nsecret\n\nNext Action:\nsecret\n",
+                sentinel.read_bytes(),
+            )
+
+    def test_non_git_target_returns_three_with_stable_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            payload, exit_code = scan_repository(Path(directory))
+
+            self.assertEqual(EXIT_NOT_GIT, exit_code)
+            self.assertEqual("FAILED", payload["scan_completion"])
+            self.assertEqual("UNDETERMINED", payload["mode"])
+            self.assertEqual(
+                RECOMMENDATION_INSUFFICIENT, recommendation(payload)
+            )
+            self.assertNotIn(str(Path(directory)), repr(payload))
+
+    def test_ambient_git_environment_cannot_redirect_or_trace_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            target_parent = parent / "target-parent"
+            other_parent = parent / "other-parent"
+            target_parent.mkdir()
+            other_parent.mkdir()
+            repository = create_unmanaged_repository(target_parent)
+            other = create_unmanaged_repository(other_parent)
+            (other / "other.txt").write_text("other\n", encoding="utf-8")
+            run_git(other, "add", "other.txt")
+            run_git(
+                other,
+                "-c",
+                "user.name=V13 Runner Test",
+                "-c",
+                "user.email=runner@example.invalid",
+                "commit",
+                "-m",
+                "different repository",
+            )
+            target_head = GitReader(repository).run(
+                "rev-parse", "--verify", "HEAD"
+            ).stdout.strip()
+            trace = parent / "git-trace.log"
+
+            with patch.dict(
+                os.environ,
+                {
+                    "GIT_DIR": str(other / ".git"),
+                    "GIT_WORK_TREE": str(other),
+                    "GIT_INDEX_FILE": str(other / ".git" / "index"),
+                    "GIT_TRACE": str(trace),
+                },
+            ):
+                payload, exit_code = scan_repository(repository)
+                reader = GitReader(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual(target_head, payload["repository"]["head"])
+            self.assertFalse(trace.exists())
+            self.assertNotIn("GIT_DIR", reader.environment)
+            self.assertNotIn("GIT_TRACE", reader.environment)
+            self.assertEqual("1", reader.environment["GIT_NO_LAZY_FETCH"])
+
+    def test_non_utf8_worktree_filename_is_counted_but_never_emitted(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            stable = _snapshot(GitReader(repository))
+            raw_filename_snapshot = replace(
+                stable, status="?? invalid-\udcff.txt\0"
+            )
+
+            with patch(
+                "decision_os.scan._snapshot",
+                side_effect=(raw_filename_snapshot, raw_filename_snapshot),
+            ):
+                payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("DIRTY", payload["repository"]["worktree"])
+            self.assertEqual(1, payload["repository"]["change_count"])
+            self.assertNotIn("invalid-", repr(payload))
+
+    def test_opening_and_closing_snapshot_mismatch_returns_seven(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            reader_snapshot = _snapshot(GitReader(repository))
+            closing = replace(reader_snapshot, head="0" * 40)
+
+            with patch(
+                "decision_os.scan._snapshot",
+                side_effect=(reader_snapshot, closing),
+            ):
+                payload, exit_code = scan_repository(repository)
+
+            self.assertEqual(EXIT_UNSTABLE, exit_code)
+            self.assertEqual("FAILED", payload["scan_completion"])
+            self.assertEqual(
+                "CONTRADICTORY", payload["evidence"][0]["status"]
+            )
+            self.assertEqual(
+                ["head"], payload["evidence"][0]["detail"]["changed"]
+            )
+
+    def test_status_read_disables_fsmonitor_and_uses_nul_no_renames(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(Path(directory))
+            reader = GitReader(repository)
+
+            with patch.object(reader, "run", wraps=reader.run) as run:
+                _snapshot(reader)
+
+            calls = tuple(call.args for call in run.call_args_list)
+            self.assertIn(
+                (
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain=v1",
+                    "-z",
+                    "--untracked-files=all",
+                    "--no-renames",
+                ),
+                calls,
+            )
+
+    def test_direct_scan_is_repeatable_and_does_not_write_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "multiple_instructions"
+            )
+            before = tree_digest(repository)
+
+            first_payload, first_exit = scan_repository(repository)
+            second_payload, second_exit = scan_repository(repository)
+
+            self.assertEqual(EXIT_OK, first_exit)
+            self.assertEqual(first_exit, second_exit)
+            self.assertEqual(first_payload, second_payload)
+            self.assertEqual(before, tree_digest(repository))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_scan_cli.py
+++ b/tests/test_decision_os_scan_cli.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import io
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.cli import EXIT_INTERNAL, EXIT_USAGE, main
+from decision_os.scan import (
+    EXIT_NOT_GIT,
+    EXIT_UNSTABLE,
+    failure_payload as scan_failure_payload,
+    scan_repository,
+)
+from decision_os.scan_text import render_text
+from tests.test_decision_os_checks import (
+    create_repository as create_v13_repository,
+    tree_digest,
+)
+from tests.test_decision_os_scan import create_unmanaged_repository
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BIN_ENTRY = REPO_ROOT / "bin" / "decision-os"
+CANONICAL_AS_OF = "57dc2d1f557aabf40b18c09313fabcb5b6dc96f8"
+
+CHECK_FIELDS = {
+    "authority_match",
+    "evidence",
+    "human_seat_required",
+    "missing_closure",
+    "next_authorized_action",
+    "v12_state",
+    "v13_gate",
+}
+
+PROTECTED_BLOBS = {
+    "bin/decision-os": ("100755", "07b5cd88453ec679afcc7c0b84cfc7fd50694c79"),
+    "decision_os/__init__.py": (
+        "100644",
+        "b6efd44beec1bbbf2bad47fb225081ad861c08d9",
+    ),
+    "decision_os/__main__.py": (
+        "100644",
+        "704bce80052b7adb0975c22b4424a60f7fece5fb",
+    ),
+    "decision_os/checks.py": (
+        "100644",
+        "4b7b1154d3af0a0847a0a1a588310e5877ea3f9e",
+    ),
+    "decision_os/state.py": (
+        "100644",
+        "e072baf3bc0a21c507ae9c5def795c939ad68591",
+    ),
+    "docs/v13_runner_v0_1.md": (
+        "100644",
+        "45deb95d32a832d9a8059951f04d895db906201e",
+    ),
+    "tests/fixtures/v13_runner_v0_1/complete/docs/current_signal.md": (
+        "100644",
+        "50e127f53b4eda56cb6730f6a99f12badd03fd4b",
+    ),
+    (
+        "tests/fixtures/v13_runner_v0_1/complete/"
+        "handoff/current_codex_handoff.md"
+    ): (
+        "100644",
+        "070f5630efa57595f87e8007155435b9b5539d09",
+    ),
+    "tests/fixtures/v13_runner_v0_1/contradictory/docs/current_signal.md": (
+        "100644",
+        "73f3883372b7202249816bc70a5627de864948f2",
+    ),
+    (
+        "tests/fixtures/v13_runner_v0_1/contradictory/"
+        "handoff/current_codex_handoff.md"
+    ): (
+        "100644",
+        "c034705317cbe5b20760571d3f08ab28ec7a6749",
+    ),
+    "tests/fixtures/v13_runner_v0_1/missing_closure/docs/current_signal.md": (
+        "100644",
+        "1c585ebadc8ef48820ddb26f5f8ce1abcf253d75",
+    ),
+    (
+        "tests/fixtures/v13_runner_v0_1/missing_closure/"
+        "handoff/current_codex_handoff.md"
+    ): (
+        "100644",
+        "0151506a999d19e5bdc2a535771ab9345d9d3872",
+    ),
+    "tests/test_decision_os_checks.py": (
+        "100644",
+        "c4249c22d47a2da69d54d24e3cf265f827272b5a",
+    ),
+    "tests/test_decision_os_cli.py": (
+        "100644",
+        "a4641d5033c0fb1a21313d76d273005fe4dc2bd4",
+    ),
+}
+
+
+def cli_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+    return environment
+
+
+def run_module(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (sys.executable, "-B", "-m", "decision_os", *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def run_bin(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (str(BIN_ENTRY), *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def decoded_json(
+    completed: subprocess.CompletedProcess[bytes],
+) -> dict[str, object]:
+    if completed.stderr:
+        raise AssertionError(completed.stderr.decode("utf-8", errors="replace"))
+    if completed.stdout.count(b"\n") != 1 or not completed.stdout.endswith(b"\n"):
+        raise AssertionError(
+            f"expected exactly one JSON line, got {completed.stdout!r}"
+        )
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError("JSON output is not an object")
+    return payload
+
+
+def direct_scan(
+    arguments: list[str],
+) -> tuple[int, str]:
+    output = io.StringIO()
+    exit_code = main(arguments, stdout=output)
+    return exit_code, output.getvalue()
+
+
+class ScanTextRendererTest(unittest.TestCase):
+    def test_renderer_is_payload_only_terminal_safe_and_has_no_url(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_unmanaged_repository(
+                Path(directory), "multiple_instructions"
+            )
+            payload, _ = scan_repository(repository)
+            adversarial = deepcopy(payload)
+            adversarial["repository"]["root_name"] = (
+                "/private/tmp/secret\x1b[31m\udcff"
+            )
+            adversarial["recommendation"]["minimum_next_step"] = (
+                "Click https://example.invalid/private"
+            )
+            adversarial["unknowns"][0]["reason"] = (
+                "Open https://example.invalid/private"
+            )
+            adversarial["evidence"][0]["source"] = "/private/tmp/source"
+
+            with patch(
+                "decision_os.scan.scan_repository",
+                side_effect=AssertionError("renderer performed a second scan"),
+            ):
+                first = render_text(adversarial)
+                second = render_text(adversarial)
+
+            self.assertEqual(first, second)
+            first.encode("utf-8", errors="strict")
+            self.assertTrue(first.endswith("\n"))
+            self.assertFalse(first.endswith("\n\n"))
+            self.assertNotIn("\x1b", first)
+            self.assertNotIn("\udcff", first)
+            self.assertNotIn("/private/tmp", first)
+            self.assertNotIn("http://", first)
+            self.assertNotIn("https://", first)
+            self.assertNotIn("Click ", first)
+
+
+class DecisionOsScanCliTest(unittest.TestCase):
+    def test_default_and_explicit_json_are_byte_identical_with_module_bin_parity(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_unmanaged_repository(
+                parent, "one_instruction"
+            )
+            target = str(repository)
+
+            module_first = run_module(parent, "scan", target)
+            module_second = run_module(parent, "scan", target)
+            module_explicit = run_module(
+                parent, "scan", "--format", "json", target
+            )
+            bin_default = run_bin(parent, "scan", target)
+            bin_explicit = run_bin(
+                parent, "scan", "--format", "json", target
+            )
+
+            results = (
+                module_first,
+                module_second,
+                module_explicit,
+                bin_default,
+                bin_explicit,
+            )
+            self.assertTrue(all(result.returncode == 0 for result in results))
+            self.assertTrue(all(result.stderr == b"" for result in results))
+            self.assertTrue(
+                all(result.stdout == module_first.stdout for result in results)
+            )
+            payload = decoded_json(module_first)
+            self.assertEqual("decision-os.scan.v0.2", payload["schema_version"])
+            self.assertEqual("scan", payload["command"])
+
+    def test_explicit_text_is_repeatable_with_module_bin_parity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_unmanaged_repository(
+                parent, "multiple_instructions"
+            )
+            target = str(repository)
+
+            module_first = run_module(
+                parent, "scan", "--format", "text", target
+            )
+            module_second = run_module(
+                parent, "scan", "--format", "text", target
+            )
+            executable = run_bin(
+                parent, "scan", "--format", "text", target
+            )
+
+            self.assertEqual(0, module_first.returncode)
+            self.assertEqual(module_first.returncode, module_second.returncode)
+            self.assertEqual(module_first.returncode, executable.returncode)
+            self.assertEqual(module_first.stdout, module_second.stdout)
+            self.assertEqual(module_first.stdout, executable.stdout)
+            self.assertEqual(b"", module_first.stderr)
+            self.assertEqual(b"", executable.stderr)
+            self.assertTrue(
+                module_first.stdout.startswith(b"Decision-OS Scan v0.2: ")
+            )
+            self.assertTrue(module_first.stdout.endswith(b"\n"))
+            self.assertFalse(module_first.stdout.endswith(b"\n\n"))
+            self.assertNotIn(str(parent).encode("utf-8"), module_first.stdout)
+            self.assertNotIn(b"\x1b", module_first.stdout)
+            self.assertNotIn(b"http://", module_first.stdout)
+            self.assertNotIn(b"https://", module_first.stdout)
+
+    def test_scan_usage_errors_return_two_and_never_check_codes(self) -> None:
+        cases = (
+            ("scan",),
+            ("scan", ".", "extra"),
+            ("scan", "--format"),
+            ("scan", "--format", "text"),
+            ("scan", "--format", "yaml", "."),
+            ("scan", ".", "--format", "text"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            cwd = Path(directory)
+            observed_codes: list[int] = []
+            for arguments in cases:
+                with self.subTest(arguments=arguments):
+                    completed = run_module(cwd, *arguments)
+                    observed_codes.append(completed.returncode)
+                    self.assertEqual(EXIT_USAGE, completed.returncode)
+                    self.assertEqual(b"", completed.stderr)
+                    if arguments != ("scan", "--format", "text"):
+                        payload = decoded_json(completed)
+                        self.assertEqual("FAILED", payload["scan_completion"])
+            self.assertNotIn(4, observed_codes)
+            self.assertNotIn(5, observed_codes)
+
+    def test_scan_non_git_is_three_and_never_check_codes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            completed = run_module(Path(directory), "scan", directory)
+
+            self.assertEqual(EXIT_NOT_GIT, completed.returncode)
+            self.assertNotIn(completed.returncode, (4, 5))
+            payload = decoded_json(completed)
+            self.assertEqual("FAILED", payload["scan_completion"])
+            self.assertEqual("UNDETERMINED", payload["mode"])
+
+    def test_scan_internal_and_unstable_exits_are_serialized(self) -> None:
+        with patch(
+            "decision_os.cli.scan_repository",
+            side_effect=RuntimeError("bounded fixture failure"),
+        ):
+            internal_code, internal_output = direct_scan(["scan", "."])
+
+        self.assertEqual(EXIT_INTERNAL, internal_code)
+        self.assertNotIn(internal_code, (4, 5))
+        internal_payload = json.loads(internal_output)
+        self.assertEqual("FAILED", internal_payload["scan_completion"])
+        self.assertEqual(
+            "scan.internal", internal_payload["evidence"][0]["check"]
+        )
+        self.assertNotIn("bounded fixture failure", internal_output)
+
+        unstable = scan_failure_payload(
+            "scan.snapshot",
+            {"changed": ["head"]},
+            status="CONTRADICTORY",
+        )
+        with patch(
+            "decision_os.cli.scan_repository",
+            return_value=(unstable, EXIT_UNSTABLE),
+        ):
+            unstable_code, unstable_output = direct_scan(["scan", "."])
+
+        self.assertEqual(EXIT_UNSTABLE, unstable_code)
+        self.assertNotIn(unstable_code, (4, 5))
+        unstable_payload = json.loads(unstable_output)
+        self.assertEqual(
+            "CONTRADICTORY", unstable_payload["evidence"][0]["status"]
+        )
+
+    def test_scan_text_failure_preserves_selected_format(self) -> None:
+        unstable = scan_failure_payload(
+            "scan.snapshot",
+            {"changed": ["worktree"]},
+            status="CONTRADICTORY",
+        )
+        with patch(
+            "decision_os.cli.scan_repository",
+            return_value=(unstable, EXIT_UNSTABLE),
+        ):
+            exit_code, output = direct_scan(
+                ["scan", "--format", "text", "."]
+            )
+
+        self.assertEqual(EXIT_UNSTABLE, exit_code)
+        self.assertTrue(output.startswith("Decision-OS Scan v0.2: FAILED\n"))
+        self.assertTrue(output.endswith("\n"))
+        self.assertFalse(output.endswith("\n\n"))
+
+    def test_existing_check_contract_and_exit_codes_are_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            complete_parent = parent / "complete"
+            missing_parent = parent / "missing"
+            contradictory_parent = parent / "contradictory"
+            for fixture_parent in (
+                complete_parent,
+                missing_parent,
+                contradictory_parent,
+            ):
+                fixture_parent.mkdir()
+            complete = create_v13_repository(complete_parent, "complete")
+            missing = create_v13_repository(
+                missing_parent, "missing_closure"
+            )
+            contradictory = create_v13_repository(
+                contradictory_parent, "contradictory"
+            )
+            non_git = parent / "non_git"
+            non_git.mkdir()
+
+            cases = (
+                (complete, 0),
+                (non_git, 3),
+                (missing, 4),
+                (contradictory, 5),
+            )
+            for repository, expected in cases:
+                with self.subTest(expected=expected):
+                    module = run_module(
+                        parent, "check", str(repository)
+                    )
+                    executable = run_bin(
+                        parent, "check", str(repository)
+                    )
+                    self.assertEqual(expected, module.returncode)
+                    self.assertEqual(module.returncode, executable.returncode)
+                    self.assertEqual(module.stdout, executable.stdout)
+                    payload = decoded_json(module)
+                    self.assertEqual(CHECK_FIELDS, set(payload))
+                    for item in payload["evidence"]:
+                        self.assertEqual(
+                            {"check", "detail", "source", "status"},
+                            set(item),
+                        )
+
+    def test_existing_check_usage_payload_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            completed = run_module(Path(directory), "check")
+
+        self.assertEqual(EXIT_USAGE, completed.returncode)
+        payload = decoded_json(completed)
+        self.assertEqual(CHECK_FIELDS, set(payload))
+        self.assertEqual(
+            {
+                "arguments": ["check"],
+                "usage": "decision-os check <repository>",
+            },
+            payload["evidence"][0]["detail"],
+        )
+        self.assertEqual("cli.usage", payload["evidence"][0]["check"])
+        self.assertEqual("decision-os", payload["evidence"][0]["source"])
+        self.assertEqual("FAIL", payload["evidence"][0]["status"])
+
+    def test_protected_v01_blobs_and_modes_are_unchanged(self) -> None:
+        for relative, (expected_mode, expected_blob) in PROTECTED_BLOBS.items():
+            with self.subTest(relative=relative):
+                path = REPO_ROOT / relative
+                completed = subprocess.run(
+                    ("git", "hash-object", str(path)),
+                    capture_output=True,
+                    check=False,
+                    cwd=REPO_ROOT,
+                    text=True,
+                )
+                self.assertEqual(0, completed.returncode, completed.stderr)
+                self.assertEqual(expected_blob, completed.stdout.strip())
+                executable = bool(path.stat().st_mode & stat.S_IXUSR)
+                actual_mode = "100755" if executable else "100644"
+                self.assertEqual(expected_mode, actual_mode)
+
+        canonical = subprocess.run(
+            ("git", "cat-file", "-e", f"{CANONICAL_AS_OF}^{{commit}}"),
+            capture_output=True,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(0, canonical.returncode)
+
+    def test_scan_module_and_bin_do_not_write_target_or_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_unmanaged_repository(
+                parent, "multiple_instructions"
+            )
+            target_before = tree_digest(repository)
+            runner_before = tree_digest(REPO_ROOT)
+            target = str(repository)
+
+            results = (
+                run_module(parent, "scan", target),
+                run_module(parent, "scan", "--format", "json", target),
+                run_module(parent, "scan", "--format", "text", target),
+                run_bin(parent, "scan", target),
+                run_bin(parent, "scan", "--format", "json", target),
+                run_bin(parent, "scan", "--format", "text", target),
+            )
+
+            self.assertTrue(all(result.returncode == 0 for result in results))
+            self.assertTrue(all(result.stderr == b"" for result in results))
+            self.assertEqual(target_before, tree_digest(repository))
+            self.assertEqual(runner_before, tree_digest(REPO_ROOT))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add repository-local decision-os scan with deterministic JSON and opt-in text
- preserve decision-os check behavior and protected v0.1 surfaces
- bound instruction, restart, symlink, Git, and snapshot evidence
- document the generic free evidence boundary and documentation-only fit-check route

## Validation
- 69 of 69 tests pass
- 12 required scan scenarios covered
- JSON/text repeated-output and module/bin parity pass
- target and Runner no-write digests pass
- protected v0.1 blobs and modes remain unchanged

## Authority boundary
- two operational loops: 2e1eb1c and 605ca44
- no package publication, release, CI, network scan, telemetry, outreach, bespoke diagnosis, Revenue change, Canon, paper, V7, runtime, or v0.3