### PR TITLE
Add a bounded audit delivery validator

### DIFF
--- a/decision_os/audit_delivery.py
+++ b/decision_os/audit_delivery.py
@@ -1,0 +1,886 @@
+"""Deterministic structural checks for one local Audit delivery packet."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+import os
+from pathlib import Path
+import re
+import stat
+from typing import Any
+import unicodedata
+
+
+EXIT_READY = 0
+EXIT_INCOMPLETE = 4
+
+RESULT_SCHEMA_VERSION = "decision-os.audit-delivery-result.v0.1"
+SUPPORTED_PROFILE = "AI_APPLICATION_WORKFLOW"
+MAX_INPUT_BYTES = 512 * 1024
+
+RESULT_READY = "DELIVERY_READY"
+RESULT_INCOMPLETE = "INCOMPLETE"
+RESULT_INVALID = "INVALID"
+
+REQUIRED_SECTIONS = (
+    "Scope",
+    "Source Materials",
+    "Incident As-of State",
+    "Friction Map",
+    "Restartability Diagnosis",
+    "Priority Fix",
+    "Operational Asset",
+    "Before / After Restart Check",
+    "Unknowns",
+    "Exclusions",
+    "Claim Boundary",
+    "Completion Line",
+)
+
+SCOPE_FIELDS = (
+    "Audit Profile",
+    "Application or Workflow",
+    "Bounded Workflow Path",
+    "Audit As-of",
+)
+SOURCE_FIELDS = (
+    "Reviewed",
+    "Not Reviewed",
+    "Material Restrictions",
+)
+INCIDENT_FIELDS = (
+    "Trigger",
+    "Expected State",
+    "Observed State",
+    "Current Restart or Fallback Path",
+    "Current Owner",
+    "Next Safe Action",
+)
+DIAGNOSIS_DIMENSIONS = (
+    "Trigger Clarity",
+    "Accepted-State Clarity",
+    "Evidence Continuity",
+    "Completion Integrity",
+    "Restartability",
+    "Ownership / Next Actor",
+    "Human Recovery Burden",
+    "Safe Next Action",
+)
+DIAGNOSIS_FIELDS = (*DIAGNOSIS_DIMENSIONS, "Overall Diagnosis")
+PRIORITY_FIELDS = ("Selected Fix", "Why Priority")
+ASSET_FIELDS = ("Asset Type", "Asset Content")
+RESTART_CHECK_FIELDS = ("Before", "After", "Still UNKNOWN")
+CLAIM_BOUNDARIES = (
+    ("Vendor Bug Fix", "NOT CLAIMED"),
+    ("Future Prevention", "NOT CLAIMED"),
+    ("Lost-State Recovery", "NOT CLAIMED"),
+    ("Security or Safety", "NOT CLAIMED"),
+    ("Productivity / Labor / Cost / Revenue", "NOT CLAIMED"),
+    ("Unreviewed Systems", "NOT DIAGNOSED"),
+    ("Native Resume", "NOT PROOF OF TRUSTWORTHY RESTART"),
+)
+CLAIM_FIELDS = tuple(field for field, _ in CLAIM_BOUNDARIES)
+
+FRICTION_TABLE_FIELD = "Friction Map table"
+UNKNOWNS_CONTENT_FIELD = "Unknowns content"
+EXCLUSIONS_CONTENT_FIELD = "Exclusions content"
+COMPLETION_CONTENT_FIELD = "Completion Line content"
+
+FIELDS_BY_SECTION = {
+    "Scope": SCOPE_FIELDS,
+    "Source Materials": SOURCE_FIELDS,
+    "Incident As-of State": INCIDENT_FIELDS,
+    "Friction Map": (FRICTION_TABLE_FIELD,),
+    "Restartability Diagnosis": DIAGNOSIS_FIELDS,
+    "Priority Fix": PRIORITY_FIELDS,
+    "Operational Asset": ASSET_FIELDS,
+    "Before / After Restart Check": RESTART_CHECK_FIELDS,
+    "Unknowns": (UNKNOWNS_CONTENT_FIELD,),
+    "Exclusions": (EXCLUSIONS_CONTENT_FIELD,),
+    "Claim Boundary": CLAIM_FIELDS,
+    "Completion Line": (COMPLETION_CONTENT_FIELD,),
+}
+FIELD_ORDER = tuple(
+    field
+    for section in REQUIRED_SECTIONS
+    for field in FIELDS_BY_SECTION[section]
+)
+
+CLAIMS_NOT_MADE = (
+    "truth or completeness of source materials",
+    "factual correctness of the diagnosis",
+    "uniqueness of the selected Priority Fix",
+    "efficacy of the Operational Asset",
+    "absence of contradictory prose elsewhere in the document",
+    "software, workflow, security, or product correctness",
+    "prevention or recovery",
+    "productivity, labor, cost, or revenue improvement",
+    "client acceptance",
+    "paid-delivery value",
+    "testimonial or external delivery evidence",
+)
+
+NEXT_STEP_READY = (
+    "Submit the structurally closed delivery for bounded human review; do not "
+    "infer diagnosis truth, repair efficacy, or client acceptance."
+)
+NEXT_STEP_INCOMPLETE = (
+    "Add or correct only the listed delivery structure, then rerun "
+    "decision-os audit-check."
+)
+NEXT_STEP_INVALID = (
+    "Provide one local regular UTF-8 Markdown file using the supported Audit "
+    "profile, then rerun decision-os audit-check."
+)
+
+_HEADING_PATTERN = re.compile(
+    r"^[ ]{0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*$"
+)
+_OPEN_FENCE_PATTERN = re.compile(
+    r"^[ ]{0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$"
+)
+_BULLET_PATTERN = re.compile(r"^[ ]{0,3}[-*+][ \t]+(.+?)\s*$")
+_TABLE_DELIMITER_PATTERN = re.compile(r"^:?-{3,}:?$")
+_RATING_PATTERN = re.compile(
+    r"^(PASS|PARTIAL|FAIL|UNKNOWN)"
+    r"(?:[ \t]+(?:(?:—|–|-|:)[ \t]+)?|(?:—|–|-|:)[ \t]*)"
+    r"(\S.*)$"
+)
+_ANGLE_PLACEHOLDER_PATTERN = re.compile(r"^<[^<>]+>$", re.DOTALL)
+_PLACEHOLDER_WORDS = frozenset(
+    ("TBD", "TODO", "FIXME", "PLACEHOLDER")
+)
+_BOUNDED_EMPTY_DECLARATION = "none recorded within the accepted scope"
+
+_SECTION_MARKER_ORDER = (
+    "Title",
+    *REQUIRED_SECTIONS,
+    "Required heading order",
+    "Fenced code block",
+)
+_UNKNOWN_MARKER_ORDER = (
+    *DIAGNOSIS_DIMENSIONS,
+    "Unknowns section",
+    "cli_usage",
+    "internal_failure",
+)
+
+
+class _InputRejected(Exception):
+    """One local input did not satisfy the bounded read contract."""
+
+
+def _safe_basename(
+    path: Path | str | os.PathLike[str] | None,
+) -> str:
+    if path is None:
+        return "unavailable"
+    try:
+        name = os.path.basename(os.path.abspath(os.fspath(path)))
+    except (TypeError, ValueError, OSError):
+        return "unavailable"
+    if not name or name in (".", ".."):
+        return "unavailable"
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+        for character in name
+    ):
+        return "unavailable"
+    return name[:255]
+
+
+def _ordered(
+    values: Iterable[str],
+    order: Sequence[str],
+) -> list[str]:
+    selected = set(values)
+    return [item for item in order if item in selected]
+
+
+def result_payload(
+    *,
+    name: str,
+    profile: str,
+    result: str,
+    observed_sections: Iterable[str] = (),
+    missing_required_sections: Iterable[str] = (),
+    invalid_sections: Iterable[str] = (),
+    observed_fields: Iterable[str] = (),
+    missing_required_fields: Iterable[str] = (),
+    invalid_fields: Iterable[str] = (),
+    unknowns: Iterable[str] = (),
+    minimum_next_step: str,
+) -> dict[str, Any]:
+    """Build one stable result without including delivery content."""
+
+    safe_profile = (
+        SUPPORTED_PROFILE
+        if profile == SUPPORTED_PROFILE
+        else "UNKNOWN"
+    )
+    return {
+        "claims_not_made": list(CLAIMS_NOT_MADE),
+        "command": "audit-check",
+        "input": {
+            "content_echoed": False,
+            "name": _safe_basename(name),
+        },
+        "invalid_fields": _ordered(invalid_fields, FIELD_ORDER),
+        "invalid_sections": _ordered(
+            invalid_sections,
+            _SECTION_MARKER_ORDER,
+        ),
+        "minimum_next_step": minimum_next_step,
+        "missing_required_fields": _ordered(
+            missing_required_fields,
+            FIELD_ORDER,
+        ),
+        "missing_required_sections": _ordered(
+            missing_required_sections,
+            _SECTION_MARKER_ORDER,
+        ),
+        "observed_fields": _ordered(observed_fields, FIELD_ORDER),
+        "observed_sections": _ordered(
+            observed_sections,
+            REQUIRED_SECTIONS,
+        ),
+        "profile": safe_profile,
+        "result": result,
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "unknowns": _ordered(unknowns, _UNKNOWN_MARKER_ORDER),
+    }
+
+
+def invalid_payload(
+    path: Path | str | os.PathLike[str] | None,
+    *,
+    minimum_next_step: str = NEXT_STEP_INVALID,
+    unknowns: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Return the stable INVALID shape for bounded read rejection."""
+
+    return result_payload(
+        name=_safe_basename(path),
+        profile="UNKNOWN",
+        result=RESULT_INVALID,
+        minimum_next_step=minimum_next_step,
+        unknowns=unknowns,
+    )
+
+
+def _regular_file_snapshot(path: Path) -> tuple[Path, os.stat_result]:
+    try:
+        absolute = Path(os.path.abspath(os.fspath(path)))
+        metadata = os.lstat(absolute)
+    except (TypeError, ValueError, OSError) as exc:
+        raise _InputRejected from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise _InputRejected
+    if metadata.st_size > MAX_INPUT_BYTES:
+        raise _InputRejected
+    return absolute, metadata
+
+
+def _snapshot_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+
+
+def _read_local_regular_file(path: Path) -> bytes:
+    absolute, before = _regular_file_snapshot(path)
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+
+    try:
+        descriptor = os.open(absolute, flags)
+    except (OSError, ValueError) as exc:
+        raise _InputRejected from exc
+
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+        ):
+            raise _InputRejected
+        if opened.st_size > MAX_INPUT_BYTES:
+            raise _InputRejected
+
+        chunks: list[bytes] = []
+        total = 0
+        while total <= MAX_INPUT_BYTES:
+            chunk = os.read(
+                descriptor,
+                min(64 * 1024, MAX_INPUT_BYTES + 1 - total),
+            )
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        if total > MAX_INPUT_BYTES:
+            raise _InputRejected
+
+        after_open = os.fstat(descriptor)
+        after_path = os.lstat(absolute)
+        identity = _snapshot_identity(before)
+        if (
+            identity != _snapshot_identity(opened)
+            or identity != _snapshot_identity(after_open)
+            or identity != _snapshot_identity(after_path)
+        ):
+            raise _InputRejected
+        return b"".join(chunks)
+    except OSError as exc:
+        raise _InputRejected from exc
+    finally:
+        os.close(descriptor)
+
+
+def _decode_markdown(content: bytes) -> str:
+    try:
+        return content.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise _InputRejected from exc
+
+
+def _visible_lines(
+    lines: Sequence[str],
+) -> tuple[list[bool], list[bool], bool]:
+    visible: list[bool] = []
+    content_visible: list[bool] = []
+    fence_character: str | None = None
+    fence_length = 0
+
+    for line in lines:
+        if fence_character is None:
+            match = _OPEN_FENCE_PATTERN.match(line)
+            if match is None:
+                visible.append(True)
+                content_visible.append(True)
+                continue
+            fence = match.group("fence")
+            fence_character = fence[0]
+            fence_length = len(fence)
+            visible.append(False)
+            content_visible.append(False)
+            continue
+
+        visible.append(False)
+        closing = re.match(
+            rf"^[ ]{{0,3}}{re.escape(fence_character)}"
+            rf"{{{fence_length},}}[ \t]*$",
+            line,
+        )
+        if closing is not None:
+            content_visible.append(False)
+            fence_character = None
+            fence_length = 0
+        else:
+            content_visible.append(True)
+
+    return visible, content_visible, fence_character is not None
+
+
+def _heading(line: str) -> tuple[int, str] | None:
+    match = _HEADING_PATTERN.match(line)
+    if match is None:
+        return None
+    text = (match.group(2) or "").strip()
+    if text and set(text) == {"#"}:
+        text = ""
+    else:
+        text = re.sub(r"[ \t]+#+[ \t]*$", "", text).strip()
+    return len(match.group(1)), text
+
+
+def _headings(
+    lines: Sequence[str],
+    visible: Sequence[bool],
+) -> list[tuple[int, int, str]]:
+    output: list[tuple[int, int, str]] = []
+    for index, line in enumerate(lines):
+        if not visible[index]:
+            continue
+        heading = _heading(line)
+        if heading is not None:
+            level, text = heading
+            output.append((index, level, text))
+    return output
+
+
+def _section_range(
+    name: str,
+    headings: Sequence[tuple[int, int, str]],
+    line_count: int,
+) -> tuple[int, int] | None:
+    matches = [
+        item
+        for item in headings
+        if item[1] == 2 and item[2] == name
+    ]
+    if len(matches) != 1:
+        return None
+    start = matches[0][0] + 1
+    end = line_count
+    for index, level, _ in headings:
+        if index >= start and level <= 2:
+            end = index
+            break
+    return start, end
+
+
+def _field_pattern(labels: Sequence[str]) -> re.Pattern[str]:
+    alternatives = "|".join(
+        re.escape(label)
+        for label in sorted(labels, key=len, reverse=True)
+    )
+    return re.compile(
+        rf"^[ ]{{0,3}}(?P<label>{alternatives}):"
+        r"[ \t]*(?P<value>.*)$"
+    )
+
+
+def _field_values(
+    lines: Sequence[str],
+    visible: Sequence[bool],
+    content_visible: Sequence[bool],
+    start: int,
+    end: int,
+    labels: Sequence[str],
+) -> dict[str, list[str]]:
+    values = {label: [] for label in labels}
+    pattern = _field_pattern(labels)
+    active_label: str | None = None
+    active_lines: list[str] = []
+
+    def finish() -> None:
+        nonlocal active_label, active_lines
+        if active_label is not None:
+            values[active_label].append(_normalized_value(active_lines))
+        active_label = None
+        active_lines = []
+
+    for index in range(start, end):
+        match = pattern.match(lines[index]) if visible[index] else None
+        if match is not None:
+            finish()
+            active_label = match.group("label")
+            active_lines = [match.group("value")]
+            if active_label != "Asset Content":
+                finish()
+        elif (
+            active_label == "Asset Content"
+            and content_visible[index]
+        ):
+            active_lines.append(lines[index])
+    finish()
+    return values
+
+
+def _normalized_value(lines: Sequence[str]) -> str:
+    meaningful = [line.strip() for line in lines if line.strip()]
+    return "\n".join(meaningful).strip()
+
+
+def _is_placeholder(value: str) -> bool:
+    normalized = value.strip()
+    if not normalized:
+        return True
+    normalized = re.sub(
+        r"^(?:(?:#{1,6}|[-*+])[ \t]+)+",
+        "",
+        normalized,
+        count=1,
+    ).strip()
+    if normalized.upper() in _PLACEHOLDER_WORDS:
+        return True
+    return bool(_ANGLE_PLACEHOLDER_PATTERN.fullmatch(normalized))
+
+
+def _starts_with_unknown(value: str) -> bool:
+    return re.match(r"^UNKNOWN\b", value.strip(), re.IGNORECASE) is not None
+
+
+def _inspect_plain_fields(
+    values: dict[str, list[str]],
+    *,
+    disallow_unknown: Iterable[str] = (),
+) -> tuple[list[str], list[str], list[str]]:
+    unknown_forbidden = set(disallow_unknown)
+    observed: list[str] = []
+    missing: list[str] = []
+    invalid: list[str] = []
+    for label, occurrences in values.items():
+        if not occurrences:
+            missing.append(label)
+        elif (
+            len(occurrences) != 1
+            or _is_placeholder(occurrences[0])
+            or (
+                label in unknown_forbidden
+                and _starts_with_unknown(occurrences[0])
+            )
+        ):
+            invalid.append(label)
+        else:
+            observed.append(label)
+    return observed, missing, invalid
+
+
+def _inspect_diagnosis_fields(
+    values: dict[str, list[str]],
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    observed: list[str] = []
+    missing: list[str] = []
+    invalid: list[str] = []
+    unknowns: list[str] = []
+    for label in DIAGNOSIS_FIELDS:
+        occurrences = values[label]
+        if not occurrences:
+            missing.append(label)
+            continue
+        if len(occurrences) != 1 or _is_placeholder(occurrences[0]):
+            invalid.append(label)
+            continue
+        value = occurrences[0]
+        if label not in DIAGNOSIS_DIMENSIONS:
+            observed.append(label)
+            continue
+        match = _RATING_PATTERN.match(value)
+        if match is None or _is_placeholder(match.group(2)):
+            invalid.append(label)
+            continue
+        observed.append(label)
+        if match.group(1) == "UNKNOWN":
+            unknowns.append(label)
+    return observed, missing, invalid, unknowns
+
+
+def _table_cells(line: str) -> list[str]:
+    indentation = len(line) - len(line.lstrip(" "))
+    if indentation > 3 or line.startswith("\t"):
+        return []
+    stripped = line.strip()
+    if not stripped or "|" not in stripped:
+        return []
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _valid_friction_table(
+    lines: Sequence[str],
+    visible: Sequence[bool],
+    start: int,
+    end: int,
+) -> tuple[bool, bool]:
+    expected = (
+        "point",
+        "expected carrier",
+        "observed gap",
+        "returned human work",
+    )
+    table_seen = False
+    for index in range(start, end):
+        if not visible[index]:
+            continue
+        header = _table_cells(lines[index])
+        if not header:
+            continue
+        table_seen = True
+        if tuple(cell.casefold() for cell in header) != expected:
+            continue
+        delimiter_index = index + 1
+        if (
+            delimiter_index >= end
+            or not visible[delimiter_index]
+        ):
+            return True, False
+        delimiter = _table_cells(lines[delimiter_index])
+        if (
+            len(delimiter) != len(expected)
+            or any(
+                _TABLE_DELIMITER_PATTERN.fullmatch(cell) is None
+                for cell in delimiter
+            )
+        ):
+            return True, False
+
+        row_index = delimiter_index + 1
+        while row_index < end:
+            if not visible[row_index]:
+                break
+            if not lines[row_index].strip():
+                break
+            row = _table_cells(lines[row_index])
+            if not row:
+                break
+            if (
+                len(row) == len(expected)
+                and all(not _is_placeholder(cell) for cell in row)
+            ):
+                return True, True
+            row_index += 1
+        return True, False
+    return table_seen, False
+
+
+def _bullet_values(
+    lines: Sequence[str],
+    visible: Sequence[bool],
+    start: int,
+    end: int,
+) -> list[str]:
+    values: list[str] = []
+    for index in range(start, end):
+        if not visible[index]:
+            continue
+        match = _BULLET_PATTERN.match(lines[index])
+        if match is not None:
+            values.append(match.group(1).strip())
+    return values
+
+
+def _section_content(
+    lines: Sequence[str],
+    visible: Sequence[bool],
+    start: int,
+    end: int,
+) -> str:
+    content = [
+        lines[index]
+        for index in range(start, end)
+        if visible[index] and _heading(lines[index]) is None
+    ]
+    return _normalized_value(content)
+
+
+def _inspect_markdown(
+    text: str,
+) -> tuple[dict[str, Any], int]:
+    lines = text.splitlines()
+    visible, content_visible, unclosed_fence = _visible_lines(lines)
+    headings = _headings(lines, visible)
+
+    observed_sections: list[str] = []
+    missing_sections: list[str] = []
+    invalid_sections: list[str] = []
+    observed_fields: list[str] = []
+    missing_fields: list[str] = []
+    invalid_fields: list[str] = []
+    unknowns: list[str] = []
+    profile = "UNKNOWN"
+    structurally_invalid = unclosed_fence
+
+    all_level_one = [item for item in headings if item[1] == 1]
+    titles = [
+        item
+        for item in all_level_one
+        if bool(item[2]) and not _is_placeholder(item[2])
+    ]
+    if not titles:
+        missing_sections.append("Title")
+    if len(all_level_one) > 1:
+        invalid_sections.append("Title")
+        structurally_invalid = True
+
+    positions: list[int] = []
+    for section in REQUIRED_SECTIONS:
+        matches = [
+            item
+            for item in headings
+            if item[1] == 2 and item[2] == section
+        ]
+        if not matches:
+            missing_sections.append(section)
+            missing_fields.extend(FIELDS_BY_SECTION[section])
+        elif len(matches) > 1:
+            invalid_sections.append(section)
+            structurally_invalid = True
+        else:
+            observed_sections.append(section)
+            positions.append(matches[0][0])
+
+    if positions != sorted(positions):
+        invalid_sections.append("Required heading order")
+        structurally_invalid = True
+    if titles and positions and titles[0][0] > min(positions):
+        invalid_sections.append("Required heading order")
+        structurally_invalid = True
+    if unclosed_fence:
+        invalid_sections.append("Fenced code block")
+
+    for section in REQUIRED_SECTIONS:
+        bounds = _section_range(section, headings, len(lines))
+        if bounds is None:
+            continue
+        start, end = bounds
+
+        if section == "Friction Map":
+            table_seen, table_valid = _valid_friction_table(
+                lines,
+                visible,
+                start,
+                end,
+            )
+            if table_valid:
+                observed_fields.append(FRICTION_TABLE_FIELD)
+            elif table_seen:
+                invalid_fields.append(FRICTION_TABLE_FIELD)
+            else:
+                missing_fields.append(FRICTION_TABLE_FIELD)
+            continue
+
+        if section in ("Unknowns", "Exclusions"):
+            marker = (
+                UNKNOWNS_CONTENT_FIELD
+                if section == "Unknowns"
+                else EXCLUSIONS_CONTENT_FIELD
+            )
+            bullets = _bullet_values(lines, visible, start, end)
+            valid_bullets = [
+                value for value in bullets if not _is_placeholder(value)
+            ]
+            if valid_bullets:
+                observed_fields.append(marker)
+                if (
+                    section == "Unknowns"
+                    and any(
+                        value.casefold()
+                        != _BOUNDED_EMPTY_DECLARATION
+                        for value in valid_bullets
+                    )
+                ):
+                    unknowns.append("Unknowns section")
+            else:
+                invalid_fields.append(marker)
+            continue
+
+        if section == "Completion Line":
+            content = _section_content(lines, visible, start, end)
+            if (
+                _is_placeholder(content)
+                or _starts_with_unknown(content)
+            ):
+                invalid_fields.append(COMPLETION_CONTENT_FIELD)
+            else:
+                observed_fields.append(COMPLETION_CONTENT_FIELD)
+            continue
+
+        labels = FIELDS_BY_SECTION[section]
+        values = _field_values(
+            lines,
+            visible,
+            content_visible,
+            start,
+            end,
+            labels,
+        )
+        if section == "Restartability Diagnosis":
+            found, missing, invalid, declared_unknowns = (
+                _inspect_diagnosis_fields(values)
+            )
+            unknowns.extend(declared_unknowns)
+        elif section == "Claim Boundary":
+            found = []
+            missing = []
+            invalid = []
+            expected_values = dict(CLAIM_BOUNDARIES)
+            for label in labels:
+                occurrences = values[label]
+                if not occurrences:
+                    missing.append(label)
+                elif (
+                    len(occurrences) != 1
+                    or occurrences[0] != expected_values[label]
+                ):
+                    invalid.append(label)
+                else:
+                    found.append(label)
+        else:
+            disallow_unknown: Iterable[str] = ()
+            if section == "Priority Fix":
+                disallow_unknown = PRIORITY_FIELDS
+            elif section == "Operational Asset":
+                disallow_unknown = ASSET_FIELDS
+            found, missing, invalid = _inspect_plain_fields(
+                values,
+                disallow_unknown=disallow_unknown,
+            )
+
+        observed_fields.extend(found)
+        missing_fields.extend(missing)
+        invalid_fields.extend(invalid)
+
+        if section == "Scope":
+            occurrences = values["Audit Profile"]
+            if (
+                len(occurrences) == 1
+                and occurrences[0] == SUPPORTED_PROFILE
+            ):
+                profile = SUPPORTED_PROFILE
+            elif (
+                len(occurrences) == 1
+                and not _is_placeholder(occurrences[0])
+            ):
+                structurally_invalid = True
+                if "Audit Profile" in observed_fields:
+                    observed_fields.remove("Audit Profile")
+                invalid_fields.append("Audit Profile")
+
+    if structurally_invalid:
+        result = RESULT_INVALID
+        exit_code = EXIT_INCOMPLETE
+        next_step = NEXT_STEP_INVALID
+    elif missing_sections or missing_fields or invalid_fields:
+        result = RESULT_INCOMPLETE
+        exit_code = EXIT_INCOMPLETE
+        next_step = NEXT_STEP_INCOMPLETE
+    else:
+        result = RESULT_READY
+        exit_code = EXIT_READY
+        next_step = NEXT_STEP_READY
+
+    payload = result_payload(
+        name="unavailable",
+        profile=profile,
+        result=result,
+        observed_sections=observed_sections,
+        missing_required_sections=missing_sections,
+        invalid_sections=invalid_sections,
+        observed_fields=observed_fields,
+        missing_required_fields=missing_fields,
+        invalid_fields=invalid_fields,
+        unknowns=unknowns,
+        minimum_next_step=next_step,
+    )
+    return payload, exit_code
+
+
+def validate_audit_delivery_file(
+    path: Path,
+) -> tuple[dict[str, Any], int]:
+    """Check one local delivery without writing, diagnosing, or echoing it."""
+
+    safe_name = _safe_basename(path)
+    try:
+        text = _decode_markdown(_read_local_regular_file(path))
+    except _InputRejected:
+        return invalid_payload(path), EXIT_INCOMPLETE
+
+    payload, exit_code = _inspect_markdown(text)
+    payload["input"]["name"] = safe_name
+    return payload, exit_code

--- a/decision_os/audit_delivery_text.py
+++ b/decision_os/audit_delivery_text.py
@@ -1,0 +1,123 @@
+"""Deterministic text rendering for an Audit delivery result payload."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .audit_delivery import (
+    FIELD_ORDER,
+    NEXT_STEP_INCOMPLETE,
+    NEXT_STEP_INVALID,
+    REQUIRED_SECTIONS,
+    SUPPORTED_PROFILE,
+)
+
+
+RESULT_LABELS = {
+    "DELIVERY_READY": "DELIVERY READY",
+    "INCOMPLETE": "INCOMPLETE",
+    "INVALID": "INVALID",
+}
+AUDIT_CHECK_USAGE = (
+    "decision-os audit-check <audit.md> | "
+    "decision-os audit-check --format json|text <audit.md>"
+)
+INTERNAL_FAILURE_NEXT_STEP = (
+    "Retry the same local delivery once; if the internal failure repeats, "
+    "stop and report the command boundary."
+)
+SECTION_MARKERS = (
+    "Title",
+    *REQUIRED_SECTIONS,
+    "Required heading order",
+    "Fenced code block",
+)
+
+
+def _ordered_list(value: Any, order: Sequence[str]) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return []
+    selected = {
+        item for item in value if isinstance(item, str) and item in order
+    }
+    return [item for item in order if item in selected]
+
+
+def _section(title: str, values: Sequence[str]) -> list[str]:
+    lines = [f"{title}:"]
+    lines.extend(
+        (f"- {value}" for value in values)
+        if values
+        else ("- none",)
+    )
+    return lines
+
+
+def render_text(payload: Mapping[str, Any]) -> str:
+    """Render one already-computed payload without reopening the input."""
+
+    result = payload.get("result")
+    label = RESULT_LABELS.get(result, "INVALID")
+    profile = (
+        SUPPORTED_PROFILE
+        if payload.get("profile") == SUPPORTED_PROFILE
+        else "UNKNOWN"
+    )
+    observed_sections = _ordered_list(
+        payload.get("observed_sections"),
+        REQUIRED_SECTIONS,
+    )
+    missing = [
+        *_ordered_list(
+            payload.get("missing_required_sections"),
+            SECTION_MARKERS,
+        ),
+        *_ordered_list(
+            payload.get("missing_required_fields"),
+            FIELD_ORDER,
+        ),
+    ]
+    invalid = [
+        *_ordered_list(
+            payload.get("invalid_sections"),
+            SECTION_MARKERS,
+        ),
+        *_ordered_list(payload.get("invalid_fields"), FIELD_ORDER),
+    ]
+
+    lines = [
+        f"Decision-OS Audit Delivery v0.1: {label}",
+        "",
+        *_section("Profile", (profile,)),
+        "",
+        *_section("Observed sections", observed_sections),
+        "",
+        *_section("Missing", missing),
+        "",
+        *_section("Invalid", invalid),
+    ]
+
+    if result != "DELIVERY_READY":
+        next_step = payload.get("minimum_next_step")
+        if next_step in (
+            NEXT_STEP_INCOMPLETE,
+            NEXT_STEP_INVALID,
+            AUDIT_CHECK_USAGE,
+            INTERNAL_FAILURE_NEXT_STEP,
+        ):
+            lines.extend(("", "Minimum next step:", next_step))
+
+    lines.extend(
+        (
+            "",
+            "This result confirms delivery structure only.",
+            (
+                "It does not validate diagnosis truth, repair efficacy, "
+                "or client acceptance."
+            ),
+        )
+    )
+    return "\n".join(lines) + "\n"

--- a/decision_os/cli.py
+++ b/decision_os/cli.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import sys
 from typing import Any, Sequence, TextIO
 
+from .audit_delivery import invalid_payload as audit_invalid_payload
+from .audit_delivery import validate_audit_delivery_file
+from .audit_delivery_text import render_text as render_audit_text
 from .checks import evidence, inspect_repository, unknown_payload
 from .intake import invalid_payload as intake_invalid_payload
 from .intake import validate_intake_file
@@ -26,6 +29,10 @@ SCAN_USAGE = (
 INTAKE_USAGE = (
     "decision-os intake <packet.json> | "
     "decision-os intake --format json|text <packet.json>"
+)
+AUDIT_CHECK_USAGE = (
+    "decision-os audit-check <audit.md> | "
+    "decision-os audit-check --format json|text <audit.md>"
 )
 
 
@@ -199,6 +206,75 @@ def _run_intake(arguments: Sequence[str], output: TextIO) -> int:
     return exit_code
 
 
+def _audit_check_format(arguments: Sequence[str]) -> str:
+    if (
+        len(arguments) >= 3
+        and arguments[0] == "audit-check"
+        and arguments[1] == "--format"
+        and arguments[2] == "text"
+    ):
+        return "text"
+    return "json"
+
+
+def _write_audit_check(
+    payload: dict[str, Any],
+    output_format: str,
+    stream: TextIO,
+) -> None:
+    if output_format == "text":
+        stream.write(render_audit_text(payload))
+        return
+    _write(payload, stream)
+
+
+def _run_audit_check(arguments: Sequence[str], output: TextIO) -> int:
+    output_format = _audit_check_format(arguments)
+    delivery: str | None = None
+    if (
+        len(arguments) == 2
+        and arguments[0] == "audit-check"
+        and arguments[1]
+        and not arguments[1].startswith("-")
+    ):
+        delivery = arguments[1]
+        output_format = "json"
+    elif (
+        len(arguments) == 4
+        and arguments[0] == "audit-check"
+        and arguments[1] == "--format"
+        and arguments[2] in ("json", "text")
+        and arguments[3]
+    ):
+        output_format = arguments[2]
+        delivery = arguments[3]
+
+    if delivery is None:
+        payload = audit_invalid_payload(
+            None,
+            minimum_next_step=AUDIT_CHECK_USAGE,
+            unknowns=("cli_usage",),
+        )
+        _write_audit_check(payload, output_format, output)
+        return EXIT_USAGE
+
+    try:
+        payload, exit_code = validate_audit_delivery_file(Path(delivery))
+    except Exception:
+        payload = audit_invalid_payload(
+            Path(delivery),
+            minimum_next_step=(
+                "Retry the same local delivery once; if the internal failure "
+                "repeats, stop and report the command boundary."
+            ),
+            unknowns=("internal_failure",),
+        )
+        exit_code = EXIT_INTERNAL
+
+    _write_audit_check(payload, output_format, output)
+    return exit_code
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -214,6 +290,9 @@ def main(
 
     if arguments and arguments[0] == "intake":
         return _run_intake(arguments, output)
+
+    if arguments and arguments[0] == "audit-check":
+        return _run_audit_check(arguments, output)
 
     if (
         len(arguments) != 2

--- a/docs/audit_delivery_validator_v0_1.md
+++ b/docs/audit_delivery_validator_v0_1.md
@@ -1,0 +1,189 @@
+# Audit Delivery Validator v0.1
+
+The Audit Delivery Validator checks whether one local Markdown delivery packet
+contains the required structure for the AI Application Workflow Audit. It is
+deterministic, dependency-free, read-only, and limited to structural closure.
+
+It does not establish that a diagnosis is true, a selected fix is unique, an
+operational asset will work, or a client should accept the delivery.
+
+## Commands
+
+JSON is the default output:
+
+```bash
+decision-os audit-check audit.md
+decision-os audit-check --format json audit.md
+```
+
+Use the deterministic text view when a human-readable receipt is preferred:
+
+```bash
+decision-os audit-check --format text audit.md
+```
+
+The executable synthetic example is
+[`examples/ai_application_workflow_audit_delivery_v0_1.md`](../examples/ai_application_workflow_audit_delivery_v0_1.md).
+
+## Supported profile
+
+v0.1 supports only:
+
+```text
+AI_APPLICATION_WORKFLOW
+```
+
+The required Scope declaration is:
+
+```text
+Audit Profile: AI_APPLICATION_WORKFLOW
+```
+
+The coding-repository Audit profile is not supported in v0.1.
+
+## Result and exit contract
+
+| Result | Exit | Meaning |
+| --- | ---: | --- |
+| `DELIVERY_READY` | `0` | All required structural surfaces are present. |
+| `INCOMPLETE` | `4` | Readable Markdown is missing or malformed required structure. |
+| `INVALID` | `4` | The local input or accepted Markdown contract is invalid. |
+| CLI usage error | `2` | The command shape is unsupported. |
+| Unexpected internal failure | `6` | The bounded validator failed unexpectedly. |
+
+`DELIVERY_READY` means structural closure only. It is not proof of diagnosis
+truth, repair efficacy, operational value, or client acceptance.
+
+## Local read boundary
+
+The command:
+
+- reads one local regular file only;
+- rejects symlinks, directories, and other non-regular inputs;
+- rejects invalid UTF-8 and files larger than 512 KiB;
+- performs no network access, telemetry, or writes;
+- reports only a safe basename and predefined structural markers;
+- does not echo delivery content;
+- ignores headings, field-like text, and tables inside fenced blocks;
+- rejects an unclosed fenced block.
+
+## Required heading order
+
+One non-empty level-one title is required. The following level-two headings must
+each appear exactly once, outside fenced blocks, in this relative order:
+
+1. `Scope`
+2. `Source Materials`
+3. `Incident As-of State`
+4. `Friction Map`
+5. `Restartability Diagnosis`
+6. `Priority Fix`
+7. `Operational Asset`
+8. `Before / After Restart Check`
+9. `Unknowns`
+10. `Exclusions`
+11. `Claim Boundary`
+12. `Completion Line`
+
+Additional headings may exist, but they cannot replace or reorder the required
+headings.
+
+## Required fields
+
+`Scope` binds the supported profile, application or workflow, bounded path, and
+Audit as-of state. `Source Materials` states what was and was not reviewed and
+the material restrictions. `Incident As-of State` records the trigger,
+expected and observed states, restart or fallback path, current owner, and next
+safe action.
+
+The eight diagnosis dimensions must begin with exactly one of `PASS`,
+`PARTIAL`, `FAIL`, or `UNKNOWN`, followed by a short rationale. `Overall
+Diagnosis` is also required. `UNKNOWN` is an explicit judgment, not a
+placeholder.
+
+`Priority Fix` requires `Selected Fix` and `Why Priority`. `Operational Asset`
+requires `Asset Type` and `Asset Content`; the content may continue across
+multiple lines or contain a closed fenced block. The Before / After section
+requires `Before`, `After`, and `Still UNKNOWN`.
+
+## Friction Map contract
+
+The Friction Map requires this four-column Markdown table:
+
+```markdown
+| Point | Expected Carrier | Observed Gap | Returned Human Work |
+| --- | --- | --- | --- |
+| one bounded point | expected evidence | observed gap | returned work |
+```
+
+Column comparison is case-insensitive. At least one non-placeholder data row is
+required. `UNKNOWN` is allowed inside a row.
+
+## Unknowns, exclusions, and placeholders
+
+`Unknowns` and `Exclusions` each require at least one non-placeholder bullet.
+When the accepted scope records none, use:
+
+```markdown
+- none recorded within the accepted scope
+```
+
+An empty value, an angle-bracket placeholder, `TBD`, `TODO`, `FIXME`, or
+`PLACEHOLDER` makes a required surface incomplete. `UNKNOWN` remains valid
+except where a known Priority Fix, Operational Asset, or Completion Line is
+required.
+
+## Exact claim declarations
+
+The Claim Boundary section requires:
+
+```text
+Vendor Bug Fix: NOT CLAIMED
+Future Prevention: NOT CLAIMED
+Lost-State Recovery: NOT CLAIMED
+Security or Safety: NOT CLAIMED
+Productivity / Labor / Cost / Revenue: NOT CLAIMED
+Unreviewed Systems: NOT DIAGNOSED
+Native Resume: NOT PROOF OF TRUSTWORTHY RESTART
+```
+
+The validator checks those declarations but does not search the rest of the
+document for contradictory prose.
+
+## Output boundary
+
+The result uses
+`decision-os.audit-delivery-result.v0.1` and exposes only section names, field
+names, bounded unknown markers, fixed claim limitations, a safe input basename,
+and a bounded next step. `input.content_echoed` is always `false`.
+
+The result explicitly does not establish:
+
+- truth or completeness of source materials;
+- factual correctness of the diagnosis;
+- uniqueness of the selected Priority Fix;
+- efficacy of the Operational Asset;
+- absence of contradictory prose elsewhere in the document;
+- software, workflow, security, or product correctness;
+- prevention or recovery;
+- productivity, labor, cost, or revenue improvement;
+- client acceptance;
+- paid-delivery value;
+- testimonial or external delivery evidence.
+
+## Service relationship
+
+The validator is an optional pre-delivery check for the existing
+[AI Application Workflow Audit delivery surface](../services/ai_application_workflow_audit_delivery_v0_1.md).
+It does not add a product family, diagnose a workflow, perform a repair, or
+accept a delivery on the client's behalf.
+
+## Rollback and re-evaluation
+
+Rollback is to remove the validator modules, tests, example, and documentation,
+remove the `audit-check` dispatch, and restore the prior service template.
+Existing `check`, `scan`, and `intake` behavior remains independent.
+
+Re-evaluate after the first real paid delivery, external validator use, a
+false-ready or false-incomplete result, or evidence that the canonical Markdown
+format creates excessive delivery burden.

--- a/examples/ai_application_workflow_audit_delivery_v0_1.md
+++ b/examples/ai_application_workflow_audit_delivery_v0_1.md
@@ -1,0 +1,96 @@
+# AI Application Workflow Audit — Executable Synthetic Example
+
+This invented, non-private packet is an executable example for the Audit
+Delivery Validator. It is not a testimonial, paid-client result, or measured
+outcome.
+
+## Scope
+
+Audit Profile: AI_APPLICATION_WORKFLOW
+Application or Workflow: Synthetic editorial approval assistant
+Bounded Workflow Path: Draft generation to human approval to publication handoff
+Audit As-of: 2026-07-26
+
+## Source Materials
+
+Reviewed: Synthetic approval event sequence and sanitized handoff summary
+Not Reviewed: Live application logs, vendor internals, and production data
+Material Restrictions: No credentials, customer data, or private code
+
+## Incident As-of State
+
+Trigger: Resume the publication handoff after an interrupted approval session
+Expected State: The resumed operator can bind the accepted draft to its approval
+Observed State: The draft exists, but its approval binding is not established
+Current Restart or Fallback Path: Stop publication and revalidate the draft
+Current Owner: Human publication operator
+Next Safe Action: Record the accepted draft identity before another handoff
+
+## Friction Map
+
+| Point | Expected Carrier | Observed Gap | Returned Human Work |
+| --- | --- | --- | --- |
+| Approval handoff | Draft identity and accepted state | Approval binding absent | Revalidation and repeated handoff decision |
+
+## Restartability Diagnosis
+
+Trigger Clarity: PASS — The interruption and attempted handoff are identified.
+Accepted-State Clarity: PARTIAL — A draft exists, but its accepted identity is not bound.
+Evidence Continuity: FAIL — The next operator lacks a durable approval record.
+Completion Integrity: FAIL — Draft existence does not establish accepted completion.
+Restartability: PARTIAL — A manual stop-and-revalidate fallback remains available.
+Ownership / Next Actor: PASS — The publication operator owns the next safe action.
+Human Recovery Burden: PARTIAL — Revalidation and a repeated handoff decision are recorded.
+Safe Next Action: PASS — Publication remains stopped until identity is re-established.
+Overall Diagnosis: The workflow has a bounded fallback but lacks a durable approval-to-draft handoff.
+
+## Priority Fix
+
+Selected Fix: Add a fallback approval restart record before publication handoff.
+Why Priority: It binds the accepted draft, current owner, evidence, and next safe action without changing the application.
+
+## Operational Asset
+
+Asset Type: Fallback approval restart record
+Asset Content: Copy and complete this record before resuming the bounded handoff.
+
+```text
+Fallback Approval Restart Record
+Run ID:
+Accepted Draft ID:
+Accepted State:
+Evidence Location:
+Current Owner:
+Next Safe Action:
+Still UNKNOWN:
+```
+
+## Before / After Restart Check
+
+Before: The next operator cannot bind the approval decision to one draft.
+After: The restart record requires that binding and its owner to be explicit.
+Still UNKNOWN: Whether the native session can be resumed or the vendor state recovered.
+
+## Unknowns
+
+- Native session recoverability and vendor-internal state remain unknown.
+
+## Exclusions
+
+- Vendor repair, live recovery, security review, and production implementation are outside scope.
+
+## Claim Boundary
+
+Vendor Bug Fix: NOT CLAIMED
+Future Prevention: NOT CLAIMED
+Lost-State Recovery: NOT CLAIMED
+Security or Safety: NOT CLAIMED
+Productivity / Labor / Cost / Revenue: NOT CLAIMED
+Unreviewed Systems: NOT DIAGNOSED
+Native Resume: NOT PROOF OF TRUSTWORTHY RESTART
+
+## Completion Line
+
+The bounded synthetic incident, diagnosis, priority fix, operational asset,
+restart distinction, unknowns, exclusions, and claim boundaries are present for
+structural validation.

--- a/services/ai_application_workflow_audit_delivery_v0_1.md
+++ b/services/ai_application_workflow_audit_delivery_v0_1.md
@@ -118,77 +118,90 @@ Copy and complete this Markdown template for one accepted incident:
 
 ## Scope
 
-Application or workflow:
-Bounded workflow path:
-Audit as-of date:
+Audit Profile: AI_APPLICATION_WORKFLOW
+Application or Workflow: <fill this>
+Bounded Workflow Path: <fill this>
+Audit As-of: <fill this>
 
-## Source materials
+## Source Materials
 
-- Reviewed:
-- Not reviewed:
-- Material restrictions:
+Reviewed: <fill this>
+Not Reviewed: <fill this>
+Material Restrictions: <fill this>
 
-## Incident as-of state
+## Incident As-of State
 
-Trigger:
-Expected state:
-Observed state:
-Current restart or fallback path:
-
-## Observed failure
-
-<What failed, stopped, drifted, or returned an untrustworthy completion state?>
-
-## Returned human burden
-
-<What rollback, cleanup, revalidation, reconstruction, or restart decision
-returned to the human? Keep quantities UNKNOWN unless recorded.>
+Trigger: <fill this>
+Expected State: <fill this>
+Observed State: <fill this>
+Current Restart or Fallback Path: <fill this>
+Current Owner: <fill this>
+Next Safe Action: <fill this>
 
 ## Friction Map
 
-| Point | Expected carrier | Observed gap | Returned human work |
-|---|---|---|---|
-| <point> | <expected evidence or state> | <gap> | <burden> |
+| Point | Expected Carrier | Observed Gap | Returned Human Work |
+| --- | --- | --- | --- |
+| <point> | <carrier> | <gap> | <work> |
 
-## Diagnosis
+## Restartability Diagnosis
 
-Trigger clarity:
-Accepted-state clarity:
-Evidence continuity:
-Completion integrity:
-Restartability:
-Ownership / next actor:
-Human recovery burden:
-Safe next action:
+Trigger Clarity: UNKNOWN — <rationale>
+Accepted-State Clarity: UNKNOWN — <rationale>
+Evidence Continuity: UNKNOWN — <rationale>
+Completion Integrity: UNKNOWN — <rationale>
+Restartability: UNKNOWN — <rationale>
+Ownership / Next Actor: UNKNOWN — <rationale>
+Human Recovery Burden: UNKNOWN — <rationale>
+Safe Next Action: UNKNOWN — <rationale>
+Overall Diagnosis: <fill this>
 
 ## Priority Fix
 
-<One bounded repair and why it has priority.>
+Selected Fix: <fill this>
+Why Priority: <fill this>
 
 ## Operational Asset
 
-<One copy-paste or directly usable asset.>
+Asset Type: <fill this>
+Asset Content: <fill this; may continue over following lines>
 
 ## Before / After Restart Check
 
-Before:
-After:
-Still UNKNOWN:
+Before: <fill this>
+After: <fill this>
+Still UNKNOWN: <fill this>
 
 ## Unknowns
 
-- <Unverified state or assumption>
+- <fill this>
 
 ## Exclusions
 
-- <System, claim, material, or action outside the accepted scope>
+- <fill this>
+
+## Claim Boundary
+
+Vendor Bug Fix: NOT CLAIMED
+Future Prevention: NOT CLAIMED
+Lost-State Recovery: NOT CLAIMED
+Security or Safety: NOT CLAIMED
+Productivity / Labor / Cost / Revenue: NOT CLAIMED
+Unreviewed Systems: NOT DIAGNOSED
+Native Resume: NOT PROOF OF TRUSTWORTHY RESTART
 
 ## Completion Line
 
-<One bounded incident diagnosed; one priority repair selected; one operational
-asset returned; before/after restart distinction visible; unknowns and
-exclusions explicit.>
+<fill this>
 ```
+
+## Validate a completed delivery
+
+The local
+[Audit Delivery Validator](../docs/audit_delivery_validator_v0_1.md) is optional
+but recommended before paid delivery. `DELIVERY_READY` means structural closure
+only. It is not proof of diagnosis truth, Operational Asset efficacy, or client
+acceptance.
 
 ## Fit-check boundary
 

--- a/tests/test_decision_os_audit_delivery.py
+++ b/tests/test_decision_os_audit_delivery.py
@@ -1,0 +1,733 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.audit_delivery import (
+    CLAIMS_NOT_MADE,
+    EXIT_INCOMPLETE,
+    EXIT_READY,
+    FIELD_ORDER,
+    MAX_INPUT_BYTES,
+    REQUIRED_SECTIONS,
+    RESULT_INCOMPLETE,
+    RESULT_INVALID,
+    RESULT_READY,
+    RESULT_SCHEMA_VERSION,
+    SUPPORTED_PROFILE,
+    validate_audit_delivery_file,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIPPED_EXAMPLE = (
+    REPO_ROOT
+    / "examples"
+    / "ai_application_workflow_audit_delivery_v0_1.md"
+)
+
+
+def ready_document() -> str:
+    return SHIPPED_EXAMPLE.read_text(encoding="utf-8")
+
+
+def write_document(directory: Path, content: str) -> Path:
+    path = directory / "audit.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def validate_text(content: str) -> tuple[dict[str, object], int]:
+    with tempfile.TemporaryDirectory() as directory:
+        return validate_audit_delivery_file(
+            write_document(Path(directory), content)
+        )
+
+
+class AuditDeliveryValidationTest(unittest.TestCase):
+    def test_ready_example_is_deterministic_read_only_and_does_not_echo(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            content = ready_document().replace(
+                "Synthetic editorial approval assistant",
+                "SECRET APPLICATION VALUE",
+            )
+            path = write_document(root, content)
+            before = path.read_bytes()
+
+            first, first_exit = validate_audit_delivery_file(path)
+            second, second_exit = validate_audit_delivery_file(path)
+
+            self.assertEqual(EXIT_READY, first_exit)
+            self.assertEqual(first_exit, second_exit)
+            self.assertEqual(first, second)
+            self.assertEqual(RESULT_READY, first["result"])
+            self.assertEqual(RESULT_SCHEMA_VERSION, first["schema_version"])
+            self.assertEqual(SUPPORTED_PROFILE, first["profile"])
+            self.assertEqual(list(REQUIRED_SECTIONS), first["observed_sections"])
+            self.assertEqual(list(FIELD_ORDER), first["observed_fields"])
+            self.assertEqual([], first["missing_required_sections"])
+            self.assertEqual([], first["missing_required_fields"])
+            self.assertEqual([], first["invalid_sections"])
+            self.assertEqual([], first["invalid_fields"])
+            self.assertEqual(list(CLAIMS_NOT_MADE), first["claims_not_made"])
+            self.assertFalse(first["input"]["content_echoed"])
+            self.assertEqual("audit.md", first["input"]["name"])
+            self.assertNotIn("SECRET APPLICATION VALUE", json.dumps(first))
+            self.assertEqual(before, path.read_bytes())
+
+    def test_missing_required_heading_is_incomplete(self) -> None:
+        payload, exit_code = validate_text(
+            ready_document().replace(
+                "## Friction Map",
+                "## Optional Map",
+                1,
+            )
+        )
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+        self.assertEqual(
+            ["Friction Map"],
+            payload["missing_required_sections"],
+        )
+        self.assertIn(
+            "Friction Map table",
+            payload["missing_required_fields"],
+        )
+
+    def test_duplicate_required_heading_is_invalid(self) -> None:
+        payload, exit_code = validate_text(
+            ready_document() + "\n## Scope\n"
+        )
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertIn("Scope", payload["invalid_sections"])
+
+    def test_required_headings_out_of_order_are_invalid(self) -> None:
+        content = ready_document()
+        content = content.replace("## Scope", "## TEMPORARY", 1)
+        content = content.replace(
+            "## Source Materials",
+            "## Scope",
+            1,
+        )
+        content = content.replace(
+            "## TEMPORARY",
+            "## Source Materials",
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertIn(
+            "Required heading order",
+            payload["invalid_sections"],
+        )
+
+    def test_title_must_be_nonplaceholder_and_before_required_sections(
+        self,
+    ) -> None:
+        title, remainder = ready_document().split("\n", 1)
+        cases = (
+            (
+                "placeholder",
+                ready_document().replace(
+                    title,
+                    "# <fill this>",
+                    1,
+                ),
+                RESULT_INCOMPLETE,
+                "missing_required_sections",
+                "Title",
+            ),
+            (
+                "misplaced",
+                remainder + "\n" + title + "\n",
+                RESULT_INVALID,
+                "invalid_sections",
+                "Required heading order",
+            ),
+        )
+        for name, content, result, output_key, marker in cases:
+            with self.subTest(name=name):
+                payload, exit_code = validate_text(content)
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(result, payload["result"])
+                self.assertIn(marker, payload[output_key])
+
+    def test_heading_and_field_inside_fence_are_ignored(self) -> None:
+        content = ready_document().replace(
+            "Fallback Approval Restart Record\n",
+            (
+                "## Scope\n"
+                "Audit Profile: UNSUPPORTED_SECRET\n"
+                "Fallback Approval Restart Record\n"
+            ),
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_READY, exit_code)
+        self.assertEqual(RESULT_READY, payload["result"])
+        self.assertEqual(SUPPORTED_PROFILE, payload["profile"])
+        self.assertNotIn("UNSUPPORTED_SECRET", json.dumps(payload))
+
+    def test_unclosed_fenced_block_is_invalid(self) -> None:
+        content = ready_document().replace(
+            "Still UNKNOWN:\n```\n",
+            "Still UNKNOWN:\n",
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertIn("Fenced code block", payload["invalid_sections"])
+
+    def test_missing_empty_and_angle_placeholder_fields_are_incomplete(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "missing",
+                (
+                    "Current Owner: Human publication operator\n",
+                    "",
+                ),
+                "Current Owner",
+                "missing_required_fields",
+            ),
+            (
+                "empty",
+                (
+                    "Application or Workflow: Synthetic editorial "
+                    "approval assistant",
+                    "Application or Workflow:",
+                ),
+                "Application or Workflow",
+                "invalid_fields",
+            ),
+            (
+                "placeholder",
+                (
+                    "Audit As-of: 2026-07-26",
+                    "Audit As-of: <fill this>",
+                ),
+                "Audit As-of",
+                "invalid_fields",
+            ),
+        )
+        for name, replacement, field, output_key in cases:
+            with self.subTest(name=name):
+                payload, exit_code = validate_text(
+                    ready_document().replace(*replacement, 1)
+                )
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                self.assertIn(field, payload[output_key])
+
+    def test_unknown_rating_with_rationale_is_accepted(self) -> None:
+        content = ready_document().replace(
+            (
+                "Trigger Clarity: PASS — The interruption and attempted "
+                "handoff are identified."
+            ),
+            "Trigger Clarity: UNKNOWN — The accepted evidence is silent.",
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_READY, exit_code)
+        self.assertEqual(RESULT_READY, payload["result"])
+        self.assertIn("Trigger Clarity", payload["unknowns"])
+
+    def test_rating_rationale_accepts_optional_separator(self) -> None:
+        original = (
+            "Trigger Clarity: PASS — The interruption and attempted "
+            "handoff are identified."
+        )
+        replacements = (
+            "Trigger Clarity: PASS: The initiating event is identified.",
+            "Trigger Clarity: PASS The initiating event is identified.",
+        )
+        for replacement in replacements:
+            with self.subTest(replacement=replacement):
+                payload, exit_code = validate_text(
+                    ready_document().replace(original, replacement, 1)
+                )
+
+                self.assertEqual(EXIT_READY, exit_code)
+                self.assertEqual(RESULT_READY, payload["result"])
+
+    def test_unknown_is_rejected_as_the_whole_priority_fix(self) -> None:
+        content = ready_document().replace(
+            (
+                "Selected Fix: Add a fallback approval restart record "
+                "before publication handoff."
+            ),
+            "Selected Fix: UNKNOWN",
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+        self.assertIn("Selected Fix", payload["invalid_fields"])
+
+    def test_unknown_with_rationale_is_not_a_known_deliverable(self) -> None:
+        cases = (
+            (
+                (
+                    "Selected Fix: Add a fallback approval restart record "
+                    "before publication handoff."
+                ),
+                "Selected Fix: UNKNOWN — No fix selected.",
+                "Selected Fix",
+            ),
+            (
+                "Asset Content: Copy and complete this record before "
+                "resuming the bounded handoff.",
+                "Asset Content: UNKNOWN — No asset delivered.",
+                "Asset Content",
+            ),
+            (
+                (
+                    "Selected Fix: Add a fallback approval restart record "
+                    "before publication handoff."
+                ),
+                "Selected Fix: UNKNOWN—No fix selected.",
+                "Selected Fix",
+            ),
+            (
+                "Asset Content: Copy and complete this record before "
+                "resuming the bounded handoff.",
+                "Asset Content: UNKNOWN:No asset delivered.",
+                "Asset Content",
+            ),
+        )
+        for old, new, field in cases:
+            with self.subTest(field=field):
+                payload, exit_code = validate_text(
+                    ready_document().replace(old, new, 1)
+                )
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                self.assertIn(field, payload["invalid_fields"])
+
+    def test_missing_or_malformed_diagnosis_dimension_is_incomplete(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "missing",
+                (
+                    "Evidence Continuity: FAIL — The next operator lacks "
+                    "a durable approval record.\n"
+                ),
+            ),
+            (
+                "invalid_rating",
+                (
+                    "Restartability: PARTIAL — A manual stop-and-revalidate "
+                    "fallback remains available.",
+                    (
+                        "Restartability: MAYBE — A manual fallback remains "
+                        "available."
+                    ),
+                ),
+            ),
+            (
+                "missing_rationale",
+                (
+                    "Safe Next Action: PASS — Publication remains stopped "
+                    "until identity is re-established.",
+                    "Safe Next Action: PASS",
+                ),
+            ),
+        )
+        for name, replacement in cases:
+            with self.subTest(name=name):
+                if isinstance(replacement, tuple):
+                    content = ready_document().replace(*replacement, 1)
+                else:
+                    content = ready_document().replace(replacement, "", 1)
+
+                payload, exit_code = validate_text(content)
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                target = {
+                    "missing": "Evidence Continuity",
+                    "invalid_rating": "Restartability",
+                    "missing_rationale": "Safe Next Action",
+                }[name]
+                output = (
+                    payload["missing_required_fields"]
+                    if name == "missing"
+                    else payload["invalid_fields"]
+                )
+                self.assertIn(target, output)
+
+    def test_friction_map_table_contract_fails_closed(self) -> None:
+        table = (
+            "| Point | Expected Carrier | Observed Gap | Returned Human Work |\n"
+            "| --- | --- | --- | --- |\n"
+            "| Approval handoff | Draft identity and accepted state | "
+            "Approval binding absent | Revalidation and repeated handoff "
+            "decision |\n"
+        )
+        cases = (
+            ("missing", "", "missing_required_fields"),
+            (
+                "wrong_columns",
+                table.replace("Expected Carrier", "Expected State"),
+                "invalid_fields",
+            ),
+            (
+                "no_rows",
+                (
+                    "| Point | Expected Carrier | Observed Gap | "
+                    "Returned Human Work |\n"
+                    "| --- | --- | --- | --- |\n"
+                ),
+                "invalid_fields",
+            ),
+            (
+                "blank_before_delimiter",
+                (
+                    "| Point | Expected Carrier | Observed Gap | "
+                    "Returned Human Work |\n"
+                    "\n"
+                    "| --- | --- | --- | --- |\n"
+                    "| Approval handoff | Draft identity | Gap | Work |\n"
+                ),
+                "invalid_fields",
+            ),
+            (
+                "fenced_gap_before_row",
+                (
+                    "| Point | Expected Carrier | Observed Gap | "
+                    "Returned Human Work |\n"
+                    "| --- | --- | --- | --- |\n"
+                    "```text\n"
+                    "not a table row\n"
+                    "```\n"
+                    "| Approval handoff | Draft identity | Gap | Work |\n"
+                ),
+                "invalid_fields",
+            ),
+            (
+                "indented_code_block",
+                (
+                    "    | Point | Expected Carrier | Observed Gap | "
+                    "Returned Human Work |\n"
+                    "    | --- | --- | --- | --- |\n"
+                    "    | Approval handoff | Draft identity | Gap | Work |\n"
+                ),
+                "missing_required_fields",
+            ),
+        )
+        for name, replacement, output_key in cases:
+            with self.subTest(name=name):
+                payload, exit_code = validate_text(
+                    ready_document().replace(table, replacement, 1)
+                )
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                self.assertIn("Friction Map table", payload[output_key])
+
+    def test_claim_boundary_must_be_complete_and_exact(self) -> None:
+        cases = (
+            (
+                "missing",
+                "Vendor Bug Fix: NOT CLAIMED\n",
+                "",
+                "missing_required_fields",
+            ),
+            (
+                "contradictory",
+                "Future Prevention: NOT CLAIMED",
+                "Future Prevention: CLAIMED",
+                "invalid_fields",
+            ),
+        )
+        for name, old, new, output_key in cases:
+            with self.subTest(name=name):
+                payload, exit_code = validate_text(
+                    ready_document().replace(old, new, 1)
+                )
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                expected = (
+                    "Vendor Bug Fix"
+                    if name == "missing"
+                    else "Future Prevention"
+                )
+                self.assertIn(expected, payload[output_key])
+
+    def test_unknowns_and_exclusions_require_nonplaceholder_bullets(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "unknowns",
+                (
+                    "- Native session recoverability and vendor-internal "
+                    "state remain unknown."
+                ),
+                "- TODO",
+                "Unknowns content",
+            ),
+            (
+                "exclusions",
+                (
+                    "- Vendor repair, live recovery, security review, and "
+                    "production implementation are outside scope."
+                ),
+                "",
+                "Exclusions content",
+            ),
+        )
+        for name, old, new, field in cases:
+            with self.subTest(name=name):
+                payload, exit_code = validate_text(
+                    ready_document().replace(old, new, 1)
+                )
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                self.assertIn(field, payload["invalid_fields"])
+
+    def test_explicit_bounded_no_unknown_declaration_is_accepted(self) -> None:
+        content = ready_document().replace(
+            (
+                "- Native session recoverability and vendor-internal "
+                "state remain unknown."
+            ),
+            "- none recorded within the accepted scope",
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_READY, exit_code)
+        self.assertEqual(RESULT_READY, payload["result"])
+        self.assertNotIn("Unknowns section", payload["unknowns"])
+
+    def test_deep_markdown_decoration_is_bounded_and_incomplete(self) -> None:
+        decorated_placeholder = "- " * 1200 + "TODO"
+        content = ready_document().replace(
+            (
+                "- Native session recoverability and vendor-internal "
+                "state remain unknown."
+            ),
+            f"- {decorated_placeholder}",
+            1,
+        )
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+        self.assertIn("Unknowns content", payload["invalid_fields"])
+
+    def test_missing_completion_line_is_incomplete(self) -> None:
+        payload, exit_code = validate_text(
+            ready_document().replace(
+                "## Completion Line",
+                "## Closure",
+                1,
+            )
+        )
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+        self.assertIn(
+            "Completion Line",
+            payload["missing_required_sections"],
+        )
+
+    def test_completion_line_requires_visible_nonheading_content(self) -> None:
+        original = (
+            "The bounded synthetic incident, diagnosis, priority fix, "
+            "operational asset,\n"
+            "restart distinction, unknowns, exclusions, and claim boundaries "
+            "are present for\n"
+            "structural validation."
+        )
+        replacements = (
+            "### TODO",
+            "```text\n```\n",
+            "UNKNOWN—No closure established.",
+        )
+        for replacement in replacements:
+            with self.subTest(replacement=replacement):
+                payload, exit_code = validate_text(
+                    ready_document().replace(original, replacement, 1)
+                )
+
+                self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                self.assertEqual(RESULT_INCOMPLETE, payload["result"])
+                self.assertIn(
+                    "Completion Line content",
+                    payload["invalid_fields"],
+                )
+
+    def test_only_asset_content_accepts_multiline_or_fenced_value(
+        self,
+    ) -> None:
+        ordinary = ready_document().replace(
+            (
+                "Application or Workflow: Synthetic editorial approval "
+                "assistant"
+            ),
+            (
+                "Application or Workflow:\n"
+                "```text\n"
+                "Synthetic editorial approval assistant\n"
+                "```"
+            ),
+            1,
+        )
+        ordinary_payload, ordinary_exit = validate_text(ordinary)
+
+        self.assertEqual(EXIT_INCOMPLETE, ordinary_exit)
+        self.assertEqual(RESULT_INCOMPLETE, ordinary_payload["result"])
+        self.assertIn(
+            "Application or Workflow",
+            ordinary_payload["invalid_fields"],
+        )
+
+        asset = ready_document().replace(
+            (
+                "Asset Content: Copy and complete this record before "
+                "resuming the bounded handoff."
+            ),
+            "Asset Content:",
+            1,
+        )
+        asset_payload, asset_exit = validate_text(asset)
+
+        self.assertEqual(EXIT_READY, asset_exit)
+        self.assertEqual(RESULT_READY, asset_payload["result"])
+
+        asset_block_start = asset.index("```text")
+        asset_block_end = asset.index("```", asset_block_start + 3) + 3
+        empty_asset = (
+            asset[:asset_block_start]
+            + "```text\n```"
+            + asset[asset_block_end:]
+        )
+        empty_payload, empty_exit = validate_text(empty_asset)
+
+        self.assertEqual(EXIT_INCOMPLETE, empty_exit)
+        self.assertEqual(RESULT_INCOMPLETE, empty_payload["result"])
+        self.assertIn("Asset Content", empty_payload["invalid_fields"])
+
+    def test_tilde_fenced_asset_content_is_supported(self) -> None:
+        content = ready_document().replace(
+            "Asset Content: Copy and complete this record before "
+            "resuming the bounded handoff.",
+            "Asset Content:",
+            1,
+        )
+        content = content.replace("```text", "~~~~text", 1)
+        content = content.replace("```", "~~~~", 1)
+
+        payload, exit_code = validate_text(content)
+
+        self.assertEqual(EXIT_READY, exit_code)
+        self.assertEqual(RESULT_READY, payload["result"])
+
+    def test_unsupported_profile_is_invalid_without_echo(self) -> None:
+        payload, exit_code = validate_text(
+            ready_document().replace(
+                SUPPORTED_PROFILE,
+                "SECRET_UNSUPPORTED_PROFILE",
+                1,
+            )
+        )
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertEqual("UNKNOWN", payload["profile"])
+        self.assertIn("Audit Profile", payload["invalid_fields"])
+        self.assertNotIn("Audit Profile", payload["observed_fields"])
+        self.assertNotIn("SECRET_UNSUPPORTED_PROFILE", json.dumps(payload))
+
+    def test_exact_size_limit_is_accepted(self) -> None:
+        content = ready_document().encode("utf-8")
+        self.assertLess(len(content), MAX_INPUT_BYTES)
+        content += b" " * (MAX_INPUT_BYTES - len(content))
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "audit.md"
+            path.write_bytes(content)
+
+            payload, exit_code = validate_audit_delivery_file(path)
+
+        self.assertEqual(EXIT_READY, exit_code)
+        self.assertEqual(RESULT_READY, payload["result"])
+
+    def test_fifo_is_rejected_before_open(self) -> None:
+        if not hasattr(os, "mkfifo"):
+            self.skipTest("FIFO creation unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "audit.fifo"
+            os.mkfifo(path)
+
+            with patch(
+                "decision_os.audit_delivery.os.open",
+                side_effect=AssertionError("non-regular input was opened"),
+            ):
+                payload, exit_code = validate_audit_delivery_file(path)
+
+        self.assertEqual(EXIT_INCOMPLETE, exit_code)
+        self.assertEqual(RESULT_INVALID, payload["result"])
+
+    def test_symlink_directory_oversize_and_invalid_utf8_are_invalid(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = write_document(root, ready_document())
+            link = root / "linked.md"
+            try:
+                link.symlink_to(target)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+            oversized = root / "oversized.md"
+            oversized.write_bytes(b"x" * (MAX_INPUT_BYTES + 1))
+            invalid_utf8 = root / "invalid.md"
+            invalid_utf8.write_bytes(b"\xff")
+
+            for path in (link, root, oversized, invalid_utf8):
+                with self.subTest(path=path.name):
+                    payload, exit_code = validate_audit_delivery_file(path)
+
+                    self.assertEqual(EXIT_INCOMPLETE, exit_code)
+                    self.assertEqual(RESULT_INVALID, payload["result"])
+                    self.assertFalse(payload["input"]["content_echoed"])
+                    self.assertNotIn(str(root), json.dumps(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_audit_delivery_cli.py
+++ b/tests/test_decision_os_audit_delivery_cli.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.audit_delivery import (
+    EXIT_INCOMPLETE,
+    REQUIRED_SECTIONS,
+    RESULT_INVALID,
+    RESULT_READY,
+)
+from decision_os.cli import (
+    AUDIT_CHECK_USAGE,
+    EXIT_INTERNAL,
+    EXIT_USAGE,
+    main,
+)
+from tests.test_decision_os_checks import tree_digest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BIN_ENTRY = REPO_ROOT / "bin" / "decision-os"
+SHIPPED_EXAMPLE = (
+    REPO_ROOT
+    / "examples"
+    / "ai_application_workflow_audit_delivery_v0_1.md"
+)
+INTAKE_EXAMPLE = REPO_ROOT / "examples" / "workflow_incident_intake_v0_1.json"
+
+
+def cli_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+    return environment
+
+
+def run_module(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (sys.executable, "-B", "-m", "decision_os", *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def run_bin(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (str(BIN_ENTRY), *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def decoded(completed: subprocess.CompletedProcess[bytes]) -> dict[str, object]:
+    if completed.stderr:
+        raise AssertionError(completed.stderr.decode("utf-8", errors="replace"))
+    if completed.stdout.count(b"\n") != 1 or not completed.stdout.endswith(b"\n"):
+        raise AssertionError(f"expected one JSON line, got {completed.stdout!r}")
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError("expected one JSON object")
+    return payload
+
+
+def write_example(directory: Path, *, secret: bool = False) -> Path:
+    content = SHIPPED_EXAMPLE.read_text(encoding="utf-8")
+    if secret:
+        content = content.replace(
+            "Synthetic editorial approval assistant",
+            "SECRET DELIVERY CONTENT",
+        )
+    path = directory / "audit.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class AuditDeliveryCliTest(unittest.TestCase):
+    def test_shipped_example_is_delivery_ready(self) -> None:
+        completed = run_module(
+            REPO_ROOT,
+            "audit-check",
+            str(SHIPPED_EXAMPLE),
+        )
+
+        self.assertEqual(0, completed.returncode)
+        payload = decoded(completed)
+        self.assertEqual(RESULT_READY, payload["result"])
+        self.assertEqual(
+            list(REQUIRED_SECTIONS),
+            payload["observed_sections"],
+        )
+
+    def test_json_default_explicit_repeated_and_bin_outputs_match(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = write_example(root, secret=True)
+            before = tree_digest(root)
+
+            default = run_module(root, "audit-check", str(path))
+            repeated = run_module(root, "audit-check", str(path))
+            explicit = run_module(
+                root,
+                "audit-check",
+                "--format",
+                "json",
+                str(path),
+            )
+            executable = run_bin(root, "audit-check", str(path))
+
+            results = (default, repeated, explicit, executable)
+            self.assertTrue(all(item.returncode == 0 for item in results))
+            self.assertTrue(all(item.stderr == b"" for item in results))
+            self.assertTrue(
+                all(item.stdout == default.stdout for item in results)
+            )
+            self.assertEqual(RESULT_READY, decoded(default)["result"])
+            self.assertNotIn(b"SECRET DELIVERY CONTENT", default.stdout)
+            self.assertEqual(before, tree_digest(root))
+
+    def test_text_output_is_exact_repeatable_and_bin_identical(self) -> None:
+        expected = (
+            "Decision-OS Audit Delivery v0.1: DELIVERY READY\n"
+            "\n"
+            "Profile:\n"
+            "- AI_APPLICATION_WORKFLOW\n"
+            "\n"
+            "Observed sections:\n"
+            "- Scope\n"
+            "- Source Materials\n"
+            "- Incident As-of State\n"
+            "- Friction Map\n"
+            "- Restartability Diagnosis\n"
+            "- Priority Fix\n"
+            "- Operational Asset\n"
+            "- Before / After Restart Check\n"
+            "- Unknowns\n"
+            "- Exclusions\n"
+            "- Claim Boundary\n"
+            "- Completion Line\n"
+            "\n"
+            "Missing:\n"
+            "- none\n"
+            "\n"
+            "Invalid:\n"
+            "- none\n"
+            "\n"
+            "This result confirms delivery structure only.\n"
+            "It does not validate diagnosis truth, repair efficacy, "
+            "or client acceptance.\n"
+        ).encode()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = write_example(root)
+
+            first = run_module(
+                root,
+                "audit-check",
+                "--format",
+                "text",
+                str(path),
+            )
+            second = run_module(
+                root,
+                "audit-check",
+                "--format",
+                "text",
+                str(path),
+            )
+            executable = run_bin(
+                root,
+                "audit-check",
+                "--format",
+                "text",
+                str(path),
+            )
+
+            self.assertEqual(0, first.returncode)
+            self.assertEqual(expected, first.stdout)
+            self.assertEqual(first.stdout, second.stdout)
+            self.assertEqual(first.stdout, executable.stdout)
+            self.assertEqual(b"", first.stderr)
+            self.assertFalse(first.stdout.endswith(b"\n\n"))
+
+    def test_usage_errors_return_two_in_selected_safe_format(self) -> None:
+        cases = (
+            (("audit-check",), b"{"),
+            (("audit-check", "audit.md", "extra"), b"{"),
+            (("audit-check", "--format"), b"{"),
+            (("audit-check", "--format", "yaml", "audit.md"), b"{"),
+            (
+                ("audit-check", "--format", "text"),
+                b"Decision-OS Audit Delivery v0.1: INVALID\n",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for arguments, prefix in cases:
+                with self.subTest(arguments=arguments):
+                    completed = run_module(root, *arguments)
+
+                    self.assertEqual(EXIT_USAGE, completed.returncode)
+                    self.assertEqual(b"", completed.stderr)
+                    self.assertTrue(completed.stdout.startswith(prefix))
+                    self.assertNotIn(str(root).encode(), completed.stdout)
+
+        output = io.StringIO()
+        exit_code = main(["audit-check"], stdout=output)
+        self.assertEqual(EXIT_USAGE, exit_code)
+        self.assertIn(AUDIT_CHECK_USAGE, output.getvalue())
+
+    def test_incomplete_and_invalid_return_four_without_content_echo(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            incomplete = write_example(root, secret=True)
+            incomplete.write_text(
+                incomplete.read_text(encoding="utf-8").replace(
+                    "## Completion Line",
+                    "## SECRET CLOSURE",
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            malformed = root / "malformed.md"
+            malformed.write_text(
+                "# SECRET TITLE\n\n```text\nSECRET VALUE\n",
+                encoding="utf-8",
+            )
+
+            incomplete_run = run_module(
+                root,
+                "audit-check",
+                str(incomplete),
+            )
+            invalid_run = run_module(
+                root,
+                "audit-check",
+                str(malformed),
+            )
+
+            self.assertEqual(EXIT_INCOMPLETE, incomplete_run.returncode)
+            self.assertEqual(EXIT_INCOMPLETE, invalid_run.returncode)
+            self.assertNotIn(b"SECRET", incomplete_run.stdout)
+            self.assertNotIn(b"SECRET", invalid_run.stdout)
+            self.assertEqual(
+                RESULT_INVALID,
+                decoded(invalid_run)["result"],
+            )
+
+    def test_unexpected_failure_returns_six_without_exception_detail(
+        self,
+    ) -> None:
+        output = io.StringIO()
+        with patch(
+            "decision_os.cli.validate_audit_delivery_file",
+            side_effect=RuntimeError("SECRET INTERNAL DETAIL"),
+        ):
+            exit_code = main(
+                ["audit-check", "safe-name.md"],
+                stdout=output,
+            )
+
+        self.assertEqual(EXIT_INTERNAL, exit_code)
+        self.assertNotIn("SECRET INTERNAL DETAIL", output.getvalue())
+        payload = json.loads(output.getvalue())
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertEqual(["internal_failure"], payload["unknowns"])
+        self.assertEqual("safe-name.md", payload["input"]["name"])
+
+    def test_existing_check_scan_and_intake_dispatch_remain_available(
+        self,
+    ) -> None:
+        cases = (
+            ("check", str(REPO_ROOT)),
+            ("scan", str(REPO_ROOT)),
+            ("intake", str(INTAKE_EXAMPLE)),
+        )
+        for command, target in cases:
+            with self.subTest(command=command):
+                completed = run_module(REPO_ROOT.parent, command, target)
+
+                self.assertEqual(0, completed.returncode)
+                self.assertEqual(b"", completed.stderr)
+                self.assertTrue(decoded(completed))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Reason

The workflow intake path can now prepare a bounded fit discussion, but paid
delivery still relies on manual checks that all required diagnosis, asset,
unknown, exclusion, and claim-boundary surfaces are present.

## Impact

Adds one local read-only structural validator for the AI Application Workflow
Audit delivery packet. It prevents structural false completion without claiming
that the diagnosis or repair is correct.

## Validation

- Full suite: 124/124 PASS
- Audit Delivery tests: 33/33 PASS
- Intake tests: 18/18 PASS unchanged
- Loop Record examples: 12/12 PASS
- Protected-blob guard: PASS unchanged
- Existing check, scan, and intake regression behavior: PASS
- JSON/text determinism and module/bin parity: PASS
- Synthetic example: DELIVERY_READY / exit 0
- Strict check: exit 0; V12 DELAY; V13 HOLD; required fields missing none;
  contradictions none
- Local Markdown links: 5/5 resolve
- Markdown hierarchy and fences: 3/3 PASS
- `git diff --check`: PASS
- Exact scope: 8 files, all mode 100644

## Rollback

Revert this PR. Existing check, scan, intake, offer, pricing, and public
distribution paths remain unchanged.

## Re-evaluation

Review after the first real paid delivery, external validator use,
false-ready or false-incomplete result, or evidence that the canonical Markdown
format creates excessive delivery burden.
