### PR TITLE
Expose incident map in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ See the
 [AI Agent Handoff Audit](services/ai_agent_handoff_audit_offer.md)
 for scope, pricing, delivery, and the free fit-check boundary.
 
+## What AI coding incidents return to the human
+
+[![AI coding incidents do not end at the error](assets/incident-map/external-ai-workflow-incident-map-v0-1.png)](case_studies/external_ai_workflow_incident_map_v0_1.md)
+
+Across 17 selected public incident worldlines from seven GitHub repositories,
+the visible error often did not end inside the tool. It returned work to the
+human as revalidation, manual cleanup, context reconstruction, rollback, or a
+lost session.
+
+These are descriptive case-presence counts from a selected public corpus, not
+population frequency or a product ranking.
+
+[Read the evidence boundary, source tables, and interpretation limits.](case_studies/external_ai_workflow_incident_map_v0_1.md)
+
 ## Secondary adoption paths
 
 ### Try one line first


### PR DESCRIPTION
## Summary

- expose the merged External AI Workflow Incident Map in `README.md`
- place the evidence surface after the Runner result-choice section and before
  secondary adoption paths
- link both the image and the evidence-boundary text to the existing incident
  map documentation

## Evidence boundary

The added text reports 17 selected public incident worldlines from seven
GitHub repositories and explicitly identifies the values as descriptive
case-presence counts, not population frequency or product ranking.

The Runner-first entry, map artifacts, documentation, corpora, displayed
counts, pricing, service copy, Canon, Runner, handoff, and current state remain
unchanged.

## Exact scope

One changed file:

- `README.md`

Inserted content: lines 105–117.

## Validation

- README image path resolves: PASS
- documentation link resolves: PASS
- GitHub-rendered README visual inspection: PASS
- Markdown heading hierarchy: PASS
- `git diff --check`: PASS
- `env PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest discover -s tests -v`:
  73/73 PASS
- `python3 -B scripts/validate_loop_record_examples.py`: 12/12 PASS
- changed-file scope: exactly `README.md`
- worktree after commit: clean

## Gate

Draft README-only PR. Merge, social posting, and social preview changes remain
unauthorized.
