### PR TITLE
Expose Verified Save in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 ![Local read-only scan](https://img.shields.io/badge/scan-local%20read--only-blue)
 ![Human approval for changes](https://img.shields.io/badge/changes-human%20approval%20required-orange)
 
+## Your coding agent asks once. The next Run remembers.
+
+1. The agent asks whether it may modify a file.
+2. You choose **Use for this repository**.
+3. A fresh later Run skips the repeated interrupt, records a Verified Save,
+   and emits a local Acceleration Receipt.
+
+In the creator-owned human live proof for the first Claude Agent SDK adapter,
+the human explicitly selected option 2 in Run 1. A separate, fresh Run 2 showed
+no second option prompt and ended with `VERIFIED_SAVE`. Its Receipt recorded
+1 Save and 1 Verified Reuse; 7.5 minutes, ¥625, and 9,467 tokens are estimates.
+
+This is creator-owned human live proof, not external-user adoption or
+third-party certification. [See the Verified Save Claude MVP
+guide.](docs/verified_save_claude_mvp_v0_1.md)
+
 ## Turn one AI incident into a paste-ready rule
 
 An AI agent said “done,” resumed from stale state, lost the accepted result,


### PR DESCRIPTION
## Summary

- expose the immediate Verified Save reward near the top of the README
- show the ask-once, repository-default, fresh-Run flow in three steps
- report the bounded creator-owned Claude Agent SDK live proof and its estimate boundary
- link directly to the detailed Verified Save Claude MVP guide

## Evidence boundary

This is creator-owned human live proof, not external-user adoption or
third-party certification. The reported 7.5 minutes, ¥625, and 9,467 tokens
remain estimates.

## Scope

- `README.md` only

## Validation

- README heading hierarchy and fences: PASS
- new local link resolution: PASS
- protected blob/mode guard: PASS
- full suite: 192 / 192 PASS
- `git diff --check`: PASS
- cumulative changed-file boundary: `README.md` only

## Gate

OPEN / Draft. Do not merge without a separate decision.
