### PR TITLE
Add a bounded Audit case link checker

### DIFF
--- a/decision_os/audit_link.py
+++ b/decision_os/audit_link.py
@@ -1,0 +1,334 @@
+"""Deterministic identity-continuity checks for one intake and one Audit."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+import re
+from typing import Any
+import unicodedata
+
+from . import audit_delivery as audit_contract
+from . import intake as intake_contract
+
+
+EXIT_LINKED = 0
+EXIT_NOT_LINKED = 4
+
+RESULT_SCHEMA_VERSION = "decision-os.audit-link-result.v0.1"
+
+RESULT_LINKED = "LINKED"
+RESULT_MISMATCH = "MISMATCH"
+RESULT_INVALID = "INVALID"
+
+IDENTITY_FIELDS = (
+    "workflow",
+    "bounded_path",
+    "trigger",
+    "expected_state",
+    "observed_state",
+    "restart_or_fallback_path",
+)
+
+AUDIT_FIELD_MAPPINGS = {
+    "workflow": ("Scope", "Application or Workflow"),
+    "bounded_path": ("Scope", "Bounded Workflow Path"),
+    "trigger": ("Incident As-of State", "Trigger"),
+    "expected_state": ("Incident As-of State", "Expected State"),
+    "observed_state": ("Incident As-of State", "Observed State"),
+    "restart_or_fallback_path": (
+        "Incident As-of State",
+        "Current Restart or Fallback Path",
+    ),
+}
+
+CLAIMS_NOT_MADE = (
+    "truth of the intake packet",
+    "correctness of the Audit diagnosis",
+    "completeness of source materials",
+    "efficacy or uniqueness of the Priority Fix",
+    "client acceptance",
+    "prevention, recovery, security, safety, productivity, cost, or revenue",
+    "identity of systems not represented by the supplied files",
+    "absence of contradictory prose elsewhere",
+)
+
+NEXT_STEP_LINKED = (
+    "Use LINKED only as bounded field-continuity evidence; continue with "
+    "human review of factual correctness."
+)
+NEXT_STEP_MISMATCH = (
+    "Copy the six accepted intake identity values into the corresponding "
+    "Audit fields without paraphrasing, then rerun decision-os audit-link."
+)
+NEXT_STEP_INVALID = (
+    "Provide one local regular UTF-8 v0.1 intake JSON file and one local "
+    "regular UTF-8 Audit Markdown file, then rerun decision-os audit-link."
+)
+
+UNKNOWN_ORDER = (
+    "intake_structure",
+    "audit_structure",
+    "cli_usage",
+    "internal_failure",
+)
+
+
+class _ContractInvalid(Exception):
+    """One input did not satisfy its full accepted v0.1 contract."""
+
+    def __init__(self, missing_fields: Iterable[str] = ()) -> None:
+        super().__init__()
+        self.missing_fields = tuple(missing_fields)
+
+
+def _safe_output_name(
+    value: Path | str | None,
+    *,
+    audit: bool,
+) -> str:
+    helper = (
+        audit_contract._safe_basename
+        if audit
+        else intake_contract._safe_basename
+    )
+    name = helper(value)
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"}
+        for character in name
+    ):
+        return "unavailable"
+    return name
+
+
+def _ordered_fields(values: Iterable[str]) -> list[str]:
+    selected = set(values)
+    return [field for field in IDENTITY_FIELDS if field in selected]
+
+
+def _ordered_unknowns(values: Iterable[str]) -> list[str]:
+    selected = set(values)
+    return [marker for marker in UNKNOWN_ORDER if marker in selected]
+
+
+def result_payload(
+    *,
+    intake_name: Path | str | None,
+    audit_name: Path | str | None,
+    result: str,
+    matched_fields: Iterable[str] = (),
+    mismatched_fields: Iterable[str] = (),
+    missing_fields: Iterable[str] = (),
+    unknowns: Iterable[str] = (),
+    minimum_next_step: str,
+) -> dict[str, Any]:
+    """Build one stable result without exposing compared field contents."""
+
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "command": "audit-link",
+        "result": result,
+        "matched_fields": _ordered_fields(matched_fields),
+        "mismatched_fields": _ordered_fields(mismatched_fields),
+        "missing_fields": _ordered_fields(missing_fields),
+        "unknowns": _ordered_unknowns(unknowns),
+        "claims_not_made": list(CLAIMS_NOT_MADE),
+        "minimum_next_step": minimum_next_step,
+        "inputs": {
+            "intake": {
+                "name": _safe_output_name(intake_name, audit=False),
+                "content_echoed": False,
+            },
+            "audit": {
+                "name": _safe_output_name(audit_name, audit=True),
+                "content_echoed": False,
+            },
+        },
+    }
+
+
+def invalid_payload(
+    intake_path: Path | str | None,
+    audit_path: Path | str | None,
+    *,
+    missing_fields: Iterable[str] = (),
+    unknowns: Iterable[str] = (),
+    minimum_next_step: str = NEXT_STEP_INVALID,
+) -> dict[str, Any]:
+    """Return the stable INVALID shape for source or command rejection."""
+
+    return result_payload(
+        intake_name=intake_path,
+        audit_name=audit_path,
+        result=RESULT_INVALID,
+        missing_fields=missing_fields,
+        unknowns=unknowns,
+        minimum_next_step=minimum_next_step,
+    )
+
+
+def normalize_identity(value: str) -> str:
+    """Apply only the bounded whitespace normalization used for comparison."""
+
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    return re.sub(r"[ \t\n]+", " ", normalized)
+
+
+def _load_intake_values(path: Path) -> dict[str, str]:
+    try:
+        content = intake_contract._read_local_regular_file(path)
+        packet = intake_contract._parse_packet(content)
+    except intake_contract._InputRejected as exc:
+        raise _ContractInvalid from exc
+
+    _, missing, invalid, _ = intake_contract._inspect_packet(packet)
+    missing_identity = [
+        field
+        for field in IDENTITY_FIELDS
+        if field in set((*missing, *invalid))
+    ]
+    if missing or invalid:
+        raise _ContractInvalid(missing_identity)
+
+    output: dict[str, str] = {}
+    for field in IDENTITY_FIELDS:
+        value = packet.get(field)
+        if not isinstance(value, str):
+            raise RuntimeError("validated intake identity field unavailable")
+        output[field] = value
+    return output
+
+
+def _audit_missing_identity_fields(payload: dict[str, Any]) -> list[str]:
+    unavailable = {
+        item
+        for key in ("missing_required_fields", "invalid_fields")
+        for item in payload.get(key, ())
+        if isinstance(item, str)
+    }
+    return [
+        field
+        for field in IDENTITY_FIELDS
+        if AUDIT_FIELD_MAPPINGS[field][1] in unavailable
+    ]
+
+
+def _load_audit_values(path: Path) -> dict[str, str]:
+    try:
+        content = audit_contract._read_local_regular_file(path)
+        text = audit_contract._decode_markdown(content)
+    except audit_contract._InputRejected as exc:
+        raise _ContractInvalid from exc
+
+    payload, exit_code = audit_contract._inspect_markdown(text)
+    if exit_code != audit_contract.EXIT_READY:
+        raise _ContractInvalid(_audit_missing_identity_fields(payload))
+
+    lines = text.splitlines()
+    visible, content_visible, unclosed_fence = audit_contract._visible_lines(
+        lines
+    )
+    if unclosed_fence:
+        raise RuntimeError("validated Audit fence state unavailable")
+    headings = audit_contract._headings(lines, visible)
+
+    by_section: dict[str, dict[str, list[str]]] = {}
+    for section in ("Scope", "Incident As-of State"):
+        bounds = audit_contract._section_range(
+            section,
+            headings,
+            len(lines),
+        )
+        if bounds is None:
+            raise RuntimeError("validated Audit section unavailable")
+        start, end = bounds
+        labels = tuple(
+            audit_label
+            for mapped_section, audit_label in AUDIT_FIELD_MAPPINGS.values()
+            if mapped_section == section
+        )
+        by_section[section] = audit_contract._field_values(
+            lines,
+            visible,
+            content_visible,
+            start,
+            end,
+            labels,
+        )
+
+    output: dict[str, str] = {}
+    for field in IDENTITY_FIELDS:
+        section, audit_label = AUDIT_FIELD_MAPPINGS[field]
+        occurrences = by_section[section][audit_label]
+        if len(occurrences) != 1:
+            raise RuntimeError("validated Audit identity field unavailable")
+        output[field] = occurrences[0]
+    return output
+
+
+def validate_audit_link_files(
+    intake_path: Path,
+    audit_path: Path,
+) -> tuple[dict[str, Any], int]:
+    """Compare accepted identity fields without writing or diagnosing."""
+
+    values: dict[str, dict[str, str]] = {}
+    missing_fields: list[str] = []
+    unknowns: list[str] = []
+
+    try:
+        values["intake"] = _load_intake_values(intake_path)
+    except _ContractInvalid as exc:
+        missing_fields.extend(exc.missing_fields)
+        unknowns.append("intake_structure")
+
+    try:
+        values["audit"] = _load_audit_values(audit_path)
+    except _ContractInvalid as exc:
+        missing_fields.extend(exc.missing_fields)
+        unknowns.append("audit_structure")
+
+    if unknowns:
+        return (
+            invalid_payload(
+                intake_path,
+                audit_path,
+                missing_fields=missing_fields,
+                unknowns=unknowns,
+            ),
+            EXIT_NOT_LINKED,
+        )
+
+    matched: list[str] = []
+    mismatched: list[str] = []
+    for field in IDENTITY_FIELDS:
+        intake_value = normalize_identity(values["intake"][field])
+        audit_value = normalize_identity(values["audit"][field])
+        if intake_value == audit_value:
+            matched.append(field)
+        else:
+            mismatched.append(field)
+
+    if mismatched:
+        return (
+            result_payload(
+                intake_name=str(intake_path),
+                audit_name=str(audit_path),
+                result=RESULT_MISMATCH,
+                matched_fields=matched,
+                mismatched_fields=mismatched,
+                minimum_next_step=NEXT_STEP_MISMATCH,
+            ),
+            EXIT_NOT_LINKED,
+        )
+
+    return (
+        result_payload(
+            intake_name=str(intake_path),
+            audit_name=str(audit_path),
+            result=RESULT_LINKED,
+            matched_fields=matched,
+            minimum_next_step=NEXT_STEP_LINKED,
+        ),
+        EXIT_LINKED,
+    )

--- a/decision_os/audit_link_text.py
+++ b/decision_os/audit_link_text.py
@@ -1,0 +1,130 @@
+"""Deterministic text rendering for one Audit case-link result."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import os
+from typing import Any
+import unicodedata
+
+from .audit_link import (
+    IDENTITY_FIELDS,
+    NEXT_STEP_INVALID,
+    NEXT_STEP_LINKED,
+    NEXT_STEP_MISMATCH,
+    UNKNOWN_ORDER,
+)
+
+
+RESULT_LABELS = {
+    "LINKED": "LINKED",
+    "MISMATCH": "MISMATCH",
+    "INVALID": "INVALID",
+}
+AUDIT_LINK_USAGE = (
+    "decision-os audit-link <intake.json> <audit.md> | "
+    "decision-os audit-link --format json|text <intake.json> <audit.md>"
+)
+INTERNAL_FAILURE_NEXT_STEP = (
+    "Retry the same two local files once; if the internal failure repeats, "
+    "stop and report the command boundary."
+)
+ALLOWED_NEXT_STEPS = frozenset(
+    (
+        NEXT_STEP_LINKED,
+        NEXT_STEP_MISMATCH,
+        NEXT_STEP_INVALID,
+        AUDIT_LINK_USAGE,
+        INTERNAL_FAILURE_NEXT_STEP,
+    )
+)
+
+
+def _ordered_list(value: Any, order: Sequence[str]) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return []
+    selected = {
+        item for item in value if isinstance(item, str) and item in order
+    }
+    return [item for item in order if item in selected]
+
+
+def _section(title: str, values: Sequence[str]) -> list[str]:
+    lines = [f"{title}:"]
+    lines.extend(
+        (f"- {value}" for value in values)
+        if values
+        else ("- none",)
+    )
+    return lines
+
+
+def _input_name(payload: Mapping[str, Any], key: str) -> str:
+    inputs = payload.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return "unavailable"
+    entry = inputs.get(key)
+    if not isinstance(entry, Mapping):
+        return "unavailable"
+    name = entry.get("name")
+    if (
+        not isinstance(name, str)
+        or not name
+        or name in (".", "..")
+        or os.path.basename(name) != name
+        or any(
+            unicodedata.category(character)
+            in {"Cc", "Cf", "Cs", "Zl", "Zp"}
+            for character in name
+        )
+    ):
+        return "unavailable"
+    return name
+
+
+def render_text(payload: Mapping[str, Any]) -> str:
+    """Render one computed result without reopening or echoing either input."""
+
+    result = payload.get("result")
+    label = RESULT_LABELS.get(result, "INVALID")
+    unknowns = _ordered_list(payload.get("unknowns"), UNKNOWN_ORDER)
+    next_step = payload.get("minimum_next_step")
+    if next_step not in ALLOWED_NEXT_STEPS:
+        next_step = NEXT_STEP_INVALID
+
+    lines = [
+        f"Decision-OS Audit Case Link v0.1: {label}",
+        "",
+        "Inputs:",
+        f"- intake: {_input_name(payload, 'intake')}",
+        f"- audit: {_input_name(payload, 'audit')}",
+        "",
+        *_section(
+            "Matched",
+            _ordered_list(payload.get("matched_fields"), IDENTITY_FIELDS),
+        ),
+        "",
+        *_section(
+            "Mismatched",
+            _ordered_list(payload.get("mismatched_fields"), IDENTITY_FIELDS),
+        ),
+        "",
+        *_section(
+            "Missing",
+            _ordered_list(payload.get("missing_fields"), IDENTITY_FIELDS),
+        ),
+        "",
+        *_section("Unknowns", unknowns),
+        "",
+        "Minimum next step:",
+        next_step,
+        "",
+        "This result checks bounded identity continuity only.",
+        (
+            "It does not establish factual correctness, diagnosis quality, "
+            "repair efficacy, or client acceptance."
+        ),
+    ]
+    return "\n".join(lines) + "\n"

