### PR TITLE
Add Codex app-server Verified Save MVP

### DIFF
--- a/decision_os/acceleration/cli.py
+++ b/decision_os/acceleration/cli.py
@@ -15,11 +15,20 @@ import tempfile
 from typing import TextIO
 
 from .claude_adapter import (
-    ADAPTER_NAME,
+    ADAPTER_NAME as CLAUDE_ADAPTER_NAME,
     CLAUDE_AGENT_SDK_VERSION,
     ClaudeAdapter,
     ClaudeAdapterFailure,
     ClaudeAdapterUnavailable,
+    ClaudeRunResult,
+)
+from .codex_adapter import (
+    ADAPTER_NAME as CODEX_ADAPTER_NAME,
+    CODEX_CLI_VERSION,
+    CodexAdapter,
+    CodexAdapterFailure,
+    CodexAdapterUnavailable,
+    CodexRunResult,
 )
 from .engine import AccelerationEngine
 from .store import AccelerationStore, StateIntegrityError
@@ -39,6 +48,16 @@ DEMO_RUN_2 = (
     "Read demo_target.txt. Use Edit exactly once to replace the line "
     "'stage: run-1' with 'stage: run-2'. Do not touch any other file."
 )
+CODEX_DEMO_RUN_1 = (
+    "In demo_target.txt, the current line is 'stage: initial'. "
+    "Use the typed file-change tool exactly once to replace it with "
+    "'stage: run-1'. Do not use a shell command or touch any other file."
+)
+CODEX_DEMO_RUN_2 = (
+    "In demo_target.txt, the current line is 'stage: run-1'. "
+    "Use the typed file-change tool exactly once to replace it with "
+    "'stage: run-2'. Do not use a shell command or touch any other file."
+)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -46,7 +65,7 @@ def _parser() -> argparse.ArgumentParser:
     subcommands = parser.add_subparsers(dest="command", required=True)
 
     run = subcommands.add_parser("run")
-    run.add_argument("--adapter", choices=("claude",), required=True)
+    run.add_argument("--adapter", choices=("claude", "codex"), required=True)
     run.add_argument("--prompt-file", type=Path, required=True)
     run.add_argument("--minutes-per-reuse", type=float, default=7.5)
     run.add_argument("--hourly-value-jpy", type=float, default=5000)
@@ -61,7 +80,11 @@ def _parser() -> argparse.ArgumentParser:
     revoke.add_argument("repository", type=Path)
 
     demo = subcommands.add_parser("demo")
-    demo.add_argument("--adapter", choices=("claude",), required=True)
+    demo.add_argument(
+        "--adapter",
+        choices=("claude", "codex"),
+        required=True,
+    )
     demo.add_argument("--tokens-per-reuse", type=int)
     return parser
 
@@ -81,6 +104,60 @@ def _settings(
     )
 
 
