### PR TITLE
Add a self-service incident-to-instruction quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@
 ![Local read-only scan](https://img.shields.io/badge/scan-local%20read--only-blue)
 ![Human approval for changes](https://img.shields.io/badge/changes-human%20approval%20required-orange)
 
+## Turn one AI incident into a paste-ready rule
+
+An AI agent said “done,” resumed from stale state, lost the accepted result,
+or left you reconstructing the restart point.
+
+You do not need to post the incident, share your repository, install LoopKit,
+or contact anyone.
+
+Paste one sanitized incident into your own AI and receive a draft rule for
+your `AGENTS.md`, `CLAUDE.md`, system prompt, or runbook.
+
+[Copy the Incident-to-Instruction prompt](copy-paste/incident-to-instruction-rule.md)
+
+[See one complete Before / After example](examples/incident-to-instruction-before-after-v0-1.md)
+
+1. Remove secrets and private data.
+2. Paste one incident into the prompt.
+3. Review the returned rule before adding it to your instruction surface.
+
+The self-service result is a draft, not a verified Audit or a guarantee that
+the underlying tool will not fail again.
+
 ## Can the next coding agent find where to restart?
 
 Your repository can contain the right instructions and current state while

--- a/copy-paste/incident-to-instruction-rule.md
+++ b/copy-paste/incident-to-instruction-rule.md
@@ -1,0 +1,81 @@
+# Turn one AI incident into a paste-ready instruction rule
+
+You do not need to share your repository, contact anyone, or post the
+incident publicly.
+
+Remove credentials, customer data, private code, and production secrets.
+Then paste the prompt below into your own AI together with one incident.
+
+## Use in three steps
+
+1. Paste an incident description after removing confidential information.
+2. Send the entire prompt to your own AI.
+3. Review the returned rule before adding it to an existing instruction surface.
+
+No account, installation, direct message, repository share, JSON edit, or CLI
+command is required.
+
+## Copy-paste prompt
+
+```text
+You are converting one observed AI workflow incident into one bounded,
+paste-ready instruction rule.
+
+Use only the incident evidence supplied below.
+
+Do not:
+- judge the operator's competence;
+- invent a root cause;
+- claim that the rule prevents future incidents;
+- redesign the entire workflow;
+- produce multiple competing fixes;
+- require the user to understand a framework.
+
+If information is missing, mark it UNKNOWN.
+Choose exactly one first operational gap and exactly one priority fix.
+
+Select the most appropriate target surface:
+AGENTS.md, CLAUDE.md, system prompt, operational runbook, or an equivalent
+project instruction file.
+
+Return the following:
+
+1. Incident As-of
+2. First Operational Gap
+3. Target Surface
+4. Target Path or Placement
+5. Intended Scope
+6. Exact Paste-Ready Insertion Block
+7. Required Completion Evidence
+8. HOLD Conditions
+9. BLOCK Conditions
+10. Handoff Requirements
+11. Rollback
+12. Re-evaluation Trigger
+13. Still UNKNOWN
+
+The Exact Paste-Ready Insertion Block must:
+- be usable without reading the analysis;
+- require inspection of the canonical artifact or accepted state;
+- require evidence before completion;
+- stop on unresolved state disagreement;
+- forbid silent retry, unauthorized overwrite, and guessed canonical state;
+- preserve UNKNOWN items;
+- name the next actor and next safe action;
+- leave an exact restart point for the next human or AI.
+
+Keep the analysis brief. Put the usable insertion block first after the
+target recommendation.
+
+Return a draft only. Do not edit or apply the target instruction surface.
+
+INCIDENT:
+<paste one sanitized incident, screenshot transcription, or log excerpt here>
+```
+
+## Paid Audit boundary
+
+This self-service prompt returns a draft. The paid AI Application Workflow
+Audit checks whether the rule addresses the right gap, belongs in the right
+surface and scope, conflicts with existing instructions, has sufficient
+completion evidence, and can be safely rolled back and handed off.

--- a/examples/incident-to-instruction-before-after-v0-1.md
+++ b/examples/incident-to-instruction-before-after-v0-1.md
@@ -1,0 +1,150 @@
+# Incident-to-Instruction Before / After v0.1
+
+**Synthetic / invented / non-private**
+
+**Not customer evidence**
+
+**Not measured effectiveness**
+
+**Not proof of incident prevention**
+
+This example shows what the
+[Incident-to-Instruction prompt](../copy-paste/incident-to-instruction-rule.md)
+can return from one sanitized invented incident. No file was edited and no
+rule was applied.
+
+## Before
+
+- The agent reported completion after a command exited successfully.
+- The remote state had not changed.
+- The next session resumed from stale state.
+- The human inspected logs and repeated the decision.
+
+The synthetic repository uses `/AGENTS.md` for repository-wide agent rules. It
+contains an existing `## Repository Authority` section followed later by
+`## Task Execution`.
+
+## After — one returned draft rule
+
+### 1. Incident As-of
+
+Synthetic scenario as of 2026-07-26.
+
+### 2. First Operational Gap
+
+Completion was reported from command exit without inspecting the canonical
+artifact, remote state, or accepted state and without retaining verification
+evidence for the next session.
+
+### 3. Target Surface
+
+`AGENTS.md`
+
+### 4. Target Path or Placement
+
+Repository-root `/AGENTS.md`, immediately after `## Repository Authority` and
+before `## Task Execution`.
+
+### 5. Intended Scope
+
+AI agents performing Git-backed repository changes whose accepted completion
+depends on local, remote, or reviewed state. The rule does not grant authority
+for unrelated workflows, publication, merge, release, or overwrite.
+
+### 6. Exact Paste-Ready Insertion Block
+
+~~~~markdown
+## Canonical Completion and Restart Rule
+
+- Apply this rule only to Git-backed repository changes whose accepted result
+  depends on local, remote, or reviewed state.
+- Do not report completion solely because a command exited successfully.
+- Before reporting completion, inspect the canonical artifact or accepted
+  state that the task was meant to change.
+- Record the verification evidence used for closure: the exact artifact,
+  reference or state, relevant check, observed result, and as-of point.
+- Compare local, remote, and accepted state whenever they participate in the
+  workflow. If they disagree, or a required identity is unresolved, set
+  `HOLD` and stop before closure.
+- Do not silently retry, guess which copy is canonical, or overwrite an
+  artifact or state without explicit authority.
+- Preserve unresolved items as `UNKNOWN`.
+- Next actor: the repository operator. Next safe action: inspect and reconcile
+  the canonical local, remote, and accepted state before another completion
+  decision.
+- Do not mark handoff complete until the next human or AI can identify the
+  exact restart point, current gate, verification evidence, unresolved items,
+  next actor, next safe action, and rollback path.
+~~~~
+
+### 7. Required Completion Evidence
+
+- The canonical target path and intended scope are recorded.
+- The insertion block appears once between the two named headings without
+  replacing unrelated instructions.
+- The canonical post-write artifact is inspected with its exact reference or
+  digest and accepted as-of point.
+- The relevant instruction-surface check and its observed result are recorded.
+- Local, remote, and accepted states agree when all three apply.
+
+### 8. HOLD Conditions
+
+- The canonical artifact, target path, placement anchor, or intended scope is
+  unresolved.
+- Local, remote, and accepted states disagree or cannot be compared with the
+  available evidence.
+- Required verification evidence or the exact restart point is missing.
+
+### 9. BLOCK Conditions
+
+- The actor lacks authority to edit the instruction surface.
+- Applying the rule would expose private material, weaken a higher-priority
+  instruction, or overwrite unrelated content.
+- The requested action requires guessed canonical state, evidence suppression,
+  or an unauthorized merge, release, publication, or overwrite.
+
+### 10. Handoff Requirements
+
+Record the target path, placement, intended scope, selected fix, canonical
+post-write state, verification evidence, current gate, all unresolved or
+`UNKNOWN` items, exact restart point, next actor, next safe action, and
+rollback path.
+
+### 11. Rollback
+
+Remove only the exact `Canonical Completion and Restart Rule` block, restore
+the recorded prior `/AGENTS.md` state when necessary, preserve unrelated later
+changes, and repeat the canonical-state and instruction-surface verification.
+
+### 12. Re-evaluation Trigger
+
+Review the wording after another false-completion or stale-resume incident, a
+change to the canonical path or instruction precedence, a state disagreement
+not handled by the rule, or evidence that the rule conflicts with the actual
+workflow.
+
+### 13. Still UNKNOWN
+
+- Whether the synthetic target layout matches any real repository.
+- Whether an authorized operator would accept or apply the rule.
+- Whether an AI agent would follow it.
+- Whether it would reduce recovery work or prevent any future incident.
+- The underlying cause of the stale remote state.
+
+### After checklist
+
+- One exact `AGENTS.md` block.
+- Canonical-state inspection.
+- Verification evidence.
+- `HOLD` on local/remote/accepted-state disagreement.
+- `UNKNOWN` preservation.
+- Next actor and restart point.
+- Rollback and re-evaluation trigger.
+
+## Free draft and paid Audit boundary
+
+This After is a structured draft, not an applied improvement, customer
+diagnosis, verified implementation, or measured result. The paid AI
+Application Workflow Audit separately reviews whether the selected gap,
+surface, scope, placement, evidence, conflicts, rollback, and handoff are
+appropriate for one accepted workflow.

--- a/validation/incident-to-instruction-self-service-run-001.md
+++ b/validation/incident-to-instruction-self-service-run-001.md
@@ -1,0 +1,249 @@
+# Incident-to-Instruction Self-Service Run 001
+
+## Status
+
+```text
+As-of:
+2026-07-26 / Asia/Tokyo
+
+Result:
+PASS / COMPLETE
+
+Repository:
+shin4141/decision-os-v13-loopkit
+
+Base:
+bead87552ef4a379d734ad9fc3c84f98315ca419
+
+Branch:
+docs/self-service-incident-to-instruction-v0-1
+
+Changed files:
+PASS / EXACT 4
+
+README links:
+PASS / 2 OF 2
+
+Prompt replacement point:
+PASS / EXACTLY 1
+
+Required output fields:
+PASS / 13 OF 13 IN PROMPT AND EXAMPLE
+
+Example:
+PASS / ONE COMPLETE BLOCK / NO TEMPLATE MARKERS
+
+Self-service boundary:
+PASS / FREE DRAFT DISTINCT FROM PAID AUDIT
+
+Markdown:
+PASS / 60 LOCAL LINKS / 94 HEADINGS / 26 CLOSED FENCES
+
+Full suite:
+PASS / 166 OF 166
+
+Protected-blob guard:
+PASS / 14 OF 14 BLOBS AND MODES
+
+git diff --check:
+PASS
+
+Publication handoff:
+PASS / CLEAN WORKTREE / LOCAL = TRACKING = REMOTE
+```
+
+## Validation question
+
+Can a first-time visitor move from the repository README to one public
+copy-paste prompt, provide one sanitized incident to their own AI, and receive
+one reviewable instruction-rule draft without installing LoopKit, sharing a
+repository, editing JSON, running a CLI, or entering the paid Audit?
+
+## Validation subject
+
+This run covers:
+
+- the new first README route in [`README.md`](../README.md);
+- the
+  [Incident-to-Instruction prompt](../copy-paste/incident-to-instruction-rule.md);
+- the complete
+  [synthetic Before / After example](../examples/incident-to-instruction-before-after-v0-1.md);
+- this validation receipt.
+
+## Exact four-file scope
+
+```text
+ADD copy-paste/incident-to-instruction-rule.md
+ADD examples/incident-to-instruction-before-after-v0-1.md
+ADD validation/incident-to-instruction-self-service-run-001.md
+MODIFY README.md
+```
+
+No checker, code, test, service, price, release, version, Canon,
+branch-protection, Reddit, or unrelated PR surface is in scope.
+
+## Self-service contract receipt
+
+The prompt must contain exactly one visible incident replacement point and all
+thirteen requested output fields:
+
+1. Incident As-of
+2. First Operational Gap
+3. Target Surface
+4. Target Path or Placement
+5. Intended Scope
+6. Exact Paste-Ready Insertion Block
+7. Required Completion Evidence
+8. HOLD Conditions
+9. BLOCK Conditions
+10. Handoff Requirements
+11. Rollback
+12. Re-evaluation Trigger
+13. Still UNKNOWN
+
+The example must contain one complete, placeholder-free `AGENTS.md` block and
+must identify itself as synthetic, invented, non-private, non-customer
+evidence, unmeasured, and not prevention proof.
+
+The public self-service path returns a draft. It does not perform the paid
+Audit, diagnose a customer workflow, verify implementation, authorize a write,
+or establish prevention or effectiveness.
+
+## Exact commands
+
+### Full suite and protected guard
+
+```sh
+python3 -B -m unittest discover -s tests
+
+python3 -B -m unittest -v \
+  tests.test_decision_os_scan_cli.DecisionOsScanCliTest.test_protected_v01_blobs_and_modes_are_unchanged
+```
+
+### Existing Loop Record examples
+
+```sh
+python3 -B scripts/validate_loop_record_examples.py \
+  --schema schema/v13_loop_record.schema.json \
+  --examples-dir examples
+```
+
+### Documentation and self-service contract
+
+The final pass uses a dependency-free, non-committed validation script to
+check the exact four files, relative links, README placement, one incident
+replacement point, all thirteen fields, the completed example, boundary
+language, ATX heading order, fenced blocks, and placeholder markers.
+
+## Command receipt
+
+```text
+Full suite:
+PASS / 166 tests / exit 0
+
+Protected-blob guard:
+PASS / 14 protected blobs and modes / exit 0
+
+Loop Record examples:
+PASS / 12 of 12 / exit 0
+
+Documentation and self-service contract:
+PASS / exit 0
+```
+
+## Documentation receipt
+
+```text
+Exact changed files:
+PASS / 4 of 4
+
+README placement:
+PASS / first H2 after the five existing badges
+
+README primary and secondary links:
+PASS / 2 of 2
+
+Visible incident replacement points:
+PASS / exactly 1
+
+Required output fields:
+PASS / 13 of 13 in the prompt
+PASS / 13 of 13 completed in the example
+
+Example template markers:
+PASS / 0
+
+Paste-ready instruction blocks:
+PASS / exactly 1
+
+Synthetic / non-private / non-evidence markers:
+PASS
+
+Free draft / paid Audit distinction:
+PASS
+
+Account, install, direct message, repository share, JSON, or CLI requirement:
+NONE
+
+Relative local links:
+PASS / 60 resolved
+
+Heading hierarchy:
+PASS / 94 headings / no level jump
+
+Fenced blocks:
+PASS / 26 closed fences
+
+git diff --check:
+PASS / no output / exit 0
+
+Clean worktree:
+PASS / after commit
+
+Branch heads:
+PASS / local = tracking = remote
+```
+
+## Scope and no-write boundary
+
+The run reads repository documents and executes the existing test suite. It
+does not send an incident, invoke an external AI, edit a target instruction
+surface, create an account, install a tool, contact Shin, open a fit check, or
+perform the paid Audit.
+
+The README keeps the existing scan, intake, Audit, and tutorial paths below the
+new first-time route without deleting or rewriting them.
+
+## Bounded conclusion
+
+The README now begins with one direct self-service reward, the copy-paste page
+contains one incident replacement point and all thirteen output fields, and
+the complete synthetic example returns one placeholder-free instruction block.
+The route requires no public incident, contact, repository share, account,
+installation, JSON edit, or CLI and remains a draft rather than a verified
+Audit or prevention claim.
+
+## Limitations
+
+- The incident and returned rule are synthetic and non-private.
+- No external AI response was measured.
+- No real target surface was inspected or edited.
+- No customer reviewed, accepted, or applied the rule.
+- One example cannot establish target correctness, instruction compliance,
+  prevention, recovery, safety, productivity, paid value, or general
+  reliability.
+
+## Completion Line
+
+A first-time Reddit visitor can:
+
+1. open the README;
+2. immediately understand the reward;
+3. open one copy-paste prompt;
+4. privately insert one sanitized incident into their own AI;
+5. receive one paste-ready instruction rule;
+6. see a complete Before / After example;
+7. understand the boundary between the free draft and the human-reviewed Audit;
+
+without posting the incident, contacting Shin, sharing a repository,
+installing LoopKit, editing JSON, or running a CLI.


### PR DESCRIPTION
## Summary

- add the first README route from one sanitized AI workflow incident to one paste-ready draft instruction rule
- add a copy-paste prompt with one visible incident replacement point and the required 13-field output contract
- add one complete synthetic Before / After example centered on a placeholder-free `AGENTS.md` block
- add a validation receipt for the self-service route and its free-draft / paid-Audit boundary

## Exact scope

- `README.md`
- `copy-paste/incident-to-instruction-rule.md`
- `examples/incident-to-instruction-before-after-v0-1.md`
- `validation/incident-to-instruction-self-service-run-001.md`

## Validation

- full suite: 166/166 PASS
- protected-blob/mode guard: 14/14 PASS
- Loop Record examples: 12/12 PASS
- documentation contract: 2/2 README CTAs, one incident replacement point, 13/13 fields in prompt and example, one placeholder-free instruction block
- Markdown: 60 local links resolve, 94 headings with no hierarchy jump, 26 closed fences
- `git diff --check`: PASS
- publication handoff: clean worktree; local, tracking, and remote branch heads match

## Boundary

The self-service result is a draft, not a completed Audit, customer diagnosis,
verified implementation, measured result, or prevention guarantee.

## HOLD

- merge
- Reddit posting
- release or version changes
- Canon changes
- branch-protection changes
- PR #24 / #4 / #5
- pricing changes
