### PR TITLE
Expose the workflow intake first-use path

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ Not only coding repositories. The paid Audit can also review one clearly bounded
 when a failure returned revalidation, cleanup, context reconstruction,
 rollback, or restart decisions to a human.
 
+## Check one AI workflow incident
+
+Use this for a released app, pilot, staging workflow, or internal workflow when
+one concrete incident has already returned cleanup, rollback, revalidation,
+reconstruction, or restart decisions to a human.
+
+This is not a pre-release safety certification or a general product audit. The
+checker verifies only whether the incident packet is structurally ready for a
+bounded fit discussion.
+
+```sh
+curl -fsSLo workflow_incident_intake_v0_1.json \
+  https://raw.githubusercontent.com/shin4141/decision-os-v13-loopkit/d3ba864c66367e5c676ec14fbaa550801e4f1889/examples/workflow_incident_intake_v0_1.json
+
+uvx --isolated --no-config --no-env-file --no-python-downloads \
+  --from "git+https://github.com/shin4141/decision-os-v13-loopkit@d3ba864c66367e5c676ec14fbaa550801e4f1889" \
+  decision-os intake --format text workflow_incident_intake_v0_1.json
+```
+
+- Edit the downloaded JSON to describe one sanitized incident.
+- Remove credentials, customer data, production secrets, and private material.
+- Expected results are `FIT_CHECK_READY`, `INCOMPLETE`, or `INVALID`.
+- `FIT_CHECK_READY` does not mean the workflow passed an Audit or was accepted
+  for paid work.
+
+Read the
+[Workflow Incident Intake Checker guide](docs/workflow_incident_intake_checker_v0_1.md),
+review the
+[AI Application Workflow Audit delivery boundary](services/ai_application_workflow_audit_delivery_v0_1.md),
+or
+[open the AI Agent Handoff Audit fit-check form](https://github.com/shin4141/decision-os-v13-loopkit/issues/new?template=ai_agent_handoff_audit_fit_check.md).
+
 ## What AI coding incidents return to the human
 
 [![AI coding incidents do not end at the error](assets/incident-map/external-ai-workflow-incident-map-v0-1.png)](case_studies/external_ai_workflow_incident_map_v0_1.md)

--- a/docs/workflow_incident_intake_checker_v0_1.md
+++ b/docs/workflow_incident_intake_checker_v0_1.md
@@ -9,6 +9,52 @@ discussion.
 It does not perform an Audit, diagnose a workflow or vendor, recover state,
 establish correctness or safety, or accept work for a paid Audit.
 
+## Exact-commit first use
+
+Download the example from the exact source commit, then run the checker from
+that same commit:
+
+```sh
+curl -fsSLo workflow_incident_intake_v0_1.json \
+  https://raw.githubusercontent.com/shin4141/decision-os-v13-loopkit/d3ba864c66367e5c676ec14fbaa550801e4f1889/examples/workflow_incident_intake_v0_1.json
+
+uvx --isolated --no-config --no-env-file --no-python-downloads \
+  --from "git+https://github.com/shin4141/decision-os-v13-loopkit@d3ba864c66367e5c676ec14fbaa550801e4f1889" \
+  decision-os intake --format text workflow_incident_intake_v0_1.json
+```
+
+Tool transport:
+
+- `curl` contacts `raw.githubusercontent.com` for the exact example blob;
+- `uvx` may contact GitHub for the exact source commit;
+- a cold run may contact the Python package index for the pinned build backend;
+- a local cache may be used;
+- transport messages may appear on stderr.
+
+Intake execution:
+
+- reads only the supplied local JSON file;
+- uploads no target workflow data through the checker;
+- uses no telemetry;
+- performs no input-file writes;
+- does not echo packet contents.
+
+## Who this is for
+
+This path is for:
+
+- released AI applications with one concrete incident;
+- staging, beta, or pilot workflows with one concrete incident;
+- internal AI-assisted operational workflows with one concrete incident.
+
+It is not for:
+
+- a pre-release application with no incident;
+- general safety approval;
+- a security audit;
+- a product-wide code review;
+- vendor bug repair.
+
 ## Commands
 
 The three Decision-OS commands remain separate:
@@ -35,7 +81,7 @@ not list them.
 
 ## Local read boundary
 
-The command:
+After tool transport, the `decision-os intake` checker:
 
 - reads one local file only;
 - performs no network access, telemetry, or writes;

--- a/services/ai_application_workflow_audit_delivery_v0_1.md
+++ b/services/ai_application_workflow_audit_delivery_v0_1.md
@@ -36,6 +36,15 @@ The incident must be specific enough to distinguish its trigger, expected
 state, observed state, returned human work, and current restart or fallback
 path.
 
+## Prepare one incident packet
+
+The local
+[Workflow Incident Intake Checker](../docs/workflow_incident_intake_checker_v0_1.md)
+can confirm whether a sanitized incident packet contains the minimum structure
+for a free fit discussion. It does not diagnose the incident, and using it is
+optional. A repository is not required. `FIT_CHECK_READY` does not imply
+acceptance for a paid Audit.
+
 ## Minimum intake
 
 Collect only:

--- a/validation/workflow_incident_intake_distribution_run_001.md
+++ b/validation/workflow_incident_intake_distribution_run_001.md
@@ -1,0 +1,213 @@
+# Workflow Incident Intake Distribution Run 001
+
+## Status
+
+```text
+As-of:
+2026-07-26 / Asia/Tokyo
+
+Result:
+PASS / COMPLETE
+
+Exact source commit:
+d3ba864c66367e5c676ec14fbaa550801e4f1889
+
+Intake result:
+FIT_CHECK_READY
+
+Exit code:
+0
+```
+
+This run tested whether a third party can download the exact example and launch
+the merged Workflow Incident Intake Checker without first cloning the
+Decision-OS repository.
+
+## Environment
+
+```text
+OS:
+macOS 26.2 build 25C56
+
+Architecture:
+arm64
+
+uv:
+uv 0.11.32 (3010295ae 2026-07-23 aarch64-apple-darwin)
+
+uvx:
+uvx 0.11.32 (3010295ae 2026-07-23 aarch64-apple-darwin)
+
+Python:
+3.14.3
+```
+
+`uv` was not installed globally or already available on `PATH`. For this run,
+the official `uv-aarch64-apple-darwin.tar.gz` for `uv 0.11.32` was downloaded
+to a mode-0700 temporary root. Its SHA-256 matched the repository's existing
+distribution guard:
+
+```text
+ed336d0ba49db8ef89b2b41fffa372ce63bd032f22a56f001c265891aec32829
+```
+
+The extracted temporary `uvx` SHA-256 was:
+
+```text
+572d4d5281ba5b20b9c94ea53fac1b2b9c19287931091b44e8693dc65780cb3d
+```
+
+The run used a dedicated empty `UV_CACHE_DIR` and the existing compatible
+`/opt/homebrew/bin/python3.14`. These were validation-environment controls, not
+changes to the published commands or to the repository.
+
+For isolated capture, the exact `uvx` command was launched inside a
+process-local environment wrapper that kept stdout and stderr separate. The
+wrapper prepended the extracted temporary uv directory to `PATH`, so bare
+`uvx` resolved to the verified temporary executable. It did not change the
+published flags, source ref, command, or input filename. The process-local
+controls were:
+
+```text
+PATH:
+<mode-0700 temporary root>/tool/uv-aarch64-apple-darwin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+UV_CACHE_DIR:
+<mode-0700 temporary root>/cache
+
+UV_PYTHON:
+/opt/homebrew/bin/python3.14
+
+HOME:
+inherited unchanged from the host; not reassigned
+
+Locale and time:
+LC_ALL=C / LANG=C / TZ=UTC
+
+Git transport:
+GIT_CONFIG_GLOBAL=/dev/null
+GIT_CONFIG_NOSYSTEM=1
+GIT_TERMINAL_PROMPT=0
+```
+
+## Exact raw-example URL
+
+```text
+https://raw.githubusercontent.com/shin4141/decision-os-v13-loopkit/d3ba864c66367e5c676ec14fbaa550801e4f1889/examples/workflow_incident_intake_v0_1.json
+```
+
+## Exact commands
+
+The temporary run directory was empty before the first command.
+
+```sh
+curl -fsSLo workflow_incident_intake_v0_1.json \
+  https://raw.githubusercontent.com/shin4141/decision-os-v13-loopkit/d3ba864c66367e5c676ec14fbaa550801e4f1889/examples/workflow_incident_intake_v0_1.json
+
+uvx --isolated --no-config --no-env-file --no-python-downloads \
+  --from "git+https://github.com/shin4141/decision-os-v13-loopkit@d3ba864c66367e5c676ec14fbaa550801e4f1889" \
+  decision-os intake --format text workflow_incident_intake_v0_1.json
+```
+
+## Command receipt
+
+### Download
+
+```text
+curl stdout:
+empty
+
+curl stderr:
+empty
+
+curl exit code:
+0
+
+Downloaded bytes:
+932
+
+Downloaded file SHA-256:
+8e8d164df7e91fa23980767b3149fb004f1f859ba2f3bafb66e72fa8c092cc87
+```
+
+The downloaded SHA-256 matched the example at the exact source commit and was
+unchanged after intake execution.
+
+### Intake stdout
+
+```text
+Decision-OS Workflow Intake v0.1: FIT CHECK READY
+
+Observed:
+- workflow
+- bounded_path
+- trigger
+- expected_state
+- observed_state
+- human_recovery_work
+- restart_or_fallback_path
+- materials_available
+- prohibited_materials
+
+Missing:
+- none
+
+This result confirms intake structure only.
+It does not diagnose the workflow or accept it for a paid Audit.
+```
+
+```text
+stdout bytes:
+352
+
+stdout lines:
+18
+
+stdout SHA-256:
+f6e87ef0b7535b56300a85468e987c8c9c0379f2655f52fdab80d2e54426940b
+
+uvx exit code:
+0
+```
+
+### Intake stderr summary
+
+The five stderr lines were cold transport messages only. They recorded:
+
+- updating the exact GitHub source commit;
+- building `decision-os-v13-loopkit` from that exact commit;
+- installing one built package.
+
+The stderr named
+`d3ba864c66367e5c676ec14fbaa550801e4f1889` throughout the source update and
+build. It contained no packet field contents and was not checker stdout.
+
+## Source and clone boundary
+
+The dedicated uv cache contained one Git checkout. A read-only
+`git rev-parse HEAD` inside that checkout returned:
+
+```text
+d3ba864c66367e5c676ec14fbaa550801e4f1889
+```
+
+No pre-existing or manual repository clone was required. The temporary run
+directory contained only `workflow_incident_intake_v0_1.json` and no `.git`
+entry. Because `--from git+...` is a Git source transport, `uvx` did perform its
+own bounded fetch and cache checkout outside the run directory.
+
+## Bounded conclusion
+
+This one run confirms that the exact-commit path distributed the example,
+launched the checker, and returned `FIT_CHECK_READY` for the example packet.
+It establishes distribution and structural intake only.
+
+## Limitations
+
+- This receipt covers one environment only.
+- It does not establish support on all platforms.
+- It does not diagnose a real workflow.
+- It does not establish demand, paid value, prevention, safety, or
+  productivity.
+- `curl` and `uvx` transport require network access.
+- After launch, the checker itself remains local and read-only.


### PR DESCRIPTION
Reason:
The Workflow Incident Intake Checker is merged and tested, but a third party cannot yet discover and run it directly from the public entry surface.

Impact:
Adds an exact-commit-pinned first-use path, a verified distribution receipt, and a direct connection from one sanitized incident to the free fit-check boundary.

Rollback:
Revert this PR. The merged intake command and paid Audit remain unchanged.

Re-evaluation:
Review after the first external run, fit-check request, user confusion, or evidence that preparing the JSON creates excessive burden.

Validation:
- Clean temporary-directory curl + uvx flow: PASS / FIT_CHECK_READY / exit 0
- Exact source commit checkout: d3ba864c66367e5c676ec14fbaa550801e4f1889
- Full suite: 91/91 PASS
- Intake tests: 18/18 PASS
- Loop Record examples: 12/12 PASS
- Protected-blob guard and existing check/scan regression coverage: PASS
- Markdown links and heading hierarchy: PASS
- Exact four-file scope and diff check: PASS