+def _configured_adapter(
+    repository: Path,
+    adapter_name: str,
+    *,
+    stdout: TextIO,
+    input_func: Callable[[], str],
+    store: AccelerationStore | None = None,
+) -> tuple[AccelerationEngine, ClaudeAdapter | CodexAdapter]:
+    if adapter_name == "claude":
+        engine = AccelerationEngine(
+            repository,
+            store=store,
+            adapter=CLAUDE_ADAPTER_NAME,
+            adapter_version=CLAUDE_AGENT_SDK_VERSION,
+        )
+        return engine, ClaudeAdapter(
+            engine,
+            input_func=input_func,
+            stdout=stdout,
+        )
+    if adapter_name == "codex":
+        engine = AccelerationEngine(
+            repository,
+            store=store,
+            adapter=CODEX_ADAPTER_NAME,
+            adapter_version=CODEX_CLI_VERSION,
+        )
+        return engine, CodexAdapter(
+            engine,
+            input_func=input_func,
+            stdout=stdout,
+        )
+    raise ValueError(f"Unsupported acceleration adapter: {adapter_name}")
+
+
+def _write_codex_identity(
+    result: CodexRunResult,
+    *,
+    stdout: TextIO,
+) -> None:
+    identity = result.runtime_identity
+    if identity is None:
+        stdout.write("Codex runtime identity: UNAVAILABLE\n")
+        return
+    stdout.write(
+        "Codex runtime identity: "
+        f"model={identity.model}; "
+        f"reasoning_effort={identity.reasoning_effort}; "
+        f"service_tier={identity.service_tier}; "
+        f"cli_version={identity.codex_cli_version}; "
+        f"account_type={identity.account_type}\n"
+    )
+
+
 def _run_command(
     arguments: argparse.Namespace,
     *,
@@ -96,22 +173,23 @@ def _run_command(
             hourly_value_jpy=arguments.hourly_value_jpy,
             tokens_per_reuse=arguments.tokens_per_reuse,
         )
-        engine = AccelerationEngine(
+        engine, adapter = _configured_adapter(
             arguments.repository,
-            store=store,
-            adapter=ADAPTER_NAME,
-            adapter_version=CLAUDE_AGENT_SDK_VERSION,
-        )
-        adapter = ClaudeAdapter(
-            engine,
+            arguments.adapter,
             input_func=input_func,
             stdout=stdout,
+            store=store,
         )
         result = asyncio.run(adapter.run(prompt))
     except (OSError, UnicodeError, StateIntegrityError) as exc:
         stdout.write(f"BLOCK: {type(exc).__name__}\n")
         return EXIT_STATE
-    except (ClaudeAdapterUnavailable, ClaudeAdapterFailure) as exc:
+    except (
+        ClaudeAdapterUnavailable,
+        ClaudeAdapterFailure,
+        CodexAdapterUnavailable,
+        CodexAdapterFailure,
+    ) as exc:
         stdout.write(f"DELAY: {exc}\n")
         return EXIT_DELAY
 
@@ -121,10 +199,12 @@ def _run_command(
     )
     if result.error_type:
         stdout.write(f"Adapter error type: {result.error_type}\n")
+    if isinstance(result, CodexRunResult):
+        _write_codex_identity(result, stdout=stdout)
     stdout.write(engine.render_receipt())
     if result.status in {"VERIFIED_SAVE", "VERIFIED_REUSE", "NORMAL_TERMINAL"}:
         return EXIT_OK
-    if result.status == "ABNORMAL_TERMINAL":
+    if result.status in {"ABNORMAL_TERMINAL", "PENDING"}:
         return EXIT_DELAY
     return EXIT_DENIED
 
@@ -156,6 +236,38 @@ def _revoke_command(arguments: argparse.Namespace, *, stdout: TextIO) -> int:
     return EXIT_OK
 
 
+def _write_live_result(
+    label: str,
+    result: ClaudeRunResult | CodexRunResult,
+    *,
+    stdout: TextIO,
+) -> None:
+    if isinstance(result, CodexRunResult):
+        identity = result.runtime_identity
+        stdout.write(
+            f"{label}: "
+            f"status={result.status}; "
+            f"turn_status={result.turn_status or 'NONE'}; "
+            f"model={identity.model if identity else 'NONE'}; "
+            "reasoning_effort="
+            f"{identity.reasoning_effort if identity else 'NONE'}; "
+            "service_tier="
+            f"{identity.service_tier if identity else 'NONE'}; "
+            "codex_cli_version="
+            f"{identity.codex_cli_version if identity else 'NONE'}; "
+            f"error_type={result.error_type or 'NONE'}\n"
+        )
+        return
+    stdout.write(
+        f"{label}: "
+        f"status={result.status}; "
+        f"result_subtype={result.result_subtype or 'NONE'}; "
+        f"api_error_status={result.api_error_status or 'NONE'}; "
+        f"stop_reason={result.stop_reason or 'NONE'}; "
+        f"error_type={result.error_type or 'NONE'}\n"
+    )
+
+
 def _demo_command(
     arguments: argparse.Namespace,
     *,
@@ -184,26 +296,18 @@ def _demo_command(
             hourly_value_jpy=5000,
             tokens_per_reuse=arguments.tokens_per_reuse,
         )
-        engine = AccelerationEngine(
+        engine, adapter = _configured_adapter(
             directory,
             store=store,
-            adapter=ADAPTER_NAME,
-            adapter_version=CLAUDE_AGENT_SDK_VERSION,
-        )
-        adapter = ClaudeAdapter(
-            engine,
+            adapter_name=arguments.adapter,
             input_func=input_func,
             stdout=stdout,
         )
-        first = asyncio.run(adapter.run(DEMO_RUN_1, demo=True))
-        stdout.write(
-            "Live Run 1: "
-            f"status={first.status}; "
-            f"result_subtype={first.result_subtype or 'NONE'}; "
-            f"api_error_status={first.api_error_status or 'NONE'}; "
-            f"stop_reason={first.stop_reason or 'NONE'}; "
-            f"error_type={first.error_type or 'NONE'}\n"
-        )
+        if isinstance(adapter, ClaudeAdapter):
+            first = asyncio.run(adapter.run(DEMO_RUN_1, demo=True))
+        else:
+            first = asyncio.run(adapter.run(CODEX_DEMO_RUN_1))
+        _write_live_result("Live Run 1", first, stdout=stdout)
         default_created = any(
             event["event_type"] == "HUMAN_DEFAULT_CREATED"
             and event["run_id"] == first.run_id
@@ -216,15 +320,11 @@ def _demo_command(
             )
             return EXIT_DELAY
 
-        second = asyncio.run(adapter.run(DEMO_RUN_2, demo=True))
-        stdout.write(
-            "Live Run 2: "
-            f"status={second.status}; "
-            f"result_subtype={second.result_subtype or 'NONE'}; "
-            f"api_error_status={second.api_error_status or 'NONE'}; "
-            f"stop_reason={second.stop_reason or 'NONE'}; "
-            f"error_type={second.error_type or 'NONE'}\n"
-        )
+        if isinstance(adapter, ClaudeAdapter):
+            second = asyncio.run(adapter.run(DEMO_RUN_2, demo=True))
+        else:
+            second = asyncio.run(adapter.run(CODEX_DEMO_RUN_2))
+        _write_live_result("Live Run 2", second, stdout=stdout)
         receipt = engine.render_receipt()
         stdout.write(receipt)
         verified_saves, verified_reuses = store.counters()
@@ -246,7 +346,12 @@ def _demo_command(
         receipt_path.write_text(receipt, encoding="utf-8")
         stdout.write(f"Sanitized receipt: {receipt_path}\n")
         return EXIT_OK
-    except (ClaudeAdapterUnavailable, ClaudeAdapterFailure) as exc:
+    except (
+        ClaudeAdapterUnavailable,
+        ClaudeAdapterFailure,
+        CodexAdapterUnavailable,
+        CodexAdapterFailure,
+    ) as exc:
         stdout.write(f"DELAY: {exc}\n")
         return EXIT_DELAY
     except (OSError, StateIntegrityError) as exc:

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -1,0 +1,1059 @@
+"""Codex app-server adapter for the agent-agnostic Verified Save engine."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import copy
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import subprocess
+import threading
+from typing import Any, Protocol, TextIO
+
+from .engine import AccelerationEngine, CheckpointOutcome, DecisionOutcome
+from .model import DecisionType, ScopeError, normalize_scope
+
+
+BUNDLED_CODEX_PATH = Path(
+    "/Applications/ChatGPT.app/Contents/Resources/codex"
+)
+CODEX_CLI_VERSION = "0.146.0-alpha.3.1"
+CODEX_MODEL = "gpt-5.6-sol"
+CODEX_REASONING_EFFORT = "ultra"
+CODEX_SERVICE_TIER = "priority"
+ADAPTER_NAME = "codex-app-server"
+
+_CLIENT_NAME = "decision_os_verified_save"
+_CLIENT_VERSION = "0.1.0"
+_DEVELOPER_INSTRUCTIONS = (
+    "Perform only the requested bounded file operation. "
+    "Do not use shell commands. "
+    "Use the typed file-change tool for exactly one file mutation. "
+    "Do not mutate files through shell commands, dynamic tools, or MCP tools. "
+    "Do not touch another path, and stop normally after the requested operation."
+)
+_UNSUPPORTED_ITEM_TYPES = frozenset(
+    {
+        "collabAgentToolCall",
+        "commandExecution",
+        "dynamicToolCall",
+        "hookPrompt",
+        "imageGeneration",
+        "mcpToolCall",
+        "subAgentActivity",
+    }
+)
+
+
+class CodexAdapterUnavailable(RuntimeError):
+    """The bundled Codex app-server executable is unavailable."""
+
+
+class CodexAdapterFailure(RuntimeError):
+    """The app-server contract or bounded run failed before a safe result."""
+
+
+@dataclass(frozen=True)
+class CodexRuntimeIdentity:
+    """Machine-readable runtime identity observed from the app-server."""
+
+    model: str
+    reasoning_effort: str
+    service_tier: str
+    codex_cli_version: str
+    account_type: str
+
+
+@dataclass(frozen=True)
+class CodexRunResult:
+    """Sanitized result of one fresh Codex app-server thread."""
+
+    run_id: str
+    normal_terminal: bool
+    status: str
+    error_type: str | None
+    turn_status: str | None
+    runtime_identity: CodexRuntimeIdentity | None
+    checkpoint_outcomes: tuple[CheckpointOutcome, ...]
+
+
+class AppServerTransport(Protocol):
+    """Small injectable JSONL transport used by the adapter and fake server."""
+
+    @property
+    def version(self) -> str:
+        """Return the exact CLI version used by this transport."""
+
+    def start(self) -> None:
+        """Start one fresh app-server process."""
+
+    def send(self, message: dict[str, Any]) -> None:
+        """Send one JSON object as one JSONL message."""
+
+    def receive(self) -> dict[str, Any]:
+        """Receive one JSONL message."""
+
+    def close(self) -> None:
+        """Close the app-server process and control stream."""
+
+
+class _SubprocessTransport:
+    """Stable stdio JSONL transport for the bundled Codex app-server."""
+
+    def __init__(self, executable: Path) -> None:
+        self.executable = executable
+        self._version = ""
+        self._process: subprocess.Popen[str] | None = None
+        self._stderr_thread: threading.Thread | None = None
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    def start(self) -> None:
+        if not self.executable.is_file():
+            raise CodexAdapterUnavailable(
+                f"Bundled Codex executable is unavailable at {self.executable}."
+            )
+        try:
+            completed = subprocess.run(
+                (str(self.executable), "--version"),
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        except OSError as exc:
+            raise CodexAdapterUnavailable(
+                "Bundled Codex version could not be read."
+            ) from exc
+        observed = completed.stdout.strip()
+        prefix = "codex-cli "
+        if completed.returncode != 0 or not observed.startswith(prefix):
+            raise CodexAdapterFailure(
+                "Bundled Codex CLI returned an invalid version identity."
+            )
+        self._version = observed[len(prefix) :].strip()
+        try:
+            self._process = subprocess.Popen(
+                (
+                    str(self.executable),
+                    "-c",
+                    "features.apps=false",
+                    "-c",
+                    "features.hooks=false",
+                    "-c",
+                    "features.multi_agent=false",
+                    "-c",
+                    "features.remote_plugin=false",
+                    "-c",
+                    "features.shell_tool=false",
+                    "-c",
+                    "features.skill_mcp_dependency_install=false",
+                    "-c",
+                    "mcp_servers={}",
+                    "-c",
+                    "plugins={}",
+                    "app-server",
+                ),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+            )
+        except OSError as exc:
+            raise CodexAdapterUnavailable(
+                "Bundled Codex app-server could not be started."
+            ) from exc
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr,
+            name="decision-os-codex-stderr",
+            daemon=True,
+        )
+        self._stderr_thread.start()
+
+    def _drain_stderr(self) -> None:
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        try:
+            for _line in process.stderr:
+                pass
+        except (OSError, UnicodeError):
+            return
+
+    def send(self, message: dict[str, Any]) -> None:
+        process = self._process
+        if process is None or process.stdin is None or process.poll() is not None:
+            raise CodexAdapterFailure("Codex app-server control stream is closed.")
+        try:
+            process.stdin.write(
+                json.dumps(
+                    message,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            process.stdin.write("\n")
+            process.stdin.flush()
+        except (BrokenPipeError, OSError, UnicodeError) as exc:
+            raise CodexAdapterFailure(
+                "Codex app-server control stream write failed."
+            ) from exc
+
+    def receive(self) -> dict[str, Any]:
+        process = self._process
+        if process is None or process.stdout is None:
+            raise CodexAdapterFailure("Codex app-server is not running.")
+        try:
+            raw = process.stdout.readline()
+        except (OSError, UnicodeError) as exc:
+            raise CodexAdapterFailure(
+                "Codex app-server control stream read failed."
+            ) from exc
+        if not raw:
+            raise CodexAdapterFailure(
+                "Codex app-server closed before the terminal checkpoint."
+            )
+        try:
+            message = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeError) as exc:
+            raise CodexAdapterFailure(
+                "Codex app-server emitted invalid JSONL."
+            ) from exc
+        if not isinstance(message, dict):
+            raise CodexAdapterFailure(
+                "Codex app-server emitted a non-object JSONL message."
+            )
+        return message
+
+    def close(self) -> None:
+        process = self._process
+        if process is None:
+            return
+        if process.stdin is not None:
+            try:
+                process.stdin.close()
+            except OSError:
+                pass
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=1)
+
+
+TransportFactory = Callable[[Path], AppServerTransport]
+
+
+class CodexAdapter:
+    """Map exact Codex file-change approvals into fixed protocol decisions."""
+
+    def __init__(
+        self,
+        engine: AccelerationEngine,
+        *,
+        input_func: Callable[[], str],
+        stdout: TextIO,
+        executable: Path | None = None,
+        transport_factory: TransportFactory | None = None,
+        expected_model: str = CODEX_MODEL,
+        expected_reasoning_effort: str = CODEX_REASONING_EFFORT,
+        expected_service_tier: str = CODEX_SERVICE_TIER,
+        expected_cli_version: str = CODEX_CLI_VERSION,
+    ) -> None:
+        self.engine = engine
+        self.input_func = input_func
+        self.stdout = stdout
+        self.executable = executable or BUNDLED_CODEX_PATH
+        self.transport_factory = transport_factory or _SubprocessTransport
+        self.expected_model = expected_model
+        self.expected_reasoning_effort = expected_reasoning_effort
+        self.expected_service_tier = expected_service_tier
+        self.expected_cli_version = expected_cli_version
+        self._request_id = 0
+        self._transport: AppServerTransport | None = None
+        self._run_id = ""
+        self._thread_id: str | None = None
+        self._turn_id: str | None = None
+        self._turn_status: str | None = None
+        self._runtime_identity: CodexRuntimeIdentity | None = None
+        self._account_type: str | None = None
+        self._thread_cli_version: str | None = None
+        self._settings_verified = False
+        self._deferred_settings: list[dict[str, Any]] = []
+        self._iteration = 0
+        self._items: dict[str, dict[str, Any]] = {}
+        self._approved_changes: dict[str, list[dict[str, Any]]] = {}
+        self._approval_requests: dict[str | int, str] = {}
+        self._accepted_items: set[str] = set()
+        self._declined_items: set[str] = set()
+        self._resolved_items: set[str] = set()
+        self._completed_items: set[str] = set()
+        self._pending: dict[str, DecisionOutcome] = {}
+        self._seen: dict[str, DecisionOutcome] = {}
+        self._permission_denied = False
+        self._unsupported_mutation = False
+        self._identity_failure = False
+
+    def _reset_run(self) -> None:
+        self._request_id = 0
+        self._run_id = self.engine.new_run_id()
+        self._thread_id = None
+        self._turn_id = None
+        self._turn_status = None
+        self._runtime_identity = None
+        self._account_type = None
+        self._thread_cli_version = None
+        self._settings_verified = False
+        self._deferred_settings = []
+        self._iteration = 0
+        self._items = {}
+        self._approved_changes = {}
+        self._approval_requests = {}
+        self._accepted_items = set()
+        self._declined_items = set()
+        self._resolved_items = set()
+        self._completed_items = set()
+        self._pending = {}
+        self._seen = {}
+        self._permission_denied = False
+        self._unsupported_mutation = False
+        self._identity_failure = False
+
+    def _send(self, message: dict[str, Any]) -> None:
+        if self._transport is None:
+            raise CodexAdapterFailure("Codex app-server transport is unavailable.")
+        self._transport.send(message)
+
+    def _receive(self) -> dict[str, Any]:
+        if self._transport is None:
+            raise CodexAdapterFailure("Codex app-server transport is unavailable.")
+        return self._transport.receive()
+
+    def _request(self, method: str, params: dict[str, Any]) -> Any:
+        self._request_id += 1
+        request_id = self._request_id
+        self._send({"id": request_id, "method": method, "params": params})
+        while True:
+            message = self._receive()
+            if (
+                message.get("id") == request_id
+                and "method" not in message
+            ):
+                if "error" in message:
+                    raise CodexAdapterFailure(
+                        f"Codex app-server {method} request failed."
+                    )
+                if "result" not in message:
+                    raise CodexAdapterFailure(
+                        f"Codex app-server {method} response is incomplete."
+                    )
+                return message["result"]
+            self._dispatch(message)
+
+    @staticmethod
+    def _require_object(value: Any, label: str) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise CodexAdapterFailure(f"{label} is not an object.")
+        return value
+
+    def _initialize(self) -> None:
+        result = self._require_object(
+            self._request(
+                "initialize",
+                {
+                    "capabilities": {"experimentalApi": False},
+                    "clientInfo": {
+                        "name": _CLIENT_NAME,
+                        "title": "Decision OS Verified Save",
+                        "version": _CLIENT_VERSION,
+                    },
+                },
+            ),
+            "initialize result",
+        )
+        for field in ("codexHome", "platformFamily", "platformOs", "userAgent"):
+            if not isinstance(result.get(field), str) or not result[field]:
+                raise CodexAdapterFailure(
+                    f"initialize result lacks {field} identity."
+                )
+        self._send({"method": "initialized", "params": {}})
+
+    def _verify_account(self) -> None:
+        result = self._require_object(
+            self._request("account/read", {"refreshToken": False}),
+            "account/read result",
+        )
+        account = self._require_object(
+            result.get("account"),
+            "account/read account",
+        )
+        if account.get("type") != "chatgpt":
+            raise CodexAdapterFailure(
+                "Codex app-server is not using ChatGPT subscription authentication."
+            )
+        self._account_type = "chatgpt"
+
+    def _verify_model_catalog(self) -> None:
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+        while True:
+            params: dict[str, Any] = {"includeHidden": False}
+            if cursor is not None:
+                params["cursor"] = cursor
+            result = self._require_object(
+                self._request("model/list", params),
+                "model/list result",
+            )
+            data = result.get("data")
+            if not isinstance(data, list):
+                raise CodexAdapterFailure("Codex model catalog is unavailable.")
+            selected = next(
+                (
+                    item
+                    for item in data
+                    if isinstance(item, dict)
+                    and (
+                        item.get("id") == self.expected_model
+                        or item.get("model") == self.expected_model
+                    )
+                ),
+                None,
+            )
+            if selected is not None:
+                efforts = selected.get("supportedReasoningEfforts")
+                tiers = selected.get("serviceTiers")
+                if not isinstance(efforts, list) or not any(
+                    isinstance(item, dict)
+                    and item.get("reasoningEffort")
+                    == self.expected_reasoning_effort
+                    for item in efforts
+                ):
+                    raise CodexAdapterFailure(
+                        "Required Codex reasoning effort is unsupported."
+                    )
+                if not isinstance(tiers, list) or not any(
+                    isinstance(item, dict)
+                    and item.get("id") == self.expected_service_tier
+                    for item in tiers
+                ):
+                    raise CodexAdapterFailure(
+                        "Required Codex service tier is unsupported."
+                    )
+                return
+            next_cursor = result.get("nextCursor")
+            if (
+                not isinstance(next_cursor, str)
+                or not next_cursor
+                or next_cursor in seen_cursors
+            ):
+                raise CodexAdapterFailure(
+                    "Required Codex model is absent from the local catalog."
+                )
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+    def _start_thread(self) -> None:
+        repository = self.engine.store.repository
+        isolated_features = {
+            "apps": False,
+            "hooks": False,
+            "multi_agent": False,
+            "remote_plugin": False,
+            "shell_tool": False,
+            "skill_mcp_dependency_install": False,
+        }
+        result = self._require_object(
+            self._request(
+                "thread/start",
+                {
+                    "approvalPolicy": "on-request",
+                    "approvalsReviewer": "user",
+                    "config": {
+                        "features": isolated_features,
+                        "mcp_servers": {},
+                        "model_reasoning_effort": (
+                            self.expected_reasoning_effort
+                        ),
+                        "plugins": {},
+                    },
+                    "cwd": str(repository),
+                    "developerInstructions": _DEVELOPER_INSTRUCTIONS,
+                    "ephemeral": True,
+                    "model": self.expected_model,
+                    "modelProvider": "openai",
+                    "sandbox": "read-only",
+                    "serviceTier": self.expected_service_tier,
+                },
+            ),
+            "thread/start result",
+        )
+        thread = self._require_object(result.get("thread"), "thread identity")
+        thread_id = thread.get("id")
+        cli_version = thread.get("cliVersion")
+        if not isinstance(thread_id, str) or not thread_id:
+            raise CodexAdapterFailure("thread/start lacks a fresh thread ID.")
+        if cli_version != self.expected_cli_version:
+            raise CodexAdapterFailure(
+                "Codex app-server thread version identity mismatch."
+            )
+        if self._transport is None or self._transport.version != cli_version:
+            raise CodexAdapterFailure(
+                "Codex CLI and app-server version identities differ."
+            )
+        if result.get("model") != self.expected_model:
+            raise CodexAdapterFailure("Codex model identity mismatch.")
+        if result.get("modelProvider") != "openai":
+            raise CodexAdapterFailure("Codex model provider identity mismatch.")
+        if result.get("reasoningEffort") != self.expected_reasoning_effort:
+            raise CodexAdapterFailure("Codex reasoning effort identity mismatch.")
+        if result.get("serviceTier") != self.expected_service_tier:
+            raise CodexAdapterFailure("Codex service tier identity mismatch.")
+        if result.get("approvalPolicy") != "on-request":
+            raise CodexAdapterFailure("Codex approval policy identity mismatch.")
+        if result.get("approvalsReviewer") != "user":
+            raise CodexAdapterFailure("Codex approval reviewer identity mismatch.")
+        if not self._cwd_matches(result.get("cwd")):
+            raise CodexAdapterFailure("Codex thread cwd identity mismatch.")
+        if not self._read_only_sandbox(result.get("sandbox")):
+            raise CodexAdapterFailure("Codex thread sandbox identity mismatch.")
+        if thread.get("ephemeral") is not True:
+            raise CodexAdapterFailure("Codex thread is not ephemeral.")
+        if not self._cwd_matches(thread.get("cwd")):
+            raise CodexAdapterFailure("Codex thread root identity mismatch.")
+        self._thread_id = thread_id
+        self._thread_cli_version = cli_version
+        deferred = tuple(self._deferred_settings)
+        self._deferred_settings = []
+        for params in deferred:
+            self._verify_settings(params)
+
+    def _start_turn(self, prompt: str) -> None:
+        if self._thread_id is None:
+            raise CodexAdapterFailure("Codex thread identity is unavailable.")
+        result = self._require_object(
+            self._request(
+                "turn/start",
+                {
+                    "approvalPolicy": "on-request",
+                    "approvalsReviewer": "user",
+                    "cwd": str(self.engine.store.repository),
+                    "effort": self.expected_reasoning_effort,
+                    "input": [{"text": prompt, "type": "text"}],
+                    "model": self.expected_model,
+                    "sandboxPolicy": {
+                        "networkAccess": False,
+                        "type": "readOnly",
+                    },
+                    "serviceTier": self.expected_service_tier,
+                    "threadId": self._thread_id,
+                },
+            ),
+            "turn/start result",
+        )
+        turn = self._require_object(result.get("turn"), "turn identity")
+        turn_id = turn.get("id")
+        if not isinstance(turn_id, str) or not turn_id:
+            raise CodexAdapterFailure("turn/start lacks a fresh turn ID.")
+        if self._turn_id is not None and self._turn_id != turn_id:
+            raise CodexAdapterFailure("Codex turn identity changed during start.")
+        self._turn_id = turn_id
+
+    def _cwd_matches(self, value: Any) -> bool:
+        if not isinstance(value, str) or not value:
+            return False
+        try:
+            return (
+                Path(value).resolve()
+                == self.engine.store.repository
+            )
+        except (OSError, RuntimeError, TypeError):
+            return False
+
+    @staticmethod
+    def _read_only_sandbox(value: Any) -> bool:
+        return bool(
+            isinstance(value, dict)
+            and value.get("type") == "readOnly"
+            and value.get("networkAccess") is False
+        )
+
+    def _human_choice(self, identity: Any) -> str | None:
+        action = (
+            "create"
+            if identity.decision_type is DecisionType.CREATE_FILE
+            else "modify"
+        )
+        self.stdout.write(
+            "\nYour coding agent needs one default.\n\n"
+            f"May it {action} {identity.normalized_scope}?\n\n"
+            "[1] Allow once\n"
+            "[2] Use for this repository\n"
+            "[3] Deny\n\n"
+            "Selection: "
+        )
+        self.stdout.flush()
+        try:
+            return self.input_func()
+        except (EOFError, KeyboardInterrupt, OSError):
+            return None
+
+    def _map_file_change(
+        self,
+        item: dict[str, Any],
+    ) -> tuple[DecisionType, str]:
+        changes = item.get("changes")
+        if not isinstance(changes, list) or len(changes) != 1:
+            raise CodexAdapterFailure(
+                "Codex file approval is not one exact file change."
+            )
+        change = self._require_object(changes[0], "Codex file change")
+        raw_path = change.get("path")
+        diff = change.get("diff")
+        kind = self._require_object(
+            change.get("kind"),
+            "Codex file change kind",
+        )
+        kind_type = kind.get("type")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise CodexAdapterFailure(
+                "Codex file change lacks an exact path."
+            )
+        if not isinstance(diff, str):
+            raise CodexAdapterFailure(
+                "Codex file change lacks a typed diff."
+            )
+        normalized = normalize_scope(self.engine.repository, raw_path)
+        target = self.engine.store.repository / normalized
+        if kind_type == "add":
+            if target.exists():
+                raise CodexAdapterFailure(
+                    "Codex add target already exists before approval."
+                )
+            return DecisionType.CREATE_FILE, raw_path
+        if kind_type == "update":
+            if kind.get("move_path") not in {None, ""}:
+                raise CodexAdapterFailure(
+                    "Codex move or rename is unsupported."
+                )
+            if not target.is_file():
+                raise CodexAdapterFailure(
+                    "Codex update target is not an existing file."
+                )
+            return DecisionType.MODIFY_FILE, raw_path
+        raise CodexAdapterFailure(
+            f"Unsupported Codex file change kind: {kind_type!r}."
+        )
+
+    def _ids_match(self, params: dict[str, Any]) -> bool:
+        if params.get("threadId") != self._thread_id:
+            return False
+        observed_turn_id = params.get("turnId")
+        if not isinstance(observed_turn_id, str) or not observed_turn_id:
+            return False
+        if self._turn_id is None:
+            self._turn_id = observed_turn_id
+        return observed_turn_id == self._turn_id
+
+    def _respond_file_approval(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        params = self._require_object(
+            message.get("params"),
+            "file approval parameters",
+        )
+        item_id = params.get("itemId")
+        if (
+            not isinstance(request_id, (str, int))
+            or isinstance(request_id, bool)
+            or request_id in self._approval_requests
+        ):
+            self._unsupported_mutation = True
+            if isinstance(item_id, str):
+                self._declined_items.add(item_id)
+            self._send(
+                {"id": request_id, "result": {"decision": "decline"}}
+            )
+            return
+        if (
+            not isinstance(item_id, str)
+            or not self._ids_match(params)
+            or not self._settings_verified
+            or item_id not in self._items
+        ):
+            self._unsupported_mutation = True
+            if isinstance(item_id, str):
+                self._declined_items.add(item_id)
+            self._send(
+                {"id": request_id, "result": {"decision": "decline"}}
+            )
+            return
+        if item_id in self._approval_requests.values():
+            self._unsupported_mutation = True
+            self._declined_items.add(item_id)
+            self._send(
+                {"id": request_id, "result": {"decision": "decline"}}
+            )
+            return
+        self._approval_requests[request_id] = item_id
+        try:
+            decision_type, raw_path = self._map_file_change(
+                self._items[item_id]
+            )
+            normalized = normalize_scope(self.engine.repository, raw_path)
+        except (CodexAdapterFailure, ScopeError):
+            self._unsupported_mutation = True
+            self._declined_items.add(item_id)
+            self._send(
+                {"id": request_id, "result": {"decision": "decline"}}
+            )
+            return
+
+        key = (
+            f"{self.engine.store.repository_id}|"
+            f"{decision_type.value}|{normalized}"
+        )
+        if key in self._seen:
+            outcome = self._seen[key]
+        else:
+            self._iteration += 1
+            outcome = self.engine.evaluate(
+                run_id=self._run_id,
+                iteration=self._iteration,
+                decision_type=decision_type,
+                requested_scope=raw_path,
+                source_interrupt_id=item_id,
+                choice_provider=self._human_choice,
+            )
+            self._seen[key] = outcome
+            if outcome.pending_cross_run_checkpoint:
+                self._pending[outcome.identity.decision_key] = outcome
+
+        if outcome.allowed:
+            self._accepted_items.add(item_id)
+            self._approved_changes[item_id] = copy.deepcopy(
+                self._items[item_id]["changes"]
+            )
+            self._send(
+                {"id": request_id, "result": {"decision": "accept"}}
+            )
+            return
+        self._permission_denied = True
+        self._declined_items.add(item_id)
+        self._send(
+            {"id": request_id, "result": {"decision": "decline"}}
+        )
+
+    def _resolve_request(self, params: dict[str, Any]) -> None:
+        if params.get("threadId") != self._thread_id:
+            self._identity_failure = True
+            return
+        request_id = params.get("requestId")
+        if (
+            not isinstance(request_id, (str, int))
+            or isinstance(request_id, bool)
+        ):
+            self._identity_failure = True
+            return
+        item_id = self._approval_requests.get(request_id)
+        if item_id is None or item_id in self._resolved_items:
+            self._identity_failure = True
+            return
+        self._resolved_items.add(item_id)
+
+    def _respond_unsupported_request(self, message: dict[str, Any]) -> None:
+        self._unsupported_mutation = True
+        request_id = message.get("id")
+        method = message.get("method")
+        if method == "item/commandExecution/requestApproval":
+            self._send(
+                {"id": request_id, "result": {"decision": "decline"}}
+            )
+            return
+        self._send(
+            {
+                "error": {
+                    "code": -32601,
+                    "message": "Unsupported approval request.",
+                },
+                "id": request_id,
+            }
+        )
+
+    def _cache_item(self, params: dict[str, Any]) -> None:
+        if not self._ids_match(params):
+            self._identity_failure = True
+            return
+        item = self._require_object(params.get("item"), "started item")
+        item_type = item.get("type")
+        if item_type in _UNSUPPORTED_ITEM_TYPES:
+            self._unsupported_mutation = True
+            return
+        if item_type != "fileChange":
+            return
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id:
+            self._identity_failure = True
+            return
+        if item_id in self._items:
+            self._identity_failure = True
+            return
+        self._items[item_id] = item
+
+    def _update_patch(self, params: dict[str, Any]) -> None:
+        if not self._ids_match(params):
+            self._identity_failure = True
+            return
+        item_id = params.get("itemId")
+        changes = params.get("changes")
+        if (
+            not isinstance(item_id, str)
+            or item_id not in self._items
+            or not isinstance(changes, list)
+        ):
+            self._identity_failure = True
+            return
+        if item_id in self._approved_changes:
+            self._identity_failure = True
+            return
+        updated = dict(self._items[item_id])
+        updated["changes"] = changes
+        self._items[item_id] = updated
+
+    def _complete_item(self, params: dict[str, Any]) -> None:
+        if not self._ids_match(params):
+            self._identity_failure = True
+            return
+        item = self._require_object(params.get("item"), "completed item")
+        item_type = item.get("type")
+        if item_type in _UNSUPPORTED_ITEM_TYPES:
+            self._unsupported_mutation = True
+            return
+        if item_type != "fileChange":
+            return
+        item_id = item.get("id")
+        if item_id in self._declined_items:
+            if (
+                item.get("status") != "declined"
+                or item_id not in self._resolved_items
+            ):
+                self._identity_failure = True
+            return
+        if item_id not in self._accepted_items:
+            self._unsupported_mutation = True
+            self._identity_failure = True
+            return
+        approved = self._approved_changes.get(item_id)
+        if (
+            item.get("status") != "completed"
+            or approved is None
+            or item.get("changes") != approved
+            or item_id in self._completed_items
+            or item_id not in self._resolved_items
+        ):
+            self._identity_failure = True
+            return
+        self._completed_items.add(item_id)
+
+    def _verify_settings(self, params: dict[str, Any]) -> None:
+        if self._thread_id is None:
+            self._deferred_settings.append(params)
+            return
+        if params.get("threadId") != self._thread_id:
+            self._identity_failure = True
+            return
+        settings = self._require_object(
+            params.get("threadSettings"),
+            "thread settings",
+        )
+        if (
+            settings.get("model") != self.expected_model
+            or settings.get("modelProvider") != "openai"
+            or settings.get("effort") != self.expected_reasoning_effort
+            or settings.get("serviceTier") != self.expected_service_tier
+            or settings.get("approvalPolicy") != "on-request"
+            or settings.get("approvalsReviewer") != "user"
+            or not self._cwd_matches(settings.get("cwd"))
+            or not self._read_only_sandbox(
+                settings.get("sandboxPolicy")
+            )
+        ):
+            self._identity_failure = True
+            self._runtime_identity = None
+            return
+        if self._account_type != "chatgpt" or self._thread_cli_version is None:
+            self._identity_failure = True
+            self._runtime_identity = None
+            return
+        self._settings_verified = True
+        self._runtime_identity = CodexRuntimeIdentity(
+            model=settings["model"],
+            reasoning_effort=settings["effort"],
+            service_tier=settings["serviceTier"],
+            codex_cli_version=self._thread_cli_version,
+            account_type=self._account_type,
+        )
+
+    def _complete_turn(self, params: dict[str, Any]) -> None:
+        if params.get("threadId") != self._thread_id:
+            self._identity_failure = True
+            return
+        turn = self._require_object(params.get("turn"), "completed turn")
+        turn_id = turn.get("id")
+        if not isinstance(turn_id, str) or not turn_id:
+            self._identity_failure = True
+            return
+        if self._turn_id is None:
+            self._turn_id = turn_id
+        elif turn_id != self._turn_id:
+            self._identity_failure = True
+            return
+        status = turn.get("status")
+        if not isinstance(status, str):
+            self._identity_failure = True
+            return
+        self._turn_status = status
+
+    def _dispatch(self, message: dict[str, Any]) -> None:
+        method = message.get("method")
+        if not isinstance(method, str):
+            raise CodexAdapterFailure(
+                "Codex app-server emitted an uncorrelated response."
+            )
+        if "id" in message:
+            if method == "item/fileChange/requestApproval":
+                self._respond_file_approval(message)
+            else:
+                self._respond_unsupported_request(message)
+            return
+        params = self._require_object(
+            message.get("params", {}),
+            f"{method} parameters",
+        )
+        if method == "item/started":
+            self._cache_item(params)
+        elif method == "item/fileChange/patchUpdated":
+            self._update_patch(params)
+        elif method == "item/completed":
+            self._complete_item(params)
+        elif method == "thread/settings/updated":
+            self._verify_settings(params)
+        elif method == "serverRequest/resolved":
+            self._resolve_request(params)
+        elif method == "turn/started":
+            if params.get("threadId") != self._thread_id:
+                self._identity_failure = True
+            else:
+                turn = self._require_object(
+                    params.get("turn"),
+                    "started turn",
+                )
+                turn_id = turn.get("id")
+                if not isinstance(turn_id, str) or not turn_id:
+                    self._identity_failure = True
+                elif self._turn_id is None:
+                    self._turn_id = turn_id
+                elif self._turn_id != turn_id:
+                    self._identity_failure = True
+        elif method == "turn/completed":
+            self._complete_turn(params)
+        elif method in {"model/rerouted", "error"}:
+            self._identity_failure = True
+            self._runtime_identity = None
+
+    async def run(self, prompt: str) -> CodexRunResult:
+        """Run one fresh thread and promote matches only at a normal checkpoint."""
+
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise CodexAdapterFailure("Codex prompt must be a non-empty string.")
+        self._reset_run()
+        self._transport = self.transport_factory(self.executable)
+        turn_started = False
+        error_type: str | None = None
+        try:
+            self._transport.start()
+            if self._transport.version != self.expected_cli_version:
+                raise CodexAdapterFailure(
+                    "Bundled Codex CLI version identity mismatch."
+                )
+            self._initialize()
+            self._verify_account()
+            self._verify_model_catalog()
+            self._start_thread()
+            self._start_turn(prompt)
+            turn_started = True
+            while self._turn_status is None:
+                self._dispatch(self._receive())
+        except (CodexAdapterUnavailable, CodexAdapterFailure) as exc:
+            if not turn_started:
+                raise
+            error_type = type(exc).__name__
+        except Exception as exc:
+            if not turn_started:
+                raise CodexAdapterFailure(
+                    "Codex app-server failed before the turn started."
+                ) from exc
+            error_type = type(exc).__name__
+        finally:
+            try:
+                self._transport.close()
+            except Exception:
+                if error_type is None and turn_started:
+                    error_type = "CodexTransportCloseError"
+
+        if self._identity_failure and error_type is None:
+            error_type = "CodexRuntimeIdentityError"
+        all_accepted_completed = self._accepted_items.issubset(
+            self._completed_items
+        )
+        normal_terminal = bool(
+            self._turn_status == "completed"
+            and self._settings_verified
+            and all_accepted_completed
+            and not self._permission_denied
+            and not self._unsupported_mutation
+            and not self._identity_failure
+            and error_type is None
+        )
+        checkpoints = tuple(
+            self.engine.finish_checkpoint(
+                outcome,
+                normal_terminal=normal_terminal,
+                checkpoint_id=(
+                    f"codex-turn:{self._run_id}:{index}"
+                    if self._turn_status is not None
+                    else f"codex-missing-turn:{self._run_id}:{index}"
+                ),
+            )
+            for index, outcome in enumerate(
+                self._pending.values(),
+                start=1,
+            )
+        )
+        if self._unsupported_mutation:
+            status = "UNSUPPORTED_MUTATION"
+        elif checkpoints:
+            status = checkpoints[-1].status
+        elif self._permission_denied:
+            status = "DENIED"
+        elif normal_terminal:
+            status = "NORMAL_TERMINAL"
+        else:
+            status = "ABNORMAL_TERMINAL"
+        return CodexRunResult(
+            run_id=self._run_id,
+            normal_terminal=normal_terminal,
+            status=status,
+            error_type=error_type,
+            turn_status=self._turn_status,
+            runtime_identity=self._runtime_identity,
+            checkpoint_outcomes=checkpoints,
+        )

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -293,7 +293,8 @@ class CodexAdapter:
         self._iteration = 0
         self._items: dict[str, dict[str, Any]] = {}
         self._approved_changes: dict[str, list[dict[str, Any]]] = {}
-        self._approval_requests: dict[str | int, str] = {}
+        self._approval_requests: dict[str | int, str | None] = {}
+        self._resolved_approval_requests: set[str | int] = set()
         self._accepted_items: set[str] = set()
         self._declined_items: set[str] = set()
         self._resolved_items: set[str] = set()
@@ -319,6 +320,7 @@ class CodexAdapter:
         self._items = {}
         self._approved_changes = {}
         self._approval_requests = {}
+        self._resolved_approval_requests = set()
         self._accepted_items = set()
         self._declined_items = set()
         self._resolved_items = set()
@@ -530,8 +532,21 @@ class CodexAdapter:
             raise CodexAdapterFailure("Codex thread is not ephemeral.")
         if not self._cwd_matches(thread.get("cwd")):
             raise CodexAdapterFailure("Codex thread root identity mismatch.")
+        account_type = self._account_type
+        if account_type != "chatgpt":
+            raise CodexAdapterFailure(
+                "Codex account identity changed during thread start."
+            )
         self._thread_id = thread_id
         self._thread_cli_version = cli_version
+        self._settings_verified = True
+        self._runtime_identity = CodexRuntimeIdentity(
+            model=result["model"],
+            reasoning_effort=result["reasoningEffort"],
+            service_tier=result["serviceTier"],
+            codex_cli_version=cli_version,
+            account_type=account_type,
+        )
         deferred = tuple(self._deferred_settings)
         self._deferred_settings = []
         for params in deferred:
@@ -664,6 +679,22 @@ class CodexAdapter:
             self._turn_id = observed_turn_id
         return observed_turn_id == self._turn_id
 
+    def _register_approval_request(
+        self,
+        request_id: Any,
+        item_id: Any,
+    ) -> bool:
+        if (
+            not isinstance(request_id, (str, int))
+            or isinstance(request_id, bool)
+            or request_id in self._approval_requests
+        ):
+            return False
+        self._approval_requests[request_id] = (
+            item_id if isinstance(item_id, str) else None
+        )
+        return True
+
     def _respond_file_approval(self, message: dict[str, Any]) -> None:
         request_id = message.get("id")
         params = self._require_object(
@@ -671,11 +702,11 @@ class CodexAdapter:
             "file approval parameters",
         )
         item_id = params.get("itemId")
-        if (
-            not isinstance(request_id, (str, int))
-            or isinstance(request_id, bool)
-            or request_id in self._approval_requests
-        ):
+        duplicate_item = (
+            isinstance(item_id, str)
+            and item_id in self._approval_requests.values()
+        )
+        if not self._register_approval_request(request_id, item_id):
             self._unsupported_mutation = True
             if isinstance(item_id, str):
                 self._declined_items.add(item_id)
@@ -696,14 +727,13 @@ class CodexAdapter:
                 {"id": request_id, "result": {"decision": "decline"}}
             )
             return
-        if item_id in self._approval_requests.values():
+        if duplicate_item:
             self._unsupported_mutation = True
             self._declined_items.add(item_id)
             self._send(
                 {"id": request_id, "result": {"decision": "decline"}}
             )
             return
-        self._approval_requests[request_id] = item_id
         try:
             decision_type, raw_path = self._map_file_change(
                 self._items[item_id]
@@ -763,8 +793,17 @@ class CodexAdapter:
         ):
             self._identity_failure = True
             return
-        item_id = self._approval_requests.get(request_id)
-        if item_id is None or item_id in self._resolved_items:
+        if (
+            request_id not in self._approval_requests
+            or request_id in self._resolved_approval_requests
+        ):
+            self._identity_failure = True
+            return
+        self._resolved_approval_requests.add(request_id)
+        item_id = self._approval_requests[request_id]
+        if item_id is None:
+            return
+        if item_id in self._resolved_items:
             self._identity_failure = True
             return
         self._resolved_items.add(item_id)
@@ -773,6 +812,9 @@ class CodexAdapter:
         self._unsupported_mutation = True
         request_id = message.get("id")
         method = message.get("method")
+        params = message.get("params")
+        item_id = params.get("itemId") if isinstance(params, dict) else None
+        self._register_approval_request(request_id, item_id)
         if method == "item/commandExecution/requestApproval":
             self._send(
                 {"id": request_id, "result": {"decision": "decline"}}
@@ -863,22 +905,33 @@ class CodexAdapter:
             return
         self._completed_items.add(item_id)
 
+    def _invalidate_runtime_identity(self) -> None:
+        self._identity_failure = True
+        self._settings_verified = False
+        self._runtime_identity = None
+
     def _verify_settings(self, params: dict[str, Any]) -> None:
         if self._thread_id is None:
             self._deferred_settings.append(params)
             return
         if params.get("threadId") != self._thread_id:
-            self._identity_failure = True
+            self._invalidate_runtime_identity()
             return
         settings = self._require_object(
             params.get("threadSettings"),
             "thread settings",
         )
+        identity = self._runtime_identity
         if (
-            settings.get("model") != self.expected_model
+            self._identity_failure
+            or not self._settings_verified
+            or identity is None
+            or identity.account_type != self._account_type
+            or identity.codex_cli_version != self._thread_cli_version
+            or settings.get("model") != identity.model
             or settings.get("modelProvider") != "openai"
-            or settings.get("effort") != self.expected_reasoning_effort
-            or settings.get("serviceTier") != self.expected_service_tier
+            or settings.get("effort") != identity.reasoning_effort
+            or settings.get("serviceTier") != identity.service_tier
             or settings.get("approvalPolicy") != "on-request"
             or settings.get("approvalsReviewer") != "user"
             or not self._cwd_matches(settings.get("cwd"))
@@ -886,21 +939,8 @@ class CodexAdapter:
                 settings.get("sandboxPolicy")
             )
         ):
-            self._identity_failure = True
-            self._runtime_identity = None
+            self._invalidate_runtime_identity()
             return
-        if self._account_type != "chatgpt" or self._thread_cli_version is None:
-            self._identity_failure = True
-            self._runtime_identity = None
-            return
-        self._settings_verified = True
-        self._runtime_identity = CodexRuntimeIdentity(
-            model=settings["model"],
-            reasoning_effort=settings["effort"],
-            service_tier=settings["serviceTier"],
-            codex_cli_version=self._thread_cli_version,
-            account_type=self._account_type,
-        )
 
     def _complete_turn(self, params: dict[str, Any]) -> None:
         if params.get("threadId") != self._thread_id:

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,5 +1,84 @@
 # Current Signal
 
+## Canonical Current State — Verified Save Codex/Sol MVP v0.1
+
+```text
+Current Layer:
+V13 — Compound Loop / Verified Save Adapter Expansion
+
+Primary Objective:
+External Proof-of-Use
+
+Companion Adapter:
+Codex app-server / product core remains agent-agnostic
+
+Starting Main:
+02ddd7af50e2366eac0c042ae3671050df5e21e0
+
+Approved Pre-Closure Head:
+c0ecd71f1ecad0692566ad831aca8268b72adc17
+
+Active Branch:
+codex/verified-save-codex-sol-mvp-v0-1
+
+V12 State:
+DELAY — creator-owned human two-Run live proof passed; external-user adoption
+remains unobserved and no external adoption claim is made
+
+V13 Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+V13 Next Loop Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+Live Proof:
+PASS — explicit human option 2 in Run 1 / Run 1 NORMAL_TERMINAL and completed /
+repeated interrupt skipped / fresh Run 2 VERIFIED_SAVE and completed /
+1 Save / 1 Verified Reuse
+
+Runtime Identity:
+gpt-5.6-sol / ultra / priority / Codex CLI 0.146.0-alpha.3.1
+
+Authentication:
+ChatGPT subscription
+
+Codex Adapter:
+PASS / 24 OF 24 TESTS ON PYTHON 3.14 AND PYTHON 3.13
+
+Full Regression:
+PASS / 220 OF 220 TESTS
+
+Draft PR:
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/36
+
+Demo GIF:
+NOT_CREATED — not authorized by the live-proof closure
+
+Live Receipt:
+7.5 estimated minutes / ¥625 estimated human-time value /
+tokens UNKNOWN because tokens_per_reuse was not configured
+
+Receipt SHA-256:
+23c6ced038a0ca2b963ed84463fe25181bbc52dddf08b052e6f6725fb3c40780
+
+Claim Boundary:
+creator-owned human live proof / not external-user adoption /
+not native Codex Desktop interception / not third-party certification /
+estimates remain estimates
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly approves review or merge
+
+Decision Owner:
+Shin
+```
+
+Everything below this boundary is a historical reverse-chronological ledger.
+Historical entries preserve their As-of truth but grant no present authority.
+
 ## Canonical Current State — Verified Save Claude MVP v0.1
 
 ```text

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,5 +1,104 @@
 # Current Codex Handoff - V13 LoopKit
 
+## Canonical Current State — Verified Save Codex/Sol MVP v0.1
+
+```text
+Current Layer:
+V13 — Compound Loop / Verified Save Adapter Expansion
+
+Primary Objective:
+External Proof-of-Use
+
+Companion Adapter:
+Codex app-server / product core remains agent-agnostic
+
+Starting Main:
+02ddd7af50e2366eac0c042ae3671050df5e21e0
+
+Approved Pre-Closure Head:
+c0ecd71f1ecad0692566ad831aca8268b72adc17
+
+Active Branch:
+codex/verified-save-codex-sol-mvp-v0-1
+
+V12 State:
+DELAY — creator-owned human two-Run live proof passed; external-user adoption
+remains unobserved and no external adoption claim is made
+
+V13 Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+V13 Next Loop Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+Live Proof:
+PASS — explicit human option 2 in Run 1 / Run 1 NORMAL_TERMINAL and completed /
+repeated interrupt skipped / fresh Run 2 VERIFIED_SAVE and completed /
+1 Save / 1 Verified Reuse
+
+Runtime Identity:
+gpt-5.6-sol / ultra / priority / Codex CLI 0.146.0-alpha.3.1
+
+Authentication:
+ChatGPT subscription
+
+Codex Adapter:
+PASS / 24 OF 24 TESTS ON PYTHON 3.14 AND PYTHON 3.13
+
+Full Regression:
+PASS / 220 OF 220 TESTS
+
+Draft PR:
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/36
+
+Demo GIF:
+NOT_CREATED — not authorized by the live-proof closure
+
+Live Receipt:
+7.5 estimated minutes / ¥625 estimated human-time value /
+tokens UNKNOWN because tokens_per_reuse was not configured
+
+Receipt SHA-256:
+23c6ced038a0ca2b963ed84463fe25181bbc52dddf08b052e6f6725fb3c40780
+
+Claim Boundary:
+creator-owned human live proof / not external-user adoption /
+not native Codex Desktop interception / not third-party certification /
+estimates remain estimates
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly approves review or merge
+
+Decision Owner:
+Shin
+```
+
+Restart evidence:
+
+- validation and exact live-proof evidence:
+  `validation/verified_save_codex_mvp_run_001.md`;
+- implementation branch:
+  `codex/verified-save-codex-sol-mvp-v0-1`;
+- Draft PR:
+  `https://github.com/shin4141/decision-os-v13-loopkit/pull/36`;
+- live-proof receipt:
+  `validation/verified_save_codex_mvp_run_001.md`, bound to sanitized receipt
+  SHA-256
+  `23c6ced038a0ca2b963ed84463fe25181bbc52dddf08b052e6f6725fb3c40780`.
+
+The passing proof is creator-owned human evidence. It is not external-user
+adoption, native Codex Desktop interception, or third-party certification.
+Estimates remain estimates. No source or test change, merge or ready-for-review
+transition, README change, pricing implementation, GIF, release, tag, package
+publication, or public post is authorized without a new exact instruction from
+Shin.
+
+Everything below this boundary is a historical reverse-chronological ledger.
+Historical entries preserve their As-of truth but grant no present authority.
+
 ## Canonical Current State — Verified Save Claude MVP v0.1
 
 ```text

--- a/tests/test_acceleration_cli.py
+++ b/tests/test_acceleration_cli.py
@@ -5,10 +5,21 @@ from pathlib import Path
 import subprocess
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from decision_os.acceleration.claude_adapter import ClaudeAdapterUnavailable
+from decision_os.acceleration.codex_adapter import (
+    CODEX_CLI_VERSION,
+    CODEX_MODEL,
+    CODEX_REASONING_EFFORT,
+    CODEX_SERVICE_TIER,
+    CodexAdapterUnavailable,
+    CodexRunResult,
+    CodexRuntimeIdentity,
+)
 from decision_os.acceleration.cli import (
+    CODEX_DEMO_RUN_1,
+    CODEX_DEMO_RUN_2,
     EXIT_DELAY,
     EXIT_OK,
     EXIT_USAGE,
@@ -140,6 +151,244 @@ class AccelerationCliTest(unittest.TestCase):
             self.assertIn("DELAY", output.getvalue())
             self.assertIn("optional extra missing", output.getvalue())
             self.assertNotIn("Traceback", output.getvalue())
+
+    def test_codex_run_dispatches_and_reports_machine_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            prompt = Path(directory) / "prompt.txt"
+            prompt.write_text("edit the target", encoding="utf-8")
+            result = CodexRunResult(
+                run_id="run-1",
+                normal_terminal=True,
+                status="NORMAL_TERMINAL",
+                error_type=None,
+                turn_status="completed",
+                runtime_identity=CodexRuntimeIdentity(
+                    model=CODEX_MODEL,
+                    reasoning_effort=CODEX_REASONING_EFFORT,
+                    service_tier=CODEX_SERVICE_TIER,
+                    codex_cli_version=CODEX_CLI_VERSION,
+                    account_type="chatgpt",
+                ),
+                checkpoint_outcomes=(),
+            )
+            output = io.StringIO()
+            run = AsyncMock(return_value=result)
+            with patch(
+                "decision_os.acceleration.cli.CodexAdapter.run",
+                new=run,
+            ):
+                exit_code = main(
+                    [
+                        "run",
+                        "--adapter",
+                        "codex",
+                        "--prompt-file",
+                        str(prompt),
+                        str(repository),
+                    ],
+                    stdout=output,
+                    stderr=io.StringIO(),
+                )
+
+            self.assertEqual(EXIT_OK, exit_code)
+            run.assert_awaited_once_with("edit the target")
+            rendered = output.getvalue()
+            self.assertIn("Run: NORMAL_TERMINAL", rendered)
+            self.assertIn(f"model={CODEX_MODEL}", rendered)
+            self.assertIn(
+                f"reasoning_effort={CODEX_REASONING_EFFORT}",
+                rendered,
+            )
+            self.assertIn(
+                f"service_tier={CODEX_SERVICE_TIER}",
+                rendered,
+            )
+            self.assertIn(
+                f"cli_version={CODEX_CLI_VERSION}",
+                rendered,
+            )
+            self.assertIn("account_type=chatgpt", rendered)
+
+    def test_codex_unavailable_returns_bounded_delay(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            prompt = Path(directory) / "prompt.txt"
+            prompt.write_text("edit the target", encoding="utf-8")
+            output = io.StringIO()
+            with patch(
+                "decision_os.acceleration.cli.CodexAdapter.run",
+                new=AsyncMock(
+                    side_effect=CodexAdapterUnavailable(
+                        "bundled Codex unavailable"
+                    )
+                ),
+            ):
+                exit_code = main(
+                    [
+                        "run",
+                        "--adapter",
+                        "codex",
+                        "--prompt-file",
+                        str(prompt),
+                        str(repository),
+                    ],
+                    stdout=output,
+                    stderr=io.StringIO(),
+                )
+
+            self.assertEqual(EXIT_DELAY, exit_code)
+            self.assertIn("DELAY", output.getvalue())
+            self.assertIn("bundled Codex unavailable", output.getvalue())
+            self.assertNotIn("Traceback", output.getvalue())
+
+    def test_codex_pending_checkpoint_returns_delay(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            prompt = Path(directory) / "prompt.txt"
+            prompt.write_text("edit the target", encoding="utf-8")
+            result = CodexRunResult(
+                run_id="run-2",
+                normal_terminal=False,
+                status="PENDING",
+                error_type=None,
+                turn_status="failed",
+                runtime_identity=CodexRuntimeIdentity(
+                    model=CODEX_MODEL,
+                    reasoning_effort=CODEX_REASONING_EFFORT,
+                    service_tier=CODEX_SERVICE_TIER,
+                    codex_cli_version=CODEX_CLI_VERSION,
+                    account_type="chatgpt",
+                ),
+                checkpoint_outcomes=(),
+            )
+            with patch(
+                "decision_os.acceleration.cli.CodexAdapter.run",
+                new=AsyncMock(return_value=result),
+            ):
+                exit_code = main(
+                    [
+                        "run",
+                        "--adapter",
+                        "codex",
+                        "--prompt-file",
+                        str(prompt),
+                        str(repository),
+                    ],
+                    stdout=io.StringIO(),
+                    stderr=io.StringIO(),
+                )
+
+            self.assertEqual(EXIT_DELAY, exit_code)
+
+    def test_codex_demo_choice_reaches_demo_dispatch(self) -> None:
+        output = io.StringIO()
+        choices = iter(("2",))
+        observed_prompts: list[str] = []
+
+        class DeterministicCodexDemoAdapter:
+            def __init__(
+                self,
+                engine: AccelerationEngine,
+                input_func,
+            ) -> None:
+                self.engine = engine
+                self.input_func = input_func
+                self.iteration = 0
+
+            async def run(self, prompt: str) -> CodexRunResult:
+                observed_prompts.append(prompt)
+                self.iteration += 1
+                run_id = self.engine.new_run_id()
+                outcome = self.engine.evaluate(
+                    run_id=run_id,
+                    iteration=1,
+                    decision_type=DecisionType.MODIFY_FILE,
+                    requested_scope="demo_target.txt",
+                    source_interrupt_id=f"item-{self.iteration}",
+                    choice_provider=lambda _identity: self.input_func(),
+                )
+                checkpoint = self.engine.finish_checkpoint(
+                    outcome,
+                    normal_terminal=True,
+                    checkpoint_id=f"checkpoint-{self.iteration}",
+                )
+                status = (
+                    checkpoint.status
+                    if outcome.pending_cross_run_checkpoint
+                    else "NORMAL_TERMINAL"
+                )
+                return CodexRunResult(
+                    run_id=run_id,
+                    normal_terminal=True,
+                    status=status,
+                    error_type=None,
+                    turn_status="completed",
+                    runtime_identity=CodexRuntimeIdentity(
+                        model=CODEX_MODEL,
+                        reasoning_effort=CODEX_REASONING_EFFORT,
+                        service_tier=CODEX_SERVICE_TIER,
+                        codex_cli_version=CODEX_CLI_VERSION,
+                        account_type="chatgpt",
+                    ),
+                    checkpoint_outcomes=(
+                        (checkpoint,)
+                        if outcome.pending_cross_run_checkpoint
+                        else ()
+                    ),
+                )
+
+        def configured(
+            repository,
+            adapter_name,
+            *,
+            stdout,
+            input_func,
+            store=None,
+        ):
+            del stdout
+            self.assertEqual("codex", adapter_name)
+            engine = AccelerationEngine(
+                repository,
+                store=store,
+                adapter="codex-app-server",
+                adapter_version=CODEX_CLI_VERSION,
+            )
+            return engine, DeterministicCodexDemoAdapter(
+                engine,
+                input_func,
+            )
+
+        with tempfile.TemporaryDirectory() as receipt_directory:
+            with (
+                patch(
+                    "decision_os.acceleration.cli._configured_adapter",
+                    side_effect=configured,
+                ),
+                patch(
+                    "decision_os.acceleration.cli.tempfile.gettempdir",
+                    return_value=receipt_directory,
+                ),
+            ):
+                exit_code = main(
+                    ["demo", "--adapter", "codex"],
+                    stdout=output,
+                    stderr=io.StringIO(),
+                    input_func=lambda: next(choices),
+                )
+            receipts = list(Path(receipt_directory).glob("*.txt"))
+
+        self.assertEqual(EXIT_OK, exit_code)
+        self.assertEqual(
+            [CODEX_DEMO_RUN_1, CODEX_DEMO_RUN_2],
+            observed_prompts,
+        )
+        rendered = output.getvalue()
+        self.assertIn("Live Run 1: status=NORMAL_TERMINAL", rendered)
+        self.assertIn("Live Run 2: status=VERIFIED_SAVE", rendered)
+        self.assertIn("1 Save", rendered)
+        self.assertIn("1 Verified Reuse", rendered)
+        self.assertEqual(1, len(receipts))
 
 
 if __name__ == "__main__":

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -69,9 +69,10 @@ def handshake_messages(
     network_access: bool = False,
     effective_cwd: str | None = None,
     ephemeral: bool = True,
+    include_settings_update: bool = False,
 ) -> list[dict[str, Any]]:
     cwd = str(repository.resolve()) if effective_cwd is None else effective_cwd
-    return [
+    messages = [
         {
             "id": 1,
             "result": {
@@ -148,26 +149,30 @@ def handshake_messages(
                 }
             },
         },
-        {
-            "method": "thread/settings/updated",
-            "params": {
-                "threadId": thread_id,
-                "threadSettings": {
-                    "approvalPolicy": approval_policy,
-                    "approvalsReviewer": approvals_reviewer,
-                    "cwd": cwd,
-                    "effort": effort,
-                    "model": model,
-                    "modelProvider": model_provider,
-                    "sandboxPolicy": {
-                        "networkAccess": network_access,
-                        "type": sandbox_type,
-                    },
-                    "serviceTier": service_tier,
-                },
-            },
-        },
     ]
+    if include_settings_update:
+        messages.append(
+            {
+                "method": "thread/settings/updated",
+                "params": {
+                    "threadId": thread_id,
+                    "threadSettings": {
+                        "approvalPolicy": approval_policy,
+                        "approvalsReviewer": approvals_reviewer,
+                        "cwd": cwd,
+                        "effort": effort,
+                        "model": model,
+                        "modelProvider": model_provider,
+                        "sandboxPolicy": {
+                            "networkAccess": network_access,
+                            "type": sandbox_type,
+                        },
+                        "serviceTier": service_tier,
+                    },
+                },
+            }
+        )
+    return messages
 
 
 def started_item(
@@ -198,7 +203,7 @@ def approval_request(
     thread_id: str,
     turn_id: str,
     item_id: str,
-    request_id: str,
+    request_id: str | int,
     method: str = "item/fileChange/requestApproval",
 ) -> dict[str, Any]:
     return {
@@ -240,7 +245,7 @@ def completed_item(
 def resolved_request(
     *,
     thread_id: str,
-    request_id: str,
+    request_id: str | int,
 ) -> dict[str, Any]:
     return {
         "method": "serverRequest/resolved",
@@ -600,6 +605,95 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 events.index("server_closed"),
             )
 
+    async def test_thread_start_identity_reaches_human_without_initial_update(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            changes = [change()]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        request_id=0,
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id=0,
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            callback_count = 0
+
+            def choose_once() -> str:
+                nonlocal callback_count
+                callback_count += 1
+                return "1"
+
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=choose_once,
+            )
+            original_send = adapter._send
+            approval_decisions: list[str] = []
+
+            def assert_registered_before_send(
+                message: dict[str, Any],
+            ) -> None:
+                result = message.get("result")
+                if message.get("id") == 0 and isinstance(result, dict):
+                    self.assertEqual(
+                        "item-1",
+                        adapter._approval_requests.get(0),
+                    )
+                    approval_decisions.append(result["decision"])
+                original_send(message)
+
+            with patch.object(
+                adapter,
+                "_send",
+                side_effect=assert_registered_before_send,
+            ):
+                result = await adapter.run("modify")
+
+            self.assertEqual(1, callback_count)
+            self.assertEqual(["accept"], approval_decisions)
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertIsNone(result.error_type)
+            self.assertIsNotNone(result.runtime_identity)
+            self.assertEqual({0: "item-1"}, adapter._approval_requests)
+            self.assertEqual({0}, adapter._resolved_approval_requests)
+            self.assertNotIn(
+                "received:thread/settings/updated",
+                factory.transports[0].events,
+            )
+
     async def test_option_one_is_not_persisted_or_verified(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
@@ -648,8 +742,27 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 factory,
                 choice=lambda: "3",
             )
+            original_send = adapter._send
 
-            result = await adapter.run("deny")
+            def assert_registered_before_decline(
+                message: dict[str, Any],
+            ) -> None:
+                result = message.get("result")
+                if isinstance(result, dict) and "decision" in result:
+                    self.assertEqual(
+                        "item-1",
+                        adapter._approval_requests.get(
+                            "approval-item-1"
+                        ),
+                    )
+                original_send(message)
+
+            with patch.object(
+                adapter,
+                "_send",
+                side_effect=assert_registered_before_decline,
+            ):
+                result = await adapter.run("deny")
 
             self.assertEqual("DENIED", result.status)
             self.assertFalse(result.normal_terminal)
@@ -660,6 +773,10 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 if "result" in message
             ]
             self.assertEqual(["decline"], approvals)
+            self.assertEqual(
+                {"approval-item-1"},
+                adapter._resolved_approval_requests,
+            )
 
     async def test_same_run_repeat_never_becomes_verified(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -804,6 +921,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         thread_id="thread-1",
                         turn_id="turn-1",
                         item_id="item-1",
+                        include_settings_update=True,
                     )
                 ]
             )
@@ -815,6 +933,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
             result = await adapter.run("identity")
 
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertIsNone(result.error_type)
             self.assertIsNotNone(result.runtime_identity)
             identity = result.runtime_identity
             assert identity is not None
@@ -874,6 +995,67 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual(ADAPTER_NAME, engine.adapter)
             self.assertEqual(CODEX_CLI_VERSION, engine.adapter_version)
+            self.assertIn(
+                "received:thread/settings/updated",
+                factory.transports[0].events,
+            )
+
+    async def test_conflicting_settings_update_stays_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = file_run_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+                item_id="item-1",
+                item_status="declined",
+                include_settings_update=True,
+            )
+            matching_update = messages[5]
+            matching_settings = matching_update["params"]["threadSettings"]
+            messages[5] = {
+                "method": "thread/settings/updated",
+                "params": {
+                    "threadId": "thread-1",
+                    "threadSettings": {
+                        **matching_settings,
+                        "serviceTier": "flex",
+                    },
+                },
+            }
+            messages.insert(6, matching_update)
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("conflicting settings")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual(
+                "CodexRuntimeIdentityError",
+                result.error_type,
+            )
+            self.assertIsNone(result.runtime_identity)
+            self.assertFalse(adapter._settings_verified)
+            self.assertEqual(
+                {"approval-item-1": "item-1"},
+                adapter._approval_requests,
+            )
+            self.assertEqual(
+                {"approval-item-1"},
+                adapter._resolved_approval_requests,
+            )
+            approvals = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+                and "decision" in message["result"]
+            ]
+            self.assertEqual(["decline"], approvals)
 
     async def test_identity_mismatches_fail_closed_before_turn(self) -> None:
         cases = (
@@ -1040,6 +1222,10 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                             "item/commandExecution/requestApproval"
                         ),
                     ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="command-approval",
+                    ),
                     completed_turn(
                         thread_id="thread-1",
                         turn_id="turn-1",
@@ -1052,11 +1238,35 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 factory,
                 choice=lambda: self.fail("must not prompt"),
             )
+            original_send = adapter._send
 
-            result = await adapter.run("shell mutation")
+            def assert_registered_before_decline(
+                message: dict[str, Any],
+            ) -> None:
+                result = message.get("result")
+                if isinstance(result, dict) and "decision" in result:
+                    self.assertEqual(
+                        "command-1",
+                        adapter._approval_requests.get(
+                            "command-approval"
+                        ),
+                    )
+                original_send(message)
+
+            with patch.object(
+                adapter,
+                "_send",
+                side_effect=assert_registered_before_decline,
+            ):
+                result = await adapter.run("shell mutation")
 
             self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertIsNone(result.error_type)
             self.assertEqual([], engine.store.read_events())
+            self.assertEqual(
+                {"command-approval"},
+                adapter._resolved_approval_requests,
+            )
             response = next(
                 message
                 for message in factory.transports[0].sent
@@ -1288,6 +1498,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 repository,
                 thread_id="thread-1",
                 turn_id="turn-1",
+                include_settings_update=True,
             )
             turn_response = base[4]
             settings = base[5]

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -1,0 +1,1525 @@
+from __future__ import annotations
+
+from collections import deque
+import io
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from decision_os.acceleration.codex_adapter import (
+    ADAPTER_NAME,
+    CODEX_CLI_VERSION,
+    CODEX_MODEL,
+    CODEX_REASONING_EFFORT,
+    CODEX_SERVICE_TIER,
+    CodexAdapter,
+    CodexAdapterFailure,
+    _SubprocessTransport,
+)
+from decision_os.acceleration.engine import AccelerationEngine
+
+
+def create_repository(parent: Path) -> Path:
+    repository = parent / "repo"
+    repository.mkdir()
+    subprocess.run(
+        ("git", "init", "-q", str(repository)),
+        check=True,
+        capture_output=True,
+    )
+    (repository / "target.txt").write_text("one\n", encoding="utf-8")
+    return repository
+
+
+def change(
+    *,
+    path: str = "target.txt",
+    kind: str = "update",
+    move_path: str | None = None,
+    diff: str = "@@ -1 +1 @@\n-one\n+two\n",
+) -> dict[str, Any]:
+    kind_value: dict[str, Any] = {"type": kind}
+    if kind == "update":
+        kind_value["move_path"] = move_path
+    return {
+        "diff": diff,
+        "kind": kind_value,
+        "path": path,
+    }
+
+
+def handshake_messages(
+    repository: Path,
+    *,
+    thread_id: str,
+    turn_id: str,
+    model: str = CODEX_MODEL,
+    effort: str = CODEX_REASONING_EFFORT,
+    service_tier: str = CODEX_SERVICE_TIER,
+    account_type: str = "chatgpt",
+    catalog_effort: str = CODEX_REASONING_EFFORT,
+    catalog_tier: str = CODEX_SERVICE_TIER,
+    model_provider: str = "openai",
+    approval_policy: str = "on-request",
+    approvals_reviewer: str = "user",
+    sandbox_type: str = "readOnly",
+    network_access: bool = False,
+    effective_cwd: str | None = None,
+    ephemeral: bool = True,
+) -> list[dict[str, Any]]:
+    cwd = str(repository.resolve()) if effective_cwd is None else effective_cwd
+    return [
+        {
+            "id": 1,
+            "result": {
+                "codexHome": "/tmp/codex-home",
+                "platformFamily": "unix",
+                "platformOs": "macos",
+                "userAgent": f"codex_cli_rs/{CODEX_CLI_VERSION}",
+            },
+        },
+        {
+            "id": 2,
+            "result": {
+                "account": {
+                    "email": None,
+                    "planType": "pro",
+                    "type": account_type,
+                },
+                "requiresOpenaiAuth": True,
+            },
+        },
+        {
+            "id": 3,
+            "result": {
+                "data": [
+                    {
+                        "id": CODEX_MODEL,
+                        "model": CODEX_MODEL,
+                        "serviceTiers": [
+                            {
+                                "description": "Fast",
+                                "id": catalog_tier,
+                                "name": "Fast",
+                            }
+                        ],
+                        "supportedReasoningEfforts": [
+                            {
+                                "description": "Ultra",
+                                "reasoningEffort": catalog_effort,
+                            }
+                        ],
+                    }
+                ]
+            },
+        },
+        {
+            "id": 4,
+            "result": {
+                "approvalPolicy": approval_policy,
+                "approvalsReviewer": approvals_reviewer,
+                "cwd": cwd,
+                "model": model,
+                "modelProvider": model_provider,
+                "reasoningEffort": effort,
+                "sandbox": {
+                    "networkAccess": network_access,
+                    "type": sandbox_type,
+                },
+                "serviceTier": service_tier,
+                "thread": {
+                    "cliVersion": CODEX_CLI_VERSION,
+                    "cwd": cwd,
+                    "ephemeral": ephemeral,
+                    "id": thread_id,
+                },
+            },
+        },
+        {
+            "id": 5,
+            "result": {
+                "turn": {
+                    "id": turn_id,
+                    "items": [],
+                    "status": "inProgress",
+                }
+            },
+        },
+        {
+            "method": "thread/settings/updated",
+            "params": {
+                "threadId": thread_id,
+                "threadSettings": {
+                    "approvalPolicy": approval_policy,
+                    "approvalsReviewer": approvals_reviewer,
+                    "cwd": cwd,
+                    "effort": effort,
+                    "model": model,
+                    "modelProvider": model_provider,
+                    "sandboxPolicy": {
+                        "networkAccess": network_access,
+                        "type": sandbox_type,
+                    },
+                    "serviceTier": service_tier,
+                },
+            },
+        },
+    ]
+
+
+def started_item(
+    *,
+    thread_id: str,
+    turn_id: str,
+    item_id: str,
+    changes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "method": "item/started",
+        "params": {
+            "item": {
+                "changes": changes,
+                "id": item_id,
+                "status": "inProgress",
+                "type": "fileChange",
+            },
+            "startedAtMs": 1,
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def approval_request(
+    *,
+    thread_id: str,
+    turn_id: str,
+    item_id: str,
+    request_id: str,
+    method: str = "item/fileChange/requestApproval",
+) -> dict[str, Any]:
+    return {
+        "id": request_id,
+        "method": method,
+        "params": {
+            "itemId": item_id,
+            "startedAtMs": 2,
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def completed_item(
+    *,
+    thread_id: str,
+    turn_id: str,
+    item_id: str,
+    changes: list[dict[str, Any]],
+    status: str = "completed",
+) -> dict[str, Any]:
+    return {
+        "method": "item/completed",
+        "params": {
+            "completedAtMs": 3,
+            "item": {
+                "changes": changes,
+                "id": item_id,
+                "status": status,
+                "type": "fileChange",
+            },
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def resolved_request(
+    *,
+    thread_id: str,
+    request_id: str,
+) -> dict[str, Any]:
+    return {
+        "method": "serverRequest/resolved",
+        "params": {
+            "requestId": request_id,
+            "threadId": thread_id,
+        },
+    }
+
+
+def patch_updated(
+    *,
+    thread_id: str,
+    turn_id: str,
+    item_id: str,
+    changes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "method": "item/fileChange/patchUpdated",
+        "params": {
+            "changes": changes,
+            "itemId": item_id,
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def completed_turn(
+    *,
+    thread_id: str,
+    turn_id: str,
+    status: str = "completed",
+) -> dict[str, Any]:
+    return {
+        "method": "turn/completed",
+        "params": {
+            "threadId": thread_id,
+            "turn": {
+                "id": turn_id,
+                "items": [],
+                "status": status,
+            },
+        },
+    }
+
+
+def file_run_messages(
+    repository: Path,
+    *,
+    thread_id: str,
+    turn_id: str,
+    item_id: str,
+    file_changes: list[dict[str, Any]] | None = None,
+    item_status: str = "completed",
+    turn_status: str = "completed",
+    include_item_completion: bool = True,
+    **handshake_overrides: Any,
+) -> list[dict[str, Any]]:
+    changes = [change()] if file_changes is None else file_changes
+    messages = handshake_messages(
+        repository,
+        thread_id=thread_id,
+        turn_id=turn_id,
+        **handshake_overrides,
+    )
+    messages.extend(
+        [
+            started_item(
+                thread_id=thread_id,
+                turn_id=turn_id,
+                item_id=item_id,
+                changes=changes,
+            ),
+            approval_request(
+                thread_id=thread_id,
+                turn_id=turn_id,
+                item_id=item_id,
+                request_id=f"approval-{item_id}",
+            ),
+            resolved_request(
+                thread_id=thread_id,
+                request_id=f"approval-{item_id}",
+            ),
+        ]
+    )
+    if include_item_completion:
+        messages.append(
+            completed_item(
+                thread_id=thread_id,
+                turn_id=turn_id,
+                item_id=item_id,
+                changes=changes,
+                status=item_status,
+            )
+        )
+    messages.append(
+        completed_turn(
+            thread_id=thread_id,
+            turn_id=turn_id,
+            status=turn_status,
+        )
+    )
+    return messages
+
+
+class FakeTransport:
+    def __init__(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        version: str = CODEX_CLI_VERSION,
+    ) -> None:
+        self.messages = deque(messages)
+        self._version = version
+        self.sent: list[dict[str, Any]] = []
+        self.events: list[str] = []
+        self.started = False
+        self.closed = False
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    def start(self) -> None:
+        self.started = True
+        self.events.append("server_opened")
+
+    def send(self, message: dict[str, Any]) -> None:
+        if not self.started or self.closed:
+            raise AssertionError("send requires an open control stream")
+        self.sent.append(message)
+        if "method" in message:
+            self.events.append(f"sent:{message['method']}")
+        elif "result" in message:
+            decision = message["result"].get("decision", "response")
+            self.events.append(f"approval_completed:{decision}")
+        else:
+            self.events.append("sent:error")
+
+    def receive(self) -> dict[str, Any]:
+        if not self.started or self.closed:
+            raise AssertionError("receive requires an open control stream")
+        if not self.messages:
+            raise EOFError("fake app-server stream ended")
+        message = self.messages.popleft()
+        method = message.get("method")
+        if method:
+            self.events.append(f"received:{method}")
+        else:
+            self.events.append(f"received:response:{message.get('id')}")
+        return message
+
+    def close(self) -> None:
+        self.closed = True
+        self.events.append("server_closed")
+
+
+class FakeTransportFactory:
+    def __init__(
+        self,
+        scripts: list[list[dict[str, Any]]],
+        *,
+        versions: list[str] | None = None,
+    ) -> None:
+        self.scripts = deque(scripts)
+        self.versions = deque(versions or [CODEX_CLI_VERSION] * len(scripts))
+        self.transports: list[FakeTransport] = []
+
+    def __call__(self, _executable: Path) -> FakeTransport:
+        transport = FakeTransport(
+            self.scripts.popleft(),
+            version=self.versions.popleft(),
+        )
+        self.transports.append(transport)
+        return transport
+
+
+class FakeProcess:
+    def __init__(self, stdout: str) -> None:
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO(stdout)
+        self.stderr = io.StringIO()
+        self.running = True
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return None if self.running else 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.running = False
+
+    def wait(self, timeout: int | None = None) -> int:
+        del timeout
+        self.running = False
+        return 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.running = False
+
+
+def adapter_for(
+    repository: Path,
+    factory: FakeTransportFactory,
+    *,
+    choice: Any,
+    output: io.StringIO | None = None,
+) -> tuple[AccelerationEngine, CodexAdapter, io.StringIO]:
+    engine = AccelerationEngine(
+        repository,
+        adapter=ADAPTER_NAME,
+        adapter_version=CODEX_CLI_VERSION,
+    )
+    stdout = output or io.StringIO()
+    return (
+        engine,
+        CodexAdapter(
+            engine,
+            input_func=choice,
+            stdout=stdout,
+            transport_factory=factory,
+        ),
+        stdout,
+    )
+
+
+class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    async def test_two_fresh_threads_create_default_then_verified_save(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    ),
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                    ),
+                ]
+            )
+            choices = iter(("2",))
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: next(choices),
+            )
+
+            first = await adapter.run("first")
+            second = await adapter.run("second")
+
+            self.assertEqual("NORMAL_TERMINAL", first.status)
+            self.assertTrue(first.normal_terminal)
+            self.assertEqual("VERIFIED_SAVE", second.status)
+            self.assertTrue(second.normal_terminal)
+            self.assertNotEqual(first.run_id, second.run_id)
+            self.assertEqual((1, 1), engine.store.counters())
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+            events = engine.store.read_events()
+            checks = [
+                event
+                for event in events
+                if event["event_type"] == "DECISION_CHECK"
+            ]
+            self.assertEqual(2, len(checks))
+            self.assertEqual(
+                checks[0]["decision_key"],
+                checks[1]["decision_key"],
+            )
+            self.assertTrue(
+                any(
+                    event["event_type"] == "INTERRUPT_SKIPPED"
+                    for event in events
+                )
+            )
+            for transport in factory.transports:
+                methods = [
+                    message.get("method")
+                    for message in transport.sent
+                    if "method" in message
+                ]
+                self.assertIn("thread/start", methods)
+                self.assertNotIn("thread/resume", methods)
+                approvals = [
+                    message["result"]["decision"]
+                    for message in transport.sent
+                    if "result" in message
+                    and "decision" in message["result"]
+                ]
+                self.assertEqual(["accept"], approvals)
+                self.assertNotIn("acceptForSession", approvals)
+            turn_thread_ids = [
+                next(
+                    message["params"]["threadId"]
+                    for message in transport.sent
+                    if message.get("method") == "turn/start"
+                )
+                for transport in factory.transports
+            ]
+            self.assertEqual(["thread-1", "thread-2"], turn_thread_ids)
+
+    async def test_control_stream_stays_open_through_terminal_checkpoint(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    )
+                ]
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("modify")
+
+            self.assertTrue(result.normal_terminal)
+            events = factory.transports[0].events
+            self.assertLess(
+                events.index(
+                    "received:item/fileChange/requestApproval"
+                ),
+                events.index("approval_completed:accept"),
+            )
+            self.assertLess(
+                events.index("approval_completed:accept"),
+                events.index("received:serverRequest/resolved"),
+            )
+            self.assertLess(
+                events.index("received:serverRequest/resolved"),
+                events.index("received:item/completed"),
+            )
+            self.assertLess(
+                events.index("received:item/completed"),
+                events.index("received:turn/completed"),
+            )
+            self.assertLess(
+                events.index("received:turn/completed"),
+                events.index("server_closed"),
+            )
+
+    async def test_option_one_is_not_persisted_or_verified(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    )
+                ]
+            )
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("allow once")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertEqual((0, 0), engine.store.counters())
+            event_types = {
+                event["event_type"] for event in engine.store.read_events()
+            }
+            self.assertNotIn("HUMAN_DEFAULT_CREATED", event_types)
+            self.assertNotIn("VERIFIED_SAVE", event_types)
+
+    async def test_option_three_declines_without_default(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        item_status="declined",
+                    )
+                ]
+            )
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "3",
+            )
+
+            result = await adapter.run("deny")
+
+            self.assertEqual("DENIED", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual((0, 0), engine.store.counters())
+            approvals = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+            ]
+            self.assertEqual(["decline"], approvals)
+
+    async def test_same_run_repeat_never_becomes_verified(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            same_change = [change()]
+            for item_id in ("item-1", "item-2"):
+                messages.extend(
+                    [
+                        started_item(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            changes=same_change,
+                        ),
+                        approval_request(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            request_id=f"approval-{item_id}",
+                        ),
+                        resolved_request(
+                            thread_id="thread-1",
+                            request_id=f"approval-{item_id}",
+                        ),
+                        completed_item(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            changes=same_change,
+                        ),
+                    ]
+                )
+            messages.append(
+                completed_turn(thread_id="thread-1", turn_id="turn-1")
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "2",
+            )
+
+            result = await adapter.run("same run repeat")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertEqual((0, 0), engine.store.counters())
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+            self.assertFalse(
+                any(
+                    event["event_type"] == "VERIFIED_SAVE"
+                    for event in engine.store.read_events()
+                )
+            )
+
+    async def test_abnormal_fresh_run_leaves_match_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    ),
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                        turn_status="failed",
+                    ),
+                ]
+            )
+            choices = iter(("2",))
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: next(choices),
+            )
+
+            await adapter.run("first")
+            second = await adapter.run("second")
+
+            self.assertEqual("PENDING", second.status)
+            self.assertFalse(second.normal_terminal)
+            self.assertEqual("failed", second.turn_status)
+            self.assertEqual((0, 0), engine.store.counters())
+            self.assertTrue(
+                any(
+                    event["event_type"] == "CHECKPOINT_PENDING"
+                    for event in engine.store.read_events()
+                )
+            )
+
+    async def test_missing_item_completion_leaves_match_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    ),
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                        include_item_completion=False,
+                    ),
+                ]
+            )
+            choices = iter(("2",))
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: next(choices),
+            )
+
+            await adapter.run("first")
+            second = await adapter.run("second")
+
+            self.assertEqual("PENDING", second.status)
+            self.assertFalse(second.normal_terminal)
+            self.assertEqual((0, 0), engine.store.counters())
+
+    async def test_machine_identity_and_wire_settings_are_exact(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    )
+                ]
+            )
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("identity")
+
+            self.assertIsNotNone(result.runtime_identity)
+            identity = result.runtime_identity
+            assert identity is not None
+            self.assertEqual(CODEX_MODEL, identity.model)
+            self.assertEqual(
+                CODEX_REASONING_EFFORT,
+                identity.reasoning_effort,
+            )
+            self.assertEqual(CODEX_SERVICE_TIER, identity.service_tier)
+            self.assertEqual(
+                CODEX_CLI_VERSION,
+                identity.codex_cli_version,
+            )
+            self.assertEqual("chatgpt", identity.account_type)
+            sent = factory.transports[0].sent
+            thread_start = next(
+                message for message in sent
+                if message.get("method") == "thread/start"
+            )
+            turn_start = next(
+                message for message in sent
+                if message.get("method") == "turn/start"
+            )
+            self.assertEqual(
+                {
+                    "features": {
+                        "apps": False,
+                        "hooks": False,
+                        "multi_agent": False,
+                        "remote_plugin": False,
+                        "shell_tool": False,
+                        "skill_mcp_dependency_install": False,
+                    },
+                    "mcp_servers": {},
+                    "model_reasoning_effort": CODEX_REASONING_EFFORT,
+                    "plugins": {},
+                },
+                thread_start["params"]["config"],
+            )
+            self.assertTrue(thread_start["params"]["ephemeral"])
+            self.assertEqual(
+                "read-only",
+                thread_start["params"]["sandbox"],
+            )
+            self.assertEqual(CODEX_MODEL, turn_start["params"]["model"])
+            self.assertEqual(
+                CODEX_REASONING_EFFORT,
+                turn_start["params"]["effort"],
+            )
+            self.assertEqual(
+                CODEX_SERVICE_TIER,
+                turn_start["params"]["serviceTier"],
+            )
+            self.assertEqual(
+                {"networkAccess": False, "type": "readOnly"},
+                turn_start["params"]["sandboxPolicy"],
+            )
+            self.assertEqual(ADAPTER_NAME, engine.adapter)
+            self.assertEqual(CODEX_CLI_VERSION, engine.adapter_version)
+
+    async def test_identity_mismatches_fail_closed_before_turn(self) -> None:
+        cases = (
+            {"model": "other-model"},
+            {"effort": "xhigh"},
+            {"service_tier": "flex"},
+            {"account_type": "apiKey"},
+            {"catalog_effort": "high"},
+            {"catalog_tier": "flex"},
+            {"model_provider": "other"},
+            {"approval_policy": "never"},
+            {"approvals_reviewer": "auto_review"},
+            {"sandbox_type": "workspaceWrite"},
+            {"network_access": True},
+            {"effective_cwd": "/tmp/other"},
+            {"ephemeral": False},
+        )
+        for index, overrides in enumerate(cases, start=1):
+            with self.subTest(overrides=overrides):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id=f"thread-{index}",
+                                turn_id=f"turn-{index}",
+                                item_id=f"item-{index}",
+                                **overrides,
+                            )
+                        ]
+                    )
+                    _, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: self.fail("must not prompt"),
+                    )
+
+                    with self.assertRaises(CodexAdapterFailure):
+                        await adapter.run("mismatch")
+
+                    self.assertTrue(factory.transports[0].closed)
+
+    async def test_cli_version_mismatch_fails_before_initialize(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    )
+                ],
+                versions=["0.0.0"],
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            with self.assertRaises(CodexAdapterFailure):
+                await adapter.run("version mismatch")
+
+            self.assertEqual([], factory.transports[0].sent)
+            self.assertTrue(factory.transports[0].closed)
+
+    async def test_add_and_update_map_to_exact_decision_types(self) -> None:
+        cases = (
+            ("update", "target.txt", "MODIFY_FILE"),
+            ("add", "new.txt", "CREATE_FILE"),
+        )
+        for index, (kind, path, expected) in enumerate(cases, start=1):
+            with self.subTest(kind=kind):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id=f"thread-{index}",
+                                turn_id=f"turn-{index}",
+                                item_id=f"item-{index}",
+                                file_changes=[
+                                    change(path=path, kind=kind)
+                                ],
+                            )
+                        ]
+                    )
+                    engine, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: "1",
+                    )
+
+                    result = await adapter.run("map")
+
+                    self.assertTrue(result.normal_terminal)
+                    event = engine.store.read_events()[0]
+                    self.assertEqual(expected, event["decision_type"])
+                    self.assertEqual(path, event["normalized_scope"])
+
+    async def test_unsupported_mutations_decline_without_protocol_events(
+        self,
+    ) -> None:
+        invalid_changes = (
+            [change(), change(path="other.txt", kind="add")],
+            [change(kind="delete")],
+            [change(move_path="renamed.txt")],
+            [change(path="../outside.txt")],
+        )
+        for index, changes in enumerate(invalid_changes, start=1):
+            with self.subTest(changes=changes):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id=f"thread-{index}",
+                                turn_id=f"turn-{index}",
+                                item_id=f"item-{index}",
+                                file_changes=changes,
+                                item_status="declined",
+                            )
+                        ]
+                    )
+                    engine, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: self.fail("must not prompt"),
+                    )
+
+                    result = await adapter.run("unsupported")
+
+                    self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+                    self.assertFalse(result.normal_terminal)
+                    self.assertEqual([], engine.store.read_events())
+                    responses = [
+                        message["result"]["decision"]
+                        for message in factory.transports[0].sent
+                        if "result" in message
+                    ]
+                    self.assertEqual(["decline"], responses)
+
+    async def test_command_approval_is_declined_as_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="command-1",
+                        request_id="command-approval",
+                        method=(
+                            "item/commandExecution/requestApproval"
+                        ),
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("shell mutation")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual([], engine.store.read_events())
+            response = next(
+                message
+                for message in factory.transports[0].sent
+                if message.get("id") == "command-approval"
+            )
+            self.assertEqual(
+                {"decision": "decline"},
+                response["result"],
+            )
+
+    async def test_image_generation_cannot_promote_pending_match(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            first_messages = file_run_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+                item_id="file-1",
+            )
+            second_messages = file_run_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+                item_id="file-2",
+            )
+            image_item = {
+                "id": "image-1",
+                "revisedPrompt": "generated artifact",
+                "savedPath": "generated.png",
+                "status": "completed",
+                "type": "imageGeneration",
+            }
+            second_messages[-1:-1] = [
+                {
+                    "method": "item/started",
+                    "params": {
+                        "item": image_item,
+                        "threadId": "thread-2",
+                        "turnId": "turn-2",
+                    },
+                },
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "item": image_item,
+                        "threadId": "thread-2",
+                        "turnId": "turn-2",
+                    },
+                },
+            ]
+            factory = FakeTransportFactory(
+                [first_messages, second_messages]
+            )
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "2",
+            )
+
+            first = await adapter.run("create default")
+            result = await adapter.run("unsupported image")
+
+            self.assertEqual("NORMAL_TERMINAL", first.status)
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual("PENDING", result.checkpoint_outcomes[-1].status)
+            self.assertEqual((0, 0), engine.store.counters())
+
+    async def test_completed_file_without_approval_is_unsupported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            changes = [change()]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("bypass")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual([], engine.store.read_events())
+
+    async def test_post_approval_patch_change_cannot_promote(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            original = [change()]
+            altered = [change(diff="@@ -1 +1 @@\n-one\n+three\n")]
+            second = handshake_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+            )
+            second.extend(
+                [
+                    started_item(
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                        changes=original,
+                    ),
+                    approval_request(
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                        request_id="approval-item-2",
+                    ),
+                    resolved_request(
+                        thread_id="thread-2",
+                        request_id="approval-item-2",
+                    ),
+                    patch_updated(
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                        changes=altered,
+                    ),
+                    completed_item(
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                        item_id="item-2",
+                        changes=altered,
+                    ),
+                    completed_turn(
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    ),
+                    second,
+                ]
+            )
+            choices = iter(("2",))
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: next(choices),
+            )
+
+            await adapter.run("first")
+            result = await adapter.run("second")
+
+            self.assertEqual("PENDING", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual((0, 0), engine.store.counters())
+
+    async def test_missing_resolved_request_cannot_promote(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            second = file_run_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+                item_id="item-2",
+            )
+            second = [
+                message
+                for message in second
+                if message.get("method") != "serverRequest/resolved"
+            ]
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    ),
+                    second,
+                ]
+            )
+            choices = iter(("2",))
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: next(choices),
+            )
+
+            await adapter.run("first")
+            result = await adapter.run("second")
+
+            self.assertEqual("PENDING", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual((0, 0), engine.store.counters())
+
+    async def test_turn_events_before_start_response_are_correlated(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            base = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            turn_response = base[4]
+            settings = base[5]
+            changes = [change()]
+            messages = base[:4]
+            messages.extend(
+                [
+                    settings,
+                    {
+                        "method": "turn/started",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turn": {
+                                "id": "turn-1",
+                                "items": [],
+                                "status": "inProgress",
+                            },
+                        },
+                    },
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        request_id="approval-item-1",
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="approval-item-1",
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    turn_response,
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("early events")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+
+    async def test_model_catalog_pagination_finds_required_model(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            selected_page = messages[2]
+            selected_page["id"] = 4
+            messages[2] = {
+                "id": 3,
+                "result": {
+                    "data": [],
+                    "nextCursor": "page-2",
+                },
+            }
+            messages[3]["id"] = 5
+            messages[4]["id"] = 6
+            messages.insert(3, selected_page)
+            messages.append(
+                completed_turn(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                )
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("paged catalog")
+
+            self.assertTrue(result.normal_terminal)
+            catalog_requests = [
+                message
+                for message in factory.transports[0].sent
+                if message.get("method") == "model/list"
+            ]
+            self.assertEqual(2, len(catalog_requests))
+            self.assertEqual(
+                "page-2",
+                catalog_requests[1]["params"]["cursor"],
+            )
+
+    def test_subprocess_transport_frames_jsonl_and_isolates_tools(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            executable = Path(directory) / "codex"
+            executable.write_text("", encoding="utf-8")
+            process = FakeProcess('{"id":1,"result":{"ok":true}}\n')
+            completed = subprocess.CompletedProcess(
+                args=(str(executable), "--version"),
+                returncode=0,
+                stdout=f"codex-cli {CODEX_CLI_VERSION}\n",
+                stderr="",
+            )
+            with (
+                patch(
+                    "decision_os.acceleration.codex_adapter.subprocess.run",
+                    return_value=completed,
+                ),
+                patch(
+                    "decision_os.acceleration.codex_adapter.subprocess.Popen",
+                    return_value=process,
+                ) as popen,
+            ):
+                transport = _SubprocessTransport(executable)
+                transport.start()
+                transport.send(
+                    {"method": "initialized", "params": {}}
+                )
+                written = process.stdin.getvalue()
+                received = transport.receive()
+                transport.close()
+
+            self.assertEqual(CODEX_CLI_VERSION, transport.version)
+            self.assertEqual(
+                '{"method":"initialized","params":{}}\n',
+                written,
+            )
+            self.assertEqual({"id": 1, "result": {"ok": True}}, received)
+            command = popen.call_args.args[0]
+            self.assertEqual("app-server", command[-1])
+            self.assertIn("features.hooks=false", command)
+            self.assertIn("features.shell_tool=false", command)
+            self.assertIn("mcp_servers={}", command)
+            self.assertIn("plugins={}", command)
+            self.assertTrue(process.terminated)
+            self.assertFalse(process.killed)
+
+    def test_subprocess_transport_rejects_invalid_json_and_eof(self) -> None:
+        cases = ("not-json\n", "")
+        for payload in cases:
+            with self.subTest(payload=payload):
+                with tempfile.TemporaryDirectory() as directory:
+                    executable = Path(directory) / "codex"
+                    executable.write_text("", encoding="utf-8")
+                    process = FakeProcess(payload)
+                    completed = subprocess.CompletedProcess(
+                        args=(str(executable), "--version"),
+                        returncode=0,
+                        stdout=f"codex-cli {CODEX_CLI_VERSION}\n",
+                        stderr="",
+                    )
+                    with (
+                        patch(
+                            "decision_os.acceleration.codex_adapter.subprocess.run",
+                            return_value=completed,
+                        ),
+                        patch(
+                            "decision_os.acceleration.codex_adapter.subprocess.Popen",
+                            return_value=process,
+                        ),
+                    ):
+                        transport = _SubprocessTransport(executable)
+                        transport.start()
+                        with self.assertRaises(CodexAdapterFailure):
+                            transport.receive()
+                        transport.close()
+
+    async def test_model_reroute_prevents_pending_promotion(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            second = file_run_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+                item_id="item-2",
+            )
+            second.insert(
+                -1,
+                {
+                    "method": "model/rerouted",
+                    "params": {
+                        "fromModel": CODEX_MODEL,
+                        "toModel": "other-model",
+                    },
+                },
+            )
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    ),
+                    second,
+                ]
+            )
+            choices = iter(("2",))
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: next(choices),
+            )
+
+            await adapter.run("first")
+            result = await adapter.run("second")
+
+            self.assertEqual("PENDING", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual(
+                "CodexRuntimeIdentityError",
+                result.error_type,
+            )
+            self.assertEqual((0, 0), engine.store.counters())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/verified_save_codex_mvp_run_001.md
+++ b/validation/verified_save_codex_mvp_run_001.md
@@ -1,0 +1,222 @@
+# Verified Save Codex MVP — Validation Run 001
+
+## Receipt Identity
+
+```text
+Packet:
+V13-VERIFIED-SAVE-CODEX-SOL-MVP-001
+
+Correction Amendment:
+V13-VERIFIED-SAVE-CODEX-SOL-MVP-001-A2
+
+Live-Proof Closure:
+V13-VERIFIED-SAVE-CODEX-SOL-LIVE-CLOSURE-001
+
+Starting main:
+02ddd7af50e2366eac0c042ae3671050df5e21e0
+
+Branch:
+codex/verified-save-codex-sol-mvp-v0-1
+
+Approved pre-closure head:
+c0ecd71f1ecad0692566ad831aca8268b72adc17
+
+Validation date:
+2026-07-27
+```
+
+## Classification
+
+```text
+LIVE_PROOF:
+PASS
+
+DETERMINISTIC_ENGINE:
+PASS
+
+CODEX_ADAPTER:
+PASS
+
+DEMO_GIF:
+NOT_CREATED
+```
+
+`LIVE_PROOF=PASS` means the creator completed the bounded human-owned two-Run
+demo. Run 1 created one Repository Default only after an explicit option-2
+selection. A separate fresh Wrapper Run reused it without a second human
+interrupt and reached `VERIFIED_SAVE` at the Wrapper-owned `turn/completed`
+checkpoint.
+
+`CODEX_ADAPTER=PASS` applies only to the companion-owned Codex app-server
+surface tested here. It does not claim interception of an existing native
+Codex Desktop session.
+
+## Runtime Identity
+
+```text
+Adapter surface:
+bundled Codex app-server over stdio
+
+Authentication:
+ChatGPT subscription
+
+Model:
+gpt-5.6-sol
+
+Reasoning effort:
+ultra
+
+Service tier:
+priority
+
+Codex CLI/app-server version:
+0.146.0-alpha.3.1
+```
+
+The runtime identity came from machine-readable app-server, account, model,
+and adapter validation surfaces rather than agent prose.
+
+## Human-Owned Two-Run Result
+
+```text
+Run 1 human selection:
+explicit option 2 — Use for this repository
+
+Run 1 status:
+NORMAL_TERMINAL
+
+Run 1 turn status:
+completed
+
+Run 1 model / effort / tier / CLI:
+gpt-5.6-sol / ultra / priority / 0.146.0-alpha.3.1
+
+Run 1 error type:
+NONE
+
+Run 2:
+fresh Wrapper Run
+
+Repeated human interrupt:
+skipped / no second option prompt
+
+Run 2 status:
+VERIFIED_SAVE
+
+Run 2 turn status:
+completed
+
+Run 2 model / effort / tier / CLI:
+gpt-5.6-sol / ultra / priority / 0.146.0-alpha.3.1
+
+Run 2 error type:
+NONE
+
+Verified Save counter:
+1 Save
+
+Verified Reuse counter:
+1 Verified Reuse
+```
+
+Shin explicitly selected option `2` in Run 1. The fresh second Run reached the
+same mechanically derived decision key, matched the active Repository Default,
+skipped the repeated interrupt, completed normally, and produced
+`VERIFIED_SAVE`. No agent, fixture, timeout, or automatic input substituted for
+the human selection.
+
+## Sanitized Receipt
+
+```text
+VERIFIED
+
+1 Save
+1 Verified Reuse
+
+ESTIMATED RECOVERED
+
+7.5 minutes
+¥625
+UNKNOWN tokens
+
+Calculated from:
+1 verified reuse × 7.5 estimated minutes per reuse × ¥5,000 per hour
+tokens remain UNKNOWN until tokens_per_reuse is configured
+
+Verified Save is a locally recorded proof-of-use event, not third-party
+certification.
+```
+
+```text
+Sanitized receipt path:
+/var/folders/8p/njjq3zy14slbn9jvv4tt82dm0000gn/T/decision-os-verified-save-receipt-5f3e1db436bc.txt
+
+Receipt SHA-256:
+23c6ced038a0ca2b963ed84463fe25181bbc52dddf08b052e6f6725fb3c40780
+```
+
+This is creator-owned human live proof. It is not external-user adoption,
+native Codex Desktop interception, or third-party certification. The 7.5
+minutes and ¥625 human-time value remain estimates. Tokens are `UNKNOWN`
+because `tokens_per_reuse` was not configured. The 1 Save and 1 Verified Reuse
+counters are observed protocol results alongside the recorded Run statuses and
+runtime identities.
+
+## Validation Receipt
+
+```text
+Pre-closure focused Codex adapter tests / Python 3.14:
+24 / 24 PASS
+
+Pre-closure focused Codex adapter tests / Python 3.13:
+24 / 24 PASS
+
+Closure full suite:
+220 / 220 PASS
+
+Changed Markdown heading/fence and introduced local-link validation:
+PASS / 0 introduced links / 0 missing introduced targets
+
+Historical unresolved local-link references:
+2 / pre-existing at the approved head / unchanged and out of scope
+
+Protected v0.1 blobs and modes:
+14 / 14 PASS
+
+git diff --check:
+PASS
+```
+
+No source or test file changed in the live-proof closure.
+
+## Exact Closure File Boundary
+
+### Create
+
+1. `validation/verified_save_codex_mvp_run_001.md`
+
+### Update
+
+1. `docs/current_signal.md`
+2. `handoff/current_codex_handoff.md`
+
+The closure boundary is exactly these three evidence files. The pre-closure
+implementation boundary remained exactly four files. No README, pricing, GIF,
+release, tag, package, source, test, or public-post surface changed.
+
+## Git and Draft PR State
+
+```text
+Draft PR:
+#36 / OPEN / DRAFT
+
+Approved pre-closure head:
+c0ecd71f1ecad0692566ad831aca8268b72adc17
+
+Merge:
+NOT AUTHORIZED / NOT PERFORMED
+```
+
+The final branch-head SHA is verified after the closure commit and reported in
+the completion receipt. A commit cannot safely embed its own hash as content,
+so no self-referential SHA is claimed here.


### PR DESCRIPTION
## Summary

Adds the companion-owned Codex app-server adapter for the existing
provider-neutral Verified Save protocol.

- launches the bundled Codex app-server over stdio with one fresh ephemeral
  thread per Wrapper Run
- requires and machine-verifies ChatGPT authentication, `gpt-5.6-sol`,
  `ultra`, `priority`, and Codex CLI `0.146.0-alpha.3.1`
- gates typed single-file add/update approvals with Allow once /
  Use for this repository / Deny
- reuses Repository Defaults only through the existing cross-Run checkpoint
  and Receipt path
- fails closed for shell/command, MCP, dynamic-tool, hook,
  collaboration/sub-agent, image-generation, multi-file, delete, move,
  scope-escape, malformed, rerouted, or incomplete lifecycle paths
- preserves the Claude adapter and all provider-neutral engine/store/model
  definitions unchanged

## Implementation boundary

- `decision_os/acceleration/codex_adapter.py` (new)
- `tests/test_acceleration_codex_adapter.py` (new)
- `decision_os/acceleration/cli.py`
- `tests/test_acceleration_cli.py`

## Live-proof closure boundary

- `validation/verified_save_codex_mvp_run_001.md` (new)
- `docs/current_signal.md`
- `handoff/current_codex_handoff.md`

No source or test file changed in the closure update. The cumulative PR
boundary is exactly seven files.

## Deterministic validation

- Codex adapter + acceleration CLI: 31/31 PASS on Python 3.14
- Same focused set: 31/31 PASS on Python 3.13
- Full repository suite: 220/220 PASS
- Changed Markdown heading/fence and introduced local-link validation: PASS
  (0 introduced links; 0 missing introduced targets)
- Two historical unresolved link references predate the approved closure head
  and remain unchanged and out of scope
- Protected v0.1 blob/mode guard: 14/14 PASS
- `git diff --check`: PASS
- Exact three-file closure and seven-file cumulative PR boundaries: PASS
- New file modes: `100644`

## Creator-owned live proof

- `LIVE_PROOF: PASS`
- Run 1: Shin explicitly selected option 2; `NORMAL_TERMINAL`;
  `turn_status=completed`.
- Run 2: fresh Wrapper Run; no second human option prompt;
  `VERIFIED_SAVE`; `turn_status=completed`.
- Runtime identity in both Runs: `gpt-5.6-sol` / `ultra` / `priority` /
  Codex CLI `0.146.0-alpha.3.1`; `error_type=NONE`.
- Receipt: 1 Save / 1 Verified Reuse / 7.5 estimated minutes / ¥625
  estimated human-time value / tokens `UNKNOWN` because `tokens_per_reuse`
  was not configured.
- Receipt SHA-256:
  `23c6ced038a0ca2b963ed84463fe25181bbc52dddf08b052e6f6725fb3c40780`.
- Evidence: `validation/verified_save_codex_mvp_run_001.md`.

## Gate

Keep this PR OPEN / Draft. Merge and ready-for-review are not authorized.

This is a creator-owned human proof on the companion-owned Codex app-server
surface. It is not native Codex Desktop interception, transparent reuse in
existing Desktop tasks, universal Codex support, external-user adoption, or
third-party certification. The time and human-value figures remain estimates;
no token estimate was configured.
