### PR TITLE
Extend the Audit to bounded AI application workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai_agent_handoff_audit_fit_check.md
+++ b/.github/ISSUE_TEMPLATE/ai_agent_handoff_audit_fit_check.md
@@ -22,7 +22,7 @@ payment.
 <!-- Add one public repository URL, or describe one bounded workflow without
 sharing private material. -->
 
-## Coding-agent tool
+## AI tool, application, or workflow
 
 <!-- For example: Codex, Claude Code, Cursor, Cline, or another agent. -->
 
@@ -31,7 +31,7 @@ sharing private material. -->
 <!-- Describe one concrete handoff, context-loss, restart, instruction-drift,
 or completion-state failure. Do not ask for a diagnosis here. -->
 
-## What the next session or agent needs to understand
+## What the next human, agent, or operator needs to understand
 
 <!-- State the restart outcome you need. -->
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ See the
 [AI Agent Handoff Audit](services/ai_agent_handoff_audit_offer.md)
 for scope, pricing, delivery, and the free fit-check boundary.
 
+Not only coding repositories. The paid Audit can also review one clearly bounded
+[AI application or operational workflow](services/ai_application_workflow_audit_delivery_v0_1.md)
+when a failure returned revalidation, cleanup, context reconstruction,
+rollback, or restart decisions to a human.
+
 ## What AI coding incidents return to the human
 
 [![AI coding incidents do not end at the error](assets/incident-map/external-ai-workflow-incident-map-v0-1.png)](case_studies/external_ai_workflow_incident_map_v0_1.md)

--- a/services/ai_agent_handoff_audit_offer.md
+++ b/services/ai_agent_handoff_audit_offer.md
@@ -41,13 +41,15 @@ After the first 3 paid pilots, the listed standard rate applies unless Shin
 publishes a later explicit Forward-only pricing change.
 
 Scope:
-One repository or one clearly bounded AI-agent workflow.
+One repository or one clearly bounded AI-agent or AI-application workflow.
 
 ## Who this is for
 
 - solo builders;
 - small teams;
 - maintainers using Codex, Claude Code, Cursor, or similar coding agents;
