### PR TITLE
Add Claude-first Verified Save MVP

### DIFF
--- a/decision_os/acceleration/__init__.py
+++ b/decision_os/acceleration/__init__.py
@@ -1,0 +1,23 @@
+"""Agent-agnostic Verified Save protocol and local acceleration state."""
+
+from .engine import AccelerationEngine, DeterministicAdapter
+from .model import (
+    DecisionType,
+    ScopeError,
+    decision_key,
+    normalize_scope,
+    rule_hash,
+)
+from .store import AccelerationStore, StateIntegrityError
+
+__all__ = [
+    "AccelerationEngine",
+    "AccelerationStore",
+    "DecisionType",
+    "DeterministicAdapter",
+    "ScopeError",
+    "StateIntegrityError",
+    "decision_key",
+    "normalize_scope",
+    "rule_hash",
+]

--- a/decision_os/acceleration/claude_adapter.py
+++ b/decision_os/acceleration/claude_adapter.py
@@ -1,0 +1,319 @@
+"""Claude Agent SDK adapter for the agent-agnostic Verified Save engine."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import importlib
+from pathlib import Path
+import subprocess
+from typing import Any, TextIO
+
+from .engine import AccelerationEngine, CheckpointOutcome, DecisionOutcome
+from .model import DecisionType, ScopeError, normalize_scope
+
+
+CLAUDE_AGENT_SDK_VERSION = "0.2.123"
+BUNDLED_CLAUDE_CODE_VERSION = "2.1.215"
+ADAPTER_NAME = "claude-agent-sdk"
+
+
+class ClaudeAdapterUnavailable(RuntimeError):
+    """The optional Claude adapter dependency is unavailable."""
+
+
+class ClaudeAdapterFailure(RuntimeError):
+    """The SDK contract or bounded run failed before a normal checkpoint."""
+
+
+@dataclass(frozen=True)
+class ClaudeRunResult:
+    """Sanitized result of one fresh Claude SDK query."""
+
+    run_id: str
+    normal_terminal: bool
+    status: str
+    error_type: str | None
+    result_subtype: str | None
+    api_error_status: int | None
+    stop_reason: str | None
+    checkpoint_outcomes: tuple[CheckpointOutcome, ...]
+
+
+class ClaudeAdapter:
+    """Map exact Claude Edit/Write callbacks into fixed protocol decisions."""
+
+    def __init__(
+        self,
+        engine: AccelerationEngine,
+        *,
+        input_func: Callable[[], str],
+        stdout: TextIO,
+        sdk_module: Any | None = None,
+    ) -> None:
+        self.engine = engine
+        self.input_func = input_func
+        self.stdout = stdout
+        self._sdk_module = sdk_module
+        self._run_id = ""
+        self._iteration = 0
+        self._pending: dict[str, DecisionOutcome] = {}
+        self._seen: dict[str, DecisionOutcome] = {}
+        self._permission_denied = False
+
+    def _load_sdk(self) -> Any:
+        if self._sdk_module is None:
+            try:
+                module = importlib.import_module("claude_agent_sdk")
+            except ModuleNotFoundError as exc:
+                raise ClaudeAdapterUnavailable(
+                    "Claude adapter unavailable. Install with "
+                    "'pip install decision-os-v13-loopkit[claude]'."
+                ) from exc
+        else:
+            module = self._sdk_module
+        version = getattr(module, "__version__", None)
+        if version != CLAUDE_AGENT_SDK_VERSION:
+            raise ClaudeAdapterFailure(
+                "Claude Agent SDK version mismatch: "
+                f"expected {CLAUDE_AGENT_SDK_VERSION}, observed {version!r}."
+            )
+        return module
+
+    @staticmethod
+    def bundled_cli_identity(sdk_module: Any) -> str:
+        """Read the bundled CLI version without invoking a system Claude binary."""
+
+        module_file = getattr(sdk_module, "__file__", None)
+        if not module_file:
+            raise ClaudeAdapterFailure("Claude SDK package path is unavailable.")
+        executable = Path(module_file).resolve().parent / "_bundled" / "claude"
+        if not executable.is_file():
+            raise ClaudeAdapterFailure("Bundled Claude Code CLI is unavailable.")
+        completed = subprocess.run(
+            (str(executable), "--version"),
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise ClaudeAdapterFailure("Bundled Claude Code CLI version failed.")
+        observed = completed.stdout.strip()
+        if not observed.startswith(BUNDLED_CLAUDE_CODE_VERSION):
+            raise ClaudeAdapterFailure(
+                "Bundled Claude Code CLI version mismatch: "
+                f"expected {BUNDLED_CLAUDE_CODE_VERSION}, observed {observed!r}."
+            )
+        return observed
+
+    def _map_tool(
+        self,
+        tool_name: str,
+        input_data: dict[str, Any],
+    ) -> tuple[DecisionType, str]:
+        if tool_name not in {"Edit", "Write"}:
+            raise ClaudeAdapterFailure(f"Unsupported Claude tool: {tool_name}")
+        raw_path = input_data.get("file_path")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise ClaudeAdapterFailure(
+                f"{tool_name} input lacks the validated file_path string."
+            )
+        normalized = normalize_scope(self.engine.repository, raw_path)
+        if tool_name == "Edit":
+            return DecisionType.MODIFY_FILE, raw_path
+        target = self.engine.store.repository / normalized
+        decision_type = (
+            DecisionType.MODIFY_FILE
+            if target.exists()
+            else DecisionType.CREATE_FILE
+        )
+        return decision_type, raw_path
+
+    def _human_choice(self, identity: Any) -> str | None:
+        action = (
+            "create"
+            if identity.decision_type is DecisionType.CREATE_FILE
+            else "modify"
+        )
+        self.stdout.write(
+            "\nYour coding agent needs one default.\n\n"
+            f"May it {action} {identity.normalized_scope}?\n\n"
+            "[1] Allow once\n"
+            "[2] Use for this repository\n"
+            "[3] Deny\n\n"
+            "Selection: "
+        )
+        self.stdout.flush()
+        try:
+            return self.input_func()
+        except (EOFError, KeyboardInterrupt, OSError):
+            return None
+
+    async def _permission_callback(
+        self,
+        sdk_module: Any,
+        tool_name: str,
+        input_data: dict[str, Any],
+        context: Any,
+    ) -> Any:
+        try:
+            decision_type, raw_path = self._map_tool(tool_name, input_data)
+            normalized = normalize_scope(self.engine.repository, raw_path)
+        except (ClaudeAdapterFailure, ScopeError) as exc:
+            self._permission_denied = True
+            return sdk_module.PermissionResultDeny(
+                message=f"Verified Save denied: {type(exc).__name__}",
+                interrupt=False,
+            )
+
+        repository_identity = self.engine.store.repository_id
+        key = (
+            f"{repository_identity}|{decision_type.value}|{normalized}"
+        )
+        if key in self._seen:
+            existing = self._seen[key]
+            if existing.allowed:
+                return sdk_module.PermissionResultAllow()
+            return sdk_module.PermissionResultDeny(
+                message="Verified Save denied for this decision.",
+                interrupt=False,
+            )
+
+        self._iteration += 1
+        tool_use_id = getattr(context, "tool_use_id", None)
+        outcome = self.engine.evaluate(
+            run_id=self._run_id,
+            iteration=self._iteration,
+            decision_type=decision_type,
+            requested_scope=raw_path,
+            source_interrupt_id=tool_use_id,
+            choice_provider=self._human_choice,
+        )
+        self._seen[key] = outcome
+        if outcome.pending_cross_run_checkpoint:
+            self._pending[outcome.identity.decision_key] = outcome
+        if outcome.allowed:
+            return sdk_module.PermissionResultAllow()
+        self._permission_denied = True
+        return sdk_module.PermissionResultDeny(
+            message="Human denied or no explicit selection was available.",
+            interrupt=False,
+        )
+
+    def _options(
+        self,
+        sdk_module: Any,
+        *,
+        demo: bool,
+    ) -> Any:
+        available_tools = ["Read", "Edit"] if demo else ["Read", "Edit", "Write"]
+
+        async def callback(
+            tool_name: str,
+            input_data: dict[str, Any],
+            context: Any,
+        ) -> Any:
+            return await self._permission_callback(
+                sdk_module,
+                tool_name,
+                input_data,
+                context,
+            )
+
+        return sdk_module.ClaudeAgentOptions(
+            allowed_tools=["Read"],
+            can_use_tool=callback,
+            continue_conversation=False,
+            cwd=self.engine.store.repository,
+            disallowed_tools=[],
+            permission_mode="default",
+            setting_sources=[],
+            skills=[],
+            strict_mcp_config=True,
+            system_prompt=(
+                "Perform only the requested bounded file operation. "
+                "Use Read when needed and exactly one Edit or Write operation. "
+                "Do not use Bash, do not touch another path, and stop normally "
+                "after the requested operation."
+            ),
+            tools=available_tools,
+        )
+
+    async def run(self, prompt: str, *, demo: bool = False) -> ClaudeRunResult:
+        """Run one fresh query and promote pending matches only on normal result."""
+
+        sdk = self._load_sdk()
+        self._run_id = self.engine.new_run_id()
+        self._iteration = 0
+        self._pending = {}
+        self._seen = {}
+        self._permission_denied = False
+        options = self._options(sdk, demo=demo)
+        result_message: Any | None = None
+        error_type: str | None = None
+
+        async def prompt_stream() -> Any:
+            yield {
+                "type": "user",
+                "message": {"role": "user", "content": prompt},
+                "parent_tool_use_id": None,
+            }
+
+        try:
+            async for message in sdk.query(
+                prompt=prompt_stream(),
+                options=options,
+            ):
+                if isinstance(message, sdk.ResultMessage):
+                    result_message = message
+        except Exception as exc:
+            error_type = type(exc).__name__
+
+        normal_terminal = bool(
+            result_message is not None
+            and getattr(result_message, "subtype", None) == "success"
+            and not bool(getattr(result_message, "is_error", True))
+            and error_type is None
+        )
+        checkpoints = tuple(
+            self.engine.finish_checkpoint(
+                outcome,
+                normal_terminal=normal_terminal,
+                checkpoint_id=(
+                    f"claude-result:{self._run_id}:{index}"
+                    if result_message is not None
+                    else f"claude-missing-result:{self._run_id}:{index}"
+                ),
+            )
+            for index, outcome in enumerate(self._pending.values(), start=1)
+        )
+        if checkpoints:
+            status = checkpoints[-1].status
+        elif self._permission_denied:
+            status = "DENIED"
+        elif normal_terminal:
+            status = "NORMAL_TERMINAL"
+        else:
+            status = "ABNORMAL_TERMINAL"
+        return ClaudeRunResult(
+            run_id=self._run_id,
+            normal_terminal=normal_terminal,
+            status=status,
+            error_type=error_type,
+            result_subtype=(
+                getattr(result_message, "subtype", None)
+                if result_message is not None
+                else None
+            ),
+            api_error_status=(
+                getattr(result_message, "api_error_status", None)
+                if result_message is not None
+                else None
+            ),
+            stop_reason=(
+                getattr(result_message, "stop_reason", None)
+                if result_message is not None
+                else None
+            ),
+            checkpoint_outcomes=checkpoints,
+        )

--- a/decision_os/acceleration/claude_adapter.py
+++ b/decision_os/acceleration/claude_adapter.py
@@ -252,20 +252,12 @@ class ClaudeAdapter:
         result_message: Any | None = None
         error_type: str | None = None
 
-        async def prompt_stream() -> Any:
-            yield {
-                "type": "user",
-                "message": {"role": "user", "content": prompt},
-                "parent_tool_use_id": None,
-            }
-
         try:
-            async for message in sdk.query(
-                prompt=prompt_stream(),
-                options=options,
-            ):
-                if isinstance(message, sdk.ResultMessage):
-                    result_message = message
+            async with sdk.ClaudeSDKClient(options=options) as client:
+                await client.query(prompt)
+                async for message in client.receive_response():
+                    if isinstance(message, sdk.ResultMessage):
+                        result_message = message
         except Exception as exc:
             error_type = type(exc).__name__
 

--- a/decision_os/acceleration/cli.py
+++ b/decision_os/acceleration/cli.py
@@ -1,0 +1,295 @@
+"""Separate ``decision-os-accelerate`` command surface."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Callable, Sequence
+from contextlib import redirect_stderr
+import io
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import TextIO
+
+from .claude_adapter import (
+    ADAPTER_NAME,
+    CLAUDE_AGENT_SDK_VERSION,
+    ClaudeAdapter,
+    ClaudeAdapterFailure,
+    ClaudeAdapterUnavailable,
+)
+from .engine import AccelerationEngine
+from .store import AccelerationStore, StateIntegrityError
+
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_STATE = 3
+EXIT_DELAY = 4
+EXIT_DENIED = 5
+
+DEMO_RUN_1 = (
+    "Read demo_target.txt. Use Edit exactly once to replace the line "
+    "'stage: initial' with 'stage: run-1'. Do not touch any other file."
+)
+DEMO_RUN_2 = (
+    "Read demo_target.txt. Use Edit exactly once to replace the line "
+    "'stage: run-1' with 'stage: run-2'. Do not touch any other file."
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="decision-os-accelerate")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    run = subcommands.add_parser("run")
+    run.add_argument("--adapter", choices=("claude",), required=True)
+    run.add_argument("--prompt-file", type=Path, required=True)
+    run.add_argument("--minutes-per-reuse", type=float, default=7.5)
+    run.add_argument("--hourly-value-jpy", type=float, default=5000)
+    run.add_argument("--tokens-per-reuse", type=int)
+    run.add_argument("repository", type=Path)
+
+    receipt = subcommands.add_parser("receipt")
+    receipt.add_argument("repository", type=Path)
+
+    revoke = subcommands.add_parser("revoke")
+    revoke.add_argument("--decision-key", required=True)
+    revoke.add_argument("repository", type=Path)
+
+    demo = subcommands.add_parser("demo")
+    demo.add_argument("--adapter", choices=("claude",), required=True)
+    demo.add_argument("--tokens-per-reuse", type=int)
+    return parser
+
+
+def _settings(
+    store: AccelerationStore,
+    *,
+    minutes_per_reuse: float,
+    hourly_value_jpy: float,
+    tokens_per_reuse: int | None,
+) -> None:
+    store.update_settings(
+        minutes_per_reuse=minutes_per_reuse,
+        hourly_value_jpy=hourly_value_jpy,
+        tokens_per_reuse=tokens_per_reuse,
+        set_tokens=tokens_per_reuse is not None,
+    )
+
+
+def _run_command(
+    arguments: argparse.Namespace,
+    *,
+    stdout: TextIO,
+    input_func: Callable[[], str],
+) -> int:
+    try:
+        prompt = arguments.prompt_file.read_text(encoding="utf-8")
+        store = AccelerationStore(arguments.repository)
+        _settings(
+            store,
+            minutes_per_reuse=arguments.minutes_per_reuse,
+            hourly_value_jpy=arguments.hourly_value_jpy,
+            tokens_per_reuse=arguments.tokens_per_reuse,
+        )
+        engine = AccelerationEngine(
+            arguments.repository,
+            store=store,
+            adapter=ADAPTER_NAME,
+            adapter_version=CLAUDE_AGENT_SDK_VERSION,
+        )
+        adapter = ClaudeAdapter(
+            engine,
+            input_func=input_func,
+            stdout=stdout,
+        )
+        result = asyncio.run(adapter.run(prompt))
+    except (OSError, UnicodeError, StateIntegrityError) as exc:
+        stdout.write(f"BLOCK: {type(exc).__name__}\n")
+        return EXIT_STATE
+    except (ClaudeAdapterUnavailable, ClaudeAdapterFailure) as exc:
+        stdout.write(f"DELAY: {exc}\n")
+        return EXIT_DELAY
+
+    stdout.write(
+        f"Run: {result.status} / "
+        f"{'normal' if result.normal_terminal else 'abnormal'} checkpoint\n"
+    )
+    if result.error_type:
+        stdout.write(f"Adapter error type: {result.error_type}\n")
+    stdout.write(engine.render_receipt())
+    if result.status in {"VERIFIED_SAVE", "VERIFIED_REUSE", "NORMAL_TERMINAL"}:
+        return EXIT_OK
+    if result.status == "ABNORMAL_TERMINAL":
+        return EXIT_DELAY
+    return EXIT_DENIED
+
+
+def _receipt_command(arguments: argparse.Namespace, *, stdout: TextIO) -> int:
+    try:
+        engine = AccelerationEngine(arguments.repository)
+        stdout.write(engine.render_receipt())
+    except StateIntegrityError as exc:
+        stdout.write(f"BLOCK: {type(exc).__name__}\n")
+        return EXIT_STATE
+    return EXIT_OK
+
+
+def _revoke_command(arguments: argparse.Namespace, *, stdout: TextIO) -> int:
+    try:
+        engine = AccelerationEngine(arguments.repository)
+        status = engine.revoke(
+            run_id=engine.new_run_id(),
+            decision_key=arguments.decision_key,
+        )
+    except StateIntegrityError as exc:
+        stdout.write(f"BLOCK: {type(exc).__name__}\n")
+        return EXIT_STATE
+    except ValueError as exc:
+        stdout.write(f"DENIED: {exc}\n")
+        return EXIT_DENIED
+    stdout.write(f"{status}\n")
+    return EXIT_OK
+
+
+def _demo_command(
+    arguments: argparse.Namespace,
+    *,
+    stdout: TextIO,
+    input_func: Callable[[], str],
+) -> int:
+    directory = Path(tempfile.mkdtemp(prefix="decision-os-verified-save-"))
+    try:
+        completed = subprocess.run(
+            ("git", "init", "-q", str(directory)),
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if completed.returncode != 0:
+            stdout.write("BLOCK: disposable Git repository creation failed.\n")
+            return EXIT_STATE
+        (directory / "demo_target.txt").write_text(
+            "stage: initial\n",
+            encoding="utf-8",
+        )
+        store = AccelerationStore(directory)
+        _settings(
+            store,
+            minutes_per_reuse=7.5,
+            hourly_value_jpy=5000,
+            tokens_per_reuse=arguments.tokens_per_reuse,
+        )
+        engine = AccelerationEngine(
+            directory,
+            store=store,
+            adapter=ADAPTER_NAME,
+            adapter_version=CLAUDE_AGENT_SDK_VERSION,
+        )
+        adapter = ClaudeAdapter(
+            engine,
+            input_func=input_func,
+            stdout=stdout,
+        )
+        first = asyncio.run(adapter.run(DEMO_RUN_1, demo=True))
+        stdout.write(
+            "Live Run 1: "
+            f"status={first.status}; "
+            f"result_subtype={first.result_subtype or 'NONE'}; "
+            f"api_error_status={first.api_error_status or 'NONE'}; "
+            f"stop_reason={first.stop_reason or 'NONE'}; "
+            f"error_type={first.error_type or 'NONE'}\n"
+        )
+        default_created = any(
+            event["event_type"] == "HUMAN_DEFAULT_CREATED"
+            and event["run_id"] == first.run_id
+            for event in store.read_events()
+        )
+        if not first.normal_terminal or not default_created:
+            stdout.write(
+                "DELAY: Run 1 did not end normally with an explicit "
+                "Repository Default.\n"
+            )
+            return EXIT_DELAY
+
+        second = asyncio.run(adapter.run(DEMO_RUN_2, demo=True))
+        stdout.write(
+            "Live Run 2: "
+            f"status={second.status}; "
+            f"result_subtype={second.result_subtype or 'NONE'}; "
+            f"api_error_status={second.api_error_status or 'NONE'}; "
+            f"stop_reason={second.stop_reason or 'NONE'}; "
+            f"error_type={second.error_type or 'NONE'}\n"
+        )
+        receipt = engine.render_receipt()
+        stdout.write(receipt)
+        verified_saves, verified_reuses = store.counters()
+        if (
+            not second.normal_terminal
+            or second.status != "VERIFIED_SAVE"
+            or (verified_saves, verified_reuses) != (1, 1)
+        ):
+            stdout.write("DELAY: live two-Run proof did not verify.\n")
+            return EXIT_DELAY
+
+        receipt_path = (
+            Path(tempfile.gettempdir())
+            / (
+                "decision-os-verified-save-receipt-"
+                f"{store.chain_head()[:12]}.txt"
+            )
+        )
+        receipt_path.write_text(receipt, encoding="utf-8")
+        stdout.write(f"Sanitized receipt: {receipt_path}\n")
+        return EXIT_OK
+    except (ClaudeAdapterUnavailable, ClaudeAdapterFailure) as exc:
+        stdout.write(f"DELAY: {exc}\n")
+        return EXIT_DELAY
+    except (OSError, StateIntegrityError) as exc:
+        stdout.write(f"BLOCK: {type(exc).__name__}\n")
+        return EXIT_STATE
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    input_func: Callable[[], str] = input,
+) -> int:
+    """Run the bounded acceleration CLI without disturbing ``decision-os``."""
+
+    output = sys.stdout if stdout is None else stdout
+    errors = sys.stderr if stderr is None else stderr
+    try:
+        with redirect_stderr(errors):
+            arguments = _parser().parse_args(
+                list(sys.argv[1:] if argv is None else argv)
+            )
+    except SystemExit as exc:
+        return EXIT_OK if exc.code == 0 else EXIT_USAGE
+
+    if arguments.command == "run":
+        return _run_command(
+            arguments,
+            stdout=output,
+            input_func=input_func,
+        )
+    if arguments.command == "receipt":
+        return _receipt_command(arguments, stdout=output)
+    if arguments.command == "revoke":
+        return _revoke_command(arguments, stdout=output)
+    if arguments.command == "demo":
+        return _demo_command(
+            arguments,
+            stdout=output,
+            input_func=input_func,
+        )
+    output.write("Unknown command.\n")
+    return EXIT_USAGE

