### PR TITLE
Add a bounded workflow incident intake checker

### DIFF
--- a/decision_os/cli.py
+++ b/decision_os/cli.py
@@ -8,6 +8,9 @@ import sys
 from typing import Any, Sequence, TextIO
 
 from .checks import evidence, inspect_repository, unknown_payload
+from .intake import invalid_payload as intake_invalid_payload
+from .intake import validate_intake_file
+from .intake_text import render_text as render_intake_text
 from .scan import failure_payload as scan_failure_payload
 from .scan import scan_repository
 from .scan_text import render_text
@@ -19,6 +22,10 @@ USAGE = "decision-os check <repository>"
 SCAN_USAGE = (
     "decision-os scan <repository> | "
     "decision-os scan --format json|text <repository>"
+)
+INTAKE_USAGE = (
+    "decision-os intake <packet.json> | "
+    "decision-os intake --format json|text <packet.json>"
 )
 
 
@@ -123,6 +130,75 @@ def _run_scan(arguments: Sequence[str], output: TextIO) -> int:
     return exit_code
 
 
+def _intake_format(arguments: Sequence[str]) -> str:
+    if (
+        len(arguments) >= 3
+        and arguments[0] == "intake"
+        and arguments[1] == "--format"
+        and arguments[2] == "text"
+    ):
+        return "text"
+    return "json"
+
+
+def _write_intake(
+    payload: dict[str, Any],
+    output_format: str,
+    stream: TextIO,
+) -> None:
+    if output_format == "text":
+        stream.write(render_intake_text(payload))
+        return
+    _write(payload, stream)
+
+
+def _run_intake(arguments: Sequence[str], output: TextIO) -> int:
+    output_format = _intake_format(arguments)
+    packet: str | None = None
+    if (
+        len(arguments) == 2
+        and arguments[0] == "intake"
+        and arguments[1]
+        and not arguments[1].startswith("-")
+    ):
+        packet = arguments[1]
+        output_format = "json"
+    elif (
+        len(arguments) == 4
+        and arguments[0] == "intake"
+        and arguments[1] == "--format"
+        and arguments[2] in ("json", "text")
+        and arguments[3]
+    ):
+        output_format = arguments[2]
+        packet = arguments[3]
+
+    if packet is None:
+        payload = intake_invalid_payload(
+            None,
+            minimum_next_step=INTAKE_USAGE,
+            unknowns=("cli_usage",),
+        )
+        _write_intake(payload, output_format, output)
+        return EXIT_USAGE
+
+    try:
+        payload, exit_code = validate_intake_file(Path(packet))
+    except Exception:
+        payload = intake_invalid_payload(
+            Path(packet),
+            minimum_next_step=(
+                "Retry the same local packet once; if the internal failure "
+                "repeats, stop and report the command boundary."
+            ),
+            unknowns=("internal_failure",),
+        )
+        exit_code = EXIT_INTERNAL
+
+    _write_intake(payload, output_format, output)
+    return exit_code
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -135,6 +211,9 @@ def main(
 
     if arguments and arguments[0] == "scan":
         return _run_scan(arguments, output)
+
+    if arguments and arguments[0] == "intake":
+        return _run_intake(arguments, output)
 
     if (
         len(arguments) != 2

--- a/decision_os/intake.py
+++ b/decision_os/intake.py
@@ -1,0 +1,399 @@
+"""Deterministic structural checks for one local workflow incident packet."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+from typing import Any, Iterable
+import unicodedata
+
+
+EXIT_READY = 0
+EXIT_INCOMPLETE = 4
+
+INPUT_SCHEMA_VERSION = "decision-os.workflow-intake.v0.1"
+RESULT_SCHEMA_VERSION = "decision-os.workflow-intake-result.v0.1"
+MAX_INPUT_BYTES = 256 * 1024
+
+RESULT_READY = "FIT_CHECK_READY"
+RESULT_INCOMPLETE = "INCOMPLETE"
+RESULT_INVALID = "INVALID"
+
+REQUIRED_STRING_FIELDS = (
+    "workflow",
+    "bounded_path",
+    "incident_as_of",
+    "trigger",
+    "expected_state",
+    "observed_state",
+    "restart_or_fallback_path",
+)
+REQUIRED_NONEMPTY_LIST_FIELDS = (
+    "human_recovery_work",
+    "materials_available",
+)
+REQUIRED_LIST_FIELDS = ("prohibited_materials",)
+OPTIONAL_STRING_FIELDS = (
+    "next_actor",
+    "next_safe_action",
+)
+OPTIONAL_LIST_FIELDS = ("unknowns",)
+FIELD_ORDER = (
+    "schema_version",
+    "workflow",
+    "bounded_path",
+    "incident_as_of",
+    "trigger",
+    "expected_state",
+    "observed_state",
+    "human_recovery_work",
+    "restart_or_fallback_path",
+    "materials_available",
+    "prohibited_materials",
+    "next_actor",
+    "next_safe_action",
+    "unknowns",
+)
+REQUIRED_FIELD_ORDER = (
+    "schema_version",
+    *REQUIRED_STRING_FIELDS,
+    *REQUIRED_NONEMPTY_LIST_FIELDS,
+    *REQUIRED_LIST_FIELDS,
+)
+ACCEPTED_FIELDS = frozenset(FIELD_ORDER)
+
+CLAIMS_NOT_MADE = (
+    "workflow diagnosis",
+    "vendor bug diagnosis",
+    "task or product correctness",
+    "security or safety",
+    "recovery of lost state",
+    "prevention of future incidents",
+    "productivity, labor, cost, or revenue improvement",
+    "paid Audit acceptance",
+    "native resume as proof of trustworthy restart",
+)
+
+NEXT_STEP_READY = (
+    "Discuss bounded fit using only the listed material classes; do not share "
+    "prohibited material."
+)
+NEXT_STEP_INCOMPLETE = (
+    "Add or correct only the listed intake fields, then rerun decision-os "
+    "intake."
+)
+NEXT_STEP_INVALID = (
+    "Provide one local regular UTF-8 JSON packet using the accepted schema, "
+    "then rerun decision-os intake."
+)
+
+
+class _InputRejected(Exception):
+    """One local input did not satisfy the bounded read contract."""
+
+
+def _safe_basename(path: Path | str | os.PathLike[str] | None) -> str:
+    if path is None:
+        return "unavailable"
+    try:
+        name = os.path.basename(os.path.abspath(os.fspath(path)))
+    except (TypeError, ValueError, OSError):
+        return "unavailable"
+    if not name or name in (".", ".."):
+        return "unavailable"
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+        for character in name
+    ):
+        return "unavailable"
+    return name[:255]
+
+
+def _ordered(values: Iterable[str]) -> list[str]:
+    selected = set(values)
+    ordered = [field for field in FIELD_ORDER if field in selected]
+    if "unsupported_fields" in selected:
+        ordered.append("unsupported_fields")
+    return ordered
+
+
+def result_payload(
+    *,
+    name: str,
+    result: str,
+    observed_fields: Iterable[str] = (),
+    missing_required_fields: Iterable[str] = (),
+    invalid_fields: Iterable[str] = (),
+    unknowns: Iterable[str] = (),
+    minimum_next_step: str,
+) -> dict[str, Any]:
+    """Build one stable result without including packet field contents."""
+
+    return {
+        "claims_not_made": list(CLAIMS_NOT_MADE),
+        "command": "intake",
+        "input": {
+            "content_echoed": False,
+            "name": _safe_basename(name),
+        },
+        "invalid_fields": _ordered(invalid_fields),
+        "minimum_next_step": minimum_next_step,
+        "missing_required_fields": _ordered(missing_required_fields),
+        "observed_fields": _ordered(observed_fields),
+        "result": result,
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "unknowns": list(unknowns),
+    }
+
+
+def invalid_payload(
+    path: Path | str | os.PathLike[str] | None,
+    *,
+    minimum_next_step: str = NEXT_STEP_INVALID,
+    unknowns: Iterable[str] = ("packet_structure",),
+) -> dict[str, Any]:
+    """Return the stable INVALID shape for bounded read or parse rejection."""
+
+    return result_payload(
+        name=_safe_basename(path),
+        result=RESULT_INVALID,
+        minimum_next_step=minimum_next_step,
+        unknowns=unknowns,
+    )
+
+
+def _regular_file_snapshot(path: Path) -> tuple[Path, os.stat_result]:
+    try:
+        absolute = Path(os.path.abspath(os.fspath(path)))
+        metadata = os.lstat(absolute)
+    except (TypeError, ValueError, OSError) as exc:
+        raise _InputRejected from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise _InputRejected
+    if metadata.st_size > MAX_INPUT_BYTES:
+        raise _InputRejected
+    return absolute, metadata
+
+
+def _snapshot_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+
+
+def _read_local_regular_file(path: Path) -> bytes:
+    absolute, before = _regular_file_snapshot(path)
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+
+    try:
+        descriptor = os.open(absolute, flags)
+    except (OSError, ValueError) as exc:
+        raise _InputRejected from exc
+
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+        ):
+            raise _InputRejected
+        if opened.st_size > MAX_INPUT_BYTES:
+            raise _InputRejected
+
+        chunks: list[bytes] = []
+        total = 0
+        while total <= MAX_INPUT_BYTES:
+            chunk = os.read(
+                descriptor,
+                min(64 * 1024, MAX_INPUT_BYTES + 1 - total),
+            )
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        if total > MAX_INPUT_BYTES:
+            raise _InputRejected
+
+        after_open = os.fstat(descriptor)
+        after_path = os.lstat(absolute)
+        identity = _snapshot_identity(before)
+        if (
+            identity != _snapshot_identity(opened)
+            or identity != _snapshot_identity(after_open)
+            or identity != _snapshot_identity(after_path)
+        ):
+            raise _InputRejected
+        return b"".join(chunks)
+    except OSError as exc:
+        raise _InputRejected from exc
+    finally:
+        os.close(descriptor)
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in output:
+            raise ValueError("duplicate JSON object key")
+        output[key] = value
+    return output
+
+
+def _reject_json_constant(_: str) -> None:
+    raise ValueError("non-finite JSON constant")
+
+
+def _parse_packet(content: bytes) -> dict[str, Any]:
+    try:
+        text = content.decode("utf-8", errors="strict")
+        packet = json.loads(
+            text,
+            object_pairs_hook=_strict_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        RecursionError,
+        ValueError,
+    ):
+        raise _InputRejected
+    if not isinstance(packet, dict):
+        raise _InputRejected
+    return packet
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _string_list(value: Any, *, allow_empty: bool) -> bool:
+    if not isinstance(value, list):
+        return False
+    if not allow_empty and not value:
+        return False
+    return all(_nonempty_string(item) for item in value)
+
+
+def _inspect_packet(
+    packet: dict[str, Any],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    missing = [
+        field for field in REQUIRED_FIELD_ORDER if field not in packet
+    ]
+    invalid: list[str] = []
+    observed: list[str] = []
+
+    if "schema_version" in packet:
+        if packet["schema_version"] != INPUT_SCHEMA_VERSION:
+            invalid.append("schema_version")
+        else:
+            observed.append("schema_version")
+
+    for field in REQUIRED_STRING_FIELDS:
+        if field not in packet:
+            continue
+        if _nonempty_string(packet[field]):
+            observed.append(field)
+        else:
+            invalid.append(field)
+
+    for field in REQUIRED_NONEMPTY_LIST_FIELDS:
+        if field not in packet:
+            continue
+        if _string_list(packet[field], allow_empty=False):
+            observed.append(field)
+        else:
+            invalid.append(field)
+
+    for field in REQUIRED_LIST_FIELDS:
+        if field not in packet:
+            continue
+        if _string_list(packet[field], allow_empty=True):
+            observed.append(field)
+        else:
+            invalid.append(field)
+
+    for field in OPTIONAL_STRING_FIELDS:
+        if field not in packet:
+            continue
+        if _nonempty_string(packet[field]):
+            observed.append(field)
+        else:
+            invalid.append(field)
+
+    for field in OPTIONAL_LIST_FIELDS:
+        if field not in packet:
+            continue
+        if _string_list(packet[field], allow_empty=True):
+            observed.append(field)
+        else:
+            invalid.append(field)
+
+    if any(field not in ACCEPTED_FIELDS for field in packet):
+        invalid.append("unsupported_fields")
+
+    unknowns = (
+        ["input_unknowns_present"]
+        if (
+            "unknowns" in packet
+            and isinstance(packet["unknowns"], list)
+            and bool(packet["unknowns"])
+        )
+        else []
+    )
+    return (
+        _ordered(observed),
+        _ordered(missing),
+        _ordered(invalid),
+        unknowns,
+    )
+
+
+def validate_intake_file(path: Path) -> tuple[dict[str, Any], int]:
+    """Check one local packet without writing, diagnosing, or echoing content."""
+
+    safe_name = _safe_basename(path)
+    try:
+        packet = _parse_packet(_read_local_regular_file(path))
+    except _InputRejected:
+        return invalid_payload(path), EXIT_INCOMPLETE
+
+    observed, missing, invalid, unknowns = _inspect_packet(packet)
+    if missing or invalid:
+        return (
+            result_payload(
+                name=safe_name,
+                result=RESULT_INCOMPLETE,
+                observed_fields=observed,
+                missing_required_fields=missing,
+                invalid_fields=invalid,
+                unknowns=unknowns,
+                minimum_next_step=NEXT_STEP_INCOMPLETE,
+            ),
+            EXIT_INCOMPLETE,
+        )
+
+    return (
+        result_payload(
+            name=safe_name,
+            result=RESULT_READY,
+            observed_fields=observed,
+            unknowns=unknowns,
+            minimum_next_step=NEXT_STEP_READY,
+        ),
+        EXIT_READY,
+    )

--- a/decision_os/intake_text.py
+++ b/decision_os/intake_text.py
@@ -1,0 +1,123 @@
+"""Deterministic text rendering for a workflow intake result payload."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+RESULT_LABELS = {
+    "FIT_CHECK_READY": "FIT CHECK READY",
+    "INCOMPLETE": "INCOMPLETE",
+    "INVALID": "INVALID",
+}
+TEXT_FIELD_ORDER = (
+    "workflow",
+    "bounded_path",
+    "trigger",
+    "expected_state",
+    "observed_state",
+    "human_recovery_work",
+    "restart_or_fallback_path",
+    "materials_available",
+    "prohibited_materials",
+)
+KNOWN_FIELDS = frozenset(
+    (
+        "schema_version",
+        "incident_as_of",
+        *TEXT_FIELD_ORDER,
+        "next_actor",
+        "next_safe_action",
+        "unknowns",
+        "unsupported_fields",
+    )
+)
+
+
+def _field_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return []
+    selected = {
+        item for item in value if isinstance(item, str) and item in KNOWN_FIELDS
+    }
+    return [field for field in TEXT_FIELD_ORDER if field in selected]
+
+
+def _all_fields(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return []
+    selected = {
+        item for item in value if isinstance(item, str) and item in KNOWN_FIELDS
+    }
+    ordered = [
+        field
+        for field in (
+            "schema_version",
+            "workflow",
+            "bounded_path",
+            "incident_as_of",
+            "trigger",
+            "expected_state",
+            "observed_state",
+            "human_recovery_work",
+            "restart_or_fallback_path",
+            "materials_available",
+            "prohibited_materials",
+            "next_actor",
+            "next_safe_action",
+            "unknowns",
+            "unsupported_fields",
+        )
+        if field in selected
+    ]
+    return ordered
+
+
+def _section(title: str, values: list[str]) -> list[str]:
+    lines = [f"{title}:"]
+    lines.extend(
+        (f"- {value}" for value in values)
+        if values
+        else ("- none",)
+    )
+    return lines
+
+
+def render_text(payload: Mapping[str, Any]) -> str:
+    """Render one already-computed payload without reading the input again."""
+
+    result = payload.get("result")
+    label = RESULT_LABELS.get(result, "INVALID")
+    lines = [
+        f"Decision-OS Workflow Intake v0.1: {label}",
+        "",
+        *_section("Observed", _field_list(payload.get("observed_fields"))),
+        "",
+        *_section(
+            "Missing",
+            _all_fields(payload.get("missing_required_fields")),
+        ),
+    ]
+
+    invalid = _all_fields(payload.get("invalid_fields"))
+    if invalid:
+        lines.extend(("", *_section("Invalid", invalid)))
+
+    if result != "FIT_CHECK_READY":
+        next_step = payload.get("minimum_next_step")
+        if isinstance(next_step, str) and next_step:
+            lines.extend(("", "Minimum next step:", next_step))
+
+    lines.extend(
+        (
+            "",
+            "This result confirms intake structure only.",
+            "It does not diagnose the workflow or accept it for a paid Audit.",
+        )
+    )
+    return "\n".join(lines) + "\n"

--- a/docs/workflow_incident_intake_checker_v0_1.md
+++ b/docs/workflow_incident_intake_checker_v0_1.md
@@ -1,0 +1,142 @@
+# Workflow Incident Intake Checker v0.1
+
+## Purpose
+
+`decision-os intake` checks whether one local, non-repository AI workflow
+incident packet contains enough bounded structure to begin a free fit
+discussion.
+
+It does not perform an Audit, diagnose a workflow or vendor, recover state,
+establish correctness or safety, or accept work for a paid Audit.
+
+## Commands
+
+The three Decision-OS commands remain separate:
+
+```text
+decision-os check <repository>
+decision-os scan <repository>
+decision-os intake <packet.json>
+```
+
+Workflow Intake Checker accepts exactly:
+
+```text
+decision-os intake <packet.json>
+decision-os intake --format json <packet.json>
+decision-os intake --format text <packet.json>
+```
+
+JSON is the default. JSON reports all accepted field presence. Text provides a
+fixed summary of the nine fit-boundary fields shown in the example output.
+Both formats are deterministic and do not echo field contents. The schema
+version and `incident_as_of` remain validated even though the text summary does
+not list them.
+
+## Local read boundary
+
+The command:
+
+- reads one local file only;
+- performs no network access, telemetry, or writes;
+- rejects an input whose final path component is a symlink, plus directories
+  and other non-regular files;
+- rejects invalid UTF-8 and malformed or non-standard JSON;
+- rejects inputs larger than 256 KiB;
+- reports only a safe basename, never the supplied path or packet contents.
+
+Do not place credentials, customer data, production secrets, or other private
+material in an intake packet. `prohibited_materials` records excluded material
+classes; it does not authorize their collection.
+
+## Input schema
+
+The schema version is:
+
+```text
+decision-os.workflow-intake.v0.1
+```
+
+Required non-empty string fields:
+
+- `workflow`
+- `bounded_path`
+- `incident_as_of`
+- `trigger`
+- `expected_state`
+- `observed_state`
+- `restart_or_fallback_path`
+
+Required non-empty string-list fields:
+
+- `human_recovery_work`
+- `materials_available`
+
+`prohibited_materials` must exist and must be a string list. An explicit empty
+list is accepted when no prohibited material class is known.
+
+Optional fields are:
+
+- `next_actor`: non-empty string when present
+- `next_safe_action`: non-empty string when present
+- `unknowns`: string list; an empty list is accepted
+
+Other top-level fields are unsupported in v0.1. String contents are not
+diagnosed or fact-checked.
+
+See the bounded
+[workflow incident intake example](../examples/workflow_incident_intake_v0_1.json).
+
+## Result contract
+
+JSON uses:
+
+```text
+decision-os.workflow-intake-result.v0.1
+```
+
+Results and exits are:
+
+| Result | Exit | Meaning |
+| --- | ---: | --- |
+| `FIT_CHECK_READY` | 0 | Required structure and material-class presence are available. |
+| `INCOMPLETE` | 4 | JSON parsed, but a required or accepted field is missing or malformed. |
+| `INVALID` | 4 | The file could not be safely read or parsed as the accepted schema. |
+| CLI usage error | 2 | The command form is unsupported. |
+| Unexpected internal failure | 6 | The bounded checker did not complete. |
+
+`FIT_CHECK_READY` means only that a bounded fit discussion can begin. It is not
+a PASS/FAIL Audit judgment and does not imply paid Audit acceptance.
+
+The result never claims:
+
+- workflow or vendor-bug diagnosis;
+- task or product correctness;
+- security or safety;
+- recovery or prevention;
+- productivity, labor, cost, or revenue improvement;
+- paid Audit acceptance;
+- native resume as proof of trustworthy restart.
+
+## Example
+
+```sh
+python3 -B -m decision_os intake \
+  examples/workflow_incident_intake_v0_1.json
+
+python3 -B -m decision_os intake --format text \
+  examples/workflow_incident_intake_v0_1.json
+```
+
+The example contains invented, non-private structure only. Replace it with a
+sanitized packet that names one bounded workflow path and excludes private
+material.
+
+## Rollback and re-evaluation
+
+Rollback: revert the Workflow Intake Checker PR. Existing `check`, `scan`,
+offer, pricing, and delivery surfaces remain unchanged.
+
+Re-evaluate after the first external use, a malformed real-world packet, a
+fit-check request, or evidence that preparing this JSON creates excessive
+human burden.

--- a/examples/workflow_incident_intake_v0_1.json
+++ b/examples/workflow_incident_intake_v0_1.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "decision-os.workflow-intake.v0.1",
+  "workflow": "Customer-support approval workflow",
+  "bounded_path": "draft response -> human approval -> send decision",
+  "incident_as_of": "2026-07-26",
+  "trigger": "The workflow resumed after an interrupted approval step.",
+  "expected_state": "The approved draft remained current and ready for the send decision.",
+  "observed_state": "The resumed workflow could not establish which draft the approval covered.",
+  "human_recovery_work": [
+    "Revalidated the draft and repeated the send decision."
+  ],
+  "restart_or_fallback_path": "Keep the workflow stopped at approval until the draft identity is re-established.",
+  "materials_available": [
+    "Sanitized workflow diagram",
+    "Redacted event timeline",
+    "Configuration field names without values"
+  ],
+  "prohibited_materials": [
+    "Credentials",
+    "Customer messages",
+    "Production secrets"
+  ]
+}

--- a/scripts/validate_loop_record_examples.py
+++ b/scripts/validate_loop_record_examples.py
@@ -27,6 +27,12 @@ SUPPORTED_SCHEMA_KEYS = {
 }
 
 SUPPORTED_TYPES = {"object", "array", "string"}
+LOOP_RECORD_EXAMPLE_PATTERNS = (
+    "go.*.json",
+    "hold.*.json",
+    "cap.*.json",
+    "block.*.json",
+)
 
 
 class SchemaSupportError(Exception):
@@ -203,9 +209,17 @@ def validate_examples(schema_path: Path, examples_dir: Path) -> int:
         raise SchemaSupportError(f"{schema_path}: root schema must be an object")
     audit_schema(schema)
 
-    example_paths = sorted(examples_dir.glob("*.json"))
+    example_paths = sorted(
+        {
+            path
+            for pattern in LOOP_RECORD_EXAMPLE_PATTERNS
+            for path in examples_dir.glob(pattern)
+        }
+    )
     if not example_paths:
-        raise RecordValidationError(f"{examples_dir}: no JSON examples found")
+        raise RecordValidationError(
+            f"{examples_dir}: no Loop Record examples found"
+        )
 
     failures: list[str] = []
     for example_path in example_paths:
@@ -235,9 +249,9 @@ def parse_args() -> argparse.Namespace:
     repo_root = Path(__file__).resolve().parents[1]
     parser = argparse.ArgumentParser(
         description=(
-            "Validate examples/*.json against the supported subset used by "
-            "schema/v13_loop_record.schema.json. Unsupported schema keywords "
-            "fail closed."
+            "Validate canonical gate-prefixed Loop Record examples against "
+            "the supported subset used by schema/v13_loop_record.schema.json. "
+            "Unsupported schema keywords fail closed."
         )
     )
     parser.add_argument(

--- a/tests/test_decision_os_intake.py
+++ b/tests/test_decision_os_intake.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.intake import (
+    EXIT_INCOMPLETE,
+    EXIT_READY,
+    INPUT_SCHEMA_VERSION,
+    MAX_INPUT_BYTES,
+    RESULT_INCOMPLETE,
+    RESULT_INVALID,
+    RESULT_READY,
+    validate_intake_file,
+)
+
+
+def ready_packet() -> dict[str, object]:
+    return {
+        "schema_version": INPUT_SCHEMA_VERSION,
+        "workflow": "Approval workflow",
+        "bounded_path": "draft -> approval -> send decision",
+        "incident_as_of": "2026-07-26",
+        "trigger": "Resume after an interrupted approval.",
+        "expected_state": "The approved draft remains current.",
+        "observed_state": "The resumed run cannot identify the draft.",
+        "human_recovery_work": ["Revalidated the draft."],
+        "restart_or_fallback_path": "Stop before send and re-establish identity.",
+        "materials_available": ["Sanitized event timeline."],
+        "prohibited_materials": [],
+    }
+
+
+def write_packet(directory: Path, packet: object) -> Path:
+    path = directory / "packet.json"
+    path.write_text(
+        json.dumps(packet, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+class WorkflowIntakeValidationTest(unittest.TestCase):
+    def test_ready_packet_is_deterministic_and_does_not_echo_content(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = ready_packet()
+            packet["workflow"] = "SECRET WORKFLOW VALUE"
+            path = write_packet(root, packet)
+            before = path.read_bytes()
+
+            first, first_exit = validate_intake_file(path)
+            second, second_exit = validate_intake_file(path)
+
+            self.assertEqual(EXIT_READY, first_exit)
+            self.assertEqual(first_exit, second_exit)
+            self.assertEqual(first, second)
+            self.assertEqual(RESULT_READY, first["result"])
+            self.assertEqual([], first["missing_required_fields"])
+            self.assertEqual([], first["invalid_fields"])
+            self.assertFalse(first["input"]["content_echoed"])
+            self.assertEqual("packet.json", first["input"]["name"])
+            self.assertNotIn("SECRET WORKFLOW VALUE", json.dumps(first))
+            self.assertEqual(before, path.read_bytes())
+
+    def test_missing_required_field_is_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = ready_packet()
+            del packet["observed_state"]
+            path = write_packet(root, packet)
+
+            payload, exit_code = validate_intake_file(path)
+
+            self.assertEqual(EXIT_INCOMPLETE, exit_code)
+            self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+            self.assertEqual(
+                ["observed_state"],
+                payload["missing_required_fields"],
+            )
+            self.assertEqual([], payload["invalid_fields"])
+
+    def test_empty_required_lists_are_invalid_but_empty_prohibited_is_valid(
+        self,
+    ) -> None:
+        for field in ("human_recovery_work", "materials_available"):
+            with self.subTest(field=field):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    packet = ready_packet()
+                    packet[field] = []
+                    path = write_packet(root, packet)
+
+                    payload, exit_code = validate_intake_file(path)
+
+                    self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                    self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                    self.assertEqual([field], payload["invalid_fields"])
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            payload, exit_code = validate_intake_file(
+                write_packet(root, ready_packet())
+            )
+            self.assertEqual(EXIT_READY, exit_code)
+            self.assertIn(
+                "prohibited_materials",
+                payload["observed_fields"],
+            )
+
+    def test_optional_fields_and_unknowns_are_structural_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = ready_packet()
+            packet.update(
+                {
+                    "next_actor": "PRIVATE PERSON",
+                    "next_safe_action": "PRIVATE ACTION",
+                    "unknowns": ["PRIVATE UNKNOWN"],
+                }
+            )
+            path = write_packet(root, packet)
+
+            payload, exit_code = validate_intake_file(path)
+            encoded = json.dumps(payload)
+
+            self.assertEqual(EXIT_READY, exit_code)
+            self.assertEqual(["input_unknowns_present"], payload["unknowns"])
+            self.assertIn("next_actor", payload["observed_fields"])
+            self.assertIn("next_safe_action", payload["observed_fields"])
+            self.assertIn("unknowns", payload["observed_fields"])
+            self.assertNotIn("PRIVATE PERSON", encoded)
+            self.assertNotIn("PRIVATE ACTION", encoded)
+            self.assertNotIn("PRIVATE UNKNOWN", encoded)
+
+    def test_malformed_unsupported_and_non_object_json_are_rejected(self) -> None:
+        cases = (
+            b'{"schema_version":',
+            b'{"value":NaN}',
+            b'{"value":1,"value":2}',
+            b"[]",
+        )
+        for content in cases:
+            with self.subTest(content=content):
+                with tempfile.TemporaryDirectory() as directory:
+                    path = Path(directory) / "packet.json"
+                    path.write_bytes(content)
+
+                    payload, exit_code = validate_intake_file(path)
+
+                    self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                    self.assertEqual(RESULT_INVALID, payload["result"])
+                    self.assertEqual([], payload["observed_fields"])
+
+    def test_unsupported_schema_and_extra_field_are_incomplete(self) -> None:
+        cases = (
+            ("schema_version", "unsupported"),
+            ("private_extra_field", "SECRET"),
+        )
+        for field, value in cases:
+            with self.subTest(field=field):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    packet = ready_packet()
+                    packet[field] = value
+                    path = write_packet(root, packet)
+
+                    payload, exit_code = validate_intake_file(path)
+
+                    self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                    self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                    expected = (
+                        ["schema_version"]
+                        if field == "schema_version"
+                        else ["unsupported_fields"]
+                    )
+                    self.assertEqual(expected, payload["invalid_fields"])
+                    self.assertNotIn("SECRET", json.dumps(payload))
+
+    def test_oversized_invalid_utf8_directory_and_missing_file_are_invalid(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            oversized = root / "oversized.json"
+            oversized.write_bytes(b"x" * (MAX_INPUT_BYTES + 1))
+            invalid_utf8 = root / "invalid.json"
+            invalid_utf8.write_bytes(b"\xff")
+            missing = root / "missing.json"
+
+            for path in (oversized, invalid_utf8, root, missing):
+                with self.subTest(path=path.name):
+                    payload, exit_code = validate_intake_file(path)
+                    self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                    self.assertEqual(RESULT_INVALID, payload["result"])
+                    self.assertFalse(payload["input"]["content_echoed"])
+                    self.assertNotIn(str(root), json.dumps(payload))
+
+    def test_exact_size_limit_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = ready_packet()
+            packet["workflow"] = "x"
+            content = json.dumps(packet, ensure_ascii=False).encode("utf-8")
+            packet["workflow"] = "x" * (1 + MAX_INPUT_BYTES - len(content))
+            content = json.dumps(packet, ensure_ascii=False).encode("utf-8")
+            self.assertEqual(MAX_INPUT_BYTES, len(content))
+            path = root / "packet.json"
+            path.write_bytes(content)
+
+            payload, exit_code = validate_intake_file(path)
+
+            self.assertEqual(EXIT_READY, exit_code)
+            self.assertEqual(RESULT_READY, payload["result"])
+
+    def test_fifo_is_rejected_before_open(self) -> None:
+        if not hasattr(os, "mkfifo"):
+            self.skipTest("FIFO creation unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "packet.fifo"
+            os.mkfifo(path)
+
+            with patch(
+                "decision_os.intake.os.open",
+                side_effect=AssertionError("non-regular input was opened"),
+            ):
+                payload, exit_code = validate_intake_file(path)
+
+            self.assertEqual(EXIT_INCOMPLETE, exit_code)
+            self.assertEqual(RESULT_INVALID, payload["result"])
+
+    def test_parser_depth_exhaustion_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "packet.json"
+            path.write_bytes(b"{}")
+
+            with patch(
+                "decision_os.intake.json.loads",
+                side_effect=RecursionError,
+            ):
+                payload, exit_code = validate_intake_file(path)
+
+            self.assertEqual(EXIT_INCOMPLETE, exit_code)
+            self.assertEqual(RESULT_INVALID, payload["result"])
+
+    def test_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            real_directory = root / "real"
+            real_directory.mkdir()
+            target = write_packet(real_directory, ready_packet())
+            link = root / "linked.json"
+            try:
+                link.symlink_to(target)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+
+            payload, exit_code = validate_intake_file(link)
+
+            self.assertEqual(EXIT_INCOMPLETE, exit_code)
+            self.assertEqual(RESULT_INVALID, payload["result"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_intake_cli.py
+++ b/tests/test_decision_os_intake_cli.py
@@ -23,6 +23,9 @@ from tests.test_decision_os_checks import tree_digest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BIN_ENTRY = REPO_ROOT / "bin" / "decision-os"
 SHIPPED_EXAMPLE = REPO_ROOT / "examples" / "workflow_incident_intake_v0_1.json"
+LOOP_RECORD_VALIDATOR = (
+    REPO_ROOT / "scripts" / "validate_loop_record_examples.py"
+)
 
 
 def cli_environment() -> dict[str, str]:
@@ -86,6 +89,24 @@ def decoded(completed: subprocess.CompletedProcess[bytes]) -> dict[str, object]:
 
 
 class WorkflowIntakeCliTest(unittest.TestCase):
+    def test_loop_record_validator_does_not_consume_intake_example(self) -> None:
+        completed = subprocess.run(
+            (sys.executable, "-B", str(LOOP_RECORD_VALIDATOR)),
+            capture_output=True,
+            check=False,
+            cwd=REPO_ROOT,
+            env=cli_environment(),
+        )
+
+        self.assertEqual(0, completed.returncode)
+        self.assertEqual(b"", completed.stderr)
+        self.assertTrue(
+            completed.stdout.startswith(
+                b"PASS: 12/12 Loop Record examples validate against "
+            )
+        )
+        self.assertNotIn(SHIPPED_EXAMPLE.name.encode(), completed.stdout)
+
     def test_shipped_example_is_fit_check_ready(self) -> None:
         completed = run_module(
             REPO_ROOT,

--- a/tests/test_decision_os_intake_cli.py
+++ b/tests/test_decision_os_intake_cli.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.cli import EXIT_INTERNAL, EXIT_USAGE, INTAKE_USAGE, main
+from decision_os.intake import (
+    EXIT_INCOMPLETE,
+    INPUT_SCHEMA_VERSION,
+    RESULT_INVALID,
+    RESULT_READY,
+)
+from tests.test_decision_os_checks import tree_digest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BIN_ENTRY = REPO_ROOT / "bin" / "decision-os"
+SHIPPED_EXAMPLE = REPO_ROOT / "examples" / "workflow_incident_intake_v0_1.json"
+
+
+def cli_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+    return environment
+
+
+def run_module(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (sys.executable, "-B", "-m", "decision_os", *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def run_bin(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (str(BIN_ENTRY), *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def packet() -> dict[str, object]:
+    return {
+        "schema_version": INPUT_SCHEMA_VERSION,
+        "workflow": "Approval workflow",
+        "bounded_path": "draft -> approval -> send decision",
+        "incident_as_of": "2026-07-26",
+        "trigger": "Resume after interruption.",
+        "expected_state": "Approved draft remains current.",
+        "observed_state": "Draft identity is unavailable.",
+        "human_recovery_work": ["Revalidated the draft."],
+        "restart_or_fallback_path": "Stop before send.",
+        "materials_available": ["Sanitized event timeline."],
+        "prohibited_materials": [],
+    }
+
+
+def write_packet(directory: Path) -> Path:
+    path = directory / "packet.json"
+    path.write_text(json.dumps(packet()), encoding="utf-8")
+    return path
+
+
+def decoded(completed: subprocess.CompletedProcess[bytes]) -> dict[str, object]:
+    if completed.stderr:
+        raise AssertionError(completed.stderr.decode("utf-8", errors="replace"))
+    if completed.stdout.count(b"\n") != 1 or not completed.stdout.endswith(b"\n"):
+        raise AssertionError(f"expected one JSON line, got {completed.stdout!r}")
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError("expected one JSON object")
+    return payload
+
+
+class WorkflowIntakeCliTest(unittest.TestCase):
+    def test_shipped_example_is_fit_check_ready(self) -> None:
+        completed = run_module(
+            REPO_ROOT,
+            "intake",
+            str(SHIPPED_EXAMPLE),
+        )
+
+        self.assertEqual(0, completed.returncode)
+        self.assertEqual(RESULT_READY, decoded(completed)["result"])
+
+    def test_json_default_explicit_repeated_and_bin_outputs_match(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = write_packet(root)
+            before = tree_digest(root)
+
+            default = run_module(root, "intake", str(path))
+            repeated = run_module(root, "intake", str(path))
+            explicit = run_module(
+                root, "intake", "--format", "json", str(path)
+            )
+            executable = run_bin(root, "intake", str(path))
+
+            results = (default, repeated, explicit, executable)
+            self.assertTrue(all(item.returncode == 0 for item in results))
+            self.assertTrue(all(item.stderr == b"" for item in results))
+            self.assertTrue(
+                all(item.stdout == default.stdout for item in results)
+            )
+            self.assertEqual(RESULT_READY, decoded(default)["result"])
+            self.assertEqual(before, tree_digest(root))
+
+    def test_text_output_is_exact_repeatable_and_bin_identical(self) -> None:
+        expected = (
+            "Decision-OS Workflow Intake v0.1: FIT CHECK READY\n"
+            "\n"
+            "Observed:\n"
+            "- workflow\n"
+            "- bounded_path\n"
+            "- trigger\n"
+            "- expected_state\n"
+            "- observed_state\n"
+            "- human_recovery_work\n"
+            "- restart_or_fallback_path\n"
+            "- materials_available\n"
+            "- prohibited_materials\n"
+            "\n"
+            "Missing:\n"
+            "- none\n"
+            "\n"
+            "This result confirms intake structure only.\n"
+            "It does not diagnose the workflow or accept it for a paid Audit.\n"
+        ).encode()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = write_packet(root)
+
+            first = run_module(
+                root, "intake", "--format", "text", str(path)
+            )
+            second = run_module(
+                root, "intake", "--format", "text", str(path)
+            )
+            executable = run_bin(
+                root, "intake", "--format", "text", str(path)
+            )
+
+            self.assertEqual(0, first.returncode)
+            self.assertEqual(expected, first.stdout)
+            self.assertEqual(first.stdout, second.stdout)
+            self.assertEqual(first.stdout, executable.stdout)
+            self.assertEqual(b"", first.stderr)
+            self.assertFalse(first.stdout.endswith(b"\n\n"))
+
+    def test_usage_errors_return_two_in_selected_safe_format(self) -> None:
+        cases = (
+            (("intake",), b"{"),
+            (("intake", "packet.json", "extra"), b"{"),
+            (("intake", "--format"), b"{"),
+            (("intake", "--format", "yaml", "packet.json"), b"{"),
+            (
+                ("intake", "--format", "text"),
+                b"Decision-OS Workflow Intake v0.1: INVALID\n",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for arguments, prefix in cases:
+                with self.subTest(arguments=arguments):
+                    completed = run_module(root, *arguments)
+                    self.assertEqual(EXIT_USAGE, completed.returncode)
+                    self.assertEqual(b"", completed.stderr)
+                    self.assertTrue(completed.stdout.startswith(prefix))
+                    self.assertNotIn(str(root).encode(), completed.stdout)
+
+        output = io.StringIO()
+        exit_code = main(["intake"], stdout=output)
+        self.assertEqual(EXIT_USAGE, exit_code)
+        self.assertIn(INTAKE_USAGE, output.getvalue())
+
+    def test_incomplete_and_invalid_return_four_without_content_echo(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            incomplete_packet = packet()
+            incomplete_packet["workflow"] = "SECRET VALUE"
+            incomplete_packet["materials_available"] = []
+            incomplete = root / "incomplete.json"
+            incomplete.write_text(
+                json.dumps(incomplete_packet),
+                encoding="utf-8",
+            )
+            malformed = root / "malformed.json"
+            malformed.write_text('{"SECRET VALUE":', encoding="utf-8")
+
+            incomplete_run = run_module(root, "intake", str(incomplete))
+            invalid_run = run_module(root, "intake", str(malformed))
+
+            self.assertEqual(EXIT_INCOMPLETE, incomplete_run.returncode)
+            self.assertEqual(EXIT_INCOMPLETE, invalid_run.returncode)
+            self.assertNotIn(b"SECRET VALUE", incomplete_run.stdout)
+            self.assertNotIn(b"SECRET VALUE", invalid_run.stdout)
+            self.assertEqual(
+                ["materials_available"],
+                decoded(incomplete_run)["invalid_fields"],
+            )
+            self.assertEqual(RESULT_INVALID, decoded(invalid_run)["result"])
+
+    def test_unexpected_failure_returns_six_without_exception_detail(self) -> None:
+        output = io.StringIO()
+        with patch(
+            "decision_os.cli.validate_intake_file",
+            side_effect=RuntimeError("SECRET INTERNAL DETAIL"),
+        ):
+            exit_code = main(
+                ["intake", "safe-name.json"],
+                stdout=output,
+            )
+
+        self.assertEqual(EXIT_INTERNAL, exit_code)
+        self.assertNotIn("SECRET INTERNAL DETAIL", output.getvalue())
+        payload = json.loads(output.getvalue())
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertEqual(["internal_failure"], payload["unknowns"])
+        self.assertEqual("safe-name.json", payload["input"]["name"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason:
The paid Audit now accepts bounded non-repository AI workflows, but the public tooling only inspects Git repositories. A local intake checker creates an executable bridge between an incident report and the free fit-check boundary.

Impact:
Adds one local read-only command that verifies whether a workflow incident packet is structurally ready for bounded fit discussion. It performs no diagnosis and changes no existing Runner command.

Rollback:
Revert this PR. Existing check, scan, offer, pricing, and delivery surfaces remain unchanged.

Re-evaluation:
Review after the first external use, malformed real-world packet, fit-check request, or evidence that the JSON intake creates excessive burden.

Validation:
- Full suite: 91/91 PASS
- Intake tests: 18/18 PASS
- Loop Record examples: 12/12 PASS
- Existing protected-blob guard: PASS without modification
- Existing check and scan regression coverage: PASS
- Negative instance, unsupported schema-keyword, and empty-selection probes: fail closed
- Deterministic JSON/text and module/bin parity: PASS
- Diff check, exact eight-file scope, file modes, and Markdown link resolution: PASS

Resolved validator topology conflict:
The Loop Record validator previously globbed every examples/*.json file.
It now selects only canonical gate-prefixed Loop Record examples, so the new
workflow-intake example remains under examples/ without being misclassified.