+- operators, founders, consultants, or small teams running bounded AI
+  applications or AI-assisted operational workflows;
 - repositories using `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `.cursor/rules`,
   handoffs, operational prompts, or long-running agent sessions;
 - people experiencing drift, restart friction, context bloat, unclear
@@ -96,6 +98,13 @@ delivered audit and asset; it does not expand the accepted scope.
 
 The sample demonstrates the audit format and reasoning process. It is not a
 client testimonial or paid-delivery result.
+
+## AI application workflow delivery
+
+For an accepted non-repository case, use
+[AI Application Workflow Audit — Delivery v0.1](ai_application_workflow_audit_delivery_v0_1.md)
+to see the bounded intake, audit dimensions, delivery template, and claim
+boundary. Not every AI application or workflow qualifies.
 
 ## Why this audit is credible
 

--- a/services/ai_application_workflow_audit_delivery_v0_1.md
+++ b/services/ai_application_workflow_audit_delivery_v0_1.md
@@ -1,0 +1,214 @@
+# AI Application Workflow Audit — Delivery v0.1
+
+This is a delivery surface for the existing
+[AI Agent Handoff Audit](ai_agent_handoff_audit_offer.md). It extends that
+bounded offer to one accepted AI application or operational workflow; it does
+not create a separate product family.
+
+## What this covers
+
+An accepted case may involve:
+
+- an AI SaaS workflow;
+- a multi-agent application;
+- an AI content or production pipeline;
+- a RAG or knowledge-assistant workflow;
+- an AI customer-support workflow;
+- a no-code or automation chain containing AI;
+- one clearly bounded internal AI-assisted process.
+
+This is not a general product audit, code review, security audit, model
+evaluation, or vendor bug-fix service.
+
+## Accepted incident boundary
+
+The review accepts one concrete operational failure inside one clearly bounded
+workflow path. Examples include:
+
+- false or stale completion;
+- a lost handoff or agent result;
+- a failed restart or resume path;
+- state disagreement between components;
+- manual rollback, cleanup, revalidation, or context reconstruction;
+- output that exists but leaves the next human unable to continue safely.
+
+The incident must be specific enough to distinguish its trigger, expected
+state, observed state, returned human work, and current restart or fallback
+path.
+
+## Minimum intake
+
+Collect only:
+
+- the application or workflow name;
+- one bounded workflow path;
+- the triggering incident;
+- the expected state;
+- the observed state;
+- the human recovery work;
+- the current restart or fallback path;
+- the materials available for review;
+- prohibited or confidential materials.
+
+A repository is not required. Usable review materials may include public
+screenshots, logs with secrets removed, workflow diagrams, high-level state
+descriptions, runbooks, prompts, or selected configuration.
+
+Do not provide credentials, secrets, customer data, private production data, or
+materials that the requester is not authorized to share.
+
+## Audit outputs
+
+The paid delivery preserves the existing commercial structure:
+
+1. **Friction Map** — show where the accepted incident returned work or
+   uncertainty to the human.
+2. **Restartability Diagnosis** — identify what the next human, agent, or
+   operator cannot safely reconstruct.
+3. **One Priority Fix** — select one bounded repair with the greatest practical
+   value inside the accepted scope.
+4. **One Copy-Paste or directly usable Operational Asset** — return one asset
+   that can be applied without a broader implementation project.
+5. **Before / After Restart Check** — make the changed restart condition
+   visible.
+6. **One bounded clarification round** — answer questions about the delivered
+   audit and asset without expanding scope.
+
+The operational asset may be:
+
+- a fallback restart record;
+- a completion gate;
+- a state handoff block;
+- an operator recovery checklist;
+- a bounded incident intake;
+- a next-safe-action record;
+- an escalation or stop condition.
+
+## Audit dimensions
+
+Each dimension receives one result: `PASS`, `PARTIAL`, `FAIL`, or `UNKNOWN`.
+
+- Trigger clarity
+- Accepted-state clarity
+- Evidence continuity
+- Completion integrity
+- Restartability
+- Ownership / next actor
+- Human recovery burden
+- Safe next action
+
+`UNKNOWN` remains explicit when the accepted materials do not establish a
+dimension. It is not silently converted into failure, permission, or diagnosis.
+
+## Delivery template
+
+Copy and complete this Markdown template for one accepted incident:
+
+```markdown
+# AI Application Workflow Audit
+
+## Scope
+
+Application or workflow:
+Bounded workflow path:
+Audit as-of date:
+
+## Source materials
+
+- Reviewed:
+- Not reviewed:
+- Material restrictions:
+
+## Incident as-of state
+
+Trigger:
+Expected state:
+Observed state:
+Current restart or fallback path:
+
+## Observed failure
+
+<What failed, stopped, drifted, or returned an untrustworthy completion state?>
+
+## Returned human burden
+
+<What rollback, cleanup, revalidation, reconstruction, or restart decision
+returned to the human? Keep quantities UNKNOWN unless recorded.>
+
+## Friction Map
+
+| Point | Expected carrier | Observed gap | Returned human work |
+|---|---|---|---|
+| <point> | <expected evidence or state> | <gap> | <burden> |
+
+## Diagnosis
+
+Trigger clarity:
+Accepted-state clarity:
+Evidence continuity:
+Completion integrity:
+Restartability:
+Ownership / next actor:
+Human recovery burden:
+Safe next action:
+
+## Priority Fix
+
+<One bounded repair and why it has priority.>
+
+## Operational Asset
+
+<One copy-paste or directly usable asset.>
+
+## Before / After Restart Check
+
+Before:
+After:
+Still UNKNOWN:
+
+## Unknowns
+
+- <Unverified state or assumption>
+
+## Exclusions
+
+- <System, claim, material, or action outside the accepted scope>
+
+## Completion Line
+
+<One bounded incident diagnosed; one priority repair selected; one operational
+asset returned; before/after restart distinction visible; unknowns and
+exclusions explicit.>
+```
+
+## Fit-check boundary
+
+The free fit check determines only:
+
+- whether the incident fits;
+- whether the workflow is sufficiently bounded;
+- whether usable material exists;
+- whether the review can be performed without unsafe or unauthorized access.
+
+The free fit check does not include a diagnosis or implementation plan.
+
+## Claim boundary
+
+The delivery must not claim:
+
+- that the underlying vendor bug will be fixed;
+- that future incidents will be prevented;
+- that lost data or sessions will be recovered;
+- that security, safety, productivity, or revenue will improve;
+- that native auto-resume is equivalent to trustworthy restart;
+- that systems not reviewed have been diagnosed.
+
+## Completion Line
+
+The delivery is complete when:
+
+- one bounded incident is diagnosed;
+- one priority repair is selected;
+- one usable operational asset is returned;
+- the before / after restart distinction is visible;
+- all unknowns and exclusions remain explicit.


### PR DESCRIPTION
## Reason

The current public offer technically allows a bounded workflow, but its buyer language, intake, and delivery examples remain coding-agent centered. Public prospect research shows that contactable AI-application operators are a larger adjacent acquisition lane.

## Impact

Adds one non-repository delivery surface while preserving the existing offer, pricing, Runner, and coding-agent entry point.

## Scope

- Add the bounded AI application/workflow delivery packet.
- Extend the existing Audit offer without renaming it or changing commercial terms.
- Generalize only two fit-check intake labels.
- Add one compact README link near the private Audit surface.

## Validation

- Changed-file scope: exactly four authorized files.
- Local Markdown links: 58 checked, all resolve.
- Markdown heading hierarchy: PASS.
- Full test suite: 73/73 PASS.
- Loop Record examples: 12/12 PASS.
- Strict repository check: exit 0; V12 DELAY; V13 HOLD; required fields missing `[]`; contradictions `[]`.
- `git diff --check`: PASS.
- Pricing and Runner v0.2 paths: unchanged.

## Rollback

Revert this PR. No data migration, pricing change, or Runner compatibility impact.

## Re-evaluation

Review after the first external fit check, rejection reason, or paid delivery involving a non-repository workflow.