--- a/decision_os/acceleration/engine.py
+++ b/decision_os/acceleration/engine.py
@@ -1,0 +1,486 @@
+"""Agent-agnostic Verified Save state transitions and receipts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+import uuid
+from typing import Any
+
+from .model import DecisionIdentity, DecisionType, derive_decision_identity, sha256_text
+from .store import AccelerationStore
+
+
+ChoiceProvider = Callable[[DecisionIdentity], str | None]
+
+
+@dataclass(frozen=True)
+class DecisionOutcome:
+    """Result of one mechanically typed decision check."""
+
+    identity: DecisionIdentity
+    run_id: str
+    iteration: int
+    allowed: bool
+    status: str
+    source_interrupt_id: str | None
+    default_created_run_id: str | None = None
+    pending_cross_run_checkpoint: bool = False
+
+
+@dataclass(frozen=True)
+class CheckpointOutcome:
+    """Terminal classification after a Wrapper-owned checkpoint attempt."""
+
+    status: str
+    verified: bool
+    event_hash: str | None
+
+
+class AccelerationEngine:
+    """Fail-closed Verified Save engine over one local append-only store."""
+
+    def __init__(
+        self,
+        repository: Path,
+        *,
+        store: AccelerationStore | None = None,
+        adapter: str = "core",
+        adapter_version: str = "v0.1",
+    ) -> None:
+        self.repository = Path(repository)
+        self.store = store or AccelerationStore(self.repository)
+        self.adapter = adapter
+        self.adapter_version = adapter_version
+
+    @staticmethod
+    def new_run_id() -> str:
+        return str(uuid.uuid4())
+
+    def evaluate(
+        self,
+        *,
+        run_id: str,
+        iteration: int,
+        decision_type: DecisionType,
+        requested_scope: str,
+        source_interrupt_id: str | None,
+        choice_provider: ChoiceProvider | None,
+    ) -> DecisionOutcome:
+        """Record DECISION_CHECK, reuse a valid Default, or ask the human."""
+
+        identity = derive_decision_identity(
+            self.repository,
+            decision_type,
+            requested_scope,
+        )
+        self.store.append(
+            "DECISION_CHECK",
+            identity,
+            run_id=run_id,
+            iteration=iteration,
+            adapter=self.adapter,
+            adapter_version=self.adapter_version,
+            status="CHECKED",
+            source_interrupt_id=source_interrupt_id,
+        )
+        active = self.store.active_default(identity.decision_key)
+        if active is not None:
+            if active.rule_hash != identity.rule_hash:
+                return DecisionOutcome(
+                    identity,
+                    run_id,
+                    iteration,
+                    False,
+                    "RULE_HASH_MISMATCH",
+                    source_interrupt_id,
+                    default_created_run_id=active.created_run_id,
+                )
+            if active.created_run_id == run_id:
+                return DecisionOutcome(
+                    identity,
+                    run_id,
+                    iteration,
+                    True,
+                    "SAME_RUN_DEFAULT",
+                    source_interrupt_id,
+                    default_created_run_id=active.created_run_id,
+                )
+            self.store.append(
+                "DEFAULT_MATCHED",
+                identity,
+                run_id=run_id,
+                iteration=iteration,
+                adapter=self.adapter,
+                adapter_version=self.adapter_version,
+                status="MATCHED_PENDING_CHECKPOINT",
+                default_created_run_id=active.created_run_id,
+                default_rule_hash=active.rule_hash,
+                matched_rule_hash=identity.rule_hash,
+                source_interrupt_id=source_interrupt_id,
+            )
+            self.store.append(
+                "INTERRUPT_SKIPPED",
+                identity,
+                run_id=run_id,
+                iteration=iteration,
+                adapter=self.adapter,
+                adapter_version=self.adapter_version,
+                status="PENDING_CHECKPOINT",
+                default_created_run_id=active.created_run_id,
+                default_rule_hash=active.rule_hash,
+                matched_rule_hash=identity.rule_hash,
+                source_interrupt_id=source_interrupt_id,
+                interrupt_skipped=True,
+            )
+            return DecisionOutcome(
+                identity,
+                run_id,
+                iteration,
+                True,
+                "DEFAULT_MATCHED",
+                source_interrupt_id,
+                default_created_run_id=active.created_run_id,
+                pending_cross_run_checkpoint=True,
+            )
+
+        choice: str | None = None
+        if choice_provider is not None:
+            try:
+                choice = choice_provider(identity)
+            except (EOFError, KeyboardInterrupt, OSError):
+                choice = None
+        normalized_choice = "" if choice is None else str(choice).strip()
+        if normalized_choice == "1":
+            return DecisionOutcome(
+                identity,
+                run_id,
+                iteration,
+                True,
+                "ALLOW_ONCE",
+                source_interrupt_id,
+            )
+        if normalized_choice == "2":
+            self.store.append(
+                "HUMAN_DEFAULT_CREATED",
+                identity,
+                run_id=run_id,
+                iteration=iteration,
+                adapter=self.adapter,
+                adapter_version=self.adapter_version,
+                status="ACTIVE",
+                default_created_run_id=run_id,
+                default_rule_hash=identity.rule_hash,
+                source_interrupt_id=source_interrupt_id,
+            )
+            return DecisionOutcome(
+                identity,
+                run_id,
+                iteration,
+                True,
+                "HUMAN_DEFAULT_CREATED",
+                source_interrupt_id,
+                default_created_run_id=run_id,
+            )
+        return DecisionOutcome(
+            identity,
+            run_id,
+            iteration,
+            False,
+            "DENIED",
+            source_interrupt_id,
+        )
+
+    def finish_checkpoint(
+        self,
+        outcome: DecisionOutcome,
+        *,
+        normal_terminal: bool,
+        override_before_checkpoint: bool = False,
+        checkpoint_id: str | None = None,
+    ) -> CheckpointOutcome:
+        """Promote only a valid cross-Run candidate after a normal checkpoint."""
+
+        if not outcome.pending_cross_run_checkpoint:
+            return CheckpointOutcome(outcome.status, False, None)
+        identity = outcome.identity
+        checkpoint = checkpoint_id or str(uuid.uuid4())
+        common = {
+            "run_id": outcome.run_id,
+            "iteration": outcome.iteration,
+            "adapter": self.adapter,
+            "adapter_version": self.adapter_version,
+            "default_created_run_id": outcome.default_created_run_id,
+            "default_rule_hash": identity.rule_hash,
+            "matched_rule_hash": identity.rule_hash,
+            "source_interrupt_id": outcome.source_interrupt_id,
+            "checkpoint_id": checkpoint,
+            "interrupt_skipped": True,
+        }
+        if override_before_checkpoint:
+            self.store.append(
+                "OVERRIDE",
+                identity,
+                status="PRE_CHECKPOINT_OVERRIDE",
+                **common,
+            )
+            event = self.store.append(
+                "REVOKED_SAVE",
+                identity,
+                status="NOT_VERIFIED",
+                **common,
+            )
+            return CheckpointOutcome(
+                "REVOKED_SAVE",
+                False,
+                event["event_hash"],
+            )
+        if not normal_terminal:
+            event = self.store.append(
+                "CHECKPOINT_PENDING",
+                identity,
+                status="PENDING_ABNORMAL_TERMINAL",
+                **common,
+            )
+            return CheckpointOutcome("PENDING", False, event["event_hash"])
+
+        self.store.append(
+            "CHECKPOINT_PASSED",
+            identity,
+            status="PASSED",
+            **common,
+        )
+        first_verified_use = (
+            identity.decision_key not in self.store.verified_decision_keys()
+        )
+        event_type = "VERIFIED_SAVE" if first_verified_use else "VERIFIED_REUSE"
+        event = self.store.append(
+            event_type,
+            identity,
+            status=event_type,
+            **common,
+        )
+        return CheckpointOutcome(event_type, True, event["event_hash"])
+
+    def revoke(self, *, run_id: str, decision_key: str) -> str:
+        """Deactivate one Default without rewriting historical verified reuse."""
+
+        active = self.store.active_default(decision_key)
+        if active is None:
+            raise ValueError("No active Repository Default matches the key.")
+        events = self.store.read_events()
+        source = next(
+            (
+                event
+                for event in reversed(events)
+                if event["decision_key"] == decision_key
+            ),
+            None,
+        )
+        if source is None:
+            raise ValueError("Decision key is not present in the event chain.")
+        identity = DecisionIdentity(
+            repository_id=source["repository_id"],
+            decision_type=DecisionType(source["decision_type"]),
+            normalized_scope=source["normalized_scope"],
+            decision_key=source["decision_key"],
+            rule_hash=active.rule_hash,
+        )
+        verified = decision_key in self.store.verified_decision_keys()
+        if verified:
+            self.store.append(
+                "DEFAULT_REVOKED_AFTER_USE",
+                identity,
+                run_id=run_id,
+                iteration=1,
+                adapter=self.adapter,
+                adapter_version=self.adapter_version,
+                status="INACTIVE_HISTORY_PRESERVED",
+                default_created_run_id=active.created_run_id,
+                default_rule_hash=active.rule_hash,
+            )
+            return "DEFAULT_REVOKED_AFTER_USE"
+        self.store.append(
+            "OVERRIDE",
+            identity,
+            run_id=run_id,
+            iteration=1,
+            adapter=self.adapter,
+            adapter_version=self.adapter_version,
+            status="DEFAULT_REVOKED_BEFORE_VERIFIED_USE",
+            default_created_run_id=active.created_run_id,
+            default_rule_hash=active.rule_hash,
+        )
+        self.store.append(
+            "REVOKED_SAVE",
+            identity,
+            run_id=run_id,
+            iteration=1,
+            adapter=self.adapter,
+            adapter_version=self.adapter_version,
+            status="NOT_VERIFIED",
+            default_created_run_id=active.created_run_id,
+            default_rule_hash=active.rule_hash,
+        )
+        return "REVOKED_SAVE"
+
+    def supersede(self, *, run_id: str, decision_key: str) -> str:
+        """Deactivate one Default as superseded while preserving prior reuse."""
+
+        active = self.store.active_default(decision_key)
+        if active is None:
+            raise ValueError("No active Repository Default matches the key.")
+        source = next(
+            (
+                event
+                for event in reversed(self.store.read_events())
+                if event["decision_key"] == decision_key
+            ),
+            None,
+        )
+        if source is None:
+            raise ValueError("Decision key is not present in the event chain.")
+        identity = DecisionIdentity(
+            repository_id=source["repository_id"],
+            decision_type=DecisionType(source["decision_type"]),
+            normalized_scope=source["normalized_scope"],
+            decision_key=source["decision_key"],
+            rule_hash=active.rule_hash,
+        )
+        self.store.append(
+            "DEFAULT_SUPERSEDED",
+            identity,
+            run_id=run_id,
+            iteration=1,
+            adapter=self.adapter,
+            adapter_version=self.adapter_version,
+            status="INACTIVE_HISTORY_PRESERVED",
+            default_created_run_id=active.created_run_id,
+            default_rule_hash=active.rule_hash,
+        )
+        return "DEFAULT_SUPERSEDED"
+
+    def receipt(self) -> dict[str, Any]:
+        """Build a privacy-safe Receipt from verified events and current estimates."""
+
+        verified_saves, verified_reuses = self.store.counters()
+        settings = self.store.read_settings()
+        minutes = verified_reuses * settings.minutes_per_reuse
+        money = minutes / 60 * settings.hourly_value_jpy
+        tokens = (
+            None
+            if settings.tokens_per_reuse is None
+            else verified_reuses * settings.tokens_per_reuse
+        )
+        return {
+            "claim_boundary": (
+                "Verified Save is a locally recorded proof-of-use event, "
+                "not third-party certification."
+            ),
+            "estimated": {
+                "hourly_value_jpy": settings.hourly_value_jpy,
+                "minutes": minutes,
+                "minutes_per_reuse": settings.minutes_per_reuse,
+                "money_jpy": money,
+                "tokens": tokens,
+                "tokens_per_reuse": settings.tokens_per_reuse,
+            },
+            "hard_metrics": {
+                "verified_reuses": verified_reuses,
+                "verified_saves": verified_saves,
+            },
+            "receipt_identity": (
+                f"receipt:v1:{sha256_text(self.store.chain_head())}"
+            ),
+            "status": "VERIFIED" if verified_reuses else "NO_VERIFIED_REUSE",
+        }
+
+    def render_receipt(self) -> str:
+        """Render one compact Receipt with hard metrics separated from estimates."""
+
+        receipt = self.receipt()
+        hard = receipt["hard_metrics"]
+        estimated = receipt["estimated"]
+        tokens = (
+            "UNKNOWN"
+            if estimated["tokens"] is None
+            else f"{estimated['tokens']:,}"
+        )
+        token_formula = (
+            "tokens remain UNKNOWN until tokens_per_reuse is configured"
+            if estimated["tokens_per_reuse"] is None
+            else (
+                f"{hard['verified_reuses']} verified reuse"
+                f" × {estimated['tokens_per_reuse']:,} configured tokens per reuse"
+            )
+        )
+        return "\n".join(
+            (
+                receipt["status"],
+                "",
+                f"{hard['verified_saves']} Save",
+                f"{hard['verified_reuses']} Verified Reuse",
+                "",
+                "ESTIMATED RECOVERED",
+                "",
+                f"{estimated['minutes']:.1f} minutes",
+                f"¥{estimated['money_jpy']:,.0f}",
+                f"{tokens} tokens",
+                "",
+                "Calculated from:",
+                (
+                    f"{hard['verified_reuses']} verified reuse"
+                    f" × {estimated['minutes_per_reuse']:g} estimated minutes"
+                    " per reuse"
+                    f" × ¥{estimated['hourly_value_jpy']:,.0f} per hour"
+                ),
+                token_formula,
+                "",
+                receipt["claim_boundary"],
+                "",
+            )
+        )
+
+
+class DeterministicAdapter:
+    """Internal no-network adapter used only to validate engine transitions."""
+
+    name = "deterministic-test"
+    version = "v0.1"
+
+    def __init__(self, engine: AccelerationEngine) -> None:
+        self.engine = engine
+
+    def run(
+        self,
+        *,
+        decision_type: DecisionType,
+        scope: str,
+        human_choice: str | None = None,
+        run_id: str | None = None,
+        iteration: int = 1,
+        normal_terminal: bool = True,
+        override_before_checkpoint: bool = False,
+    ) -> tuple[DecisionOutcome, CheckpointOutcome]:
+        fixed_run_id = run_id or self.engine.new_run_id()
+        provider = (
+            None
+            if human_choice is None
+            else lambda _identity: human_choice
+        )
+        outcome = self.engine.evaluate(
+            run_id=fixed_run_id,
+            iteration=iteration,
+            decision_type=decision_type,
+            requested_scope=scope,
+            source_interrupt_id=f"fixture:{fixed_run_id}:{iteration}",
+            choice_provider=provider,
+        )
+        checkpoint = self.engine.finish_checkpoint(
+            outcome,
+            normal_terminal=normal_terminal,
+            override_before_checkpoint=override_before_checkpoint,
+            checkpoint_id=f"fixture-checkpoint:{fixed_run_id}:{iteration}",
+        )
+        return outcome, checkpoint

--- a/decision_os/acceleration/model.py
+++ b/decision_os/acceleration/model.py
@@ -1,0 +1,301 @@
+"""Pure Verified Save protocol identities and path normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+PROTOCOL_VERSION = "decision-os.acceleration.v0.1"
+GENESIS_EVENT_HASH = "0" * 64
+EVENT_TYPES = frozenset(
+    {
+        "HUMAN_DEFAULT_CREATED",
+        "DECISION_CHECK",
+        "DEFAULT_MATCHED",
+        "INTERRUPT_SKIPPED",
+        "CHECKPOINT_PASSED",
+        "CHECKPOINT_PENDING",
+        "OVERRIDE",
+        "VERIFIED_SAVE",
+        "VERIFIED_REUSE",
+        "REVOKED_SAVE",
+        "DEFAULT_REVOKED_AFTER_USE",
+        "DEFAULT_SUPERSEDED",
+    }
+)
+EVENT_FIELDS = frozenset(
+    {
+        "event_id",
+        "event_type",
+        "timestamp",
+        "run_id",
+        "iteration",
+        "repository_id",
+        "decision_key",
+        "decision_type",
+        "normalized_scope",
+        "default_created_run_id",
+        "default_rule_hash",
+        "matched_rule_hash",
+        "adapter",
+        "adapter_version",
+        "protocol_version",
+        "source_interrupt_id",
+        "checkpoint_id",
+        "interrupt_skipped",
+        "status",
+        "prev_event_hash",
+        "event_hash",
+    }
+)
+_GLOB_CHARACTERS = frozenset("*?[]{}")
+_SCP_REMOTE = re.compile(
+    r"^(?:(?P<user>[^@/:]+)@)?(?P<host>[^/:]+):(?P<path>.+)$"
+)
+
+
+class AccelerationError(RuntimeError):
+    """Base error for bounded acceleration operations."""
+
+
+class RepositoryIdentityError(AccelerationError):
+    """Repository identity cannot be established safely."""
+
+
+class ScopeError(AccelerationError):
+    """A requested scope is unsupported or escapes the repository."""
+
+
+class UnsupportedDecisionError(AccelerationError):
+    """A decision type is outside the fixed v0.1 protocol."""
+
+
+class DecisionType(str, Enum):
+    """Fixed protocol decision types."""
+
+    ADD_TESTS = "ADD_TESTS"
+    CREATE_FILE = "CREATE_FILE"
+    MODIFY_FILE = "MODIFY_FILE"
+    DELETE_OR_RENAME = "DELETE_OR_RENAME"
+    ADD_DEPENDENCY = "ADD_DEPENDENCY"
+
+
+@dataclass(frozen=True)
+class DecisionIdentity:
+    """Mechanically derived identity for one structured decision."""
+
+    repository_id: str
+    decision_type: DecisionType
+    normalized_scope: str
+    decision_key: str
+    rule_hash: str
+
+
+def canonical_json(value: Any) -> str:
+    """Return stable UTF-8 JSON suitable for hashing."""
+
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def sha256_text(value: str) -> str:
+    """Hash one UTF-8 string."""
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def hash_payload(payload: dict[str, Any]) -> str:
+    """Hash one canonical JSON object."""
+
+    return sha256_text(canonical_json(payload))
+
+
+def git_output(repository: Path, *arguments: str) -> str:
+    """Run one read-only Git identity command."""
+
+    completed = subprocess.run(
+        ("git", "-C", str(repository), *arguments),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RepositoryIdentityError(
+            completed.stderr.strip() or "Git repository identity is unavailable."
+        )
+    return completed.stdout.strip()
+
+
+def git_root(repository: Path) -> Path:
+    """Resolve the canonical Git worktree root."""
+
+    raw = git_output(repository, "rev-parse", "--show-toplevel")
+    root = Path(raw).resolve(strict=True)
+    if not root.is_dir():
+        raise RepositoryIdentityError("Git root is not a directory.")
+    return root
+
+
+def _credential_free_remote(raw: str) -> str | None:
+    remote = raw.strip()
+    if not remote:
+        return None
+
+    scp_match = _SCP_REMOTE.match(remote)
+    if "://" not in remote and scp_match:
+        host = scp_match.group("host").lower()
+        path = scp_match.group("path").strip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        return f"ssh://{host}/{path}" if host and path else None
+
+    parsed = urlsplit(remote)
+    if parsed.scheme not in {"http", "https", "ssh", "git"}:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None
+    port = f":{parsed.port}" if parsed.port else ""
+    path = parsed.path.rstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    if not path:
+        return None
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            f"{host.lower()}{port}",
+            path,
+            "",
+            "",
+        )
+    )
+
+
+def repository_id(repository: Path) -> str:
+    """Derive a hashed repository identity without storing its raw name."""
+
+    root = git_root(repository)
+    completed = subprocess.run(
+        ("git", "-C", str(root), "remote", "get-url", "origin"),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    normalized_remote = (
+        _credential_free_remote(completed.stdout)
+        if completed.returncode == 0
+        else None
+    )
+    identity = normalized_remote or f"local:{root.as_posix()}"
+    return f"repo:v1:{sha256_text(identity)}"
+
+
+def normalize_scope(repository: Path, requested_scope: str) -> str:
+    """Normalize one exact file scope and reject escapes or ambiguous syntax."""
+
+    if not isinstance(requested_scope, str):
+        raise ScopeError("Scope must be a string.")
+    raw = requested_scope.strip()
+    if not raw or "\x00" in raw:
+        raise ScopeError("Scope must be a non-empty path.")
+    if any(character in raw for character in _GLOB_CHARACTERS):
+        raise ScopeError("Glob syntax is unsupported.")
+
+    root = git_root(repository)
+    portable = raw.replace("\\", "/")
+    requested = Path(portable)
+    candidate = requested if requested.is_absolute() else root / requested
+
+    try:
+        resolved = candidate.resolve(strict=False)
+        relative = resolved.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ScopeError("Scope escapes or cannot be resolved safely.") from exc
+
+    if relative == Path("."):
+        raise ScopeError("Repository root is not an exact file scope.")
+    if resolved.exists() and resolved.is_dir():
+        raise ScopeError("Directory scopes are unsupported.")
+
+    ancestor = resolved.parent
+    while not ancestor.exists() and ancestor != root:
+        ancestor = ancestor.parent
+    try:
+        ancestor.resolve(strict=True).relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ScopeError("Parent identity is outside the repository.") from exc
+
+    normalized = relative.as_posix()
+    if normalized.startswith("../") or normalized in {"", "."}:
+        raise ScopeError("Scope escapes the repository.")
+    return normalized
+
+
+def decision_key(
+    repository_identity: str,
+    decision_type: DecisionType,
+    normalized_scope: str,
+) -> str:
+    """Build the exact v1 decision key."""
+
+    try:
+        fixed_type = DecisionType(decision_type)
+    except ValueError as exc:
+        raise UnsupportedDecisionError(str(decision_type)) from exc
+    return (
+        "dk:v1|"
+        f"{repository_identity}|{fixed_type.value}|{normalized_scope}"
+    )
+
+
+def rule_hash(
+    decision_type: DecisionType,
+    normalized_scope: str,
+) -> str:
+    """Hash the stable allow rule without run-specific or display data."""
+
+    try:
+        fixed_type = DecisionType(decision_type)
+    except ValueError as exc:
+        raise UnsupportedDecisionError(str(decision_type)) from exc
+    return hash_payload(
+        {
+            "decision": "allow",
+            "decision_type": fixed_type.value,
+            "normalized_scope": normalized_scope,
+            "protocol_version": PROTOCOL_VERSION,
+        }
+    )
+
+
+def derive_decision_identity(
+    repository: Path,
+    decision_type: DecisionType,
+    requested_scope: str,
+) -> DecisionIdentity:
+    """Derive all mechanically stable fields for a decision check."""
+
+    repo_id = repository_id(repository)
+    normalized = normalize_scope(repository, requested_scope)
+    fixed_type = DecisionType(decision_type)
+    return DecisionIdentity(
+        repository_id=repo_id,
+        decision_type=fixed_type,
+        normalized_scope=normalized,
+        decision_key=decision_key(repo_id, fixed_type, normalized),
+        rule_hash=rule_hash(fixed_type, normalized),
+    )

--- a/decision_os/acceleration/store.py
+++ b/decision_os/acceleration/store.py
@@ -1,0 +1,350 @@
+"""Append-only, hash-chained local storage for Verified Save."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import math
+from pathlib import Path
+import uuid
+from typing import Any
+
+from .model import (
+    EVENT_FIELDS,
+    EVENT_TYPES,
+    GENESIS_EVENT_HASH,
+    PROTOCOL_VERSION,
+    DecisionIdentity,
+    canonical_json,
+    git_output,
+    git_root,
+    hash_payload,
+    repository_id,
+)
+
+
+class StateIntegrityError(RuntimeError):
+    """The local event chain or configuration is unverifiable."""
+
+
+@dataclass(frozen=True)
+class DefaultRecord:
+    """One active repository default reconstructed from the event chain."""
+
+    decision_key: str
+    created_run_id: str
+    rule_hash: str
+
+
+@dataclass(frozen=True)
+class ReceiptSettings:
+    """User-configurable estimate inputs, separate from verified events."""
+
+    minutes_per_reuse: float = 7.5
+    hourly_value_jpy: float = 5000.0
+    tokens_per_reuse: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "hourly_value_jpy": self.hourly_value_jpy,
+            "minutes_per_reuse": self.minutes_per_reuse,
+            "protocol_version": PROTOCOL_VERSION,
+            "tokens_per_reuse": self.tokens_per_reuse,
+        }
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _new_event_id() -> str:
+    return str(uuid.uuid4())
+
+
+class AccelerationStore:
+    """Single-writer local state under the target repository Git common dir."""
+
+    def __init__(
+        self,
+        repository: Path,
+        *,
+        clock: Callable[[], str] = _utc_now,
+        event_id_factory: Callable[[], str] = _new_event_id,
+    ) -> None:
+        self.repository = git_root(repository)
+        self.repository_id = repository_id(self.repository)
+        common_raw = git_output(self.repository, "rev-parse", "--git-common-dir")
+        common = Path(common_raw)
+        if not common.is_absolute():
+            common = self.repository / common
+        self.git_common_dir = common.resolve(strict=True)
+        self.state_dir = (
+            self.git_common_dir / "decision-os" / "acceleration" / "v0.1"
+        )
+        self.events_path = self.state_dir / "events.jsonl"
+        self.config_path = self.state_dir / "config.json"
+        self._clock = clock
+        self._event_id_factory = event_id_factory
+
+    def read_events(self) -> list[dict[str, Any]]:
+        """Read and verify the complete append-only chain."""
+
+        if not self.events_path.exists():
+            return []
+        try:
+            raw_lines = self.events_path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise StateIntegrityError("Event chain is unreadable.") from exc
+
+        events: list[dict[str, Any]] = []
+        previous = GENESIS_EVENT_HASH
+        seen_ids: set[str] = set()
+        for index, line in enumerate(raw_lines, start=1):
+            if not line.strip():
+                raise StateIntegrityError(
+                    f"Event chain contains an empty line at {index}."
+                )
+            try:
+                event = json.loads(line)
+            except (json.JSONDecodeError, UnicodeError) as exc:
+                raise StateIntegrityError(
+                    f"Event chain JSON is invalid at line {index}."
+                ) from exc
+            if not isinstance(event, dict):
+                raise StateIntegrityError(
+                    f"Event chain value is not an object at line {index}."
+                )
+            missing = EVENT_FIELDS.difference(event)
+            if missing:
+                raise StateIntegrityError(
+                    f"Event chain fields are missing at line {index}: "
+                    f"{sorted(missing)}"
+                )
+            if event["event_type"] not in EVENT_TYPES:
+                raise StateIntegrityError(
+                    f"Unsupported event type at line {index}."
+                )
+            if event["protocol_version"] != PROTOCOL_VERSION:
+                raise StateIntegrityError(
+                    f"Protocol version mismatch at line {index}."
+                )
+            if event["repository_id"] != self.repository_id:
+                raise StateIntegrityError(
+                    f"Repository identity mismatch at line {index}."
+                )
+            if event["prev_event_hash"] != previous:
+                raise StateIntegrityError(
+                    f"Previous hash mismatch at line {index}."
+                )
+            event_id = event["event_id"]
+            if not isinstance(event_id, str) or not event_id or event_id in seen_ids:
+                raise StateIntegrityError(
+                    f"Event ID is invalid or duplicated at line {index}."
+                )
+            expected = hash_payload(
+                {key: value for key, value in event.items() if key != "event_hash"}
+            )
+            if event["event_hash"] != expected:
+                raise StateIntegrityError(
+                    f"Event hash mismatch at line {index}."
+                )
+            seen_ids.add(event_id)
+            previous = expected
+            events.append(event)
+        return events
+
+    def append(
+        self,
+        event_type: str,
+        identity: DecisionIdentity,
+        *,
+        run_id: str,
+        iteration: int,
+        adapter: str,
+        adapter_version: str,
+        status: str,
+        default_created_run_id: str | None = None,
+        default_rule_hash: str | None = None,
+        matched_rule_hash: str | None = None,
+        source_interrupt_id: str | None = None,
+        checkpoint_id: str | None = None,
+        interrupt_skipped: bool = False,
+    ) -> dict[str, Any]:
+        """Verify the chain, then append one canonical event."""
+
+        if event_type not in EVENT_TYPES:
+            raise ValueError(f"Unsupported event type: {event_type}")
+        if not run_id or iteration < 1:
+            raise ValueError("run_id and positive iteration are required.")
+        events = self.read_events()
+        previous = (
+            events[-1]["event_hash"] if events else GENESIS_EVENT_HASH
+        )
+        event: dict[str, Any] = {
+            "adapter": adapter,
+            "adapter_version": adapter_version,
+            "checkpoint_id": checkpoint_id,
+            "decision_key": identity.decision_key,
+            "decision_type": identity.decision_type.value,
+            "default_created_run_id": default_created_run_id,
+            "default_rule_hash": default_rule_hash,
+            "event_id": self._event_id_factory(),
+            "event_type": event_type,
+            "interrupt_skipped": bool(interrupt_skipped),
+            "iteration": iteration,
+            "matched_rule_hash": matched_rule_hash,
+            "normalized_scope": identity.normalized_scope,
+            "prev_event_hash": previous,
+            "protocol_version": PROTOCOL_VERSION,
+            "repository_id": identity.repository_id,
+            "run_id": run_id,
+            "source_interrupt_id": source_interrupt_id,
+            "status": status,
+            "timestamp": self._clock(),
+        }
+        event["event_hash"] = hash_payload(event)
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            with self.events_path.open("a", encoding="utf-8", newline="\n") as stream:
+                stream.write(canonical_json(event))
+                stream.write("\n")
+        except OSError as exc:
+            raise StateIntegrityError("Event append failed.") from exc
+        return event
+
+    def read_settings(self) -> ReceiptSettings:
+        """Read estimate settings without changing verified state."""
+
+        if not self.config_path.exists():
+            return ReceiptSettings()
+        try:
+            value = json.loads(self.config_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise StateIntegrityError("Acceleration config is invalid.") from exc
+        if not isinstance(value, dict):
+            raise StateIntegrityError("Acceleration config is not an object.")
+        try:
+            settings = ReceiptSettings(
+                minutes_per_reuse=float(value["minutes_per_reuse"]),
+                hourly_value_jpy=float(value["hourly_value_jpy"]),
+                tokens_per_reuse=(
+                    None
+                    if value.get("tokens_per_reuse") is None
+                    else int(value["tokens_per_reuse"])
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise StateIntegrityError(
+                "Acceleration config fields are invalid."
+            ) from exc
+        self._validate_settings(settings)
+        return settings
+
+    def update_settings(
+        self,
+        *,
+        minutes_per_reuse: float | None = None,
+        hourly_value_jpy: float | None = None,
+        tokens_per_reuse: int | None = None,
+        set_tokens: bool = False,
+    ) -> ReceiptSettings:
+        """Atomically update estimate inputs without adding protocol events."""
+
+        current = self.read_settings()
+        updated = ReceiptSettings(
+            minutes_per_reuse=(
+                current.minutes_per_reuse
+                if minutes_per_reuse is None
+                else float(minutes_per_reuse)
+            ),
+            hourly_value_jpy=(
+                current.hourly_value_jpy
+                if hourly_value_jpy is None
+                else float(hourly_value_jpy)
+            ),
+            tokens_per_reuse=(
+                tokens_per_reuse if set_tokens else current.tokens_per_reuse
+            ),
+        )
+        self._validate_settings(updated)
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        temporary = self.config_path.with_suffix(".json.tmp")
+        try:
+            temporary.write_text(
+                f"{canonical_json(updated.as_dict())}\n",
+                encoding="utf-8",
+            )
+            temporary.replace(self.config_path)
+        except OSError as exc:
+            raise StateIntegrityError("Acceleration config update failed.") from exc
+        return updated
+
+    @staticmethod
+    def _validate_settings(settings: ReceiptSettings) -> None:
+        if (
+            not math.isfinite(settings.minutes_per_reuse)
+            or settings.minutes_per_reuse <= 0
+            or not math.isfinite(settings.hourly_value_jpy)
+            or settings.hourly_value_jpy <= 0
+        ):
+            raise StateIntegrityError("Estimate settings must be positive.")
+        if (
+            settings.tokens_per_reuse is not None
+            and settings.tokens_per_reuse <= 0
+        ):
+            raise StateIntegrityError("tokens_per_reuse must be positive.")
+
+    def active_default(self, decision_key: str) -> DefaultRecord | None:
+        """Reconstruct the current active Default for one decision key."""
+
+        active: DefaultRecord | None = None
+        for event in self.read_events():
+            if event["decision_key"] != decision_key:
+                continue
+            if event["event_type"] == "HUMAN_DEFAULT_CREATED":
+                created_run_id = event["default_created_run_id"]
+                rule = event["default_rule_hash"]
+                if not isinstance(created_run_id, str) or not isinstance(rule, str):
+                    raise StateIntegrityError("Default identity is incomplete.")
+                active = DefaultRecord(decision_key, created_run_id, rule)
+            elif event["event_type"] in {
+                "OVERRIDE",
+                "DEFAULT_REVOKED_AFTER_USE",
+                "DEFAULT_SUPERSEDED",
+            }:
+                active = None
+        return active
+
+    def verified_decision_keys(self) -> set[str]:
+        """Return unique repository decision pairs that became Verified Saves."""
+
+        return {
+            event["decision_key"]
+            for event in self.read_events()
+            if event["event_type"] == "VERIFIED_SAVE"
+        }
+
+    def counters(self) -> tuple[int, int]:
+        """Return unique Saves and total verified cross-Run reuses."""
+
+        events = self.read_events()
+        saves = len(
+            {
+                event["decision_key"]
+                for event in events
+                if event["event_type"] == "VERIFIED_SAVE"
+            }
+        )
+        reuses = sum(
+            event["event_type"] in {"VERIFIED_SAVE", "VERIFIED_REUSE"}
+            for event in events
+        )
+        return saves, reuses
+
+    def chain_head(self) -> str:
+        """Return the verified event-chain head hash."""
+
+        events = self.read_events()
+        return events[-1]["event_hash"] if events else GENESIS_EVENT_HASH

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,5 +1,61 @@
 # Current Signal
 
+## Canonical Current State — Verified Save Claude MVP v0.1
+
+```text
+Current Layer:
+V13 — Compound Loop / Verified Save Proof-of-Use MVP
+
+Primary Objective:
+External Proof-of-Use
+
+First Adapter:
+Claude Agent SDK / product core remains agent-agnostic
+
+Starting Main:
+3c9142692dfe60785a033b91ad7b6e5226712a93
+
+Active Branch:
+feat/verified-save-claude-mvp-v0-1
+
+V12 State:
+DELAY — deterministic engine and Claude adapter passed; live human-owned proof
+is recoverably incomplete because Claude authentication is unavailable
+
+V13 Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+V13 Next Loop Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+Live Proof:
+DELAY — bundled Claude CLI reports loggedIn=false / no human option-2 selection
+
+Deterministic Engine:
+PASS / 25 OF 25 ACCELERATION TESTS
+
+Full Regression:
+PASS / 191 OF 191 TESTS
+
+Draft PR:
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/34
+
+Demo GIF:
+NOT_CREATED — conditional on passing live proof
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly approves review or merge
+
+Decision Owner:
+Shin
+```
+
+Everything below this boundary is a historical reverse-chronological ledger.
+Historical entries preserve their As-of truth but grant no present authority.
+
 ## Canonical Current State — Consistency Cleanup v0.1
 
 ```text

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -19,8 +19,8 @@ Active Branch:
 feat/verified-save-claude-mvp-v0-1
 
 V12 State:
-DELAY — deterministic engine and Claude adapter passed; live human-owned proof
-is recoverably incomplete because Claude authentication is unavailable
+DELAY — creator-owned human two-Run live proof passed; external-user adoption
+remains unobserved and no external adoption claim is made
 
 V13 Gate:
 HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
@@ -29,19 +29,31 @@ V13 Next Loop Gate:
 HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
 
 Live Proof:
-DELAY — bundled Claude CLI reports loggedIn=false / no human option-2 selection
+PASS — Run 1 normal terminal / repeated interrupt skipped / fresh Run 2
+VERIFIED_SAVE / 1 Save / 1 Verified Reuse
 
 Deterministic Engine:
-PASS / 25 OF 25 ACCELERATION TESTS
+PASS / 26 OF 26 ACCELERATION TESTS
 
 Full Regression:
-PASS / 191 OF 191 TESTS
+PASS / 192 OF 192 TESTS
 
 Draft PR:
 OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/34
 
 Demo GIF:
-NOT_CREATED — conditional on passing live proof
+NOT_CREATED — not authorized by the live-proof closure
+
+Live Receipt:
+7.5 estimated minutes / ¥625 estimated human-time value /
+9,467 configured estimated tokens
+
+Receipt SHA-256:
+027368f679b7ce1f14bf7ca42bfe686c34c8af313d801f7cc086e0b2a5c3e100
+
+Claim Boundary:
+creator-owned human live proof / not external-user adoption /
+not third-party certification / estimates remain estimates
 
 Merge Authority:
 NONE

--- a/docs/verified_save_claude_mvp_v0_1.md
+++ b/docs/verified_save_claude_mvp_v0_1.md
@@ -1,0 +1,355 @@
+# Claude-first Verified Save MVP v0.1
+
+## Product Objective
+
+Verified Save records one local proof-of-use event when a coding agent reuses a
+human-selected repository default in a later Run and passes a Wrapper-owned
+checkpoint.
+
+The visible result is simple: the coding agent asks the human one fewer repeated
+question.
+
+Claude Agent SDK is the first adapter. The protocol, event chain, counters, and
+Receipt remain agent-agnostic.
+
+## Install
+
+From a local checkout:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install '.[claude]'
+```
+
+The Claude extra is optional and pinned:
+
+```text
+claude-agent-sdk==0.2.123
+bundled Claude Code CLI: 2.1.215
+```
+
+The existing `decision-os` entry point is unchanged. Acceleration uses the
+separate `decision-os-accelerate` entry point.
+
+## Supported Decision Types
+
+The fixed core enum is:
+
+- `ADD_TESTS`
+- `CREATE_FILE`
+- `MODIFY_FILE`
+- `DELETE_OR_RENAME`
+- `ADD_DEPENDENCY`
+
+The Claude v0.1 adapter verifies only mechanically typed `CREATE_FILE` and
+`MODIFY_FILE` decisions:
+
+- Claude `Edit` maps to `MODIFY_FILE`.
+- Claude `Write` maps to `CREATE_FILE` when the normalized target did not exist
+  before the request.
+- Claude `Write` maps to `MODIFY_FILE` when the normalized target already
+  existed.
+
+Bash mutation, NotebookEdit, rename, delete, dependency intent, test intent,
+semantic similarity, and prose classification are unsupported.
+
+## Exact Verified Save Definition
+
+A Verified Save exists only when all of the following are true:
+
+1. A human explicitly selected `Use for this repository`.
+2. A different `run_id` is active.
+3. A structured `DECISION_CHECK` occurred.
+4. The same mechanically derived `decision_key` reappeared.
+5. The stored Repository Default is active.
+6. `default.created_run_id != current run_id`.
+7. The stored and matched `rule_hash` values are identical.
+8. The second human interrupt was actually skipped.
+9. A Wrapper-owned checkpoint passed.
+10. No related override occurred before the checkpoint.
+11. This is the first verified repository × decision pair.
+
+The decision key is:
+
+```text
+dk:v1|<hashed repository_id>|<decision_type>|<normalized_scope>
+```
+
+The rule hash uses canonical JSON containing only:
+
+```json
+{
+  "decision": "allow",
+  "decision_type": "<fixed enum>",
+  "normalized_scope": "<Git-root-relative path>",
+  "protocol_version": "decision-os.acceleration.v0.1"
+}
+```
+
+Prompt text, model identity, display questions, timestamps, and Run IDs never
+enter the rule hash.
+
+## Human Choice
+
+Edit and Write are not auto-approved. The SDK callback displays:
+
+```text
+Your coding agent needs one default.
+
+May it <create|modify> <normalized scope>?
+
+[1] Allow once
+[2] Use for this repository
+[3] Deny
+```
+
+Only an explicit `2` creates `HUMAN_DEFAULT_CREATED`.
+
+Invalid input, EOF, callback failure, unavailable stdin, or option `3` denies
+the request. Option `1`, timeout, same-Run reuse, and absence of a question do
+not create a Verified Save or increment a reuse counter.
+
+## Run Boundary
+
+Each `decision-os-accelerate run` invocation creates a new Wrapper `run_id` and
+one fresh Claude SDK query.
+
+The adapter sets:
+
+- `continue_conversation=False`;
+- no `resume` session;
+- filesystem settings sources to `[]`;
+- skills to `[]`;
+- strict MCP configuration;
+- `Read` as the only auto-approved tool;
+- Edit and Write through `can_use_tool`;
+- permission mode `default`.
+
+The demo exposes only Read and Edit. It never enables Bash or a dangerous
+permission-bypass mode.
+
+## Checkpoint
+
+The Wrapper owns checkpoint classification.
+
+For this two-query MVP, a checkpoint passes only after the matched Default was
+applied and the SDK emitted a non-error `ResultMessage` with subtype `success`.
+
+Authentication errors, billing errors, API errors, cancellation, timeouts,
+decode failures, process failures, a missing result, and error results remain
+`PENDING`. Agent prose is not checkpoint evidence.
+
+`CHECKPOINT_PENDING` is the one documented internal v0.1 event used to preserve
+an abnormal terminal candidate without promoting it.
+
+## Counters
+
+The counters have different meanings:
+
+- `verified_saves` is the number of unique repository × decision pairs that
+  first reached `VERIFIED_SAVE`.
+- `verified_reuses` is the total number of valid cross-Run uses that passed a
+  checkpoint, including the first use that created each Verified Save.
+
+Therefore:
+
+- `VERIFIED_SAVE` increments both counters.
+- `VERIFIED_REUSE` increments only `verified_reuses`.
+
+All estimates use `verified_reuses`. Estimates are never unlock currency.
+
+## Local Storage
+
+State is local to the target Git repository:
+
+```text
+<git-common-dir>/decision-os/acceleration/v0.1/events.jsonl
+<git-common-dir>/decision-os/acceleration/v0.1/config.json
+```
+
+`events.jsonl` is append-only and hash-chained with canonical JSON. The full
+chain is verified before a Default is applied, a pending candidate is promoted,
+counters are printed, or a Receipt is generated.
+
+Chain corruption blocks reuse. The implementation does not truncate, repair,
+or guess through invalid state.
+
+The v0.1 store is single-writer only. Concurrent agent Runs against the same
+store are unsupported and must be serialized by the caller.
+
+## Privacy Boundary
+
+The local event log contains mechanical protocol metadata, including the local
+normalized scope. It does not contain:
+
+- prompts or conversation bodies;
+- code or file content;
+- credentials;
+- raw remote URLs;
+- raw repository names.
+
+Repository identity is hashed before storage. The outward Receipt uses a hashed
+receipt identity and does not print normalized file paths, repository names,
+raw remotes, prompts, or session identifiers.
+
+No telemetry, server submission, OAuth, or external state service is used.
+
+## Commands
+
+Run one fresh Claude query:
+
+```bash
+decision-os-accelerate run \
+  --adapter claude \
+  --prompt-file examples/verified_save_demo/run_1.txt \
+  --minutes-per-reuse 7.5 \
+  --hourly-value-jpy 5000 \
+  --tokens-per-reuse 9467 \
+  /path/to/repository
+```
+
+Run the same mechanical decision in a separate invocation with a second prompt:
+
+```bash
+decision-os-accelerate run \
+  --adapter claude \
+  --prompt-file examples/verified_save_demo/run_2.txt \
+  /path/to/repository
+```
+
+Print the current Receipt:
+
+```bash
+decision-os-accelerate receipt /path/to/repository
+```
+
+Revoke one active Default:
+
+```bash
+decision-os-accelerate revoke \
+  --decision-key '<local decision key>' \
+  /path/to/repository
+```
+
+Revocation after a checkpoint preserves the historical Verified Save and Reuse.
+It prevents future application of the inactive Default.
+
+## Live Demo
+
+The fixed demo prompts are:
+
+- [Run 1](../examples/verified_save_demo/run_1.txt)
+- [Run 2](../examples/verified_save_demo/run_2.txt)
+
+Authenticate Claude first:
+
+```bash
+claude auth login
+claude auth status
+```
+
+Then run:
+
+```bash
+decision-os-accelerate demo \
+  --adapter claude \
+  --tokens-per-reuse 9467
+```
+
+The command creates a disposable Git repository and an existing file, starts
+two fresh Claude queries, and requires one explicit option-2 selection in Run 1.
+Run 2 must reach the same normalized Edit scope without another human
+interrupt. A sanitized Receipt is copied outside the disposable repository
+before that repository is cleaned.
+
+Deterministic fixtures cannot produce the live-proof classification or demo
+GIF.
+
+## Acceleration Receipt
+
+Hard metrics and estimates are separated:
+
+```text
+VERIFIED
+
+1 Save
+1 Verified Reuse
+
+ESTIMATED RECOVERED
+
+7.5 minutes
+¥625
+9,467 tokens
+```
+
+The compact formula is:
+
+```text
+verified_reuses
+× configured estimated minutes per reuse
+× configured hourly value
+× configured tokens per reuse
+```
+
+Minutes default to `7.5` per reuse and hourly value defaults to `¥5,000`.
+Tokens remain `UNKNOWN` until explicitly configured. Changing estimate settings
+does not rewrite or add Verified Save or Reuse events.
+
+## Claim Boundary
+
+Verified Save is a locally recorded proof-of-use event, not third-party
+certification.
+
+The Receipt may describe a local estimated result. It does not establish a
+universal productivity result, measured percentage improvement, incident
+prevention, or third-party verification.
+
+## Rollback and State Removal
+
+To stop future reuse of one Default, use `decision-os-accelerate revoke`.
+
+For a full local reset:
+
+1. Stop all acceleration Runs for the repository.
+2. Resolve the exact Git common directory with
+   `git rev-parse --git-common-dir`.
+3. Preserve a backup if historical evidence is required.
+4. Remove only its exact
+   `decision-os/acceleration/v0.1/` child directory.
+
+Full state removal is intentionally not automatic. It removes local event-chain
+history and cannot be reconstructed from the outward Receipt.
+
+Code rollback is a normal history-preserving revert of the implementation
+commit. It does not silently delete repository-local acceleration state.
+
+## Known Unsupported Cases
+
+- same-Run Verified Save;
+- concurrent writers;
+- non-Git targets;
+- repository-escaping or glob scopes;
+- unsupported or changed Claude tool schemas;
+- Bash-based file mutation;
+- multi-file operations;
+- rename and delete;
+- semantic decision matching;
+- automatic defaults;
+- session resume;
+- unsupported normal/abnormal result contracts;
+- a live claim without two fresh authenticated SDK Runs and explicit human
+  option 2.
+
+## Deterministic Tests Versus Live Proof
+
+The deterministic adapter validates protocol transitions without network,
+Claude credentials, paid calls, or human input. It covers Save/Reuse
+classification, abnormal terminals, overrides, revocation, supersession,
+same-Run exclusion, corruption, unsupported scope, and Receipt math.
+
+The live proof separately requires the pinned official SDK, Claude
+authentication, two fresh queries, explicit human option 2, one skipped
+interrupt, and a normal Wrapper checkpoint.
+
+The current evidence classification is recorded in
+[Validation Run 001](../validation/verified_save_claude_mvp_run_001.md).

--- a/examples/verified_save_demo/run_1.txt
+++ b/examples/verified_save_demo/run_1.txt
@@ -1,0 +1,2 @@
+Read demo_target.txt. Use Edit exactly once to replace the line
+`stage: initial` with `stage: run-1`. Do not touch any other file.

--- a/examples/verified_save_demo/run_2.txt
+++ b/examples/verified_save_demo/run_2.txt
@@ -1,0 +1,2 @@
+Read demo_target.txt. Use Edit exactly once to replace the line
+`stage: run-1` with `stage: run-2`. Do not touch any other file.

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,5 +1,79 @@
 # Current Codex Handoff - V13 LoopKit
 
+## Canonical Current State — Verified Save Claude MVP v0.1
+
+```text
+Current Layer:
+V13 — Compound Loop / Verified Save Proof-of-Use MVP
+
+Primary Objective:
+External Proof-of-Use
+
+First Adapter:
+Claude Agent SDK / product core remains agent-agnostic
+
+Starting Main:
+3c9142692dfe60785a033b91ad7b6e5226712a93
+
+Active Branch:
+feat/verified-save-claude-mvp-v0-1
+
+V12 State:
+DELAY — deterministic engine and Claude adapter passed; live human-owned proof
+is recoverably incomplete because Claude authentication is unavailable
+
+V13 Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+V13 Next Loop Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+Live Proof:
+DELAY — bundled Claude CLI reports loggedIn=false / no human option-2 selection
+
+Deterministic Engine:
+PASS / 25 OF 25 ACCELERATION TESTS
+
+Full Regression:
+PASS / 191 OF 191 TESTS
+
+Draft PR:
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/34
+
+Demo GIF:
+NOT_CREATED — conditional on passing live proof
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly approves review or merge
+
+Decision Owner:
+Shin
+```
+
+Restart evidence:
+
+- protocol and external usage:
+  `docs/verified_save_claude_mvp_v0_1.md`;
+- validation and exact re-entry:
+  `validation/verified_save_claude_mvp_run_001.md`;
+- implementation branch:
+  `feat/verified-save-claude-mvp-v0-1`;
+- Draft PR:
+  `https://github.com/shin4141/decision-os-v13-loopkit/pull/34`;
+- live-proof re-entry:
+  authenticate Claude until `claude auth status` reports `loggedIn=true`, then
+  run the documented demo interactively with one explicit human option `2`.
+
+Do not treat deterministic fixtures as live proof. Do not create the GIF,
+modify README, add another adapter, merge, release, tag, or publish a package
+without a new exact instruction from Shin.
+
+Everything below this boundary is a historical reverse-chronological ledger.
+Historical entries preserve their As-of truth but grant no present authority.
+
 ## Canonical Current State — Consistency Cleanup v0.1
 
 ```text

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -19,8 +19,8 @@ Active Branch:
 feat/verified-save-claude-mvp-v0-1
 
 V12 State:
-DELAY — deterministic engine and Claude adapter passed; live human-owned proof
-is recoverably incomplete because Claude authentication is unavailable
+DELAY — creator-owned human two-Run live proof passed; external-user adoption
+remains unobserved and no external adoption claim is made
 
 V13 Gate:
 HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
@@ -29,19 +29,31 @@ V13 Next Loop Gate:
 HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
 
 Live Proof:
-DELAY — bundled Claude CLI reports loggedIn=false / no human option-2 selection
+PASS — Run 1 normal terminal / repeated interrupt skipped / fresh Run 2
+VERIFIED_SAVE / 1 Save / 1 Verified Reuse
 
 Deterministic Engine:
-PASS / 25 OF 25 ACCELERATION TESTS
+PASS / 26 OF 26 ACCELERATION TESTS
 
 Full Regression:
-PASS / 191 OF 191 TESTS
+PASS / 192 OF 192 TESTS
 
 Draft PR:
 OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/34
 
 Demo GIF:
-NOT_CREATED — conditional on passing live proof
+NOT_CREATED — not authorized by the live-proof closure
+
+Live Receipt:
+7.5 estimated minutes / ¥625 estimated human-time value /
+9,467 configured estimated tokens
+
+Receipt SHA-256:
+027368f679b7ce1f14bf7ca42bfe686c34c8af313d801f7cc086e0b2a5c3e100
+
+Claim Boundary:
+creator-owned human live proof / not external-user adoption /
+not third-party certification / estimates remain estimates
 
 Merge Authority:
 NONE
@@ -63,13 +75,15 @@ Restart evidence:
   `feat/verified-save-claude-mvp-v0-1`;
 - Draft PR:
   `https://github.com/shin4141/decision-os-v13-loopkit/pull/34`;
-- live-proof re-entry:
-  authenticate Claude until `claude auth status` reports `loggedIn=true`, then
-  run the documented demo interactively with one explicit human option `2`.
+- live-proof receipt:
+  `validation/verified_save_claude_mvp_run_001.md`, bound to sanitized receipt
+  SHA-256
+  `027368f679b7ce1f14bf7ca42bfe686c34c8af313d801f7cc086e0b2a5c3e100`.
 
-Do not treat deterministic fixtures as live proof. Do not create the GIF,
-modify README, add another adapter, merge, release, tag, or publish a package
-without a new exact instruction from Shin.
+The passing proof is creator-owned human evidence, not external-user adoption
+or third-party certification. Estimates remain estimates. Do not create the
+GIF, modify README, add another adapter, merge, release, tag, or publish a
+package without a new exact instruction from Shin.
 
 Everything below this boundary is a historical reverse-chronological ledger.
 Historical entries preserve their As-of truth but grant no present authority.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,15 @@ license-files = ["LICENSE"]
 authors = [{ name = "Shinichi Nagata" }]
 dependencies = []
 
+[project.optional-dependencies]
+claude = ["claude-agent-sdk==0.2.123"]
+
 [project.urls]
 Repository = "https://github.com/shin4141/decision-os-v13-loopkit"
 
 [project.scripts]
 decision-os = "decision_os.cli:main"
+decision-os-accelerate = "decision_os.acceleration.cli:main"
 
 [tool.flit.module]
 name = "decision_os"

--- a/tests/test_acceleration_claude_adapter.py
+++ b/tests/test_acceleration_claude_adapter.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import io
+from pathlib import Path
+from types import SimpleNamespace
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.acceleration.claude_adapter import (
+    CLAUDE_AGENT_SDK_VERSION,
+    ClaudeAdapter,
+    ClaudeAdapterFailure,
+    ClaudeAdapterUnavailable,
+)
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import DecisionType
+
+
+@dataclass
+class FakeAllow:
+    behavior: str = "allow"
+
+
+@dataclass
+class FakeDeny:
+    message: str = ""
+    interrupt: bool = False
+    behavior: str = "deny"
+
+
+@dataclass
+class FakeResult:
+    subtype: str = "success"
+    is_error: bool = False
+
+
+@dataclass
+class FakeContext:
+    tool_use_id: str = "tool-use-1"
+
+
+class FakeOptions:
+    def __init__(self, **values: object) -> None:
+        self.__dict__.update(values)
+
+
+def create_repository(parent: Path) -> Path:
+    repository = parent / "repo"
+    repository.mkdir()
+    subprocess.run(
+        ("git", "init", "-q", str(repository)),
+        check=True,
+        capture_output=True,
+    )
+    (repository / "target.txt").write_text("one\n", encoding="utf-8")
+    return repository
+
+
+def fake_sdk(
+    *,
+    tool_name: str = "Edit",
+    path: str = "target.txt",
+    result: FakeResult | None = None,
+    callback_results: list[object] | None = None,
+) -> SimpleNamespace:
+    observed = callback_results if callback_results is not None else []
+
+    async def query(*, prompt: object, options: FakeOptions):
+        messages = [message async for message in prompt]
+        if not messages:
+            raise AssertionError("missing streaming prompt")
+        permission = await options.can_use_tool(
+            tool_name,
+            {"file_path": path},
+            FakeContext(),
+        )
+        observed.append(permission)
+        yield result or FakeResult()
+
+    return SimpleNamespace(
+        __version__=CLAUDE_AGENT_SDK_VERSION,
+        ClaudeAgentOptions=FakeOptions,
+        PermissionResultAllow=FakeAllow,
+        PermissionResultDeny=FakeDeny,
+        ResultMessage=FakeResult,
+        query=query,
+    )
+
+
+class ClaudeAdapterTest(unittest.IsolatedAsyncioTestCase):
+    async def test_two_fresh_runs_create_default_then_verified_save(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(
+                repository,
+                adapter="claude-agent-sdk",
+                adapter_version=CLAUDE_AGENT_SDK_VERSION,
+            )
+            choices = iter(("2",))
+            output = io.StringIO()
+            permissions: list[object] = []
+            adapter = ClaudeAdapter(
+                engine,
+                input_func=lambda: next(choices),
+                stdout=output,
+                sdk_module=fake_sdk(callback_results=permissions),
+            )
+
+            first = await adapter.run("first")
+            second = await adapter.run("second")
+
+            self.assertTrue(first.normal_terminal)
+            self.assertEqual("NORMAL_TERMINAL", first.status)
+            self.assertTrue(second.normal_terminal)
+            self.assertEqual("VERIFIED_SAVE", second.status)
+            self.assertEqual((1, 1), engine.store.counters())
+            self.assertEqual(2, len(permissions))
+            self.assertTrue(all(item.behavior == "allow" for item in permissions))
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+
+    async def test_error_result_leaves_cross_run_candidate_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(
+                repository,
+                adapter="claude-agent-sdk",
+                adapter_version=CLAUDE_AGENT_SDK_VERSION,
+            )
+            first = ClaudeAdapter(
+                engine,
+                input_func=lambda: "2",
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(),
+            )
+            await first.run("first")
+            second = ClaudeAdapter(
+                engine,
+                input_func=lambda: self.fail("human prompt must be skipped"),
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(
+                    result=FakeResult(subtype="error", is_error=True)
+                ),
+            )
+
+            result = await second.run("second")
+
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual("PENDING", result.status)
+            self.assertEqual("error", result.result_subtype)
+            self.assertEqual((0, 0), engine.store.counters())
+
+    async def test_options_isolate_settings_and_do_not_auto_allow_edits(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(repository)
+            adapter = ClaudeAdapter(
+                engine,
+                input_func=lambda: "3",
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(),
+            )
+
+            options = adapter._options(adapter._sdk_module, demo=False)
+
+            self.assertEqual(["Read", "Edit", "Write"], options.tools)
+            self.assertEqual(["Read"], options.allowed_tools)
+            self.assertNotIn("Edit", options.allowed_tools)
+            self.assertNotIn("Write", options.allowed_tools)
+            self.assertEqual("default", options.permission_mode)
+            self.assertEqual([], options.setting_sources)
+            self.assertEqual([], options.skills)
+            self.assertTrue(options.strict_mcp_config)
+            self.assertFalse(options.continue_conversation)
+
+    async def test_write_mapping_uses_pre_request_file_existence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(repository)
+            adapter = ClaudeAdapter(
+                engine,
+                input_func=lambda: "3",
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(),
+            )
+
+            existing, _ = adapter._map_tool(
+                "Write", {"file_path": "target.txt"}
+            )
+            missing, _ = adapter._map_tool(
+                "Write", {"file_path": "new.txt"}
+            )
+
+            self.assertIs(DecisionType.MODIFY_FILE, existing)
+            self.assertIs(DecisionType.CREATE_FILE, missing)
+
+    async def test_unsupported_tool_and_scope_escape_are_denied(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(repository)
+            denied: list[object] = []
+            bash = ClaudeAdapter(
+                engine,
+                input_func=lambda: self.fail("must not prompt"),
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(
+                    tool_name="Bash",
+                    callback_results=denied,
+                ),
+            )
+            escape = ClaudeAdapter(
+                engine,
+                input_func=lambda: self.fail("must not prompt"),
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(
+                    path="../outside.txt",
+                    callback_results=denied,
+                ),
+            )
+
+            await bash.run("unsupported")
+            await escape.run("escape")
+
+            self.assertEqual(2, len(denied))
+            self.assertTrue(all(item.behavior == "deny" for item in denied))
+            self.assertEqual([], engine.store.read_events())
+
+    async def test_missing_validated_file_path_schema_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            adapter = ClaudeAdapter(
+                AccelerationEngine(repository),
+                input_func=lambda: self.fail("must not prompt"),
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(),
+            )
+
+            with self.assertRaises(ClaudeAdapterFailure):
+                adapter._map_tool("Edit", {})
+
+    async def test_optional_sdk_is_loaded_lazily(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            adapter = ClaudeAdapter(
+                AccelerationEngine(repository),
+                input_func=lambda: "3",
+                stdout=io.StringIO(),
+            )
+            with patch(
+                "decision_os.acceleration.claude_adapter.importlib.import_module",
+                side_effect=ModuleNotFoundError,
+            ):
+                with self.assertRaises(ClaudeAdapterUnavailable):
+                    adapter._load_sdk()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_acceleration_claude_adapter.py
+++ b/tests/test_acceleration_claude_adapter.py
@@ -65,28 +65,64 @@ def fake_sdk(
     path: str = "target.txt",
     result: FakeResult | None = None,
     callback_results: list[object] | None = None,
+    lifecycle_events: list[str] | None = None,
 ) -> SimpleNamespace:
     observed = callback_results if callback_results is not None else []
+    events = lifecycle_events if lifecycle_events is not None else []
 
-    async def query(*, prompt: object, options: FakeOptions):
-        messages = [message async for message in prompt]
-        if not messages:
-            raise AssertionError("missing streaming prompt")
-        permission = await options.can_use_tool(
-            tool_name,
-            {"file_path": path},
-            FakeContext(),
-        )
-        observed.append(permission)
-        yield result or FakeResult()
+    class FakeClaudeSDKClient:
+        def __init__(self, *, options: FakeOptions) -> None:
+            self.options = options
+            self.connected = False
+            self.prompt: str | None = None
+
+        async def __aenter__(self) -> FakeClaudeSDKClient:
+            self.connected = True
+            events.append("control_stream_opened")
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            traceback: object,
+        ) -> None:
+            self.connected = False
+            events.append("control_stream_closed")
+
+        async def query(self, prompt: str) -> None:
+            if not self.connected:
+                raise AssertionError("query requires an open control stream")
+            if not isinstance(prompt, str) or not prompt:
+                raise AssertionError("missing prompt")
+            self.prompt = prompt
+            events.append("prompt_sent")
+
+        async def receive_response(self):
+            if not self.connected or self.prompt is None:
+                raise AssertionError("response requires an open control stream")
+            events.append("permission_requested")
+            permission = await self.options.can_use_tool(
+                tool_name,
+                {"file_path": path},
+                FakeContext(),
+            )
+            if not self.connected:
+                raise AssertionError(
+                    "control stream closed before permission completed"
+                )
+            observed.append(permission)
+            events.append("permission_completed")
+            events.append("terminal_result_received")
+            yield result or FakeResult()
 
     return SimpleNamespace(
         __version__=CLAUDE_AGENT_SDK_VERSION,
         ClaudeAgentOptions=FakeOptions,
+        ClaudeSDKClient=FakeClaudeSDKClient,
         PermissionResultAllow=FakeAllow,
         PermissionResultDeny=FakeDeny,
         ResultMessage=FakeResult,
-        query=query,
     )
 
 
@@ -120,6 +156,39 @@ class ClaudeAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(2, len(permissions))
             self.assertTrue(all(item.behavior == "allow" for item in permissions))
             self.assertEqual(1, output.getvalue().count("Selection:"))
+
+    async def test_control_stream_stays_open_through_gated_edit_and_result(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            lifecycle: list[str] = []
+            permissions: list[object] = []
+            adapter = ClaudeAdapter(
+                AccelerationEngine(repository),
+                input_func=lambda: "1",
+                stdout=io.StringIO(),
+                sdk_module=fake_sdk(
+                    callback_results=permissions,
+                    lifecycle_events=lifecycle,
+                ),
+            )
+
+            result = await adapter.run("modify target")
+
+            self.assertTrue(result.normal_terminal)
+            self.assertEqual(1, len(permissions))
+            self.assertEqual(
+                [
+                    "control_stream_opened",
+                    "prompt_sent",
+                    "permission_requested",
+                    "permission_completed",
+                    "terminal_result_received",
+                    "control_stream_closed",
+                ],
+                lifecycle,
+            )
 
     async def test_error_result_leaves_cross_run_candidate_pending(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_acceleration_cli.py
+++ b/tests/test_acceleration_cli.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.acceleration.claude_adapter import ClaudeAdapterUnavailable
+from decision_os.acceleration.cli import (
+    EXIT_DELAY,
+    EXIT_OK,
+    EXIT_USAGE,
+    main,
+)
+from decision_os.acceleration.engine import AccelerationEngine, DeterministicAdapter
+from decision_os.acceleration.model import DecisionType
+
+
+def create_repository(parent: Path) -> Path:
+    repository = parent / "repo"
+    repository.mkdir()
+    subprocess.run(
+        ("git", "init", "-q", str(repository)),
+        check=True,
+        capture_output=True,
+    )
+    (repository / "target.txt").write_text("one\n", encoding="utf-8")
+    return repository
+
+
+class AccelerationCliTest(unittest.TestCase):
+    def test_usage_is_nonzero_without_traceback(self) -> None:
+        output = io.StringIO()
+        errors = io.StringIO()
+
+        exit_code = main([], stdout=output, stderr=errors)
+
+        self.assertEqual(EXIT_USAGE, exit_code)
+        self.assertNotIn("Traceback", errors.getvalue())
+
+    def test_help_is_a_normal_zero_exit(self) -> None:
+        output = io.StringIO()
+
+        exit_code = main(
+            ["--help"],
+            stdout=output,
+            stderr=io.StringIO(),
+        )
+
+        self.assertEqual(EXIT_OK, exit_code)
+
+    def test_receipt_reads_verified_state_without_exposing_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+            )
+            output = io.StringIO()
+
+            exit_code = main(
+                ["receipt", str(repository)],
+                stdout=output,
+                stderr=io.StringIO(),
+            )
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertIn("1 Save", output.getvalue())
+            self.assertIn("1 Verified Reuse", output.getvalue())
+            self.assertNotIn("target.txt", output.getvalue())
+
+    def test_revoke_preserves_verified_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = AccelerationEngine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+            verified, _ = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+            )
+            output = io.StringIO()
+
+            exit_code = main(
+                [
+                    "revoke",
+                    "--decision-key",
+                    verified.identity.decision_key,
+                    str(repository),
+                ],
+                stdout=output,
+                stderr=io.StringIO(),
+            )
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertIn("DEFAULT_REVOKED_AFTER_USE", output.getvalue())
+            self.assertEqual((1, 1), engine.store.counters())
+
+    def test_missing_optional_extra_returns_bounded_delay(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            prompt = Path(directory) / "prompt.txt"
+            prompt.write_text("edit the target", encoding="utf-8")
+            output = io.StringIO()
+            with patch(
+                "decision_os.acceleration.cli.ClaudeAdapter._load_sdk",
+                side_effect=ClaudeAdapterUnavailable("optional extra missing"),
+            ):
+                exit_code = main(
+                    [
+                        "run",
+                        "--adapter",
+                        "claude",
+                        "--prompt-file",
+                        str(prompt),
+                        str(repository),
+                    ],
+                    stdout=output,
+                    stderr=io.StringIO(),
+                )
+
+            self.assertEqual(EXIT_DELAY, exit_code)
+            self.assertIn("DELAY", output.getvalue())
+            self.assertIn("optional extra missing", output.getvalue())
+            self.assertNotIn("Traceback", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_acceleration_engine.py
+++ b/tests/test_acceleration_engine.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from decision_os.acceleration.engine import AccelerationEngine, DeterministicAdapter
+from decision_os.acceleration.model import DecisionType
+from decision_os.acceleration.store import AccelerationStore
+
+
+def create_repository(parent: Path, name: str = "private-repository") -> Path:
+    repository = parent / name
+    repository.mkdir()
+    subprocess.run(
+        ("git", "init", "-q", str(repository)),
+        check=True,
+        capture_output=True,
+    )
+    (repository / "target.txt").write_text("one\n", encoding="utf-8")
+    return repository
+
+
+class AccelerationEngineTest(unittest.TestCase):
+    def make_engine(self, repository: Path) -> AccelerationEngine:
+        return AccelerationEngine(
+            repository,
+            adapter="deterministic-test",
+            adapter_version="v0.1",
+        )
+
+    def test_cross_run_first_save_then_reuse_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+
+            first, first_checkpoint = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+            second, second_checkpoint = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+            )
+            third, third_checkpoint = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-3",
+            )
+
+            self.assertEqual("HUMAN_DEFAULT_CREATED", first.status)
+            self.assertEqual("HUMAN_DEFAULT_CREATED", first_checkpoint.status)
+            self.assertEqual("DEFAULT_MATCHED", second.status)
+            self.assertEqual("VERIFIED_SAVE", second_checkpoint.status)
+            self.assertEqual("VERIFIED_REUSE", third_checkpoint.status)
+            self.assertTrue(third.allowed)
+            self.assertEqual((1, 2), engine.store.counters())
+
+    def test_allow_once_deny_timeout_and_same_run_are_excluded(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+
+            allowed, _ = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="1",
+                run_id="allow-once",
+            )
+            denied, _ = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice=None,
+                run_id="timeout",
+            )
+            created, _ = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="same-run",
+                iteration=1,
+            )
+            same_run, same_checkpoint = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="same-run",
+                iteration=2,
+            )
+
+            self.assertEqual("ALLOW_ONCE", allowed.status)
+            self.assertEqual("DENIED", denied.status)
+            self.assertEqual("HUMAN_DEFAULT_CREATED", created.status)
+            self.assertEqual("SAME_RUN_DEFAULT", same_run.status)
+            self.assertEqual("SAME_RUN_DEFAULT", same_checkpoint.status)
+            self.assertEqual((0, 0), engine.store.counters())
+
+    def test_abnormal_terminal_remains_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+
+            _, checkpoint = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+                normal_terminal=False,
+            )
+
+            self.assertEqual("PENDING", checkpoint.status)
+            self.assertEqual((0, 0), engine.store.counters())
+            self.assertEqual(
+                "CHECKPOINT_PENDING",
+                engine.store.read_events()[-1]["event_type"],
+            )
+
+    def test_pre_checkpoint_override_rejects_save(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+
+            _, checkpoint = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+                override_before_checkpoint=True,
+            )
+
+            self.assertEqual("REVOKED_SAVE", checkpoint.status)
+            self.assertEqual((0, 0), engine.store.counters())
+            self.assertIsNone(
+                engine.store.active_default(
+                    engine.store.read_events()[0]["decision_key"]
+                )
+            )
+
+    def test_post_checkpoint_revocation_preserves_history(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+            verified, _ = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+            )
+
+            result = engine.revoke(
+                run_id="revoke-run",
+                decision_key=verified.identity.decision_key,
+            )
+
+            self.assertEqual("DEFAULT_REVOKED_AFTER_USE", result)
+            self.assertEqual((1, 1), engine.store.counters())
+            self.assertIsNone(
+                engine.store.active_default(verified.identity.decision_key)
+            )
+
+    def test_receipt_separates_estimates_and_keeps_outward_privacy(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory), "secret-project")
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+            )
+            before_events = list(engine.store.read_events())
+            engine.store.update_settings(
+                minutes_per_reuse=7.5,
+                hourly_value_jpy=5000,
+                tokens_per_reuse=9467,
+                set_tokens=True,
+            )
+
+            receipt = engine.receipt()
+            rendered = engine.render_receipt()
+
+            self.assertEqual(1, receipt["hard_metrics"]["verified_saves"])
+            self.assertEqual(1, receipt["hard_metrics"]["verified_reuses"])
+            self.assertEqual(7.5, receipt["estimated"]["minutes"])
+            self.assertEqual(625, receipt["estimated"]["money_jpy"])
+            self.assertEqual(9467, receipt["estimated"]["tokens"])
+            self.assertEqual(before_events, engine.store.read_events())
+            self.assertNotIn("secret-project", rendered)
+            self.assertNotIn("target.txt", rendered)
+            self.assertNotIn(str(repository), rendered)
+            self.assertIn("not third-party certification", rendered)
+
+    def test_default_tokens_are_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+
+            self.assertIsNone(engine.receipt()["estimated"]["tokens"])
+            self.assertIn("UNKNOWN tokens", engine.render_receipt())
+
+    def test_supersede_preserves_verified_history_and_deactivates_default(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            engine = self.make_engine(repository)
+            adapter = DeterministicAdapter(engine)
+            adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                human_choice="2",
+                run_id="run-1",
+            )
+            verified, _ = adapter.run(
+                decision_type=DecisionType.MODIFY_FILE,
+                scope="target.txt",
+                run_id="run-2",
+            )
+
+            status = engine.supersede(
+                run_id="supersede-run",
+                decision_key=verified.identity.decision_key,
+            )
+
+            self.assertEqual("DEFAULT_SUPERSEDED", status)
+            self.assertEqual((1, 1), engine.store.counters())
+            self.assertIsNone(
+                engine.store.active_default(verified.identity.decision_key)
+            )
+            self.assertEqual(
+                "DEFAULT_SUPERSEDED",
+                engine.store.read_events()[-1]["event_type"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_acceleration_store.py
+++ b/tests/test_acceleration_store.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from decision_os.acceleration.model import (
+    DecisionType,
+    ScopeError,
+    derive_decision_identity,
+    normalize_scope,
+    repository_id,
+)
+from decision_os.acceleration.store import AccelerationStore, StateIntegrityError
+
+
+def create_repository(parent: Path, name: str = "repo") -> Path:
+    repository = parent / name
+    repository.mkdir()
+    subprocess.run(
+        ("git", "init", "-q", str(repository)),
+        check=True,
+        capture_output=True,
+    )
+    return repository
+
+
+class AccelerationStoreTest(unittest.TestCase):
+    def test_state_lives_under_git_common_dir_and_chain_is_reproducible(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            (repository / "target.txt").write_text("one\n", encoding="utf-8")
+            ids = iter(("event-1", "event-2"))
+            store = AccelerationStore(
+                repository,
+                clock=lambda: "2026-07-27T00:00:00Z",
+                event_id_factory=lambda: next(ids),
+            )
+            identity = derive_decision_identity(
+                repository,
+                DecisionType.MODIFY_FILE,
+                "./target.txt",
+            )
+
+            first = store.append(
+                "DECISION_CHECK",
+                identity,
+                run_id="run-1",
+                iteration=1,
+                adapter="test",
+                adapter_version="1",
+                status="CHECKED",
+            )
+            second = store.append(
+                "HUMAN_DEFAULT_CREATED",
+                identity,
+                run_id="run-1",
+                iteration=1,
+                adapter="test",
+                adapter_version="1",
+                status="ACTIVE",
+                default_created_run_id="run-1",
+                default_rule_hash=identity.rule_hash,
+            )
+
+            self.assertEqual(first["event_hash"], second["prev_event_hash"])
+            self.assertEqual(second["event_hash"], store.chain_head())
+            self.assertEqual(2, len(store.read_events()))
+            self.assertTrue(
+                store.events_path.is_relative_to(
+                    (repository / ".git").resolve(strict=True)
+                )
+            )
+            self.assertFalse((repository / "events.jsonl").exists())
+
+    def test_corruption_blocks_reads_and_future_appends(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            store = AccelerationStore(repository)
+            identity = derive_decision_identity(
+                repository,
+                DecisionType.CREATE_FILE,
+                "new.txt",
+            )
+            store.append(
+                "DECISION_CHECK",
+                identity,
+                run_id="run-1",
+                iteration=1,
+                adapter="test",
+                adapter_version="1",
+                status="CHECKED",
+            )
+            event = json.loads(store.events_path.read_text(encoding="utf-8"))
+            event["status"] = "TAMPERED"
+            store.events_path.write_text(
+                f"{json.dumps(event, sort_keys=True)}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(StateIntegrityError):
+                store.read_events()
+            with self.assertRaises(StateIntegrityError):
+                store.append(
+                    "DECISION_CHECK",
+                    identity,
+                    run_id="run-2",
+                    iteration=1,
+                    adapter="test",
+                    adapter_version="1",
+                    status="CHECKED",
+                )
+
+    def test_scope_normalization_rejects_escape_glob_directory_and_symlink(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository = create_repository(parent)
+            target = repository / "folder" / "target.txt"
+            target.parent.mkdir()
+            target.write_text("one\n", encoding="utf-8")
+            outside = parent / "outside.txt"
+            outside.write_text("secret\n", encoding="utf-8")
+            (repository / "outside-link").symlink_to(outside)
+
+            self.assertEqual(
+                "folder/target.txt",
+                normalize_scope(repository, "./folder//target.txt"),
+            )
+            self.assertEqual(
+                "folder/new.txt",
+                normalize_scope(repository, "folder/sub/../new.txt"),
+            )
+            first = derive_decision_identity(
+                repository,
+                DecisionType.MODIFY_FILE,
+                "folder/target.txt",
+            )
+            second = derive_decision_identity(
+                repository,
+                DecisionType.MODIFY_FILE,
+                "./folder/target.txt",
+            )
+            self.assertEqual(first.decision_key, second.decision_key)
+            self.assertEqual(first.rule_hash, second.rule_hash)
+            for invalid in (
+                "../outside.txt",
+                "*.txt",
+                ".",
+                "folder",
+                "outside-link",
+            ):
+                with self.subTest(invalid=invalid):
+                    with self.assertRaises(ScopeError):
+                        normalize_scope(repository, invalid)
+
+    def test_repository_id_hashes_credential_free_remote_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory), "private-name")
+            remote = "https://secret-user:secret-token@github.com/acme/private.git"
+            subprocess.run(
+                ("git", "-C", str(repository), "remote", "add", "origin", remote),
+                check=True,
+                capture_output=True,
+            )
+
+            identity = repository_id(repository)
+
+            self.assertTrue(identity.startswith("repo:v1:"))
+            self.assertNotIn("secret", identity)
+            self.assertNotIn("private", identity)
+            self.assertNotIn("github", identity)
+
+    def test_settings_are_validated_and_do_not_add_events(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            store = AccelerationStore(repository)
+
+            updated = store.update_settings(
+                minutes_per_reuse=8,
+                hourly_value_jpy=6000,
+                tokens_per_reuse=1000,
+                set_tokens=True,
+            )
+
+            self.assertEqual(8, updated.minutes_per_reuse)
+            self.assertEqual(6000, updated.hourly_value_jpy)
+            self.assertEqual(1000, updated.tokens_per_reuse)
+            self.assertEqual([], store.read_events())
+            with self.assertRaises(StateIntegrityError):
+                store.update_settings(minutes_per_reuse=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_distribution.py
+++ b/tests/test_decision_os_distribution.py
@@ -55,7 +55,12 @@ class DistributionMetadataTest(unittest.TestCase):
 
         self.assertEqual(
             metadata["project"]["scripts"],
-            {"decision-os": "decision_os.cli:main"},
+            {
+                "decision-os": "decision_os.cli:main",
+                "decision-os-accelerate": (
+                    "decision_os.acceleration.cli:main"
+                ),
+            },
         )
 
 

--- a/validation/verified_save_claude_mvp_run_001.md
+++ b/validation/verified_save_claude_mvp_run_001.md
@@ -23,7 +23,7 @@ Validation date:
 
 ```text
 LIVE_PROOF:
-DELAY
+PASS
 
 DETERMINISTIC_ENGINE:
 PASS
@@ -40,7 +40,11 @@ mapping, normal/error ResultMessage boundary, lazy optional import, and
 fail-closed callback behavior passed implementation and deterministic adapter
 tests.
 
-It does not mean a live two-Run Verified Save occurred.
+`LIVE_PROOF=PASS` means the creator completed the bounded two-Run demo with one
+explicit human Repository Default and a separate fresh Run that produced the
+first Verified Save. It is not external-user adoption or third-party
+certification. Receipt time, human-time value, and token values remain
+estimates.
 
 ## Starting-State Receipt
 
@@ -109,7 +113,7 @@ dependencies.
 
 ```text
 Acceleration-specific tests:
-25 / 25 PASS
+26 / 26 PASS
 
 Network:
 not required
@@ -165,7 +169,7 @@ Baseline before implementation:
 166 / 166 PASS
 
 Final full suite:
-191 / 191 PASS
+192 / 192 PASS
 
 Protected v0.1 blobs and modes:
 14 / 14 PASS
@@ -250,73 +254,68 @@ repository name, or raw remote URL.
 
 No telemetry or server submission was added.
 
-## Live Proof Attempt
+## Live Proof Closure
 
-One bounded attempt used the installed official SDK and the bundled CLI in a
-disposable Git repository.
+The creator ran the installed official SDK and bundled CLI in the disposable
+demo repository from corrected PR head
+`73435f4d98592dfd9e626a897daa2498b465b7f2`.
 
-Observed result:
-
-```text
-Run 1 normal terminal:
-no
-
-Human option-2 callback reached:
-no
-
-Repository Default created:
-no
-
-Run 2 started:
-no
-
-Verified Save:
-no
-
-Verified Reuse:
-no
-```
-
-The bundled Claude CLI authentication check returned:
+The authenticated human-owned two-Run result was:
 
 ```text
-loggedIn:
-false
+Run 1 human selection:
+explicit option 2
 
-authMethod:
-none
+Live Run 1 status:
+NORMAL_TERMINAL
 
-apiProvider:
-firstParty
+Live Run 1 result subtype:
+success
+
+Live Run 1 API error status:
+NONE
+
+Live Run 1 stop reason:
+end_turn
+
+Live Run 1 error type:
+NONE
+
+Run 2:
+fresh Wrapper invocation
+
+Repeated human interrupt:
+skipped / no second option prompt
+
+Live Run 2 status:
+VERIFIED_SAVE
+
+Live Run 2 result subtype:
+success
+
+Live Run 2 API error status:
+NONE
+
+Live Run 2 stop reason:
+end_turn
+
+Live Run 2 error type:
+NONE
+
+Verified Save counter:
+1 Save
+
+Verified Reuse counter:
+1 Verified Reuse
 ```
 
-This is a recoverable authentication prerequisite, so the correct
-classification is `LIVE_PROOF=DELAY`, not FAIL or PASS.
+The first Run created the Repository Default only after Shin explicitly chose
+option `2`. The fresh second Run reached the same mechanically derived decision
+key, skipped the repeated interrupt, completed normally, and produced the
+first `VERIFIED_SAVE`. No agent, fixture, timeout, or automatic input
+substituted for the human selection.
 
-Exact re-entry condition:
-
-```text
-claude auth login
-claude auth status
-
-Required status:
-loggedIn=true
-```
-
-Then run from an interactive terminal:
-
-```bash
-decision-os-accelerate demo \
-  --adapter claude \
-  --tokens-per-reuse 9467
-```
-
-The human must explicitly select option `2` in Run 1. No agent, fixture, timeout,
-or automatic input may substitute for that selection.
-
-## Receipt Example
-
-The deterministic, privacy-safe rendering contract passed with:
+The sanitized live Receipt was:
 
 ```text
 VERIFIED
@@ -335,14 +334,25 @@ Calculated from:
 1 verified reuse × 9,467 configured tokens per reuse
 ```
 
-This is deterministic engine evidence, not a live Proof-of-Use claim.
-
-The renderer also includes:
-
 ```text
 Verified Save is a locally recorded proof-of-use event, not third-party
 certification.
 ```
+
+Receipt evidence:
+
+```text
+Sanitized receipt path:
+/var/folders/8p/njjq3zy14slbn9jvv4tt82dm0000gn/T/decision-os-verified-save-receipt-8b15f620b6f9.txt
+
+Receipt SHA-256:
+027368f679b7ce1f14bf7ca42bfe686c34c8af313d801f7cc086e0b2a5c3e100
+```
+
+This is a creator-owned human live proof. It is not external-user adoption,
+customer evidence, or third-party certification. The 7.5 minutes, ¥625
+human-time value, and 9,467 configured tokens remain estimates; only the
+1 Save and 1 Verified Reuse counters are hard observed protocol results.
 
 ## GIF Result
 
@@ -351,9 +361,9 @@ DEMO_GIF:
 NOT_CREATED
 ```
 
-A GIF is conditional on a passing real live proof. No fabricated fixture visual
-was substituted, so dimensions, duration, frame count, renderer identity,
-source receipt identity, and GIF hash are not applicable.
+The live proof passed, but GIF creation was not authorized by the closure
+packet. No visual was created, so dimensions, duration, frame count, renderer
+identity, source receipt identity, and GIF hash are not applicable.
 
 ## Exact File Boundary
 

--- a/validation/verified_save_claude_mvp_run_001.md
+++ b/validation/verified_save_claude_mvp_run_001.md
@@ -391,25 +391,23 @@ untouched.
 
 ## Git and Draft PR State
 
-This section is completed only from actual post-push evidence in the closure
-commit.
-
 ```text
-Implementation commit:
-PENDING INITIAL COMMIT
+Initial implementation commit:
+75bf881e191c1e5959b9364bb559bce84787be4b
 
-Closure commit:
-PENDING CLOSURE COMMIT
+Initial remote branch:
+75bf881e191c1e5959b9364bb559bce84787be4b
 
-Remote branch:
-PENDING INITIAL PUSH
+Canonical closure content:
+this receipt and the two canonical current-state blocks in final branch HEAD
 
 Draft PR:
-PENDING CREATION
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/34
 
 Merge:
 NOT AUTHORIZED / NOT PERFORMED
 ```
 
-These are explicit current facts at this validation stage, not planned-success
-claims.
+The final branch-head SHA is verified after the closure commit and reported in
+the receiver-authored completion report. A commit cannot safely embed its own
+hash as content, so no self-referential SHA is claimed here.

--- a/validation/verified_save_claude_mvp_run_001.md
+++ b/validation/verified_save_claude_mvp_run_001.md
@@ -1,0 +1,415 @@
+# Verified Save Claude MVP — Validation Run 001
+
+## Receipt Identity
+
+```text
+Packet:
+V13-VERIFIED-SAVE-CLAUDE-MVP-001
+
+Scope Amendment:
+V13-VERIFIED-SAVE-CLAUDE-MVP-001-A1
+
+Starting main:
+3c9142692dfe60785a033b91ad7b6e5226712a93
+
+Branch:
+feat/verified-save-claude-mvp-v0-1
+
+Validation date:
+2026-07-27
+```
+
+## Classification
+
+```text
+LIVE_PROOF:
+DELAY
+
+DETERMINISTIC_ENGINE:
+PASS
+
+CLAUDE_ADAPTER:
+PASS
+
+DEMO_GIF:
+NOT_CREATED
+```
+
+`CLAUDE_ADAPTER=PASS` means the pinned SDK API, permission options, typed tool
+mapping, normal/error ResultMessage boundary, lazy optional import, and
+fail-closed callback behavior passed implementation and deterministic adapter
+tests.
+
+It does not mean a live two-Run Verified Save occurred.
+
+## Starting-State Receipt
+
+The amended preflight passed before implementation:
+
+- GitHub repository identity:
+  `https://github.com/shin4141/decision-os-v13-loopkit`;
+- local `main`, `origin/main`, fetched `main`, and remote `main`:
+  `3c9142692dfe60785a033b91ad7b6e5226712a93`;
+- implementation branch:
+  `feat/verified-save-claude-mvp-v0-1`;
+- implementation branch starting HEAD:
+  `3c9142692dfe60785a033b91ad7b6e5226712a93`;
+- remote implementation branch:
+  absent before implementation;
+- worktree and index:
+  clean;
+- GitHub CLI account:
+  authenticated as repository owner;
+- A1 added only
+  `tests/test_decision_os_distribution.py` to the update allowlist.
+
+The existing local branch was reused without recreation, reset, deletion, or
+switching.
+
+## Validated SDK Identity
+
+The current official package was inspected from its PyPI wheel and sdist before
+adapter implementation:
+
+```text
+Package:
+claude-agent-sdk
+
+Version:
+0.2.123
+
+Wheel:
+claude_agent_sdk-0.2.123-py3-none-macosx_11_0_arm64.whl
+
+Wheel SHA-256:
+e333c7edd50dde407b366b1124370e18767fb366d3c5389440891e7417d3c1ca
+
+Bundled Claude Code CLI:
+2.1.215 (Claude Code)
+```
+
+The inspected API contract included:
+
+- `ClaudeAgentOptions`;
+- `can_use_tool(tool_name, input_data, context)`;
+- `ToolPermissionContext.tool_use_id`;
+- `PermissionResultAllow`;
+- `PermissionResultDeny`;
+- `ResultMessage.subtype`;
+- `ResultMessage.is_error`;
+- `ResultMessage.api_error_status`;
+- Edit and Write `file_path` input;
+- async-iterable streaming mode required for `can_use_tool`.
+
+The committed optional dependency is pinned exactly to
+`claude-agent-sdk==0.2.123`. The core package retains zero mandatory runtime
+dependencies.
+
+## Deterministic Engine Result
+
+```text
+Acceleration-specific tests:
+25 / 25 PASS
+
+Network:
+not required
+
+Claude credentials:
+not required
+
+Human input:
+not required
+```
+
+The deterministic test boundary covered:
+
+- canonical decision key and rule-hash reproducibility;
+- hashed repository identity;
+- exact path normalization;
+- duplicate separator and `..` normalization;
+- repository escape rejection;
+- glob rejection;
+- directory rejection;
+- outside-root symlink rejection;
+- append-only event hashing;
+- previous-hash verification;
+- chain-corruption fail-closed behavior;
+- explicit option-2 Default creation;
+- Allow-once exclusion;
+- invalid/EOF/timeout-style exclusion;
+- same-Run exclusion;
+- cross-Run match;
+- interrupt-skipped event;
+- normal Wrapper checkpoint;
+- abnormal terminal PENDING;
+- first `VERIFIED_SAVE`;
+- repeated `VERIFIED_REUSE`;
+- pre-checkpoint override rejection;
+- post-checkpoint revocation preservation;
+- Default supersession preservation;
+- separate Save and Reuse counters;
+- estimate-setting independence;
+- Receipt formula;
+- token estimate UNKNOWN by default;
+- outward Receipt privacy;
+- missing optional extra behavior;
+- unsupported Claude tool rejection;
+- unsupported Claude input schema rejection;
+- Write create/modify mapping from pre-request existence;
+- isolated Claude settings and permission configuration.
+
+## Full Regression
+
+```text
+Baseline before implementation:
+166 / 166 PASS
+
+Final full suite:
+191 / 191 PASS
+
+Protected v0.1 blobs and modes:
+14 / 14 PASS
+
+git diff --check:
+PASS
+```
+
+The existing `decision-os` console mapping remains unchanged. The amended
+distribution contract verifies the complete two-entry `project.scripts`
+mapping rather than weakening the assertion to membership checks.
+
+## Package and Entry-Point Validation
+
+The final source built successfully with the pinned Flit backend:
+
+```text
+Wheel:
+decision_os_v13_loopkit-0.2.0-py3-none-any.whl
+
+Wheel SHA-256:
+396e0c588fb8fe0db2d3ece3dd34523fa2bd2a12ddb640cc88556e1d2a069164
+```
+
+An isolated environment without the Claude extra passed:
+
+```text
+Core import:
+PASS
+
+claude_agent_sdk present:
+no
+
+decision-os-accelerate --help:
+PASS / exit 0
+
+decision-os-accelerate run without extra:
+DELAY / nonzero / no traceback
+```
+
+An isolated environment with the Claude extra passed:
+
+```text
+decision_os import:
+PASS
+
+claude_agent_sdk version:
+0.2.123
+
+bundled Claude Code identity:
+2.1.215 (Claude Code)
+
+console entry-point import:
+PASS
+```
+
+No package was published.
+
+## Event-Chain and Privacy Result
+
+The local state root is mechanically derived as:
+
+```text
+<git-common-dir>/decision-os/acceleration/v0.1/
+```
+
+The required state files are:
+
+```text
+events.jsonl
+config.json
+```
+
+The implementation verifies the complete canonical JSON hash chain before
+Default application, candidate promotion, counter reporting, and Receipt
+generation.
+
+Tests verified that outward Receipts contain no raw repository name, raw remote,
+working path, or normalized target filename. The event model has no fields for
+prompt text, conversation body, code body, file content, credentials, raw
+repository name, or raw remote URL.
+
+No telemetry or server submission was added.
+
+## Live Proof Attempt
+
+One bounded attempt used the installed official SDK and the bundled CLI in a
+disposable Git repository.
+
+Observed result:
+
+```text
+Run 1 normal terminal:
+no
+
+Human option-2 callback reached:
+no
+
+Repository Default created:
+no
+
+Run 2 started:
+no
+
+Verified Save:
+no
+
+Verified Reuse:
+no
+```
+
+The bundled Claude CLI authentication check returned:
+
+```text
+loggedIn:
+false
+
+authMethod:
+none
+
+apiProvider:
+firstParty
+```
+
+This is a recoverable authentication prerequisite, so the correct
+classification is `LIVE_PROOF=DELAY`, not FAIL or PASS.
+
+Exact re-entry condition:
+
+```text
+claude auth login
+claude auth status
+
+Required status:
+loggedIn=true
+```
+
+Then run from an interactive terminal:
+
+```bash
+decision-os-accelerate demo \
+  --adapter claude \
+  --tokens-per-reuse 9467
+```
+
+The human must explicitly select option `2` in Run 1. No agent, fixture, timeout,
+or automatic input may substitute for that selection.
+
+## Receipt Example
+
+The deterministic, privacy-safe rendering contract passed with:
+
+```text
+VERIFIED
+
+1 Save
+1 Verified Reuse
+
+ESTIMATED RECOVERED
+
+7.5 minutes
+¥625
+9,467 tokens
+
+Calculated from:
+1 verified reuse × 7.5 estimated minutes per reuse × ¥5,000 per hour
+1 verified reuse × 9,467 configured tokens per reuse
+```
+
+This is deterministic engine evidence, not a live Proof-of-Use claim.
+
+The renderer also includes:
+
+```text
+Verified Save is a locally recorded proof-of-use event, not third-party
+certification.
+```
+
+## GIF Result
+
+```text
+DEMO_GIF:
+NOT_CREATED
+```
+
+A GIF is conditional on a passing real live proof. No fabricated fixture visual
+was substituted, so dimensions, duration, frame count, renderer identity,
+source receipt identity, and GIF hash are not applicable.
+
+## Exact File Boundary
+
+The authorized boundary is 18 files:
+
+### Create
+
+1. `decision_os/acceleration/__init__.py`
+2. `decision_os/acceleration/model.py`
+3. `decision_os/acceleration/store.py`
+4. `decision_os/acceleration/engine.py`
+5. `decision_os/acceleration/claude_adapter.py`
+6. `decision_os/acceleration/cli.py`
+7. `tests/test_acceleration_engine.py`
+8. `tests/test_acceleration_store.py`
+9. `tests/test_acceleration_cli.py`
+10. `tests/test_acceleration_claude_adapter.py`
+11. `examples/verified_save_demo/run_1.txt`
+12. `examples/verified_save_demo/run_2.txt`
+13. `docs/verified_save_claude_mvp_v0_1.md`
+14. `validation/verified_save_claude_mvp_run_001.md`
+
+### Update
+
+1. `pyproject.toml`
+2. `tests/test_decision_os_distribution.py`
+3. `docs/current_signal.md`
+4. `handoff/current_codex_handoff.md`
+
+The conditional GIF path was not created.
+
+`README.md`, `AGENTS.md`, existing Runner source, release/version, tag, OAuth,
+server, telemetry, pricing, public claim, and adjacent adapter surfaces remain
+untouched.
+
+## Git and Draft PR State
+
+This section is completed only from actual post-push evidence in the closure
+commit.
+
+```text
+Implementation commit:
+PENDING INITIAL COMMIT
+
+Closure commit:
+PENDING CLOSURE COMMIT
+
+Remote branch:
+PENDING INITIAL PUSH
+
+Draft PR:
+PENDING CREATION
+
+Merge:
+NOT AUTHORIZED / NOT PERFORMED
+```
+
+These are explicit current facts at this validation stage, not planned-success
+claims.


### PR DESCRIPTION
## Purpose

Build the first Claude Agent SDK adapter for an agent-agnostic Verified Save
protocol: one explicit human Repository Default, a separate later Run, the same
mechanically derived decision key, a skipped repeated interrupt, a
Wrapper-owned checkpoint, and a local Acceleration Receipt.

## Starting state

- starting `main`: `3c9142692dfe60785a033b91ad7b6e5226712a93`
- corrected implementation head:
  `73435f4d98592dfd9e626a897daa2498b465b7f2`
- live-proof closure head: `f6e682b904e746c6caa578afe78ec8d5178da1ac`
- core implementation commit: `75bf881e191c1e5959b9364bb559bce84787be4b`
- branch: `feat/verified-save-claude-mvp-v0-1`

## What changed

- adds an agent-agnostic Verified Save model, append-only hash-chained local
  store, state engine, Receipt renderer, and deterministic adapter
- adds a separate `decision-os-accelerate` CLI with `run`, `receipt`, `revoke`,
  and `demo`
- adds a Claude Agent SDK adapter with explicit Edit/Write permission callbacks
  and no dangerous bypass mode
- keeps the official bidirectional SDK control stream open through the gated
  permission callback and terminal ResultMessage
- pins the optional Claude extra without adding a mandatory dependency to the
  existing Runner
- adds deterministic protocol, storage, CLI, and Claude-boundary tests
- adds fixed two-Run demo prompts, external MVP documentation, and Validation
  Run 001
- preserves the existing `decision-os` entry point and its complete metadata
  assertion
- records the passing creator-owned human two-Run live proof

## Exact changed files

18 files across the implementation, correction, and closure commits:

- `decision_os/acceleration/__init__.py`
- `decision_os/acceleration/model.py`
- `decision_os/acceleration/store.py`
- `decision_os/acceleration/engine.py`
- `decision_os/acceleration/claude_adapter.py`
- `decision_os/acceleration/cli.py`
- `tests/test_acceleration_engine.py`
- `tests/test_acceleration_store.py`
- `tests/test_acceleration_cli.py`
- `tests/test_acceleration_claude_adapter.py`
- `examples/verified_save_demo/run_1.txt`
- `examples/verified_save_demo/run_2.txt`
- `docs/verified_save_claude_mvp_v0_1.md`
- `docs/current_signal.md`
- `handoff/current_codex_handoff.md`
- `validation/verified_save_claude_mvp_run_001.md`
- `pyproject.toml`
- `tests/test_decision_os_distribution.py`

## SDK identity

- `claude-agent-sdk==0.2.123`
- bundled Claude Code CLI: `2.1.215`
- inspected macOS arm64 SDK wheel SHA-256:
  `e333c7edd50dde407b366b1124370e18767fb366d3c5389440891e7417d3c1ca`

## Validation

- baseline: 166/166 PASS
- final full suite: 192/192 PASS
- acceleration-specific deterministic tests: 26/26 PASS
- SDK control-stream lifecycle regression: PASS
- protected v0.1 blobs/modes: 14/14 PASS
- initial package build: PASS
- initial built wheel SHA-256:
  `396e0c588fb8fe0db2d3ece3dd34523fa2bd2a12ddb640cc88556e1d2a069164`
- core import without Claude extra: PASS
- missing-extra behavior: bounded DELAY / nonzero / no traceback
- installed SDK + bundled CLI identity: PASS
- local links, Markdown hierarchy/fences, Python AST, and
  `git diff --check`: PASS

## Evidence classification

- `DETERMINISTIC_ENGINE`: PASS
- `CLAUDE_ADAPTER`: PASS
- `LIVE_PROOF`: PASS
- `DEMO_GIF`: NOT_CREATED

The creator completed the authenticated two-Run demo from corrected head
`73435f4d98592dfd9e626a897daa2498b465b7f2`.

- Shin explicitly selected option 2 in Run 1.
- Run 1 ended `NORMAL_TERMINAL / success / end_turn`.
- Run 2 was a fresh Wrapper invocation.
- The repeated human interrupt was skipped; no second option prompt appeared.
- Run 2 ended `VERIFIED_SAVE / success / end_turn`.
- The Receipt reported 1 Save and 1 Verified Reuse.
- Estimates reported 7.5 minutes, ¥625 human-time value, and 9,467 configured
  tokens.
- Sanitized Receipt SHA-256:
  `027368f679b7ce1f14bf7ca42bfe686c34c8af313d801f7cc086e0b2a5c3e100`.

This is creator-owned human live proof. It is not external-user adoption,
customer evidence, or third-party certification. Time, human-time value, and
token values remain estimates.

## Limitations

- Claude v0.1 verifies only mechanically typed Edit/Write file decisions
- single writer only; concurrent Runs against one local store are unsupported
- no Bash mutation, semantic similarity, automatic defaults, session resume,
  OAuth, server, telemetry, or second adapter
- deterministic fixtures cannot substitute for the human-owned live proof

## Privacy and Claim Boundary

State stays under the target Git common directory. The event model stores no
prompt, conversation body, code/file content, credential, raw repository name,
or raw remote. Outward Receipts omit normalized filenames and use a hashed
receipt identity.

Verified Save is a locally recorded proof-of-use event, not third-party
certification. Estimates are labeled and remain separate from hard Save/Reuse
counters.

## Rollback identity

- starting main: `3c9142692dfe60785a033b91ad7b6e5226712a93`
- corrected implementation head:
  `73435f4d98592dfd9e626a897daa2498b465b7f2`
- live-proof closure head: `f6e682b904e746c6caa578afe78ec8d5178da1ac`
- core implementation commit:
  `75bf881e191c1e5959b9364bb559bce84787be4b`
- code rollback: history-preserving revert only
- repository-local acceleration state is separate and is not silently removed
  by a code revert

## Merge gate

**HOLD.** This PR is Draft. Do not mark ready, merge, release, tag, publish a
package, modify README, start public exposure, or begin another adapter.
