### PR TITLE
Expose tutorial and selective fork workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,30 @@ This is not only a prompt kit. Used as a fork, LoopKit becomes a small external 
 
 The 5-minute check shows the first benefit. A fork captures the longer benefit: fewer repeated mistakes, less re-explanation, lower token waste, and safer restartability over time.
 
+### What a fork unlocks
+
+Forking does not mean copying every LoopKit rule into your workflow.
+
+It gives your AI a library it can selectively connect to your repository:
+
+- **Interactive tutorial** — Ask your AI to read
+  [`AI_TUTORIAL_CAPSULE.md`](AI_TUTORIAL_CAPSULE.md) and
+  [`docs/codex_tutorial_guide.md`](docs/codex_tutorial_guide.md).
+  The tutorial starts with a menu instead of explaining the entire framework at once.
+
+- **A repo-specific starter pack** — Use the `Setup Pill` to inspect only the
+  smallest useful surfaces of one repository and return its likely boundaries,
+  first files to read, suggested memory surfaces, Lite Footer, and first tiny task.
+  It remains read-only until you approve changes.
+
+- **Selective operational reuse** — Your AI does not need to load or copy every
+  field note. It should read only the notes related to the current task or failure,
+  then carry forward only the reusable residue that belongs in a handoff, example,
+  document, or candidate operating rule.
+
+The fork is not a documentation burden. It is a selective operating library for
+your AI-assisted work.
+
 ## After you fork: where to write
 
 A fork becomes useful when your AI work starts leaving memory outside the chat.


### PR DESCRIPTION
## Summary

Expose existing value unlocked by forking LoopKit without changing the Runner-first public entry or adding a feature.

The new `What a fork unlocks` section makes three existing workflows discoverable:

- the interactive tutorial;
- the read-only repo-specific starter pack;
- selective operational reuse of only the field notes and residue relevant to the current task.

## Scope

`README.md` only.

The section is inserted inside `Why fork this repo?`, immediately after the longer-term fork-benefit paragraph and before `After you fork: where to write`.

## Preserved boundaries

- README opening and Runner-first order are unchanged.
- The immutable `uvx` command is unchanged.
- The anonymized result and `UNKNOWN` explanation are unchanged.
- The free Runner / paid Audit boundary is unchanged.
- Pricing and delivery conditions are unchanged.
- No Runner, service, Reddit, main-protection, or feature change is included.

This documents existing capabilities only. It does not claim automatic migration, automatic rule promotion, or automatic repository modification.

## Validation

- README protected-blob preflight — **PASS**; no exact README blob guard exists.
- Added local links — **PASS**; `AI_TUTORIAL_CAPSULE.md` and `docs/codex_tutorial_guide.md` resolve.
- Markdown heading hierarchy — **PASS**.
- `git diff --check 9190125bd0a37f2b30ef6bad9b8efc14fe166e2d..HEAD` — **PASS**.
- Changed-file scope — **PASS, README.md only**.
- `env PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest discover -s tests -v` — **PASS, 73/73 in 40.056s**.
- Worktree after commit — **clean**.

## Rollback

If later merged and rollback is authorized, revert this README-only PR merge. No Runner or other repository behavior is in scope.

This Draft PR must not be merged without a later explicit decision.