--- a/decision_os/cli.py
+++ b/decision_os/cli.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import sys
 from typing import Any, Sequence, TextIO
 
+from .audit_link import invalid_payload as audit_link_invalid_payload
+from .audit_link import validate_audit_link_files
+from .audit_link_text import render_text as render_audit_link_text
 from .audit_delivery import invalid_payload as audit_invalid_payload
 from .audit_delivery import validate_audit_delivery_file
 from .audit_delivery_text import render_text as render_audit_text
@@ -33,6 +36,10 @@ INTAKE_USAGE = (
 AUDIT_CHECK_USAGE = (
     "decision-os audit-check <audit.md> | "
     "decision-os audit-check --format json|text <audit.md>"
+)
+AUDIT_LINK_USAGE = (
+    "decision-os audit-link <intake.json> <audit.md> | "
+    "decision-os audit-link --format json|text <intake.json> <audit.md>"
 )
 
 
@@ -275,6 +282,88 @@ def _run_audit_check(arguments: Sequence[str], output: TextIO) -> int:
     return exit_code
 
 
+def _audit_link_format(arguments: Sequence[str]) -> str:
+    if (
+        len(arguments) >= 3
+        and arguments[0] == "audit-link"
+        and arguments[1] == "--format"
+        and arguments[2] == "text"
+    ):
+        return "text"
+    return "json"
+
+
+def _write_audit_link(
+    payload: dict[str, Any],
+    output_format: str,
+    stream: TextIO,
+) -> None:
+    if output_format == "text":
+        stream.write(render_audit_link_text(payload))
+        return
+    _write(payload, stream)
+
+
+def _run_audit_link(arguments: Sequence[str], output: TextIO) -> int:
+    output_format = _audit_link_format(arguments)
+    intake_path: str | None = None
+    audit_path: str | None = None
+    if (
+        len(arguments) == 3
+        and arguments[0] == "audit-link"
+        and arguments[1]
+        and arguments[2]
+        and not arguments[1].startswith("-")
+        and not arguments[2].startswith("-")
+    ):
+        intake_path = arguments[1]
+        audit_path = arguments[2]
+        output_format = "json"
+    elif (
+        len(arguments) == 5
+        and arguments[0] == "audit-link"
+        and arguments[1] == "--format"
+        and arguments[2] in ("json", "text")
+        and arguments[3]
+        and arguments[4]
+        and not arguments[3].startswith("-")
+        and not arguments[4].startswith("-")
+    ):
+        output_format = arguments[2]
+        intake_path = arguments[3]
+        audit_path = arguments[4]
+
+    if intake_path is None or audit_path is None:
+        payload = audit_link_invalid_payload(
+            None,
+            None,
+            minimum_next_step=AUDIT_LINK_USAGE,
+            unknowns=("cli_usage",),
+        )
+        _write_audit_link(payload, output_format, output)
+        return EXIT_USAGE
+
+    try:
+        payload, exit_code = validate_audit_link_files(
+            Path(intake_path),
+            Path(audit_path),
+        )
+    except Exception:
+        payload = audit_link_invalid_payload(
+            Path(intake_path),
+            Path(audit_path),
+            minimum_next_step=(
+                "Retry the same two local files once; if the internal failure "
+                "repeats, stop and report the command boundary."
+            ),
+            unknowns=("internal_failure",),
+        )
+        exit_code = EXIT_INTERNAL
+
+    _write_audit_link(payload, output_format, output)
+    return exit_code
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -293,6 +382,9 @@ def main(
 
     if arguments and arguments[0] == "audit-check":
         return _run_audit_check(arguments, output)
+
+    if arguments and arguments[0] == "audit-link":
+        return _run_audit_link(arguments, output)
 
     if (
         len(arguments) != 2

--- a/docs/audit_case_link_checker_v0_1.md
+++ b/docs/audit_case_link_checker_v0_1.md
@@ -1,0 +1,196 @@
+# Audit Case Link Checker v0.1
+
+## Purpose
+
+`decision-os audit-link` checks whether one local AI workflow Audit delivery
+preserves the same six accepted incident-identity values as one local
+[Workflow Incident Intake Checker](workflow_incident_intake_checker_v0_1.md)
+packet.
+
+The check is deterministic, dependency-free, local, and read-only. It checks
+bounded field continuity only. It does not diagnose the incident, evaluate a
+repair, or establish that either supplied file is factually correct.
+
+## Commands
+
+JSON is the default output:
+
+```bash
+decision-os audit-link accepted-intake.json audit.md
+decision-os audit-link --format json accepted-intake.json audit.md
+```
+
+Use the deterministic text receipt when preferred:
+
+```bash
+decision-os audit-link --format text accepted-intake.json audit.md
+```
+
+The command accepts exactly one intake JSON file and one Audit Markdown file.
+It performs no repository scan.
+
+## Compared identity fields
+
+The accepted intake values map to the Audit fields as follows:
+
+| Intake JSON | Audit section | Audit field |
+| --- | --- | --- |
+| `workflow` | `Scope` | `Application or Workflow` |
+| `bounded_path` | `Scope` | `Bounded Workflow Path` |
+| `trigger` | `Incident As-of State` | `Trigger` |
+| `expected_state` | `Incident As-of State` | `Expected State` |
+| `observed_state` | `Incident As-of State` | `Observed State` |
+| `restart_or_fallback_path` | `Incident As-of State` | `Current Restart or Fallback Path` |
+
+Carry these six values into the Audit without paraphrasing.
+
+`incident_as_of` and `Audit As-of` are independently required by their source
+contracts but are not compared by v0.1. A `LINKED` result must not be used to
+claim that unlisted fields or prose are identical.
+
+## Comparison normalization
+
+Before exact comparison, each of the six values is normalized only by:
+
+1. converting CRLF and CR line endings to LF;
+2. removing leading and trailing whitespace;
+3. collapsing internal runs of spaces, tabs, and line breaks to one ASCII
+   space.
+
+All other text must be exactly equal. Comparison is case-sensitive and
+punctuation-sensitive. The checker does not use fuzzy matching, embeddings, AI
+inference, synonyms, case-folding, or Unicode semantic normalization.
+
+## Accepted source contracts
+
+The intake must satisfy the complete
+`decision-os.workflow-intake.v0.1` contract. The Audit must be
+`DELIVERY_READY` under the
+[Audit Delivery Validator](audit_delivery_validator_v0_1.md) and use the
+`AI_APPLICATION_WORKFLOW` profile.
+
+An incomplete source contract is `INVALID` for `audit-link`, even when some of
+the six values can be found. The checker does not weaken either source
+validator or produce a partial continuity claim from an invalid source.
+
+Audit headings and field-like text inside fenced blocks remain ignored. The
+six mapped Audit fields are read using the same visible-heading and
+visible-field rules used by `audit-check`.
+
+## Local read boundary
+
+The command:
+
+- reads the two supplied local files only;
+- performs no network access, telemetry, or writes;
+- rejects symlinks, directories, and non-regular files;
+- rejects invalid UTF-8;
+- rejects intake files larger than 256 KiB;
+- rejects Audit files larger than 512 KiB;
+- reports only safe basenames, fixed result markers, and field names;
+- never echoes compared values or full paths.
+
+Do not place credentials, customer data, production secrets, or unauthorized
+private material in either supplied file.
+
+## Result and exit contract
+
+| Result | Exit | Meaning |
+| --- | ---: | --- |
+| `LINKED` | `0` | All six accepted identity fields match after bounded whitespace normalization. |
+| `MISMATCH` | `4` | Both complete source contracts are usable, but at least one identity field differs. |
+| `INVALID` | `4` | Either file cannot be safely read, parsed, or mapped to its accepted v0.1 contract. |
+| CLI usage error | `2` | The command form is unsupported. |
+| Unexpected internal failure | `6` | The bounded checker did not complete. |
+
+`LINKED` proves only field continuity between the two supplied files. It does
+not establish source truth, diagnosis quality, repair efficacy, or client
+acceptance.
+
+## JSON output
+
+The result schema is:
+
+```text
+decision-os.audit-link-result.v0.1
+```
+
+The JSON shape is:
+
+```json
+{
+  "schema_version": "decision-os.audit-link-result.v0.1",
+  "command": "audit-link",
+  "result": "LINKED | MISMATCH | INVALID",
+  "matched_fields": [],
+  "mismatched_fields": [],
+  "missing_fields": [],
+  "unknowns": [],
+  "claims_not_made": [],
+  "minimum_next_step": "",
+  "inputs": {
+    "intake": {
+      "name": "accepted-intake.json",
+      "content_echoed": false
+    },
+    "audit": {
+      "name": "audit.md",
+      "content_echoed": false
+    }
+  }
+}
+```
+
+Field-name lists always follow the fixed six-field order shown above. Compared
+contents never appear in JSON or text output.
+
+## Claims not made
+
+The checker does not establish:
+
+- truth of the intake packet;
+- correctness of the Audit diagnosis;
+- completeness of source materials;
+- efficacy or uniqueness of the Priority Fix;
+- client acceptance;
+- prevention, recovery, security, safety, productivity, cost, or revenue;
+- identity of systems not represented by the supplied files;
+- absence of contradictory prose elsewhere.
+
+## Synthetic example
+
+The shipped
+[workflow incident intake](../examples/workflow_incident_intake_v0_1.json) and
+[Audit delivery](../examples/ai_application_workflow_audit_delivery_v0_1.md)
+form one synthetic, non-private pair:
+
+```bash
+python3 -B -m decision_os audit-link \
+  examples/workflow_incident_intake_v0_1.json \
+  examples/ai_application_workflow_audit_delivery_v0_1.md
+
+python3 -B -m decision_os audit-check \
+  examples/ai_application_workflow_audit_delivery_v0_1.md
+```
+
+The first command returns `LINKED`. The second returns `DELIVERY_READY`.
+Neither result is client evidence, a testimonial, a measured result, or proof
+that the invented incident and diagnosis are true.
+
+## Service relationship
+
+The checker is an optional but recommended pre-delivery continuity check for
+the existing
+[AI Application Workflow Audit delivery surface](../services/ai_application_workflow_audit_delivery_v0_1.md).
+It creates no new product family, diagnosis, repair, acceptance decision, or
+remote service.
+
+## Rollback and re-evaluation
+
+Rollback: revert the Audit Case Link Checker PR. This removes the two checker
+modules, tests, documentation, CLI dispatch, and service reference, and
+restores the prior synthetic example and Audit validator test fixtures.
+
+Re-evaluate after the first real paid delivery, a false link or false mismatch,
+an accepted source-contract change, or evidence that preserving the six exact
+values creates excessive delivery burden.

--- a/examples/ai_application_workflow_audit_delivery_v0_1.md
+++ b/examples/ai_application_workflow_audit_delivery_v0_1.md
@@ -1,14 +1,14 @@
 # AI Application Workflow Audit — Executable Synthetic Example
 
-This invented, non-private packet is an executable example for the Audit
-Delivery Validator. It is not a testimonial, paid-client result, or measured
-outcome.
+This synthetic, invented, non-private packet is an executable example for the
+Audit Delivery Validator and Audit Case Link Checker. It is not client
+evidence, a testimonial, a paid-client result, or a measured result.
 
 ## Scope
 
 Audit Profile: AI_APPLICATION_WORKFLOW
-Application or Workflow: Synthetic editorial approval assistant
-Bounded Workflow Path: Draft generation to human approval to publication handoff
+Application or Workflow: Customer-support approval workflow
+Bounded Workflow Path: draft response -> human approval -> send decision
 Audit As-of: 2026-07-26
 
 ## Source Materials
@@ -19,10 +19,10 @@ Material Restrictions: No credentials, customer data, or private code
 
 ## Incident As-of State
 
-Trigger: Resume the publication handoff after an interrupted approval session
-Expected State: The resumed operator can bind the accepted draft to its approval
-Observed State: The draft exists, but its approval binding is not established
-Current Restart or Fallback Path: Stop publication and revalidate the draft
+Trigger: The workflow resumed after an interrupted approval step.
+Expected State: The approved draft remained current and ready for the send decision.
+Observed State: The resumed workflow could not establish which draft the approval covered.
+Current Restart or Fallback Path: Keep the workflow stopped at approval until the draft identity is re-established.
 Current Owner: Human publication operator
 Next Safe Action: Record the accepted draft identity before another handoff
 

--- a/services/ai_application_workflow_audit_delivery_v0_1.md
+++ b/services/ai_application_workflow_audit_delivery_v0_1.md
@@ -195,6 +195,24 @@ Native Resume: NOT PROOF OF TRUSTWORTHY RESTART
 <fill this>
 ```
 
+## Preserve accepted incident identity
+
+Carry the six accepted intake values into the corresponding Audit fields
+without paraphrasing:
+
+- `workflow` → `Application or Workflow`
+- `bounded_path` → `Bounded Workflow Path`
+- `trigger` → `Trigger`
+- `expected_state` → `Expected State`
+- `observed_state` → `Observed State`
+- `restart_or_fallback_path` → `Current Restart or Fallback Path`
+
+The local
+[Audit Case Link Checker](../docs/audit_case_link_checker_v0_1.md) is optional
+but recommended before delivery. `LINKED` proves only bounded field continuity
+between the two supplied files. It does not prove that either file is
+factually correct.
+
 ## Validate a completed delivery
 
 The local

--- a/tests/test_decision_os_audit_delivery.py
+++ b/tests/test_decision_os_audit_delivery.py
@@ -55,7 +55,7 @@ class AuditDeliveryValidationTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             content = ready_document().replace(
-                "Synthetic editorial approval assistant",
+                "Customer-support approval workflow",
                 "SECRET APPLICATION VALUE",
             )
             path = write_document(root, content)
@@ -213,8 +213,8 @@ class AuditDeliveryValidationTest(unittest.TestCase):
             (
                 "empty",
                 (
-                    "Application or Workflow: Synthetic editorial "
-                    "approval assistant",
+                    "Application or Workflow: Customer-support approval "
+                    "workflow",
                     "Application or Workflow:",
                 ),
                 "Application or Workflow",
@@ -597,13 +597,12 @@ class AuditDeliveryValidationTest(unittest.TestCase):
     ) -> None:
         ordinary = ready_document().replace(
             (
-                "Application or Workflow: Synthetic editorial approval "
-                "assistant"
+                "Application or Workflow: Customer-support approval workflow"
             ),
             (
                 "Application or Workflow:\n"
                 "```text\n"
-                "Synthetic editorial approval assistant\n"
+                "Customer-support approval workflow\n"
                 "```"
             ),
             1,

--- a/tests/test_decision_os_audit_delivery_cli.py
+++ b/tests/test_decision_os_audit_delivery_cli.py
@@ -77,7 +77,7 @@ def write_example(directory: Path, *, secret: bool = False) -> Path:
     content = SHIPPED_EXAMPLE.read_text(encoding="utf-8")
     if secret:
         content = content.replace(
-            "Synthetic editorial approval assistant",
+            "Customer-support approval workflow",
             "SECRET DELIVERY CONTENT",
         )
     path = directory / "audit.md"

--- a/tests/test_decision_os_audit_link.py
+++ b/tests/test_decision_os_audit_link.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from decision_os.audit_link import (
+    CLAIMS_NOT_MADE,
+    EXIT_LINKED,
+    EXIT_NOT_LINKED,
+    IDENTITY_FIELDS,
+    RESULT_INVALID,
+    RESULT_LINKED,
+    RESULT_MISMATCH,
+    RESULT_SCHEMA_VERSION,
+    normalize_identity,
+    validate_audit_link_files,
+)
+from decision_os.audit_delivery import MAX_INPUT_BYTES as AUDIT_MAX_INPUT_BYTES
+from decision_os.intake import MAX_INPUT_BYTES as INTAKE_MAX_INPUT_BYTES
+from tests.test_decision_os_checks import tree_digest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTAKE_EXAMPLE = REPO_ROOT / "examples" / "workflow_incident_intake_v0_1.json"
+AUDIT_EXAMPLE = (
+    REPO_ROOT
+    / "examples"
+    / "ai_application_workflow_audit_delivery_v0_1.md"
+)
+
+AUDIT_LABELS = {
+    "workflow": "Application or Workflow",
+    "bounded_path": "Bounded Workflow Path",
+    "trigger": "Trigger",
+    "expected_state": "Expected State",
+    "observed_state": "Observed State",
+    "restart_or_fallback_path": "Current Restart or Fallback Path",
+}
+
+
+def example_packet() -> dict[str, object]:
+    packet = json.loads(INTAKE_EXAMPLE.read_text(encoding="utf-8"))
+    if not isinstance(packet, dict):
+        raise AssertionError("expected object example")
+    return packet
+
+
+def example_audit() -> str:
+    return AUDIT_EXAMPLE.read_text(encoding="utf-8")
+
+
+def write_packet(directory: Path, packet: dict[str, object]) -> Path:
+    path = directory / "accepted-intake.json"
+    path.write_text(
+        json.dumps(packet, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_audit(directory: Path, content: str) -> Path:
+    path = directory / "delivery.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def write_pair(directory: Path) -> tuple[Path, Path]:
+    return (
+        write_packet(directory, example_packet()),
+        write_audit(directory, example_audit()),
+    )
+
+
+def replace_audit_field(content: str, field: str, value: str) -> str:
+    label = AUDIT_LABELS[field]
+    prefix = f"{label}: "
+    lines = content.splitlines()
+    matches = [index for index, line in enumerate(lines) if line.startswith(prefix)]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one {label!r} field")
+    lines[matches[0]] = f"{label}: {value}"
+    return "\n".join(lines) + "\n"
+
+
+class AuditCaseLinkValidationTest(unittest.TestCase):
+    def test_example_pair_is_linked_deterministic_read_only_and_no_echo(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = example_packet()
+            packet["workflow"] = "SECRET SHARED IDENTITY"
+            intake = write_packet(root, packet)
+            audit = write_audit(
+                root,
+                replace_audit_field(
+                    example_audit(),
+                    "workflow",
+                    "SECRET SHARED IDENTITY",
+                ),
+            )
+            before = tree_digest(root)
+
+            first, first_exit = validate_audit_link_files(intake, audit)
+            second, second_exit = validate_audit_link_files(intake, audit)
+
+            self.assertEqual(EXIT_LINKED, first_exit)
+            self.assertEqual(first_exit, second_exit)
+            self.assertEqual(first, second)
+            self.assertEqual(RESULT_LINKED, first["result"])
+            self.assertEqual(RESULT_SCHEMA_VERSION, first["schema_version"])
+            self.assertEqual("audit-link", first["command"])
+            self.assertEqual(list(IDENTITY_FIELDS), first["matched_fields"])
+            self.assertEqual([], first["mismatched_fields"])
+            self.assertEqual([], first["missing_fields"])
+            self.assertEqual([], first["unknowns"])
+            self.assertEqual(list(CLAIMS_NOT_MADE), first["claims_not_made"])
+            self.assertEqual(
+                {
+                    "intake": {
+                        "name": "accepted-intake.json",
+                        "content_echoed": False,
+                    },
+                    "audit": {
+                        "name": "delivery.md",
+                        "content_echoed": False,
+                    },
+                },
+                first["inputs"],
+            )
+            self.assertNotIn("SECRET SHARED IDENTITY", json.dumps(first))
+            self.assertEqual(before, tree_digest(root))
+
+    def test_each_identity_field_mismatch_is_reported_in_fixed_order(
+        self,
+    ) -> None:
+        for field in IDENTITY_FIELDS:
+            with self.subTest(field=field):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    packet = example_packet()
+                    packet[field] = f"{packet[field]} changed"
+                    intake = write_packet(root, packet)
+                    audit = write_audit(root, example_audit())
+
+                    payload, exit_code = validate_audit_link_files(
+                        intake,
+                        audit,
+                    )
+
+                    self.assertEqual(EXIT_NOT_LINKED, exit_code)
+                    self.assertEqual(RESULT_MISMATCH, payload["result"])
+                    self.assertEqual([field], payload["mismatched_fields"])
+                    self.assertEqual(
+                        [
+                            candidate
+                            for candidate in IDENTITY_FIELDS
+                            if candidate != field
+                        ],
+                        payload["matched_fields"],
+                    )
+
+    def test_multiple_mismatches_remain_deterministically_ordered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = example_packet()
+            changed = (
+                "bounded_path",
+                "observed_state",
+                "restart_or_fallback_path",
+            )
+            for field in changed:
+                packet[field] = f"{packet[field]} changed"
+
+            payload, exit_code = validate_audit_link_files(
+                write_packet(root, packet),
+                write_audit(root, example_audit()),
+            )
+
+            self.assertEqual(EXIT_NOT_LINKED, exit_code)
+            self.assertEqual(RESULT_MISMATCH, payload["result"])
+            self.assertEqual(list(changed), payload["mismatched_fields"])
+
+    def test_bounded_whitespace_normalization_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = example_packet()
+            packet["workflow"] = (
+                " \tCustomer-support\r\napproval\n\tworkflow \t"
+            )
+            packet["bounded_path"] = (
+                "draft response  ->\thuman approval\r-> send decision"
+            )
+            audit_content = replace_audit_field(
+                example_audit(),
+                "workflow",
+                "\tCustomer-support   approval workflow\t",
+            )
+
+            payload, exit_code = validate_audit_link_files(
+                write_packet(root, packet),
+                write_audit(root, audit_content),
+            )
+
+            self.assertEqual(EXIT_LINKED, exit_code)
+            self.assertEqual(RESULT_LINKED, payload["result"])
+            self.assertEqual(
+                "one two three",
+                normalize_identity(" \tone\r\ntwo\n  three\t "),
+            )
+
+    def test_case_and_punctuation_differences_remain_mismatches(self) -> None:
+        cases = (
+            ("workflow", "customer-support approval workflow"),
+            (
+                "trigger",
+                "The workflow resumed after an interrupted approval step!",
+            ),
+        )
+        for field, replacement in cases:
+            with self.subTest(field=field):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    packet = example_packet()
+                    packet[field] = replacement
+                    payload, exit_code = validate_audit_link_files(
+                        write_packet(root, packet),
+                        write_audit(root, example_audit()),
+                    )
+
+                    self.assertEqual(EXIT_NOT_LINKED, exit_code)
+                    self.assertEqual(RESULT_MISMATCH, payload["result"])
+                    self.assertEqual([field], payload["mismatched_fields"])
+
+    def test_missing_intake_identity_field_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            packet = example_packet()
+            del packet["expected_state"]
+
+            payload, exit_code = validate_audit_link_files(
+                write_packet(root, packet),
+                write_audit(root, example_audit()),
+            )
+
+            self.assertEqual(EXIT_NOT_LINKED, exit_code)
+            self.assertEqual(RESULT_INVALID, payload["result"])
+            self.assertEqual(["expected_state"], payload["missing_fields"])
+            self.assertEqual(["intake_structure"], payload["unknowns"])
+            self.assertEqual([], payload["matched_fields"])
+            self.assertEqual([], payload["mismatched_fields"])
+
+    def test_missing_audit_identity_field_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            missing = example_audit().replace(
+                "Expected State: The approved draft remained current and "
+                "ready for the send decision.\n",
+                "",
+                1,
+            )
+
+            payload, exit_code = validate_audit_link_files(
+                write_packet(root, example_packet()),
+                write_audit(root, missing),
+            )
+
+            self.assertEqual(EXIT_NOT_LINKED, exit_code)
+            self.assertEqual(RESULT_INVALID, payload["result"])
+            self.assertEqual(["expected_state"], payload["missing_fields"])
+            self.assertEqual(["audit_structure"], payload["unknowns"])
+
+    def test_malformed_intake_and_invalid_audit_are_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            malformed = root / "malformed.json"
+            malformed.write_text('{"workflow":', encoding="utf-8")
+            invalid_audit = write_audit(
+                root,
+                example_audit() + "\n```text\nunclosed\n",
+            )
+
+            payload, exit_code = validate_audit_link_files(
+                malformed,
+                invalid_audit,
+            )
+
+            self.assertEqual(EXIT_NOT_LINKED, exit_code)
+            self.assertEqual(RESULT_INVALID, payload["result"])
+            self.assertEqual(
+                ["intake_structure", "audit_structure"],
+                payload["unknowns"],
+            )
+            self.assertEqual([], payload["matched_fields"])
+
+    def test_field_like_text_inside_fences_is_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            content = example_audit().replace(
+                "## Scope\n",
+                (
+                    "## Scope\n\n"
+                    "```text\n"
+                    "Application or Workflow: SECRET FENCED VALUE\n"
+                    "Bounded Workflow Path: SECRET FENCED VALUE\n"
+                    "```\n"
+                ),
+                1,
+            )
+
+            payload, exit_code = validate_audit_link_files(
+                write_packet(root, example_packet()),
+                write_audit(root, content),
+            )
+
+            self.assertEqual(EXIT_LINKED, exit_code)
+            self.assertEqual(RESULT_LINKED, payload["result"])
+            self.assertNotIn("SECRET FENCED VALUE", json.dumps(payload))
+
+    def test_unicode_line_separators_are_not_emitted_in_basenames(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            unsafe_intake = root / "intake\u2028forged.json"
+            unsafe_audit = root / "audit\u2029forged.md"
+            unsafe_intake.write_bytes(intake.read_bytes())
+            unsafe_audit.write_bytes(audit.read_bytes())
+
+            intake_payload, intake_exit = validate_audit_link_files(
+                unsafe_intake,
+                audit,
+            )
+            audit_payload, audit_exit = validate_audit_link_files(
+                intake,
+                unsafe_audit,
+            )
+
+            self.assertEqual(EXIT_LINKED, intake_exit)
+            self.assertEqual(EXIT_LINKED, audit_exit)
+            self.assertEqual(
+                "unavailable",
+                intake_payload["inputs"]["intake"]["name"],
+            )
+            self.assertEqual(
+                "unavailable",
+                audit_payload["inputs"]["audit"]["name"],
+            )
+            serialized = json.dumps(
+                (intake_payload, audit_payload),
+                ensure_ascii=False,
+            )
+            self.assertNotIn("\u2028", serialized)
+            self.assertNotIn("\u2029", serialized)
+
+    def test_symlinks_are_rejected_for_each_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            intake_link = root / "intake-link.json"
+            audit_link = root / "audit-link.md"
+            intake_link.symlink_to(intake)
+            audit_link.symlink_to(audit)
+
+            cases = (
+                (intake_link, audit, ["intake_structure"]),
+                (intake, audit_link, ["audit_structure"]),
+            )
+            for supplied_intake, supplied_audit, unknowns in cases:
+                with self.subTest(unknowns=unknowns):
+                    payload, exit_code = validate_audit_link_files(
+                        supplied_intake,
+                        supplied_audit,
+                    )
+                    self.assertEqual(EXIT_NOT_LINKED, exit_code)
+                    self.assertEqual(RESULT_INVALID, payload["result"])
+                    self.assertEqual(unknowns, payload["unknowns"])
+
+    def test_directories_are_rejected_for_each_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            cases = (
+                (root, audit, ["intake_structure"]),
+                (intake, root, ["audit_structure"]),
+            )
+            for supplied_intake, supplied_audit, unknowns in cases:
+                with self.subTest(unknowns=unknowns):
+                    payload, exit_code = validate_audit_link_files(
+                        supplied_intake,
+                        supplied_audit,
+                    )
+                    self.assertEqual(EXIT_NOT_LINKED, exit_code)
+                    self.assertEqual(RESULT_INVALID, payload["result"])
+                    self.assertEqual(unknowns, payload["unknowns"])
+
+    def test_oversized_inputs_are_rejected_at_each_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            oversized_intake = root / "oversized.json"
+            oversized_intake.write_bytes(b" " * (INTAKE_MAX_INPUT_BYTES + 1))
+            oversized_audit = root / "oversized.md"
+            oversized_audit.write_bytes(b" " * (AUDIT_MAX_INPUT_BYTES + 1))
+            cases = (
+                (oversized_intake, audit, ["intake_structure"]),
+                (intake, oversized_audit, ["audit_structure"]),
+            )
+            for supplied_intake, supplied_audit, unknowns in cases:
+                with self.subTest(unknowns=unknowns):
+                    payload, exit_code = validate_audit_link_files(
+                        supplied_intake,
+                        supplied_audit,
+                    )
+                    self.assertEqual(EXIT_NOT_LINKED, exit_code)
+                    self.assertEqual(unknowns, payload["unknowns"])
+
+    def test_invalid_utf8_is_rejected_for_each_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            invalid_intake = root / "invalid.json"
+            invalid_intake.write_bytes(b"\xff")
+            invalid_audit = root / "invalid.md"
+            invalid_audit.write_bytes(b"\xff")
+            cases = (
+                (invalid_intake, audit, ["intake_structure"]),
+                (intake, invalid_audit, ["audit_structure"]),
+            )
+            for supplied_intake, supplied_audit, unknowns in cases:
+                with self.subTest(unknowns=unknowns):
+                    payload, exit_code = validate_audit_link_files(
+                        supplied_intake,
+                        supplied_audit,
+                    )
+                    self.assertEqual(EXIT_NOT_LINKED, exit_code)
+                    self.assertEqual(RESULT_INVALID, payload["result"])
+                    self.assertEqual(unknowns, payload["unknowns"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_audit_link_cli.py
+++ b/tests/test_decision_os_audit_link_cli.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.audit_link import (
+    EXIT_NOT_LINKED,
+    IDENTITY_FIELDS,
+    RESULT_INVALID,
+    RESULT_LINKED,
+    RESULT_MISMATCH,
+)
+from decision_os.cli import (
+    AUDIT_LINK_USAGE,
+    EXIT_INTERNAL,
+    EXIT_USAGE,
+    main,
+    serialize,
+)
+from decision_os.audit_link_text import render_text as render_audit_link_text
+from tests.test_decision_os_checks import tree_digest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BIN_ENTRY = REPO_ROOT / "bin" / "decision-os"
+INTAKE_EXAMPLE = REPO_ROOT / "examples" / "workflow_incident_intake_v0_1.json"
+AUDIT_EXAMPLE = (
+    REPO_ROOT
+    / "examples"
+    / "ai_application_workflow_audit_delivery_v0_1.md"
+)
+
+
+def cli_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+    return environment
+
+
+def run_module(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (sys.executable, "-B", "-m", "decision_os", *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def run_bin(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        (str(BIN_ENTRY), *arguments),
+        capture_output=True,
+        check=False,
+        cwd=cwd,
+        env=cli_environment(),
+    )
+
+
+def decoded(completed: subprocess.CompletedProcess[bytes]) -> dict[str, object]:
+    if completed.stderr:
+        raise AssertionError(completed.stderr.decode("utf-8", errors="replace"))
+    if completed.stdout.count(b"\n") != 1 or not completed.stdout.endswith(b"\n"):
+        raise AssertionError(f"expected one JSON line, got {completed.stdout!r}")
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError("expected one JSON object")
+    return payload
+
+
+def write_pair(
+    directory: Path,
+    *,
+    shared_workflow: str = "SECRET SHARED WORKFLOW",
+) -> tuple[Path, Path]:
+    packet = json.loads(INTAKE_EXAMPLE.read_text(encoding="utf-8"))
+    if not isinstance(packet, dict):
+        raise AssertionError("expected object example")
+    packet["workflow"] = shared_workflow
+    intake = directory / "packet.json"
+    intake.write_text(
+        json.dumps(packet, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    audit_content = AUDIT_EXAMPLE.read_text(encoding="utf-8").replace(
+        "Application or Workflow: Customer-support approval workflow",
+        f"Application or Workflow: {shared_workflow}",
+        1,
+    )
+    audit = directory / "audit.md"
+    audit.write_text(audit_content, encoding="utf-8")
+    return intake, audit
+
+
+class AuditCaseLinkCliTest(unittest.TestCase):
+    def test_json_default_explicit_repeated_and_bin_outputs_match(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            before = tree_digest(root)
+
+            default = run_module(
+                root,
+                "audit-link",
+                str(intake),
+                str(audit),
+            )
+            repeated = run_module(
+                root,
+                "audit-link",
+                str(intake),
+                str(audit),
+            )
+            explicit = run_module(
+                root,
+                "audit-link",
+                "--format",
+                "json",
+                str(intake),
+                str(audit),
+            )
+            executable = run_bin(
+                root,
+                "audit-link",
+                str(intake),
+                str(audit),
+            )
+
+            results = (default, repeated, explicit, executable)
+            self.assertTrue(all(item.returncode == 0 for item in results))
+            self.assertTrue(all(item.stderr == b"" for item in results))
+            self.assertTrue(
+                all(item.stdout == default.stdout for item in results)
+            )
+            payload = decoded(default)
+            self.assertEqual(RESULT_LINKED, payload["result"])
+            self.assertEqual(
+                (serialize(payload) + "\n").encode(),
+                default.stdout,
+            )
+            self.assertNotIn(b"SECRET SHARED WORKFLOW", default.stdout)
+            self.assertEqual(before, tree_digest(root))
+
+    def test_text_output_is_exact_repeatable_and_bin_identical(self) -> None:
+        expected = (
+            "Decision-OS Audit Case Link v0.1: LINKED\n"
+            "\n"
+            "Inputs:\n"
+            "- intake: packet.json\n"
+            "- audit: audit.md\n"
+            "\n"
+            "Matched:\n"
+            "- workflow\n"
+            "- bounded_path\n"
+            "- trigger\n"
+            "- expected_state\n"
+            "- observed_state\n"
+            "- restart_or_fallback_path\n"
+            "\n"
+            "Mismatched:\n"
+            "- none\n"
+            "\n"
+            "Missing:\n"
+            "- none\n"
+            "\n"
+            "Unknowns:\n"
+            "- none\n"
+            "\n"
+            "Minimum next step:\n"
+            "Use LINKED only as bounded field-continuity evidence; continue "
+            "with human review of factual correctness.\n"
+            "\n"
+            "This result checks bounded identity continuity only.\n"
+            "It does not establish factual correctness, diagnosis quality, "
+            "repair efficacy, or client acceptance.\n"
+        ).encode()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+
+            first = run_module(
+                root,
+                "audit-link",
+                "--format",
+                "text",
+                str(intake),
+                str(audit),
+            )
+            second = run_module(
+                root,
+                "audit-link",
+                "--format",
+                "text",
+                str(intake),
+                str(audit),
+            )
+            executable = run_bin(
+                root,
+                "audit-link",
+                "--format",
+                "text",
+                str(intake),
+                str(audit),
+            )
+
+            self.assertEqual(0, first.returncode)
+            self.assertEqual(expected, first.stdout)
+            self.assertEqual(first.stdout, second.stdout)
+            self.assertEqual(first.stdout, executable.stdout)
+            self.assertEqual(b"", first.stderr)
+            self.assertNotIn(b"SECRET SHARED WORKFLOW", first.stdout)
+            self.assertFalse(first.stdout.endswith(b"\n\n"))
+
+    def test_usage_errors_return_two_in_selected_safe_format(self) -> None:
+        cases = (
+            (("audit-link",), b"{"),
+            (("audit-link", "packet.json"), b"{"),
+            (("audit-link", "packet.json", "audit.md", "extra"), b"{"),
+            (("audit-link", "--format"), b"{"),
+            (
+                ("audit-link", "--format", "yaml", "packet.json", "audit.md"),
+                b"{",
+            ),
+            (
+                ("audit-link", "--format", "text", "packet.json"),
+                b"Decision-OS Audit Case Link v0.1: INVALID\n",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for arguments, prefix in cases:
+                with self.subTest(arguments=arguments):
+                    completed = run_module(root, *arguments)
+
+                    self.assertEqual(EXIT_USAGE, completed.returncode)
+                    self.assertEqual(b"", completed.stderr)
+                    self.assertTrue(completed.stdout.startswith(prefix))
+                    self.assertNotIn(str(root).encode(), completed.stdout)
+
+        output = io.StringIO()
+        exit_code = main(["audit-link"], stdout=output)
+        self.assertEqual(EXIT_USAGE, exit_code)
+        self.assertIn(AUDIT_LINK_USAGE, output.getvalue())
+
+    def test_mismatch_and_invalid_return_four_without_content_echo(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            mismatch_content = audit.read_text(encoding="utf-8").replace(
+                "Application or Workflow: SECRET SHARED WORKFLOW",
+                "Application or Workflow: SECRET DIFFERENT WORKFLOW",
+                1,
+            )
+            audit.write_text(mismatch_content, encoding="utf-8")
+            mismatch = run_module(
+                root,
+                "audit-link",
+                str(intake),
+                str(audit),
+            )
+
+            malformed = root / "malformed.json"
+            malformed.write_text('{"SECRET INVALID":', encoding="utf-8")
+            invalid = run_module(
+                root,
+                "audit-link",
+                str(malformed),
+                str(audit),
+            )
+
+            self.assertEqual(EXIT_NOT_LINKED, mismatch.returncode)
+            self.assertEqual(RESULT_MISMATCH, decoded(mismatch)["result"])
+            self.assertEqual(EXIT_NOT_LINKED, invalid.returncode)
+            self.assertEqual(RESULT_INVALID, decoded(invalid)["result"])
+            self.assertNotIn(b"SECRET", mismatch.stdout)
+            self.assertNotIn(b"SECRET", invalid.stdout)
+
+    def test_unexpected_failure_returns_six_without_exception_detail(
+        self,
+    ) -> None:
+        output = io.StringIO()
+        with patch(
+            "decision_os.cli.validate_audit_link_files",
+            side_effect=RuntimeError("SECRET INTERNAL DETAIL"),
+        ):
+            exit_code = main(
+                ["audit-link", "safe-intake.json", "safe-audit.md"],
+                stdout=output,
+            )
+
+        self.assertEqual(EXIT_INTERNAL, exit_code)
+        self.assertNotIn("SECRET INTERNAL DETAIL", output.getvalue())
+        payload = json.loads(output.getvalue())
+        self.assertEqual(RESULT_INVALID, payload["result"])
+        self.assertEqual(["internal_failure"], payload["unknowns"])
+        self.assertEqual(
+            "safe-intake.json",
+            payload["inputs"]["intake"]["name"],
+        )
+        self.assertEqual(
+            "safe-audit.md",
+            payload["inputs"]["audit"]["name"],
+        )
+
+    def test_shipped_pair_and_audit_are_independently_valid(self) -> None:
+        linked = run_module(
+            REPO_ROOT,
+            "audit-link",
+            str(INTAKE_EXAMPLE),
+            str(AUDIT_EXAMPLE),
+        )
+        delivery = run_module(
+            REPO_ROOT,
+            "audit-check",
+            str(AUDIT_EXAMPLE),
+        )
+
+        self.assertEqual(0, linked.returncode)
+        self.assertEqual(RESULT_LINKED, decoded(linked)["result"])
+        self.assertEqual(0, delivery.returncode)
+        self.assertEqual("DELIVERY_READY", decoded(delivery)["result"])
+
+    def test_existing_commands_remain_available(self) -> None:
+        cases = (
+            ("check", str(REPO_ROOT)),
+            ("scan", str(REPO_ROOT)),
+            ("intake", str(INTAKE_EXAMPLE)),
+            ("audit-check", str(AUDIT_EXAMPLE)),
+        )
+        for command, target in cases:
+            with self.subTest(command=command):
+                completed = run_module(REPO_ROOT.parent, command, target)
+
+                self.assertEqual(0, completed.returncode)
+                self.assertEqual(b"", completed.stderr)
+                self.assertTrue(decoded(completed))
+
+    def test_json_field_order_is_canonical_for_mismatches(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            intake, audit = write_pair(root)
+            packet = json.loads(intake.read_text(encoding="utf-8"))
+            for field in reversed(IDENTITY_FIELDS):
+                packet[field] = f"{packet[field]} changed"
+            intake.write_text(json.dumps(packet), encoding="utf-8")
+
+            completed = run_module(
+                root,
+                "audit-link",
+                str(intake),
+                str(audit),
+            )
+
+            self.assertEqual(EXIT_NOT_LINKED, completed.returncode)
+            payload = decoded(completed)
+            self.assertEqual(list(IDENTITY_FIELDS), payload["mismatched_fields"])
+            self.assertEqual(
+                (serialize(payload) + "\n").encode(),
+                completed.stdout,
+            )
+
+    def test_text_renderer_rejects_unsafe_supplied_input_names(self) -> None:
+        payload = {
+            "result": RESULT_INVALID,
+            "matched_fields": [],
+            "mismatched_fields": [],
+            "missing_fields": [],
+            "unknowns": ["internal_failure"],
+            "minimum_next_step": (
+                "Retry the same two local files once; if the internal failure "
+                "repeats, stop and report the command boundary."
+            ),
+            "inputs": {
+                "intake": {"name": "intake\u2028forged.json"},
+                "audit": {"name": "../audit.md"},
+            },
+        }
+
+        rendered = render_audit_link_text(payload)
+
+        self.assertNotIn("\u2028", rendered)
+        self.assertNotIn("forged", rendered)
+        self.assertNotIn("../audit.md", rendered)
+        self.assertIn("- intake: unavailable", rendered)
+        self.assertIn("- audit: unavailable", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Reason

Add one deterministic, dependency-free, local read-only command that checks
whether an AI Application Workflow Audit preserves the same six accepted
incident-identity values as its workflow intake packet.

This is bounded identity continuity only. It does not diagnose the incident,
evaluate a repair, or establish that either supplied file is factually correct.

## Command and result contract

```text
decision-os audit-link <intake.json> <audit.md>
decision-os audit-link --format json|text <intake.json> <audit.md>
```

- `LINKED` / exit `0`: all six fields match after bounded whitespace
  normalization
- `MISMATCH` / exit `4`: both complete source contracts are usable, but one or
  more fields differ
- `INVALID` / exit `4`: either source cannot be safely read, parsed, or mapped
  to its accepted v0.1 contract
- usage error / exit `2`
- unexpected internal failure / exit `6`

The command reuses the existing bounded intake and Audit parsing rules, rejects
unsafe local inputs, ignores fenced Audit fields, reports safe basenames and
field names only, and never echoes compared values.

## Exact scope

Adds:

1. `decision_os/audit_link.py`
2. `decision_os/audit_link_text.py`
3. `tests/test_decision_os_audit_link.py`
4. `tests/test_decision_os_audit_link_cli.py`
5. `docs/audit_case_link_checker_v0_1.md`

Modifies:

6. `decision_os/cli.py`
7. `services/ai_application_workflow_audit_delivery_v0_1.md`
8. `examples/ai_application_workflow_audit_delivery_v0_1.md`
9. `tests/test_decision_os_audit_delivery.py`
10. `tests/test_decision_os_audit_delivery_cli.py`

The two existing Audit test files were included by approved scope correction so
the synchronized synthetic workflow identity retains meaningful validator and
no-content-echo coverage. No protected blob or protected-blob guard changed.

## Synthetic example boundary

The shipped intake and Audit example now preserve the same six source identity
values. The pair is synthetic, invented, and non-private. It is not client
evidence, a testimonial, a paid-client result, or a measured result.

## Validation

- Full suite: 147/147 PASS
- Audit Link tests: 23/23 PASS
- Audit Delivery tests: 33/33 PASS
- Workflow Intake tests: 18/18 PASS
- Synthetic pair: `LINKED`, exit `0`
- Synthetic Audit: `DELIVERY_READY`, exit `0`
- Loop Record examples: 12/12 PASS
- Protected v0.1 blob/mode guard: PASS unchanged
- Strict check: exit `0`; clean worktree; required fields missing `[]`;
  contradictions `[]`
- Markdown hierarchy: 3/3 PASS
- Local Markdown links: 9/9 resolve
- `git diff --check`: PASS
- Exact changed-file scope: 10 files
- Local/tracking/remote branch head:
  `a04dfc1ecc3f421702561e72c6a92587ee2ba613`
- Independent security, specification, and documentation review: no remaining
  blocking findings

## Claim boundary

`LINKED` does not establish intake truth, Audit diagnosis correctness,
source-material completeness, Priority Fix efficacy or uniqueness, client
acceptance, prevention, recovery, security, safety, productivity, cost,
revenue, unrepresented-system identity, or the absence of contradictory prose
elsewhere.

## Rollback

Revert this PR. Existing `check`, `scan`, `intake`, and `audit-check` behavior
remains independently covered.
