### PR TITLE
V13: Add private Decision OS Companion v0.1

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -44,6 +44,26 @@ _UNSUPPORTED_ITEM_TYPES = frozenset(
         "subAgentActivity",
     }
 )
+_UNSUPPORTED_REQUEST_METHOD_REASONS = {
+    f"item/{item_type}/requestApproval": (
+        f"unsupported_request_method:{item_type}"
+    )
+    for item_type in _UNSUPPORTED_ITEM_TYPES
+}
+_UNSUPPORTED_REASON_CODES = frozenset(
+    {
+        "approval_identity_mismatch",
+        "duplicate_approval_request",
+        "unapproved_file_completion",
+        "unsupported_file_change_shape",
+        "unsupported_request_method:other",
+    }
+    | {
+        f"unsupported_item_type:{item_type}"
+        for item_type in _UNSUPPORTED_ITEM_TYPES
+    }
+    | set(_UNSUPPORTED_REQUEST_METHOD_REASONS.values())
+)
 
 
 class CodexAdapterUnavailable(RuntimeError):
@@ -78,6 +98,22 @@ class CodexRunResult:
     checkpoint_outcomes: tuple[CheckpointOutcome, ...]
     final_message: str = ""
     file_actions: tuple[CodexFileAction, ...] = ()
+    unsupported_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.unsupported_reason is not None
+            and self.unsupported_reason not in _UNSUPPORTED_REASON_CODES
+        ):
+            raise ValueError(
+                "Codex unsupported reason must be a bounded code."
+            )
+        if (
+            self.status == "UNSUPPORTED_MUTATION"
+        ) != (self.unsupported_reason is not None):
+            raise ValueError(
+                "Codex unsupported status and reason must agree."
+            )
 
 
 @dataclass(frozen=True)
@@ -107,6 +143,15 @@ class CodexFileAction:
     normalized_scope: str
     access: str
     status: str
+
+
+@dataclass(frozen=True)
+class _CodexFileActionCandidate:
+    """Internal action facts retained until terminal proof is available."""
+
+    action: str
+    item_id: str
+    outcome: DecisionOutcome
 
 
 class AppServerTransport(Protocol):
@@ -340,9 +385,10 @@ class CodexAdapter:
         self._seen: dict[str, DecisionOutcome] = {}
         self._permission_denied = False
         self._unsupported_mutation = False
+        self._unsupported_reason: str | None = None
         self._identity_failure = False
         self._final_message = ""
-        self._file_actions: list[CodexFileAction] = []
+        self._file_action_candidates: list[_CodexFileActionCandidate] = []
 
     def _reset_run(self) -> None:
         self._request_id = 0
@@ -368,9 +414,10 @@ class CodexAdapter:
         self._seen = {}
         self._permission_denied = False
         self._unsupported_mutation = False
+        self._unsupported_reason = None
         self._identity_failure = False
         self._final_message = ""
-        self._file_actions = []
+        self._file_action_candidates = []
 
     def _emit(self, kind: str, message: str) -> None:
         if self.lifecycle_sink is None:
@@ -709,14 +756,80 @@ class CodexAdapter:
             )
         )
 
-    @staticmethod
-    def _access_label(status: str) -> str:
-        return {
-            "ALLOW_ONCE": "one-time",
-            "HUMAN_DEFAULT_CREATED": "newly-saved",
-            "DEFAULT_MATCHED": "reused",
-            "SAME_RUN_DEFAULT": "newly-saved",
-        }.get(status, "denied")
+    def _mark_unsupported(self, reason: str) -> None:
+        if reason not in _UNSUPPORTED_REASON_CODES:
+            raise CodexAdapterFailure(
+                "Codex unsupported reason is not a bounded code."
+            )
+        self._unsupported_mutation = True
+        if self._unsupported_reason is None:
+            self._unsupported_reason = reason
+
+    def _final_file_actions(
+        self,
+        checkpoint_by_decision_key: dict[str, CheckpointOutcome],
+        *,
+        normal_terminal: bool,
+    ) -> tuple[CodexFileAction, ...]:
+        actions: list[CodexFileAction] = []
+        for candidate in self._file_action_candidates:
+            outcome = candidate.outcome
+            if not outcome.allowed:
+                if outcome.status != "DENIED":
+                    continue
+                access = "denied"
+                status = "denied"
+            elif outcome.status == "DEFAULT_MATCHED":
+                checkpoint = checkpoint_by_decision_key.get(
+                    outcome.identity.decision_key
+                )
+                verified = bool(
+                    checkpoint is not None
+                    and checkpoint.verified
+                    and checkpoint.status
+                    in {"VERIFIED_SAVE", "VERIFIED_REUSE"}
+                )
+                access = (
+                    "reused" if verified else "matched-not-verified"
+                )
+                status = "approved"
+            elif outcome.status == "ALLOW_ONCE":
+                if candidate.item_id not in self._completed_items:
+                    continue
+                access = "one-time"
+                status = "approved"
+            elif outcome.status in {
+                "HUMAN_DEFAULT_CREATED",
+                "SAME_RUN_DEFAULT",
+            }:
+                if not normal_terminal:
+                    continue
+                access = "newly-saved"
+                status = "approved"
+            else:
+                continue
+            actions.append(
+                CodexFileAction(
+                    action=candidate.action,
+                    normalized_scope=outcome.identity.normalized_scope,
+                    access=access,
+                    status=status,
+                )
+            )
+        return tuple(actions)
+
+    def _final_message_with_diagnostic(self, status: str) -> str:
+        if (
+            status != "UNSUPPORTED_MUTATION"
+            or self._unsupported_reason is None
+        ):
+            return self._final_message
+        diagnostic = (
+            "Decision OS verification: not verified "
+            f"({self._unsupported_reason})."
+        )
+        separator = "\n\n" if self._final_message else ""
+        return f"{self._final_message}{separator}{diagnostic}"
 
     def _map_file_change(
         self,
@@ -803,7 +916,16 @@ class CodexAdapter:
             and item_id in self._approval_requests.values()
         )
         if not self._register_approval_request(request_id, item_id):
-            self._unsupported_mutation = True
+            reason = (
+                "duplicate_approval_request"
+                if (
+                    isinstance(request_id, (str, int))
+                    and not isinstance(request_id, bool)
+                    and request_id in self._approval_requests
+                )
+                else "approval_identity_mismatch"
+            )
+            self._mark_unsupported(reason)
             if isinstance(item_id, str):
                 self._declined_items.add(item_id)
             self._send(
@@ -816,7 +938,7 @@ class CodexAdapter:
             or not self._settings_verified
             or item_id not in self._items
         ):
-            self._unsupported_mutation = True
+            self._mark_unsupported("approval_identity_mismatch")
             if isinstance(item_id, str):
                 self._declined_items.add(item_id)
             self._send(
@@ -824,7 +946,7 @@ class CodexAdapter:
             )
             return
         if duplicate_item:
-            self._unsupported_mutation = True
+            self._mark_unsupported("duplicate_approval_request")
             self._declined_items.add(item_id)
             self._send(
                 {"id": request_id, "result": {"decision": "decline"}}
@@ -836,7 +958,7 @@ class CodexAdapter:
             )
             normalized = normalize_scope(self.engine.repository, raw_path)
         except (CodexAdapterFailure, ScopeError):
-            self._unsupported_mutation = True
+            self._mark_unsupported("unsupported_file_change_shape")
             self._declined_items.add(item_id)
             self._send(
                 {"id": request_id, "result": {"decision": "decline"}}
@@ -869,23 +991,17 @@ class CodexAdapter:
 
         if outcome.allowed:
             decision_type, _ = self._map_file_change(self._items[item_id])
-            self._file_actions.append(
-                CodexFileAction(
+            self._file_action_candidates.append(
+                _CodexFileActionCandidate(
                     action=(
                         "Create"
                         if decision_type is DecisionType.CREATE_FILE
                         else "Modify"
                     ),
-                    normalized_scope=outcome.identity.normalized_scope,
-                    access=self._access_label(outcome.status),
-                    status="approved",
+                    item_id=item_id,
+                    outcome=outcome,
                 )
             )
-            if outcome.status == "DEFAULT_MATCHED":
-                self._emit(
-                    "reuse",
-                    "Matching saved repository access was reused.",
-                )
             self._accepted_items.add(item_id)
             self._approved_changes[item_id] = copy.deepcopy(
                 self._items[item_id]["changes"]
@@ -895,16 +1011,15 @@ class CodexAdapter:
             )
             return
         self._permission_denied = True
-        self._file_actions.append(
-            CodexFileAction(
+        self._file_action_candidates.append(
+            _CodexFileActionCandidate(
                 action=(
                     "Create"
                     if outcome.identity.decision_type is DecisionType.CREATE_FILE
                     else "Modify"
                 ),
-                normalized_scope=outcome.identity.normalized_scope,
-                access="denied",
-                status="denied",
+                item_id=item_id,
+                outcome=outcome,
             )
         )
         self._declined_items.add(item_id)
@@ -939,9 +1054,13 @@ class CodexAdapter:
         self._resolved_items.add(item_id)
 
     def _respond_unsupported_request(self, message: dict[str, Any]) -> None:
-        self._unsupported_mutation = True
         request_id = message.get("id")
         method = message.get("method")
+        reason = _UNSUPPORTED_REQUEST_METHOD_REASONS.get(
+            method,
+            "unsupported_request_method:other",
+        )
+        self._mark_unsupported(reason)
         params = message.get("params")
         item_id = params.get("itemId") if isinstance(params, dict) else None
         self._register_approval_request(request_id, item_id)
@@ -967,7 +1086,9 @@ class CodexAdapter:
         item = self._require_object(params.get("item"), "started item")
         item_type = item.get("type")
         if item_type in _UNSUPPORTED_ITEM_TYPES:
-            self._unsupported_mutation = True
+            self._mark_unsupported(
+                f"unsupported_item_type:{item_type}"
+            )
             return
         if item_type != "fileChange":
             return
@@ -1007,7 +1128,9 @@ class CodexAdapter:
         item = self._require_object(params.get("item"), "completed item")
         item_type = item.get("type")
         if item_type in _UNSUPPORTED_ITEM_TYPES:
-            self._unsupported_mutation = True
+            self._mark_unsupported(
+                f"unsupported_item_type:{item_type}"
+            )
             return
         if item_type == "agentMessage":
             text = item.get("text")
@@ -1032,7 +1155,7 @@ class CodexAdapter:
                 self._identity_failure = True
             return
         if item_id not in self._accepted_items:
-            self._unsupported_mutation = True
+            self._mark_unsupported("unapproved_file_completion")
             self._identity_failure = True
             return
         approved = self._approved_changes.get(item_id)
@@ -1207,8 +1330,13 @@ class CodexAdapter:
             and not self._identity_failure
             and error_type is None
         )
-        checkpoints = tuple(
-            self.engine.finish_checkpoint(
+        checkpoint_by_decision_key: dict[str, CheckpointOutcome] = {}
+        checkpoint_values: list[CheckpointOutcome] = []
+        for index, (decision_key, outcome) in enumerate(
+            self._pending.items(),
+            start=1,
+        ):
+            checkpoint = self.engine.finish_checkpoint(
                 outcome,
                 normal_terminal=normal_terminal,
                 checkpoint_id=(
@@ -1217,11 +1345,9 @@ class CodexAdapter:
                     else f"codex-missing-turn:{self._run_id}:{index}"
                 ),
             )
-            for index, outcome in enumerate(
-                self._pending.values(),
-                start=1,
-            )
-        )
+            checkpoint_by_decision_key[decision_key] = checkpoint
+            checkpoint_values.append(checkpoint)
+        checkpoints = tuple(checkpoint_values)
         if self._unsupported_mutation:
             status = "UNSUPPORTED_MUTATION"
         elif checkpoints:
@@ -1232,6 +1358,10 @@ class CodexAdapter:
             status = "NORMAL_TERMINAL"
         else:
             status = "ABNORMAL_TERMINAL"
+        file_actions = self._final_file_actions(
+            checkpoint_by_decision_key,
+            normal_terminal=normal_terminal,
+        )
         return CodexRunResult(
             run_id=self._run_id,
             normal_terminal=normal_terminal,
@@ -1240,6 +1370,7 @@ class CodexAdapter:
             turn_status=self._turn_status,
             runtime_identity=self._runtime_identity,
             checkpoint_outcomes=checkpoints,
-            final_message=self._final_message,
-            file_actions=tuple(self._file_actions),
+            final_message=self._final_message_with_diagnostic(status),
+            file_actions=file_actions,
+            unsupported_reason=self._unsupported_reason,
         )

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -76,6 +76,37 @@ class CodexRunResult:
     turn_status: str | None
     runtime_identity: CodexRuntimeIdentity | None
     checkpoint_outcomes: tuple[CheckpointOutcome, ...]
+    final_message: str = ""
+    file_actions: tuple[CodexFileAction, ...] = ()
+
+
+@dataclass(frozen=True)
+class CodexApproval:
+    """Presentation-safe description of one exact file-change approval."""
+
+    repository_name: str
+    action: str
+    normalized_scope: str
+    diff: str
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class CodexLifecycleEvent:
+    """Small sanitized lifecycle event for non-CLI presentation surfaces."""
+
+    kind: str
+    message: str
+
+
+@dataclass(frozen=True)
+class CodexFileAction:
+    """Presentation-safe outcome for one exact file action."""
+
+    action: str
+    normalized_scope: str
+    access: str
+    status: str
 
 
 class AppServerTransport(Protocol):
@@ -252,6 +283,8 @@ class _SubprocessTransport:
 
 
 TransportFactory = Callable[[Path], AppServerTransport]
+ApprovalProvider = Callable[[CodexApproval], str | None]
+LifecycleSink = Callable[[CodexLifecycleEvent], None]
 
 
 class CodexAdapter:
@@ -265,6 +298,8 @@ class CodexAdapter:
         stdout: TextIO,
         executable: Path | None = None,
         transport_factory: TransportFactory | None = None,
+        approval_provider: ApprovalProvider | None = None,
+        lifecycle_sink: LifecycleSink | None = None,
         expected_model: str = CODEX_MODEL,
         expected_reasoning_effort: str = CODEX_REASONING_EFFORT,
         expected_service_tier: str = CODEX_SERVICE_TIER,
@@ -275,6 +310,8 @@ class CodexAdapter:
         self.stdout = stdout
         self.executable = executable or BUNDLED_CODEX_PATH
         self.transport_factory = transport_factory or _SubprocessTransport
+        self.approval_provider = approval_provider
+        self.lifecycle_sink = lifecycle_sink
         self.expected_model = expected_model
         self.expected_reasoning_effort = expected_reasoning_effort
         self.expected_service_tier = expected_service_tier
@@ -304,6 +341,8 @@ class CodexAdapter:
         self._permission_denied = False
         self._unsupported_mutation = False
         self._identity_failure = False
+        self._final_message = ""
+        self._file_actions: list[CodexFileAction] = []
 
     def _reset_run(self) -> None:
         self._request_id = 0
@@ -330,6 +369,13 @@ class CodexAdapter:
         self._permission_denied = False
         self._unsupported_mutation = False
         self._identity_failure = False
+        self._final_message = ""
+        self._file_actions = []
+
+    def _emit(self, kind: str, message: str) -> None:
+        if self.lifecycle_sink is None:
+            return
+        self.lifecycle_sink(CodexLifecycleEvent(kind=kind, message=message))
 
     def _send(self, message: dict[str, Any]) -> None:
         if self._transport is None:
@@ -369,6 +415,7 @@ class CodexAdapter:
         return value
 
     def _initialize(self) -> None:
+        self._emit("runtime", "Starting the private Codex runtime.")
         result = self._require_object(
             self._request(
                 "initialize",
@@ -391,6 +438,7 @@ class CodexAdapter:
         self._send({"method": "initialized", "params": {}})
 
     def _verify_account(self) -> None:
+        self._emit("account", "Verifying ChatGPT authentication.")
         result = self._require_object(
             self._request("account/read", {"refreshToken": False}),
             "account/read result",
@@ -406,6 +454,7 @@ class CodexAdapter:
         self._account_type = "chatgpt"
 
     def _verify_model_catalog(self) -> None:
+        self._emit("model", "Verifying the required model and service tier.")
         cursor: str | None = None
         seen_cursors: set[str] = set()
         while True:
@@ -465,6 +514,7 @@ class CodexAdapter:
             cursor = next_cursor
 
     def _start_thread(self) -> None:
+        self._emit("run", "Starting one fresh bounded Run.")
         repository = self.engine.store.repository
         isolated_features = {
             "apps": False,
@@ -582,6 +632,7 @@ class CodexAdapter:
         if self._turn_id is not None and self._turn_id != turn_id:
             raise CodexAdapterFailure("Codex turn identity changed during start.")
         self._turn_id = turn_id
+        self._emit("working", "Codex is working on the bounded task.")
 
     def _cwd_matches(self, value: Any) -> bool:
         if not isinstance(value, str) or not value:
@@ -621,6 +672,51 @@ class CodexAdapter:
             return self.input_func()
         except (EOFError, KeyboardInterrupt, OSError):
             return None
+
+    def _approval_choice(
+        self,
+        identity: Any,
+        item: dict[str, Any],
+        params: dict[str, Any],
+    ) -> str | None:
+        if self.approval_provider is None:
+            return self._human_choice(identity)
+        change = self._require_object(
+            item["changes"][0],
+            "Codex approval change",
+        )
+        diff = change.get("diff")
+        if not isinstance(diff, str):
+            raise CodexAdapterFailure(
+                "Codex file change lacks a typed diff."
+            )
+        action = (
+            "Create"
+            if identity.decision_type is DecisionType.CREATE_FILE
+            else "Modify"
+        )
+        reason = params.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            reason = None
+        self._emit("approval", "Waiting for one exact file-change decision.")
+        return self.approval_provider(
+            CodexApproval(
+                repository_name=self.engine.store.repository.name,
+                action=action,
+                normalized_scope=identity.normalized_scope,
+                diff=diff,
+                reason=reason,
+            )
+        )
+
+    @staticmethod
+    def _access_label(status: str) -> str:
+        return {
+            "ALLOW_ONCE": "one-time",
+            "HUMAN_DEFAULT_CREATED": "newly-saved",
+            "DEFAULT_MATCHED": "reused",
+            "SAME_RUN_DEFAULT": "newly-saved",
+        }.get(status, "denied")
 
     def _map_file_change(
         self,
@@ -761,13 +857,35 @@ class CodexAdapter:
                 decision_type=decision_type,
                 requested_scope=raw_path,
                 source_interrupt_id=item_id,
-                choice_provider=self._human_choice,
+                choice_provider=lambda identity: self._approval_choice(
+                    identity,
+                    self._items[item_id],
+                    params,
+                ),
             )
             self._seen[key] = outcome
             if outcome.pending_cross_run_checkpoint:
                 self._pending[outcome.identity.decision_key] = outcome
 
         if outcome.allowed:
+            decision_type, _ = self._map_file_change(self._items[item_id])
+            self._file_actions.append(
+                CodexFileAction(
+                    action=(
+                        "Create"
+                        if decision_type is DecisionType.CREATE_FILE
+                        else "Modify"
+                    ),
+                    normalized_scope=outcome.identity.normalized_scope,
+                    access=self._access_label(outcome.status),
+                    status="approved",
+                )
+            )
+            if outcome.status == "DEFAULT_MATCHED":
+                self._emit(
+                    "reuse",
+                    "Matching saved repository access was reused.",
+                )
             self._accepted_items.add(item_id)
             self._approved_changes[item_id] = copy.deepcopy(
                 self._items[item_id]["changes"]
@@ -777,6 +895,18 @@ class CodexAdapter:
             )
             return
         self._permission_denied = True
+        self._file_actions.append(
+            CodexFileAction(
+                action=(
+                    "Create"
+                    if outcome.identity.decision_type is DecisionType.CREATE_FILE
+                    else "Modify"
+                ),
+                normalized_scope=outcome.identity.normalized_scope,
+                access="denied",
+                status="denied",
+            )
+        )
         self._declined_items.add(item_id)
         self._send(
             {"id": request_id, "result": {"decision": "decline"}}
@@ -879,6 +1009,18 @@ class CodexAdapter:
         if item_type in _UNSUPPORTED_ITEM_TYPES:
             self._unsupported_mutation = True
             return
+        if item_type == "agentMessage":
+            text = item.get("text")
+            phase = item.get("phase")
+            if (
+                not isinstance(text, str)
+                or phase not in {None, "final_answer", "commentary"}
+            ):
+                self._identity_failure = True
+                return
+            if phase in {None, "final_answer"}:
+                self._final_message = text
+            return
         if item_type != "fileChange":
             return
         item_id = item.get("id")
@@ -961,6 +1103,7 @@ class CodexAdapter:
             self._identity_failure = True
             return
         self._turn_status = status
+        self._emit("finalizing", "Finalizing the local Receipt.")
 
     def _dispatch(self, message: dict[str, Any]) -> None:
         method = message.get("method")
@@ -1015,6 +1158,7 @@ class CodexAdapter:
         if not isinstance(prompt, str) or not prompt.strip():
             raise CodexAdapterFailure("Codex prompt must be a non-empty string.")
         self._reset_run()
+        self._emit("starting", "Preparing the bounded task.")
         self._transport = self.transport_factory(self.executable)
         turn_started = False
         error_type: str | None = None
@@ -1096,4 +1240,6 @@ class CodexAdapter:
             turn_status=self._turn_status,
             runtime_identity=self._runtime_identity,
             checkpoint_outcomes=checkpoints,
+            final_message=self._final_message,
+            file_actions=tuple(self._file_actions),
         )

--- a/decision_os/acceleration/store.py
+++ b/decision_os/acceleration/store.py
@@ -39,6 +39,18 @@ class DefaultRecord:
 
 
 @dataclass(frozen=True)
+class ActiveDefaultRecord:
+    """Presentation fields for one active exact Repository Default."""
+
+    decision_key: str
+    created_run_id: str
+    rule_hash: str
+    decision_type: str
+    normalized_scope: str
+    created_at: str
+
+
+@dataclass(frozen=True)
 class ReceiptSettings:
     """User-configurable estimate inputs, separate from verified events."""
 
@@ -316,6 +328,55 @@ class AccelerationStore:
             }:
                 active = None
         return active
+
+    def active_defaults(self) -> tuple[ActiveDefaultRecord, ...]:
+        """Enumerate active exact defaults without changing protocol state."""
+
+        active: dict[str, ActiveDefaultRecord] = {}
+        for event in self.read_events():
+            key = event["decision_key"]
+            if event["event_type"] == "HUMAN_DEFAULT_CREATED":
+                created_run_id = event["default_created_run_id"]
+                rule = event["default_rule_hash"]
+                decision_type = event["decision_type"]
+                scope = event["normalized_scope"]
+                created_at = event["timestamp"]
+                if not all(
+                    isinstance(value, str) and value
+                    for value in (
+                        key,
+                        created_run_id,
+                        rule,
+                        decision_type,
+                        scope,
+                        created_at,
+                    )
+                ):
+                    raise StateIntegrityError("Default identity is incomplete.")
+                active[key] = ActiveDefaultRecord(
+                    decision_key=key,
+                    created_run_id=created_run_id,
+                    rule_hash=rule,
+                    decision_type=decision_type,
+                    normalized_scope=scope,
+                    created_at=created_at,
+                )
+            elif event["event_type"] in {
+                "OVERRIDE",
+                "DEFAULT_REVOKED_AFTER_USE",
+                "DEFAULT_SUPERSEDED",
+            }:
+                active.pop(key, None)
+        return tuple(
+            sorted(
+                active.values(),
+                key=lambda item: (
+                    item.normalized_scope,
+                    item.decision_type,
+                    item.created_at,
+                ),
+            )
+        )
 
     def verified_decision_keys(self) -> set[str]:
         """Return unique repository decision pairs that became Verified Saves."""

--- a/decision_os/companion/__init__.py
+++ b/decision_os/companion/__init__.py
@@ -1,0 +1,7 @@
+"""Private localhost companion for one bounded Decision OS Run."""
+
+from .controller import CompanionController
+from .server import CompanionServer
+
+__all__ = ["CompanionController", "CompanionServer"]
+__version__ = "0.1.0"

--- a/decision_os/companion/__main__.py
+++ b/decision_os/companion/__main__.py
@@ -1,0 +1,53 @@
+"""Launch the private Decision OS Companion without a Terminal surface."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import sys
+import webbrowser
+
+from .controller import CompanionController
+from .server import CompanionServer
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="decision-os-companion")
+    parser.add_argument("--no-browser", action="store_true")
+    parser.add_argument("--state-path", type=Path)
+    parser.add_argument("--picker-script", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    package_root = Path(__file__).resolve().parent
+    picker = arguments.picker_script
+    if picker is None:
+        configured = os.environ.get("DECISION_OS_COMPANION_PICKER_SCRIPT")
+        picker = (
+            Path(configured)
+            if configured
+            else package_root.parents[1]
+            / "macos"
+            / "DecisionOSCompanion.applescript"
+        )
+    controller = CompanionController(
+        state_path=arguments.state_path,
+        picker_script=picker,
+    )
+    server = CompanionServer(controller, static_root=package_root / "static")
+    if not arguments.no_browser:
+        webbrowser.open(server.bootstrap_url, new=1, autoraise=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -1,0 +1,612 @@
+"""Thread-safe presentation controller over the existing Verified Save backend."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import io
+import json
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import threading
+from typing import Any, Protocol
+
+from decision_os.acceleration.codex_adapter import (
+    ADAPTER_NAME,
+    CODEX_CLI_VERSION,
+    CodexAdapter,
+    CodexAdapterFailure,
+    CodexAdapterUnavailable,
+    CodexApproval,
+    CodexLifecycleEvent,
+    CodexRunResult,
+)
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import RepositoryIdentityError, git_root
+from decision_os.acceleration.store import (
+    AccelerationStore,
+    ActiveDefaultRecord,
+    StateIntegrityError,
+)
+
+
+class CompanionError(RuntimeError):
+    """Base error for the private companion presentation surface."""
+
+
+class CompanionStateError(CompanionError):
+    """The companion's minimal local state is invalid."""
+
+
+class RepositorySelectionError(CompanionError):
+    """A selected path is not a usable local Git repository."""
+
+
+class RunConflictError(CompanionError):
+    """A state-changing action conflicts with the one active Run."""
+
+
+class ApprovalStateError(CompanionError):
+    """An approval response has no matching pending approval."""
+
+
+class LifecycleEventError(CompanionError):
+    """An adapter attempted to emit a malformed presentation event."""
+
+
+class AdapterFactory(Protocol):
+    def __call__(
+        self,
+        engine: AccelerationEngine,
+        approval_provider: Callable[[CodexApproval], str | None],
+        lifecycle_sink: Callable[[CodexLifecycleEvent], None],
+    ) -> CodexAdapter:
+        """Create one adapter for one fresh Wrapper Run."""
+
+
+PickerRunner = Callable[[Path], str | None]
+
+_TERMINAL_STATES = frozenset(
+    {"completed", "denied", "unsupported", "needs_attention"}
+)
+_LIFECYCLE_MESSAGES = {
+    "starting": "Preparing the bounded task.",
+    "runtime": "Starting the private Codex runtime.",
+    "account": "Verifying ChatGPT authentication.",
+    "model": "Verifying the required model and service tier.",
+    "run": "Starting one fresh bounded Run.",
+    "working": "Codex is working on the bounded task.",
+    "approval": "Waiting for one exact file-change decision.",
+    "reuse": "Matching saved repository access was reused.",
+    "finalizing": "Finalizing the local Receipt.",
+}
+
+
+def _default_state_path() -> Path:
+    return (
+        Path.home()
+        / "Library"
+        / "Application Support"
+        / "Decision OS Companion"
+        / "state.json"
+    )
+
+
+def _default_picker_runner(script: Path) -> str | None:
+    if not script.is_file():
+        raise RepositorySelectionError(
+            "The fixed macOS repository picker is unavailable."
+        )
+    try:
+        completed = subprocess.run(
+            ("/usr/bin/osascript", str(script), "pick"),
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=300,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RepositorySelectionError(
+            "The macOS repository picker could not be opened."
+        ) from exc
+    if completed.returncode != 0:
+        raise RepositorySelectionError(
+            "The macOS repository picker did not complete."
+        )
+    selected = completed.stdout.strip()
+    return selected or None
+
+
+def _default_adapter_factory(
+    engine: AccelerationEngine,
+    approval_provider: Callable[[CodexApproval], str | None],
+    lifecycle_sink: Callable[[CodexLifecycleEvent], None],
+) -> CodexAdapter:
+    return CodexAdapter(
+        engine,
+        input_func=lambda: None,
+        stdout=io.StringIO(),
+        approval_provider=approval_provider,
+        lifecycle_sink=lifecycle_sink,
+    )
+
+
+class CompanionController:
+    """Own repository selection, one active Run, approvals, and safe receipts."""
+
+    def __init__(
+        self,
+        *,
+        state_path: Path | None = None,
+        picker_script: Path | None = None,
+        picker_runner: PickerRunner | None = None,
+        adapter_factory: AdapterFactory | None = None,
+    ) -> None:
+        self.state_path = state_path or _default_state_path()
+        self.picker_script = picker_script or Path(
+            "/Applications/Decision OS Companion.app/Contents/Resources/"
+            "DecisionOSCompanion.applescript"
+        )
+        self.picker_runner = picker_runner or _default_picker_runner
+        self.adapter_factory = adapter_factory or _default_adapter_factory
+        self._condition = threading.Condition(threading.RLock())
+        self._repository: Path | None = None
+        self._run: dict[str, Any] = self._empty_run()
+        self._approval_choice: str | None = None
+        self._default_handles: dict[str, str] = {}
+        self._worker: threading.Thread | None = None
+        self._load_last_repository()
+
+    @staticmethod
+    def _empty_run() -> dict[str, Any]:
+        return {
+            "state": "idle",
+            "progress": [],
+            "result": "",
+            "file_actions": [],
+            "runtime": None,
+            "receipt_delta": None,
+            "approval": None,
+            "error": None,
+        }
+
+    def _load_last_repository(self) -> None:
+        if not self.state_path.exists():
+            return
+        try:
+            value = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise CompanionStateError(
+                "Decision OS Companion state is invalid."
+            ) from exc
+        if (
+            not isinstance(value, dict)
+            or set(value) != {"repository"}
+            or not isinstance(value["repository"], str)
+            or not value["repository"]
+        ):
+            raise CompanionStateError(
+                "Decision OS Companion state exceeds its allowed field boundary."
+            )
+        try:
+            self._repository = self._validated_repository(
+                Path(value["repository"])
+            )
+        except RepositorySelectionError:
+            self._repository = None
+
+    def _write_last_repository(self, repository: Path) -> None:
+        directory = self.state_path.parent
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+        temporary = directory / f".state-{secrets.token_hex(8)}.tmp"
+        payload = json.dumps(
+            {"repository": str(repository)},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                stream.write(payload)
+                stream.write("\n")
+            os.replace(temporary, self.state_path)
+            os.chmod(self.state_path, 0o600)
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _validated_repository(candidate: Path) -> Path:
+        try:
+            root = git_root(candidate)
+            store = AccelerationStore(root)
+            store.read_events()
+            store.read_settings()
+        except (
+            OSError,
+            RepositoryIdentityError,
+            StateIntegrityError,
+        ) as exc:
+            raise RepositorySelectionError(
+                "Select a valid local Git repository with intact Decision OS state."
+            ) from exc
+        return root
+
+    def select_repository(self, candidate: str | Path) -> dict[str, Any]:
+        with self._condition:
+            self._require_no_active_run()
+        if not isinstance(candidate, (str, Path)):
+            raise RepositorySelectionError("Repository path is invalid.")
+        repository = self._validated_repository(Path(candidate))
+        self._write_last_repository(repository)
+        with self._condition:
+            self._repository = repository
+            self._default_handles = {}
+            self._run = self._empty_run()
+            return self._snapshot_locked()
+
+    def pick_repository(self) -> dict[str, Any]:
+        selected = self.picker_runner(self.picker_script)
+        if selected is None:
+            raise RepositorySelectionError("Repository selection was cancelled.")
+        return self.select_repository(selected)
+
+    def _require_repository(self) -> Path:
+        if self._repository is None:
+            raise RepositorySelectionError("Choose a local Git repository first.")
+        return self._repository
+
+    def _require_no_active_run(self) -> None:
+        if self._run["state"] == "running":
+            raise RunConflictError("One bounded Run is already active.")
+
+    def start_run(self, task: str) -> dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            raise CompanionError("Enter one bounded task before running.")
+        if len(task) > 20_000:
+            raise CompanionError("The bounded task exceeds the local size limit.")
+        with self._condition:
+            repository = self._require_repository()
+            self._require_no_active_run()
+            before = self._safe_receipt(repository)
+            self._run = self._empty_run()
+            self._run["state"] = "running"
+            self._run["progress"] = ["Preparing the bounded task."]
+            self._run["receipt_before"] = before
+            self._approval_choice = None
+            self._worker = threading.Thread(
+                target=self._run_worker,
+                args=(repository, task.strip()),
+                name="decision-os-companion-run",
+                daemon=True,
+            )
+            self._worker.start()
+            return self._snapshot_locked()
+
+    def _lifecycle_sink(self, event: CodexLifecycleEvent) -> None:
+        if (
+            not isinstance(event, CodexLifecycleEvent)
+            or event.kind not in _LIFECYCLE_MESSAGES
+            or event.message != _LIFECYCLE_MESSAGES[event.kind]
+        ):
+            raise LifecycleEventError("Malformed companion lifecycle event.")
+        with self._condition:
+            if self._run["state"] != "running":
+                raise LifecycleEventError(
+                    "Lifecycle event arrived outside the active Run."
+                )
+            if event.message not in self._run["progress"]:
+                self._run["progress"].append(event.message)
+            self._condition.notify_all()
+
+    def _approval_provider(self, approval: CodexApproval) -> str | None:
+        if (
+            not isinstance(approval, CodexApproval)
+            or approval.action not in {"Create", "Modify"}
+            or not approval.repository_name
+            or not approval.normalized_scope
+            or not isinstance(approval.diff, str)
+        ):
+            raise ApprovalStateError("Malformed file approval request.")
+        with self._condition:
+            if self._run["state"] != "running":
+                return "3"
+            self._run["approval"] = {
+                "repository": approval.repository_name,
+                "action": approval.action,
+                "path": approval.normalized_scope,
+                "diff": approval.diff,
+                "reason": approval.reason,
+            }
+            self._approval_choice = None
+            self._condition.notify_all()
+            while (
+                self._run["state"] == "running"
+                and self._approval_choice is None
+            ):
+                self._condition.wait(timeout=1)
+            choice = self._approval_choice or "3"
+            self._run["approval"] = None
+            self._approval_choice = None
+            self._condition.notify_all()
+            return choice
+
+    def submit_approval(self, choice: str) -> dict[str, Any]:
+        choices = {
+            "allow_once": "1",
+            "repository": "2",
+            "deny": "3",
+        }
+        if choice not in choices:
+            raise ApprovalStateError("Approval choice is unsupported.")
+        with self._condition:
+            if (
+                self._run["state"] != "running"
+                or self._run["approval"] is None
+                or self._approval_choice is not None
+            ):
+                raise ApprovalStateError("No file approval is waiting.")
+            self._approval_choice = choices[choice]
+            self._condition.notify_all()
+            return self._snapshot_locked()
+
+    def _run_worker(self, repository: Path, task: str) -> None:
+        engine = AccelerationEngine(
+            repository,
+            adapter=ADAPTER_NAME,
+            adapter_version=CODEX_CLI_VERSION,
+        )
+        try:
+            adapter = self.adapter_factory(
+                engine,
+                self._approval_provider,
+                self._lifecycle_sink,
+            )
+            result = asyncio.run(adapter.run(task))
+            self._complete_run(repository, result)
+        except Exception as exc:
+            self._fail_run(repository, exc)
+
+    @staticmethod
+    def _public_runtime(result: CodexRunResult) -> dict[str, str] | None:
+        identity = result.runtime_identity
+        if identity is None:
+            return None
+        return {
+            "authentication": identity.account_type,
+            "model": identity.model,
+            "reasoning_effort": identity.reasoning_effort,
+            "service_tier": identity.service_tier,
+            "codex_version": identity.codex_cli_version,
+        }
+
+    @staticmethod
+    def _public_actions(result: CodexRunResult) -> list[dict[str, str]]:
+        return [
+            {
+                "action": action.action,
+                "path": action.normalized_scope,
+                "access": action.access,
+                "status": action.status,
+            }
+            for action in result.file_actions
+        ]
+
+    @staticmethod
+    def _display_state(result: CodexRunResult) -> str:
+        if result.status in {
+            "NORMAL_TERMINAL",
+            "VERIFIED_SAVE",
+            "VERIFIED_REUSE",
+        }:
+            return "completed"
+        if result.status == "DENIED":
+            return "denied"
+        if result.status == "UNSUPPORTED_MUTATION":
+            return "unsupported"
+        return "needs_attention"
+
+    def _complete_run(
+        self,
+        repository: Path,
+        result: CodexRunResult,
+    ) -> None:
+        after = self._safe_receipt(repository)
+        with self._condition:
+            before = self._run.pop("receipt_before")
+            self._run["state"] = self._display_state(result)
+            self._run["result"] = result.final_message
+            self._run["file_actions"] = self._public_actions(result)
+            self._run["runtime"] = self._public_runtime(result)
+            self._run["receipt_delta"] = self._receipt_delta(before, after)
+            self._run["approval"] = None
+            self._run["error"] = None
+            self._condition.notify_all()
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> str:
+        if isinstance(exc, StateIntegrityError):
+            return "Repository verification state is corrupted."
+        if isinstance(exc, CodexAdapterUnavailable):
+            return "The private Codex runtime is unavailable."
+        if isinstance(exc, CodexAdapterFailure):
+            return "The bounded Codex Run failed closed."
+        if isinstance(exc, LifecycleEventError):
+            return "The companion received an invalid progress event."
+        if isinstance(exc, ApprovalStateError):
+            return "The companion approval bridge failed closed."
+        return "The bounded Run could not complete safely."
+
+    def _fail_run(self, repository: Path, exc: Exception) -> None:
+        try:
+            after = self._safe_receipt(repository)
+        except StateIntegrityError:
+            after = None
+        with self._condition:
+            before = self._run.pop("receipt_before", None)
+            self._run["state"] = "needs_attention"
+            self._run["result"] = ""
+            self._run["file_actions"] = []
+            self._run["runtime"] = None
+            self._run["receipt_delta"] = (
+                self._receipt_delta(before, after)
+                if before is not None and after is not None
+                else None
+            )
+            self._run["approval"] = None
+            self._run["error"] = self._safe_error(exc)
+            self._approval_choice = "3"
+            self._condition.notify_all()
+
+    def new_run(self) -> dict[str, Any]:
+        with self._condition:
+            self._require_repository()
+            self._require_no_active_run()
+            self._run = self._empty_run()
+            self._approval_choice = None
+            return self._snapshot_locked()
+
+    @staticmethod
+    def _safe_receipt(repository: Path) -> dict[str, Any]:
+        return AccelerationEngine(repository).receipt()
+
+    @staticmethod
+    def _public_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+        hard = receipt["hard_metrics"]
+        estimated = receipt["estimated"]
+        return {
+            "status": receipt["status"],
+            "verified_saves": hard["verified_saves"],
+            "verified_reuses": hard["verified_reuses"],
+            "estimated_minutes": estimated["minutes"],
+            "estimated_money_jpy": estimated["money_jpy"],
+            "estimated_tokens": estimated["tokens"],
+            "claim_boundary": receipt["claim_boundary"],
+        }
+
+    @staticmethod
+    def _receipt_delta(
+        before: dict[str, Any],
+        after: dict[str, Any],
+    ) -> dict[str, Any]:
+        before_public = CompanionController._public_receipt(before)
+        after_public = CompanionController._public_receipt(after)
+        before_tokens = before_public["estimated_tokens"]
+        after_tokens = after_public["estimated_tokens"]
+        return {
+            "verified_saves": (
+                after_public["verified_saves"]
+                - before_public["verified_saves"]
+            ),
+            "verified_reuses": (
+                after_public["verified_reuses"]
+                - before_public["verified_reuses"]
+            ),
+            "estimated_minutes": (
+                after_public["estimated_minutes"]
+                - before_public["estimated_minutes"]
+            ),
+            "estimated_money_jpy": (
+                after_public["estimated_money_jpy"]
+                - before_public["estimated_money_jpy"]
+            ),
+            "estimated_tokens": (
+                None
+                if before_tokens is None or after_tokens is None
+                else after_tokens - before_tokens
+            ),
+        }
+
+    def _default_view(
+        self,
+        records: tuple[ActiveDefaultRecord, ...],
+    ) -> list[dict[str, str]]:
+        active_keys = {record.decision_key for record in records}
+        self._default_handles = {
+            handle: key
+            for handle, key in self._default_handles.items()
+            if key in active_keys
+        }
+        key_to_handle = {
+            key: handle for handle, key in self._default_handles.items()
+        }
+        result: list[dict[str, str]] = []
+        for record in records:
+            handle = key_to_handle.get(record.decision_key)
+            if handle is None:
+                handle = secrets.token_urlsafe(18)
+                self._default_handles[handle] = record.decision_key
+            result.append(
+                {
+                    "handle": handle,
+                    "action": (
+                        "Create"
+                        if record.decision_type == "CREATE_FILE"
+                        else "Modify"
+                    ),
+                    "path": record.normalized_scope,
+                    "created_at": record.created_at,
+                }
+            )
+        return result
+
+    def revoke_default(self, handle: str) -> dict[str, Any]:
+        if not isinstance(handle, str) or not handle:
+            raise CompanionError("Saved access handle is invalid.")
+        with self._condition:
+            repository = self._require_repository()
+            self._require_no_active_run()
+            decision_key = self._default_handles.get(handle)
+            if decision_key is None:
+                raise CompanionError("Saved access is no longer active.")
+            engine = AccelerationEngine(repository)
+            engine.revoke(
+                run_id=engine.new_run_id(),
+                decision_key=decision_key,
+            )
+            self._default_handles.pop(handle, None)
+            return self._snapshot_locked()
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._condition:
+            return self._snapshot_locked()
+
+    def _snapshot_locked(self) -> dict[str, Any]:
+        if self._repository is None:
+            repository_view = None
+            receipt = None
+            defaults: list[dict[str, str]] = []
+        else:
+            store = AccelerationStore(self._repository)
+            receipt = self._public_receipt(
+                AccelerationEngine(
+                    self._repository,
+                    store=store,
+                ).receipt()
+            )
+            defaults = self._default_view(store.active_defaults())
+            repository_view = {
+                "name": self._repository.name,
+                "path": str(self._repository),
+            }
+        return {
+            "repository": repository_view,
+            "run": {
+                key: value
+                for key, value in self._run.items()
+                if key != "receipt_before"
+            },
+            "receipt": receipt,
+            "defaults": defaults,
+            "supported": (
+                "Read-only work or one exact typed single-file create or modify."
+            ),
+        }

--- a/decision_os/companion/server.py
+++ b/decision_os/companion/server.py
@@ -1,0 +1,367 @@
+"""Authenticated localhost-only HTTP presentation for Decision OS Companion."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from http.cookies import SimpleCookie
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import hmac
+import json
+from pathlib import Path
+import secrets
+import threading
+from typing import Any
+from urllib.parse import urlsplit
+
+from .controller import (
+    ApprovalStateError,
+    CompanionController,
+    CompanionError,
+    CompanionStateError,
+    RepositorySelectionError,
+    RunConflictError,
+)
+from decision_os.acceleration.store import StateIntegrityError
+
+
+_MAX_REQUEST_BYTES = 64 * 1024
+_STATIC_FILES = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "text/javascript; charset=utf-8"),
+    "/app.css": ("app.css", "text/css; charset=utf-8"),
+}
+_CSP = (
+    "default-src 'none'; "
+    "script-src 'self'; "
+    "style-src 'self'; "
+    "connect-src 'self'; "
+    "img-src 'self'; "
+    "font-src 'none'; "
+    "object-src 'none'; "
+    "base-uri 'none'; "
+    "form-action 'none'; "
+    "frame-ancestors 'none'"
+)
+
+
+class CompanionHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        controller: CompanionController,
+        static_root: Path,
+    ) -> None:
+        self.controller = controller
+        self.static_root = static_root.resolve(strict=True)
+        self.bootstrap_token = secrets.token_urlsafe(32)
+        self.session_token = secrets.token_urlsafe(32)
+        self.csrf_token = secrets.token_urlsafe(32)
+        self.bootstrap_available = True
+        super().__init__(("127.0.0.1", 0), CompanionRequestHandler)
+
+    @property
+    def origin(self) -> str:
+        host, port = self.server_address
+        return f"http://{host}:{port}"
+
+
+class CompanionRequestHandler(BaseHTTPRequestHandler):
+    server: CompanionHTTPServer
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def _security_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store, max-age=0")
+        self.send_header("Content-Security-Policy", _CSP)
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+
+    def _send_bytes(
+        self,
+        status: HTTPStatus,
+        payload: bytes,
+        content_type: str,
+        *,
+        cookie: str | None = None,
+        location: str | None = None,
+    ) -> None:
+        self.send_response(status)
+        self._security_headers()
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        if cookie is not None:
+            self.send_header("Set-Cookie", cookie)
+        if location is not None:
+            self.send_header("Location", location)
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(payload)
+
+    def _json(self, status: HTTPStatus, value: Any) -> None:
+        serialized = json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        serialized = (
+            serialized.replace("&", "\\u0026")
+            .replace("<", "\\u003c")
+            .replace(">", "\\u003e")
+        )
+        payload = serialized.encode("utf-8")
+        self._send_bytes(
+            status,
+            payload,
+            "application/json; charset=utf-8",
+        )
+
+    def _error(self, status: HTTPStatus, message: str) -> None:
+        self._json(status, {"error": message})
+
+    def _host_valid(self) -> bool:
+        expected = f"127.0.0.1:{self.server.server_address[1]}"
+        observed = self.headers.get("Host", "")
+        return hmac.compare_digest(observed, expected)
+
+    def _origin_valid(self, *, required: bool) -> bool:
+        observed = self.headers.get("Origin")
+        if observed is None:
+            return not required
+        return hmac.compare_digest(observed, self.server.origin)
+
+    def _session_valid(self) -> bool:
+        raw = self.headers.get("Cookie")
+        if not raw:
+            return False
+        cookie = SimpleCookie()
+        try:
+            cookie.load(raw)
+        except Exception:
+            return False
+        value = cookie.get("decision_os_session")
+        return bool(
+            value
+            and hmac.compare_digest(
+                value.value,
+                self.server.session_token,
+            )
+        )
+
+    def _csrf_valid(self) -> bool:
+        observed = self.headers.get("X-Decision-OS-CSRF", "")
+        return bool(
+            observed
+            and hmac.compare_digest(observed, self.server.csrf_token)
+        )
+
+    def _request_allowed(self, *, state_change: bool = False) -> bool:
+        if not self._host_valid():
+            self._error(HTTPStatus.FORBIDDEN, "Request host was rejected.")
+            return False
+        if not self._origin_valid(required=state_change):
+            self._error(HTTPStatus.FORBIDDEN, "Request origin was rejected.")
+            return False
+        if not self._session_valid():
+            self._error(HTTPStatus.UNAUTHORIZED, "Private session required.")
+            return False
+        if state_change and not self._csrf_valid():
+            self._error(HTTPStatus.FORBIDDEN, "CSRF validation failed.")
+            return False
+        return True
+
+    def _bootstrap(self, path: str) -> bool:
+        prefix = "/bootstrap/"
+        if not path.startswith(prefix):
+            return False
+        if not self._host_valid() or not self._origin_valid(required=False):
+            self._error(HTTPStatus.FORBIDDEN, "Bootstrap request was rejected.")
+            return True
+        candidate = path[len(prefix) :]
+        valid = (
+            self.server.bootstrap_available
+            and candidate
+            and hmac.compare_digest(candidate, self.server.bootstrap_token)
+        )
+        if not valid:
+            self._error(HTTPStatus.UNAUTHORIZED, "Bootstrap token was rejected.")
+            return True
+        self.server.bootstrap_available = False
+        cookie = (
+            "decision_os_session="
+            f"{self.server.session_token}; HttpOnly; SameSite=Strict; Path=/"
+        )
+        self._send_bytes(
+            HTTPStatus.SEE_OTHER,
+            b"",
+            "text/plain; charset=utf-8",
+            cookie=cookie,
+            location="/",
+        )
+        return True
+
+    def do_HEAD(self) -> None:
+        self.do_GET()
+
+    def do_GET(self) -> None:
+        path = urlsplit(self.path).path
+        if self._bootstrap(path):
+            return
+        if not self._request_allowed():
+            return
+        if path == "/api/state":
+            try:
+                snapshot = self.server.controller.snapshot()
+            except (
+                CompanionError,
+                CompanionStateError,
+                StateIntegrityError,
+            ):
+                self._error(
+                    HTTPStatus.CONFLICT,
+                    "Local companion state could not be read safely.",
+                )
+                return
+            snapshot["csrf"] = self.server.csrf_token
+            self._json(HTTPStatus.OK, snapshot)
+            return
+        static = _STATIC_FILES.get(path)
+        if static is None:
+            self._error(HTTPStatus.NOT_FOUND, "Resource not found.")
+            return
+        filename, content_type = static
+        target = self.server.static_root / filename
+        try:
+            payload = target.read_bytes()
+        except OSError:
+            self._error(HTTPStatus.INTERNAL_SERVER_ERROR, "UI resource unavailable.")
+            return
+        self._send_bytes(HTTPStatus.OK, payload, content_type)
+
+    def _read_json(self) -> dict[str, Any] | None:
+        if self.headers.get_content_type() != "application/json":
+            self._error(
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                "JSON request required.",
+            )
+            return None
+        raw_length = self.headers.get("Content-Length")
+        try:
+            length = int(raw_length or "")
+        except ValueError:
+            self._error(HTTPStatus.BAD_REQUEST, "Content length is invalid.")
+            return None
+        if length < 0 or length > _MAX_REQUEST_BYTES:
+            self._error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Request is too large.")
+            return None
+        try:
+            value = json.loads(self.rfile.read(length))
+        except (UnicodeError, json.JSONDecodeError):
+            self._error(HTTPStatus.BAD_REQUEST, "Request JSON is invalid.")
+            return None
+        if not isinstance(value, dict):
+            self._error(HTTPStatus.BAD_REQUEST, "Request object required.")
+            return None
+        return value
+
+    def do_POST(self) -> None:
+        path = urlsplit(self.path).path
+        if not self._request_allowed(state_change=True):
+            return
+        value = self._read_json()
+        if value is None:
+            return
+        try:
+            if path == "/api/repository/pick":
+                if value:
+                    raise CompanionError("Repository picker takes no input.")
+                snapshot = self.server.controller.pick_repository()
+            elif path == "/api/run":
+                if set(value) != {"task"}:
+                    raise CompanionError("Run request fields are invalid.")
+                snapshot = self.server.controller.start_run(value["task"])
+            elif path == "/api/approval":
+                if set(value) != {"choice"}:
+                    raise CompanionError("Approval request fields are invalid.")
+                snapshot = self.server.controller.submit_approval(value["choice"])
+            elif path == "/api/new-run":
+                if value:
+                    raise CompanionError("New Run takes no input.")
+                snapshot = self.server.controller.new_run()
+            elif path == "/api/default/revoke":
+                if set(value) != {"handle"}:
+                    raise CompanionError("Revoke request fields are invalid.")
+                snapshot = self.server.controller.revoke_default(value["handle"])
+            else:
+                self._error(HTTPStatus.NOT_FOUND, "Endpoint not found.")
+                return
+        except (RepositorySelectionError, CompanionStateError) as exc:
+            self._error(HTTPStatus.BAD_REQUEST, str(exc))
+            return
+        except (RunConflictError, ApprovalStateError) as exc:
+            self._error(HTTPStatus.CONFLICT, str(exc))
+            return
+        except CompanionError as exc:
+            self._error(HTTPStatus.BAD_REQUEST, str(exc))
+            return
+        except StateIntegrityError:
+            self._error(
+                HTTPStatus.CONFLICT,
+                "Repository verification state is corrupted.",
+            )
+            return
+        snapshot["csrf"] = self.server.csrf_token
+        self._json(HTTPStatus.OK, snapshot)
+
+
+class CompanionServer:
+    """Lifecycle wrapper around the authenticated loopback HTTP server."""
+
+    def __init__(
+        self,
+        controller: CompanionController,
+        *,
+        static_root: Path,
+    ) -> None:
+        self._server = CompanionHTTPServer(controller, static_root)
+        self._thread: threading.Thread | None = None
+
+    @property
+    def origin(self) -> str:
+        return self._server.origin
+
+    @property
+    def bootstrap_url(self) -> str:
+        return (
+            f"{self.origin}/bootstrap/"
+            f"{self._server.bootstrap_token}"
+        )
+
+    @property
+    def port(self) -> int:
+        return int(self._server.server_address[1])
+
+    def start_background(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("Companion server is already running.")
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="decision-os-companion-http",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def serve_forever(self) -> None:
+        self._server.serve_forever()
+
+    def close(self) -> None:
+        if self._thread is not None:
+            self._server.shutdown()
+            self._thread.join(timeout=5)
+            self._thread = None
+        self._server.server_close()

--- a/decision_os/companion/static/app.css
+++ b/decision_os/companion/static/app.css
@@ -1,0 +1,335 @@
+:root {
+  color-scheme: light;
+  --ink: #1b1c1f;
+  --muted: #666b73;
+  --line: #d9dce2;
+  --paper: #f4f2ed;
+  --card: #fff;
+  --accent: #2557d6;
+  --accent-dark: #1942aa;
+  --danger: #b3261e;
+  --soft-blue: #eaf0ff;
+  --shadow: 0 18px 55px rgba(30, 34, 45, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 12% 5%, #fff 0, transparent 32rem),
+    var(--paper);
+  color: var(--ink);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+button {
+  border-radius: 10px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-weight: 650;
+  padding: 0.72rem 1rem;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.shell {
+  width: min(880px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3.5rem 0 5rem;
+}
+
+.hero {
+  padding: 0.5rem 0 1.8rem;
+}
+
+.eyebrow {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 780;
+  letter-spacing: 0.15em;
+  margin: 0 0 0.65rem;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(2.2rem, 7vw, 4.6rem);
+  letter-spacing: -0.055em;
+  line-height: 0.96;
+  margin-bottom: 1rem;
+}
+
+h2 {
+  font-size: 1.3rem;
+  margin-bottom: 0;
+}
+
+h3 {
+  font-size: 0.86rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.subtitle,
+.boundary,
+.path-value,
+.claim-boundary {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.runtime-lock {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.runtime-lock span,
+.status {
+  background: var(--soft-blue);
+  border: 1px solid #cbd8ff;
+  border-radius: 999px;
+  color: var(--accent-dark);
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.35rem 0.65rem;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid rgba(35, 38, 45, 0.09);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  margin-top: 1rem;
+  padding: 1.35rem;
+}
+
+.section-heading {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.step {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.18rem;
+}
+
+.primary-value {
+  font-size: 1.12rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.path-value {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+textarea {
+  background: #fbfbfc;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  color: var(--ink);
+  display: block;
+  line-height: 1.5;
+  padding: 0.9rem;
+  resize: vertical;
+  width: 100%;
+}
+
+textarea:focus,
+button:focus-visible {
+  outline: 3px solid rgba(37, 87, 214, 0.25);
+  outline-offset: 2px;
+}
+
+.boundary {
+  font-size: 0.82rem;
+  margin: 0.7rem 0 1rem;
+}
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--accent-dark);
+}
+
+.secondary {
+  background: #fff;
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+.danger {
+  background: #fff;
+  border-color: #e5b7b3;
+  color: var(--danger);
+}
+
+.progress-list {
+  color: var(--muted);
+  line-height: 1.7;
+  margin: 0;
+  padding-left: 1.4rem;
+}
+
+.progress-list li:last-child {
+  color: var(--ink);
+  font-weight: 650;
+}
+
+.error {
+  background: #fff0ef;
+  border: 1px solid #efc2be;
+  border-radius: 10px;
+  color: #8f1d17;
+  margin: 1rem 0 0;
+  padding: 0.8rem;
+}
+
+.result-text,
+.diff {
+  background: #16181d;
+  border-radius: 12px;
+  color: #f4f5f7;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  max-height: 28rem;
+  overflow: auto;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.file-action,
+.default-row {
+  align-items: center;
+  border-top: 1px solid var(--line);
+  display: flex;
+  gap: 0.8rem;
+  justify-content: space-between;
+  padding: 0.8rem 0;
+}
+
+.file-action code,
+.default-row code {
+  overflow-wrap: anywhere;
+}
+
+.runtime-grid,
+.metric-grid,
+.approval-details {
+  display: grid;
+  gap: 0.45rem 1rem;
+  grid-template-columns: max-content 1fr;
+}
+
+dt {
+  color: var(--muted);
+}
+
+dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.receipt-columns {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.claim-boundary {
+  border-top: 1px solid var(--line);
+  font-size: 0.8rem;
+  margin: 1.2rem 0 0;
+  padding-top: 1rem;
+}
+
+.overlay {
+  align-items: center;
+  background: rgba(15, 17, 22, 0.72);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: fixed;
+  z-index: 20;
+}
+
+.approval-card {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.3);
+  max-height: calc(100vh - 2rem);
+  max-width: 760px;
+  overflow: auto;
+  padding: 1.4rem;
+  width: 100%;
+}
+
+.approval-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+@media (max-width: 680px) {
+  .shell {
+    padding-top: 2rem;
+  }
+
+  .receipt-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading,
+  .file-action,
+  .default-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -1,10 +1,19 @@
 "use strict";
 
+const DISCONNECTED_MESSAGE =
+  "This companion session has ended. Close this tab and relaunch Decision OS Companion.app.";
+
 let csrfToken = "";
 let latestState = null;
 let requestActive = false;
+let connected = false;
+let connectionGeneration = 0;
 
 const byId = (id) => document.getElementById(id);
+
+class CompanionUnavailableError extends Error {}
+
+class RequestRejectedError extends Error {}
 
 function setText(id, value) {
   byId(id).textContent = value == null ? "" : String(value);
@@ -123,6 +132,7 @@ function renderResult(run) {
     run.state,
   );
   setHidden("result-card", !terminal);
+  byId("new-run").disabled = !terminal;
   setText("result-state", statusLabel(run.state));
   setText(
     "result",
@@ -136,7 +146,17 @@ function renderResult(run) {
 }
 
 function renderApproval(approval) {
+  for (const button of document.querySelectorAll("[data-choice]")) {
+    button.disabled = !approval;
+  }
   setHidden("approval-overlay", !approval);
+  setText("approval-repository", "");
+  setText("approval-action", "");
+  setText("approval-path", "");
+  setText("approval-diff", "");
+  setHidden("approval-reason-label", true);
+  setHidden("approval-reason", true);
+  setText("approval-reason", "");
   if (!approval) {
     return;
   }
@@ -169,6 +189,7 @@ function renderDefaults(defaults) {
     revoke.type = "button";
     revoke.className = "danger";
     revoke.textContent = "Revoke";
+    revoke.disabled = !connected;
     revoke.addEventListener("click", async () => {
       const confirmed = window.confirm(
         "Revoke this exact saved repository access? Historical proof remains.",
@@ -183,6 +204,9 @@ function renderDefaults(defaults) {
 }
 
 function render(state) {
+  if (!connected) {
+    return;
+  }
   latestState = state;
   csrfToken = state.csrf || csrfToken;
   const repository = state.repository;
@@ -217,15 +241,81 @@ function render(state) {
   }
 }
 
+function disableStateChangingControls() {
+  byId("choose-repository").disabled = true;
+  byId("run").disabled = true;
+  byId("new-run").disabled = true;
+  byId("task").disabled = true;
+  for (const button of document.querySelectorAll("[data-choice]")) {
+    button.disabled = true;
+  }
+  for (const button of byId("defaults").querySelectorAll("button")) {
+    button.disabled = true;
+  }
+}
+
+function enterDisconnected() {
+  connectionGeneration += 1;
+  connected = false;
+  latestState = null;
+  csrfToken = "";
+  disableStateChangingControls();
+
+  setText("repository-name", "Companion disconnected");
+  setText("repository-path", DISCONNECTED_MESSAGE);
+
+  const emptyRun = {
+    state: "idle",
+    progress: [],
+    result: "",
+    file_actions: [],
+    runtime: null,
+    receipt_delta: null,
+    approval: null,
+    error: null,
+  };
+  renderProgress(emptyRun);
+  renderResult(emptyRun);
+  setText("run-state", "");
+  setText("result-state", "");
+  setText("result", "");
+  renderApproval(null);
+
+  byId("defaults").replaceChildren();
+  setText("receipt-status", "Session ended");
+  byId("run-receipt").replaceChildren();
+  byId("repository-receipt").replaceChildren();
+  setText("claim-boundary", "");
+
+  setText("global-error", DISCONNECTED_MESSAGE);
+  setHidden("global-error", false);
+}
+
+function renderAuthenticatedState(state) {
+  connected = true;
+  render(state);
+  setText("global-error", "");
+  setHidden("global-error", true);
+}
+
 async function readResponse(response) {
   let body;
   try {
     body = await response.json();
   } catch (_error) {
-    throw new Error("The local companion returned an invalid response.");
+    throw new CompanionUnavailableError();
   }
   if (!response.ok) {
-    throw new Error(body.error || "The local companion rejected the request.");
+    if (
+      response.status === 401 ||
+      response.status === 403 ||
+      response.status >= 500
+    ) {
+      throw new CompanionUnavailableError();
+    }
+    throw new RequestRejectedError(
+      body.error || "The local companion rejected the request.",
+    );
   }
   return body;
 }
@@ -239,9 +329,10 @@ async function getState() {
 }
 
 async function postJSON(path, value) {
-  if (requestActive) {
+  if (!connected || requestActive) {
     return null;
   }
+  connectionGeneration += 1;
   requestActive = true;
   setHidden("global-error", true);
   try {
@@ -259,11 +350,12 @@ async function postJSON(path, value) {
     render(state);
     return state;
   } catch (error) {
-    setText(
-      "global-error",
-      error instanceof Error ? error.message : "The local request failed.",
-    );
-    setHidden("global-error", false);
+    if (error instanceof RequestRejectedError) {
+      setText("global-error", error.message);
+      setHidden("global-error", false);
+    } else {
+      enterDisconnected();
+    }
     return null;
   } finally {
     requestActive = false;
@@ -271,7 +363,7 @@ async function postJSON(path, value) {
 }
 
 byId("task").addEventListener("input", () => {
-  if (latestState) {
+  if (connected && latestState) {
     render(latestState);
   }
 });
@@ -301,18 +393,20 @@ for (const button of document.querySelectorAll("[data-choice]")) {
 
 async function refresh() {
   if (!requestActive) {
+    const generation = connectionGeneration;
     try {
-      render(await getState());
-      setHidden("global-error", true);
-    } catch (error) {
-      setText(
-        "global-error",
-        error instanceof Error ? error.message : "The local companion is unavailable.",
-      );
-      setHidden("global-error", false);
+      const state = await getState();
+      if (generation === connectionGeneration) {
+        renderAuthenticatedState(state);
+      }
+    } catch (_error) {
+      if (generation === connectionGeneration) {
+        enterDisconnected();
+      }
     }
   }
   window.setTimeout(refresh, 750);
 }
 
+disableStateChangingControls();
 refresh();

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -1,0 +1,318 @@
+"use strict";
+
+let csrfToken = "";
+let latestState = null;
+let requestActive = false;
+
+const byId = (id) => document.getElementById(id);
+
+function setText(id, value) {
+  byId(id).textContent = value == null ? "" : String(value);
+}
+
+function setHidden(id, hidden) {
+  byId(id).classList.toggle("hidden", hidden);
+}
+
+function statusLabel(state) {
+  return {
+    idle: "Idle",
+    running: "Running",
+    completed: "Completed",
+    denied: "Denied",
+    unsupported: "Unsupported",
+    needs_attention: "Needs attention",
+  }[state] || "Needs attention";
+}
+
+function formatNumber(value, digits = 0) {
+  if (value == null) {
+    return "UNKNOWN";
+  }
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  }).format(value);
+}
+
+function metricRows(target, receipt) {
+  target.replaceChildren();
+  const rows = receipt
+    ? [
+        ["Verified Saves", formatNumber(receipt.verified_saves)],
+        ["Verified Reuses", formatNumber(receipt.verified_reuses)],
+        ["Recovered", `${formatNumber(receipt.estimated_minutes, 1)} minutes`],
+        ["Human-time value", `¥${formatNumber(receipt.estimated_money_jpy)}`],
+        [
+          "Token estimate",
+          receipt.estimated_tokens == null
+            ? "UNKNOWN"
+            : formatNumber(receipt.estimated_tokens),
+        ],
+      ]
+    : [
+        ["Verified Saves", "0"],
+        ["Verified Reuses", "0"],
+        ["Recovered", "0.0 minutes"],
+        ["Human-time value", "¥0"],
+        ["Token estimate", "UNKNOWN"],
+      ];
+  for (const [label, value] of rows) {
+    const term = document.createElement("dt");
+    const detail = document.createElement("dd");
+    term.textContent = label;
+    detail.textContent = value;
+    target.append(term, detail);
+  }
+}
+
+function renderProgress(run) {
+  const list = byId("progress");
+  list.replaceChildren();
+  for (const message of run.progress || []) {
+    const item = document.createElement("li");
+    item.textContent = message;
+    list.append(item);
+  }
+  const visible = run.state !== "idle" || (run.progress || []).length > 0;
+  setHidden("progress-card", !visible);
+  setText("run-state", statusLabel(run.state));
+  setHidden("run-error", !run.error);
+  setText("run-error", run.error || "");
+}
+
+function renderActions(actions) {
+  const container = byId("file-actions");
+  container.replaceChildren();
+  for (const action of actions || []) {
+    const row = document.createElement("div");
+    row.className = "file-action";
+    const path = document.createElement("code");
+    const status = document.createElement("span");
+    path.textContent = `${action.action}: ${action.path}`;
+    status.textContent = `${action.status} · ${action.access}`;
+    row.append(path, status);
+    container.append(row);
+  }
+}
+
+function renderRuntime(runtime) {
+  const target = byId("runtime");
+  target.replaceChildren();
+  if (!runtime) {
+    return;
+  }
+  const rows = [
+    ["Authentication", runtime.authentication],
+    ["Model", runtime.model],
+    ["Reasoning effort", runtime.reasoning_effort],
+    ["Service tier", runtime.service_tier],
+    ["Codex version", runtime.codex_version],
+  ];
+  for (const [label, value] of rows) {
+    const term = document.createElement("dt");
+    const detail = document.createElement("dd");
+    term.textContent = label;
+    detail.textContent = value;
+    target.append(term, detail);
+  }
+}
+
+function renderResult(run) {
+  const terminal = ["completed", "denied", "unsupported", "needs_attention"].includes(
+    run.state,
+  );
+  setHidden("result-card", !terminal);
+  setText("result-state", statusLabel(run.state));
+  setText(
+    "result",
+    run.result ||
+      (run.state === "completed"
+        ? "The bounded Run completed without a final text response."
+        : run.error || "No final result was available."),
+  );
+  renderActions(run.file_actions);
+  renderRuntime(run.runtime);
+}
+
+function renderApproval(approval) {
+  setHidden("approval-overlay", !approval);
+  if (!approval) {
+    return;
+  }
+  setText("approval-repository", approval.repository);
+  setText("approval-action", approval.action);
+  setText("approval-path", approval.path);
+  setText("approval-diff", approval.diff);
+  const hasReason = Boolean(approval.reason);
+  setHidden("approval-reason-label", !hasReason);
+  setHidden("approval-reason", !hasReason);
+  setText("approval-reason", approval.reason || "");
+}
+
+function renderDefaults(defaults) {
+  const target = byId("defaults");
+  target.replaceChildren();
+  if (!defaults || defaults.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "path-value";
+    empty.textContent = "No saved repository access.";
+    target.append(empty);
+    return;
+  }
+  for (const item of defaults) {
+    const row = document.createElement("div");
+    row.className = "default-row";
+    const description = document.createElement("code");
+    description.textContent = `${item.action}: ${item.path}`;
+    const revoke = document.createElement("button");
+    revoke.type = "button";
+    revoke.className = "danger";
+    revoke.textContent = "Revoke";
+    revoke.addEventListener("click", async () => {
+      const confirmed = window.confirm(
+        "Revoke this exact saved repository access? Historical proof remains.",
+      );
+      if (confirmed) {
+        await postJSON("/api/default/revoke", { handle: item.handle });
+      }
+    });
+    row.append(description, revoke);
+    target.append(row);
+  }
+}
+
+function render(state) {
+  latestState = state;
+  csrfToken = state.csrf || csrfToken;
+  const repository = state.repository;
+  setText(
+    "repository-name",
+    repository ? repository.name : "No repository selected",
+  );
+  setText(
+    "repository-path",
+    repository ? repository.path : "Select one local Git repository.",
+  );
+
+  const running = state.run.state === "running";
+  byId("run").disabled =
+    running || !repository || byId("task").value.trim().length === 0;
+  byId("choose-repository").disabled = running;
+  byId("task").disabled = running;
+
+  renderProgress(state.run);
+  renderResult(state.run);
+  renderApproval(state.run.approval);
+  renderDefaults(state.defaults);
+
+  setText(
+    "receipt-status",
+    state.receipt ? state.receipt.status : "No repository",
+  );
+  metricRows(byId("run-receipt"), state.run.receipt_delta);
+  metricRows(byId("repository-receipt"), state.receipt);
+  if (state.receipt) {
+    setText("claim-boundary", state.receipt.claim_boundary);
+  }
+}
+
+async function readResponse(response) {
+  let body;
+  try {
+    body = await response.json();
+  } catch (_error) {
+    throw new Error("The local companion returned an invalid response.");
+  }
+  if (!response.ok) {
+    throw new Error(body.error || "The local companion rejected the request.");
+  }
+  return body;
+}
+
+async function getState() {
+  const response = await fetch("/api/state", {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+  return readResponse(response);
+}
+
+async function postJSON(path, value) {
+  if (requestActive) {
+    return null;
+  }
+  requestActive = true;
+  setHidden("global-error", true);
+  try {
+    const response = await fetch(path, {
+      method: "POST",
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Decision-OS-CSRF": csrfToken,
+      },
+      body: JSON.stringify(value),
+    });
+    const state = await readResponse(response);
+    render(state);
+    return state;
+  } catch (error) {
+    setText(
+      "global-error",
+      error instanceof Error ? error.message : "The local request failed.",
+    );
+    setHidden("global-error", false);
+    return null;
+  } finally {
+    requestActive = false;
+  }
+}
+
+byId("task").addEventListener("input", () => {
+  if (latestState) {
+    render(latestState);
+  }
+});
+
+byId("choose-repository").addEventListener("click", async () => {
+  await postJSON("/api/repository/pick", {});
+});
+
+byId("run").addEventListener("click", async () => {
+  await postJSON("/api/run", { task: byId("task").value });
+});
+
+byId("new-run").addEventListener("click", async () => {
+  const state = await postJSON("/api/new-run", {});
+  if (state) {
+    byId("task").value = "";
+    render(state);
+    byId("task").focus();
+  }
+});
+
+for (const button of document.querySelectorAll("[data-choice]")) {
+  button.addEventListener("click", async () => {
+    await postJSON("/api/approval", { choice: button.dataset.choice });
+  });
+}
+
+async function refresh() {
+  if (!requestActive) {
+    try {
+      render(await getState());
+      setHidden("global-error", true);
+    } catch (error) {
+      setText(
+        "global-error",
+        error instanceof Error ? error.message : "The local companion is unavailable.",
+      );
+      setHidden("global-error", false);
+    }
+  }
+  window.setTimeout(refresh, 750);
+}
+
+refresh();

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Decision OS Companion</title>
+  <link rel="stylesheet" href="/app.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="hero">
+      <p class="eyebrow">PRIVATE LOCAL RUNNER</p>
+      <h1>Decision OS Companion</h1>
+      <p class="subtitle">One repository. One bounded task. One fresh Run.</p>
+      <div class="runtime-lock" aria-label="Locked runtime">
+        <span>ChatGPT</span>
+        <span>gpt-5.6-sol</span>
+        <span>Ultra</span>
+        <span>Priority</span>
+      </div>
+    </header>
+
+    <section class="card" aria-labelledby="repository-heading">
+      <div class="section-heading">
+        <div>
+          <p class="step">1</p>
+          <h2 id="repository-heading">Repository</h2>
+        </div>
+        <button id="choose-repository" class="secondary" type="button">
+          Choose Repository…
+        </button>
+      </div>
+      <p id="repository-name" class="primary-value">No repository selected</p>
+      <p id="repository-path" class="path-value">
+        Select one local Git repository.
+      </p>
+    </section>
+
+    <section class="card" aria-labelledby="task-heading">
+      <div class="section-heading">
+        <div>
+          <p class="step">2</p>
+          <h2 id="task-heading">Bounded task</h2>
+        </div>
+      </div>
+      <label class="visually-hidden" for="task">Bounded task</label>
+      <textarea
+        id="task"
+        rows="7"
+        maxlength="20000"
+        placeholder="Example: Read docs/guide.md and improve one unclear paragraph. Modify that file only."
+      ></textarea>
+      <p class="boundary">
+        v0.1 supports read-only work or one exact typed single-file create or
+        modify. No shell, dependencies, deletes, renames, MCP, or subagents.
+      </p>
+      <button id="run" class="primary" type="button">Run</button>
+    </section>
+
+    <section id="progress-card" class="card hidden" aria-labelledby="progress-heading">
+      <div class="section-heading">
+        <div>
+          <p class="step">3</p>
+          <h2 id="progress-heading">Run progress</h2>
+        </div>
+        <span id="run-state" class="status">Idle</span>
+      </div>
+      <ol id="progress" class="progress-list"></ol>
+      <p id="run-error" class="error hidden" role="alert"></p>
+    </section>
+
+    <section id="result-card" class="card hidden" aria-labelledby="result-heading">
+      <div class="section-heading">
+        <div>
+          <p class="step">4</p>
+          <h2 id="result-heading">Result</h2>
+        </div>
+        <span id="result-state" class="status">Completed</span>
+      </div>
+      <pre id="result" class="result-text"></pre>
+      <div id="file-actions" class="file-actions"></div>
+      <dl id="runtime" class="runtime-grid"></dl>
+      <button id="new-run" class="primary" type="button">New Run</button>
+    </section>
+
+    <section class="card receipt-card" aria-labelledby="receipt-heading">
+      <div class="section-heading">
+        <div>
+          <p class="step">R</p>
+          <h2 id="receipt-heading">Receipt</h2>
+        </div>
+        <span id="receipt-status" class="status">No repository</span>
+      </div>
+      <div class="receipt-columns">
+        <div>
+          <h3>Current Run</h3>
+          <dl id="run-receipt" class="metric-grid"></dl>
+        </div>
+        <div>
+          <h3>Repository total</h3>
+          <dl id="repository-receipt" class="metric-grid"></dl>
+        </div>
+      </div>
+      <p id="claim-boundary" class="claim-boundary">
+        Verified Save is a locally recorded proof-of-use event, not
+        third-party certification.
+      </p>
+    </section>
+
+    <section class="card" aria-labelledby="defaults-heading">
+      <div class="section-heading">
+        <div>
+          <p class="step">A</p>
+          <h2 id="defaults-heading">Saved repository access</h2>
+        </div>
+      </div>
+      <p class="boundary">
+        Each entry is limited to this repository, one action, and one exact
+        path. It is never broad repository access.
+      </p>
+      <div id="defaults" class="defaults-list"></div>
+    </section>
+
+    <p id="global-error" class="error hidden" role="alert"></p>
+  </main>
+
+  <div id="approval-overlay" class="overlay hidden" role="dialog" aria-modal="true" aria-labelledby="approval-heading">
+    <section class="approval-card">
+      <p class="eyebrow">APPROVAL REQUIRED</p>
+      <h2 id="approval-heading">One exact file change</h2>
+      <dl class="approval-details">
+        <dt>Repository</dt>
+        <dd id="approval-repository"></dd>
+        <dt>Action</dt>
+        <dd id="approval-action"></dd>
+        <dt>Path</dt>
+        <dd id="approval-path"></dd>
+        <dt id="approval-reason-label">Reason</dt>
+        <dd id="approval-reason"></dd>
+      </dl>
+      <h3>Proposed diff</h3>
+      <pre id="approval-diff" class="diff"></pre>
+      <p class="boundary">
+        “Use for this repository” saves only this exact action and path.
+      </p>
+      <div class="approval-actions">
+        <button data-choice="allow_once" class="secondary" type="button">
+          Allow once
+        </button>
+        <button data-choice="repository" class="primary" type="button">
+          Use for this repository
+        </button>
+        <button data-choice="deny" class="danger" type="button">Deny</button>
+      </div>
+    </section>
+  </div>
+
+  <script src="/app.js" defer></script>
+</body>
+</html>

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,5 +1,97 @@
 # Current Signal
 
+## Canonical Current State — Decision OS Companion Acceptance v0.1
+
+```text
+Current Layer:
+V13 — Operational Use Entry
+
+Primary Objective:
+Shin-owned local Companion acceptance
+
+Companion Surface:
+local macOS .app wrapper / localhost browser UI / one-task Runner
+
+Starting Main:
+e6e2ba7a1be8612eb781c565c7c2bb9d012b129d
+
+Approved Pre-Closure Head:
+a04f1463fc1f4bf46196eeea1702c5b096fd36e2
+
+Active Branch:
+codex/decision-os-companion-v0-1
+
+V12 State:
+DELAY — Shin-owned fresh-process local Companion acceptance passed;
+external-user adoption remains unobserved and no external adoption claim is made
+
+V13 Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+V13 Next Loop Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+Fresh-Process Acceptance:
+PASS — app launched without Terminal / repository reopened / no repeated
+approval card / saved exact access reused / normal terminal / approved reused
+
+Terminal Proof:
+PASS — CHECKPOINT_PASSED / VERIFIED_SAVE
+
+Earlier Matched Run:
+NOT VERIFIED — CHECKPOINT_PENDING / ZERO RECEIPT
+
+Acceptance Sequence:
+corrected fresh-process verification after A1 and A2 /
+not an uninterrupted clean-room two-Run final-build claim
+
+Runtime Identity:
+ChatGPT / gpt-5.6-sol / ultra / priority
+
+Authoritative Receipt:
+VERIFIED / 1 Verified Save / 1 Verified Reuse /
+7.5 estimated recovered minutes / ¥625 estimated human-time value /
+tokens UNKNOWN
+
+Focused Companion:
+PASS / 16 OF 16 TESTS
+
+Focused Codex Adapter:
+PASS / 31 OF 31 TESTS
+
+Full Regression:
+PASS / 244 OF 244 TESTS
+
+Draft PR:
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/37
+
+Acceptance Record:
+validation/decision_os_companion_acceptance_run_001.md
+
+Claim Boundary:
+Shin-owned local acceptance / not external-user adoption /
+not native Codex Desktop integration / not third-party certification /
+recovered time and money remain estimates / token value remains UNKNOWN
+
+macOS Computer Use Prompt:
+SEPARATE / NONCAUSAL / NOT REQUIRED FOR THE VERIFIED RUN
+
+Temporary Acceptance File:
+DELETED / NEVER STAGED OR COMMITTED
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly approves review-state or merge work
+
+Decision Owner:
+Shin
+```
+
+Everything below this boundary is a historical reverse-chronological ledger.
+Historical entries preserve their As-of truth but grant no present authority.
+
 ## Canonical Current State — Verified Save Codex/Sol MVP v0.1
 
 ```text

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,5 +1,126 @@
 # Current Codex Handoff - V13 LoopKit
 
+## Canonical Current State — Decision OS Companion Acceptance v0.1
+
+```text
+Current Layer:
+V13 — Operational Use Entry
+
+Primary Objective:
+Shin-owned local Companion acceptance
+
+Companion Surface:
+local macOS .app wrapper / localhost browser UI / one-task Runner
+
+Starting Main:
+e6e2ba7a1be8612eb781c565c7c2bb9d012b129d
+
+Approved Pre-Closure Head:
+a04f1463fc1f4bf46196eeea1702c5b096fd36e2
+
+Active Branch:
+codex/decision-os-companion-v0-1
+
+V12 State:
+DELAY — Shin-owned fresh-process local Companion acceptance passed;
+external-user adoption remains unobserved and no external adoption claim is made
+
+V13 Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+V13 Next Loop Gate:
+HOLD — DRAFT PR REVIEW / NO MERGE AUTHORITY
+
+Fresh-Process Acceptance:
+PASS — app launched without Terminal / repository reopened / no repeated
+approval card / saved exact access reused / normal terminal / approved reused
+
+Terminal Proof:
+PASS — CHECKPOINT_PASSED / VERIFIED_SAVE
+
+Earlier Matched Run:
+NOT VERIFIED — CHECKPOINT_PENDING / ZERO RECEIPT
+
+Acceptance Sequence:
+corrected fresh-process verification after A1 and A2 /
+not an uninterrupted clean-room two-Run final-build claim
+
+Runtime Identity:
+ChatGPT / gpt-5.6-sol / ultra / priority
+
+Authoritative Receipt:
+VERIFIED / 1 Verified Save / 1 Verified Reuse /
+7.5 estimated recovered minutes / ¥625 estimated human-time value /
+tokens UNKNOWN
+
+Focused Companion:
+PASS / 16 OF 16 TESTS
+
+Focused Codex Adapter:
+PASS / 31 OF 31 TESTS
+
+Full Regression:
+PASS / 244 OF 244 TESTS
+
+Draft PR:
+OPEN / DRAFT / https://github.com/shin4141/decision-os-v13-loopkit/pull/37
+
+Acceptance Record:
+validation/decision_os_companion_acceptance_run_001.md
+
+Claim Boundary:
+Shin-owned local acceptance / not external-user adoption /
+not native Codex Desktop integration / not third-party certification /
+recovered time and money remain estimates / token value remains UNKNOWN
+
+macOS Computer Use Prompt:
+SEPARATE / NONCAUSAL / NOT REQUIRED FOR THE VERIFIED RUN
+
+Temporary Acceptance File:
+DELETED / NEVER STAGED OR COMMITTED
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly approves review-state or merge work
+
+Decision Owner:
+Shin
+```
+
+Restart evidence:
+
+- exact acceptance evidence:
+  [Decision OS Companion Acceptance Run 001](../validation/decision_os_companion_acceptance_run_001.md);
+- implementation and closure branch:
+  `codex/decision-os-companion-v0-1`;
+- Draft PR:
+  `https://github.com/shin4141/decision-os-v13-loopkit/pull/37`;
+- approved pre-closure head:
+  `a04f1463fc1f4bf46196eeea1702c5b096fd36e2`;
+- terminal proof:
+  `CHECKPOINT_PASSED` followed by `VERIFIED_SAVE`;
+- authoritative Receipt:
+  `1 Verified Save / 1 Verified Reuse / 7.5 estimated minutes / ¥625 /
+  UNKNOWN tokens`.
+
+This is Shin-owned local acceptance. It is not external-user adoption, native
+Codex Desktop integration, or third-party certification. Recovered time and
+money remain estimates, and token value remains `UNKNOWN`. The earlier macOS
+`Codex Computer Use` prompt was separate, noncausal, and not required for the
+successful fresh-process verified Run.
+
+Decision OS Companion remains a one-task Runner inside its local browser UI,
+not a true multi-turn chat client and not an interception layer for native
+Codex Desktop. No product or test correction, app rebuild, another acceptance
+Run, merge, ready-for-review transition, README change, release, signing,
+notarization, installer, or public claim is authorized without a new exact
+instruction from Shin.
+
+Everything below this boundary is a historical reverse-chronological ledger.
+Historical entries preserve their As-of truth but grant no present authority.
+
 ## Canonical Current State — Verified Save Codex/Sol MVP v0.1
 
 ```text

--- a/macos/DecisionOSCompanion.applescript
+++ b/macos/DecisionOSCompanion.applescript
@@ -1,0 +1,22 @@
+-- APPLET_PICKER_ENTRY_BEGIN
+on run arguments
+	if (count of arguments) > 0 and item 1 of arguments is "pick" then
+		try
+			set selectedFolder to choose folder with prompt "Choose one local Git repository"
+			return POSIX path of selectedFolder
+		on error number -128
+			return ""
+		end try
+	end if
+-- APPLET_PICKER_ENTRY_END
+
+	try
+		set pythonBinary to __PYTHON_BINARY__
+		set runtimeRoot to __RUNTIME_ROOT__
+		set pickerPath to runtimeRoot & "/macos/DecisionOSCompanion.applescript"
+		set launchCommand to "/usr/bin/env PYTHONPATH=" & quoted form of runtimeRoot & " DECISION_OS_COMPANION_PICKER_SCRIPT=" & quoted form of pickerPath & " " & quoted form of pythonBinary & " -m decision_os.companion"
+		do shell script launchCommand
+	on error errorMessage
+		display dialog "Decision OS Companion could not start." & return & errorMessage buttons {"OK"} default button "OK" with icon stop
+	end try
+end run

--- a/scripts/build_companion_app.sh
+++ b/scripts/build_companion_app.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPOSITORY_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+TARGET_DIRECTORY="${HOME}/Applications"
+TARGET_APP="${TARGET_DIRECTORY}/Decision OS Companion.app"
+SUPPORT_DIRECTORY="${HOME}/Library/Application Support/Decision OS Companion"
+TARGET_RUNTIME="${SUPPORT_DIRECTORY}/runtime"
+BUILD_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/decision-os-companion-build.XXXXXX")
+STAGED_APP="${BUILD_ROOT}/Decision OS Companion.app"
+STAGED_RUNTIME="${BUILD_ROOT}/runtime"
+RENDERED_SCRIPT="${BUILD_ROOT}/DecisionOSCompanion.applescript"
+
+cleanup() {
+    rm -rf "$BUILD_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+select_python() {
+    for candidate in \
+        /opt/homebrew/bin/python3 \
+        /usr/local/bin/python3 \
+        /Library/Frameworks/Python.framework/Versions/Current/bin/python3 \
+        /usr/bin/python3
+    do
+        if [ -x "$candidate" ] && "$candidate" -c \
+            'import sys; raise SystemExit(sys.version_info < (3, 10))'
+        then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+PYTHON_BINARY=$(select_python) || {
+    printf '%s\n' "Python 3.10 or newer is required to build the private app." >&2
+    exit 1
+}
+
+"$PYTHON_BINARY" -c \
+    'import functools, json, pathlib, re, sys; source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"); marker = r"-- APPLET_PICKER_ENTRY_BEGIN.*?-- APPLET_PICKER_ENTRY_END"; assert len(re.findall(marker, source, flags=re.S)) == 1; source = re.sub(marker, "on run", source, count=1, flags=re.S); values = {"__PYTHON_BINARY__": sys.argv[3], "__RUNTIME_ROOT__": sys.argv[4]}; assert all(source.count(key) == 1 for key in values); rendered = functools.reduce(lambda text, item: text.replace(item[0], json.dumps(item[1])), values.items(), source); pathlib.Path(sys.argv[2]).write_text(rendered, encoding="utf-8")' \
+    "$REPOSITORY_ROOT/macos/DecisionOSCompanion.applescript" \
+    "$RENDERED_SCRIPT" \
+    "$PYTHON_BINARY" \
+    "$TARGET_RUNTIME"
+/usr/bin/osacompile \
+    -s \
+    -o "$STAGED_APP" \
+    "$RENDERED_SCRIPT"
+"$PYTHON_BINARY" -c \
+    'import shutil, sys; shutil.copytree(sys.argv[1], sys.argv[2], ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))' \
+    "$REPOSITORY_ROOT/decision_os" \
+    "$STAGED_RUNTIME/decision_os"
+/bin/mkdir -p "$STAGED_RUNTIME/macos"
+/bin/cp \
+    "$REPOSITORY_ROOT/macos/DecisionOSCompanion.applescript" \
+    "$STAGED_RUNTIME/macos/DecisionOSCompanion.applescript"
+
+/bin/mkdir -p "$TARGET_DIRECTORY"
+/bin/mkdir -p "$SUPPORT_DIRECTORY"
+/bin/chmod 700 "$SUPPORT_DIRECTORY"
+if [ -e "$TARGET_RUNTIME" ]; then
+    BACKUP_RUNTIME="${TARGET_RUNTIME}.backup.$(/bin/date +%Y%m%d%H%M%S)"
+    /bin/mv "$TARGET_RUNTIME" "$BACKUP_RUNTIME"
+    printf 'Previous private runtime moved to: %s\n' "$BACKUP_RUNTIME"
+fi
+/usr/bin/ditto --norsrc "$STAGED_RUNTIME" "$TARGET_RUNTIME"
+if [ -e "$TARGET_APP" ]; then
+    BACKUP_APP="${TARGET_APP}.backup.$(/bin/date +%Y%m%d%H%M%S)"
+    /bin/mv "$TARGET_APP" "$BACKUP_APP"
+    printf 'Previous private app moved to: %s\n' "$BACKUP_APP"
+fi
+/usr/bin/ditto --norsrc "$STAGED_APP" "$TARGET_APP"
+
+printf 'Built private app: %s\n' "$TARGET_APP"
+printf 'Installed private runtime: %s\n' "$TARGET_RUNTIME"
+printf 'Python runtime: %s\n' "$PYTHON_BINARY"

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -17,6 +17,8 @@ from decision_os.acceleration.codex_adapter import (
     CODEX_SERVICE_TIER,
     CodexAdapter,
     CodexAdapterFailure,
+    CodexApproval,
+    CodexLifecycleEvent,
     _SubprocessTransport,
 )
 from decision_os.acceleration.engine import AccelerationEngine
@@ -235,6 +237,29 @@ def completed_item(
                 "id": item_id,
                 "status": status,
                 "type": "fileChange",
+            },
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def completed_agent_message(
+    *,
+    thread_id: str,
+    turn_id: str,
+    text: str,
+    phase: str = "final_answer",
+) -> dict[str, Any]:
+    return {
+        "method": "item/completed",
+        "params": {
+            "completedAtMs": 4,
+            "item": {
+                "id": "agent-message-1",
+                "phase": phase,
+                "text": text,
+                "type": "agentMessage",
             },
             "threadId": thread_id,
             "turnId": turn_id,
@@ -476,6 +501,84 @@ def adapter_for(
 
 
 class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    async def test_structured_approval_lifecycle_and_final_message_bridge(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = file_run_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+                item_id="item-1",
+            )
+            approval_message = next(
+                message
+                for message in messages
+                if message.get("method")
+                == "item/fileChange/requestApproval"
+            )
+            approval_message["params"]["reason"] = "Bounded reason."
+            messages.insert(
+                -1,
+                completed_agent_message(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    text="Sanitized final result.",
+                ),
+            )
+            factory = FakeTransportFactory([messages])
+            engine = AccelerationEngine(
+                repository,
+                adapter=ADAPTER_NAME,
+                adapter_version=CODEX_CLI_VERSION,
+            )
+            approvals: list[CodexApproval] = []
+            lifecycle: list[CodexLifecycleEvent] = []
+            adapter = CodexAdapter(
+                engine,
+                input_func=lambda: (_ for _ in ()).throw(
+                    AssertionError("CLI input must not be used")
+                ),
+                stdout=io.StringIO(),
+                transport_factory=factory,
+                approval_provider=lambda approval: (
+                    approvals.append(approval) or "1"
+                ),
+                lifecycle_sink=lifecycle.append,
+            )
+
+            result = await adapter.run("Modify target.txt once.")
+
+            self.assertEqual("Sanitized final result.", result.final_message)
+            self.assertEqual(1, len(approvals))
+            self.assertEqual(
+                CodexApproval(
+                    repository_name="repo",
+                    action="Modify",
+                    normalized_scope="target.txt",
+                    diff="@@ -1 +1 @@\n-one\n+two\n",
+                    reason="Bounded reason.",
+                ),
+                approvals[0],
+            )
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual("one-time", result.file_actions[0].access)
+            self.assertEqual("approved", result.file_actions[0].status)
+            self.assertEqual(
+                [
+                    "starting",
+                    "runtime",
+                    "account",
+                    "model",
+                    "run",
+                    "working",
+                    "approval",
+                    "finalizing",
+                ],
+                [event.kind for event in lifecycle],
+            )
+
     async def test_two_fresh_threads_create_default_then_verified_save(
         self,
     ) -> None:

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -19,6 +19,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexAdapterFailure,
     CodexApproval,
     CodexLifecycleEvent,
+    CodexRunResult,
     _SubprocessTransport,
 )
 from decision_os.acceleration.engine import AccelerationEngine
@@ -501,6 +502,33 @@ def adapter_for(
 
 
 class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    def test_run_result_rejects_unbounded_unsupported_reason(self) -> None:
+        common = {
+            "run_id": "run-1",
+            "normal_terminal": False,
+            "error_type": None,
+            "turn_status": "completed",
+            "runtime_identity": None,
+            "checkpoint_outcomes": (),
+        }
+        with self.assertRaisesRegex(ValueError, "bounded code"):
+            CodexRunResult(
+                **common,
+                status="UNSUPPORTED_MUTATION",
+                unsupported_reason="PRIVATE_PROMPT",
+            )
+        with self.assertRaisesRegex(ValueError, "must agree"):
+            CodexRunResult(
+                **common,
+                status="UNSUPPORTED_MUTATION",
+            )
+        with self.assertRaisesRegex(ValueError, "must agree"):
+            CodexRunResult(
+                **common,
+                status="ABNORMAL_TERMINAL",
+                unsupported_reason="unsupported_request_method:other",
+            )
+
     async def test_structured_approval_lifecycle_and_final_message_bridge(
         self,
     ) -> None:
@@ -565,6 +593,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(1, len(result.file_actions))
             self.assertEqual("one-time", result.file_actions[0].access)
             self.assertEqual("approved", result.file_actions[0].status)
+            self.assertIsNone(result.unsupported_reason)
             self.assertEqual(
                 [
                     "starting",
@@ -615,6 +644,8 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual("VERIFIED_SAVE", second.status)
             self.assertTrue(second.normal_terminal)
             self.assertNotEqual(first.run_id, second.run_id)
+            self.assertEqual("newly-saved", first.file_actions[0].access)
+            self.assertEqual("reused", second.file_actions[0].access)
             self.assertEqual((1, 1), engine.store.counters())
             self.assertEqual(1, output.getvalue().count("Selection:"))
             events = engine.store.read_events()
@@ -659,6 +690,40 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 for transport in factory.transports
             ]
             self.assertEqual(["thread-1", "thread-2"], turn_thread_ids)
+
+    async def test_later_verified_reuse_keeps_final_reused_label(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id=f"thread-{index}",
+                        turn_id=f"turn-{index}",
+                        item_id=f"item-{index}",
+                    )
+                    for index in range(1, 4)
+                ]
+            )
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "2",
+            )
+
+            first = await adapter.run("create default")
+            second = await adapter.run("verify save")
+            third = await adapter.run("verify reuse")
+
+            self.assertEqual("NORMAL_TERMINAL", first.status)
+            self.assertEqual("VERIFIED_SAVE", second.status)
+            self.assertEqual("VERIFIED_REUSE", third.status)
+            self.assertEqual("newly-saved", first.file_actions[0].access)
+            self.assertEqual("reused", second.file_actions[0].access)
+            self.assertEqual("reused", third.file_actions[0].access)
+            self.assertEqual((1, 2), engine.store.counters())
 
     async def test_control_stream_stays_open_through_terminal_checkpoint(
         self,
@@ -870,6 +935,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual("DENIED", result.status)
             self.assertFalse(result.normal_terminal)
             self.assertEqual((0, 0), engine.store.counters())
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual("denied", result.file_actions[0].access)
+            self.assertEqual("denied", result.file_actions[0].status)
             approvals = [
                 message["result"]["decision"]
                 for message in factory.transports[0].sent
@@ -880,6 +948,43 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 {"approval-item-1"},
                 adapter._resolved_approval_requests,
             )
+
+    async def test_incomplete_access_is_not_labeled_as_completed(
+        self,
+    ) -> None:
+        cases = (
+            ("1", False, "completed"),
+            ("2", True, "failed"),
+        )
+        for index, (choice, include_completion, turn_status) in enumerate(
+            cases,
+            start=1,
+        ):
+            with self.subTest(choice=choice, turn_status=turn_status):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id=f"thread-{index}",
+                                turn_id=f"turn-{index}",
+                                item_id=f"item-{index}",
+                                include_item_completion=include_completion,
+                                turn_status=turn_status,
+                            )
+                        ]
+                    )
+                    _, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: choice,
+                    )
+
+                    result = await adapter.run("incomplete access")
+
+                    self.assertFalse(result.normal_terminal)
+                    self.assertEqual((), result.file_actions)
 
     async def test_same_run_repeat_never_becomes_verified(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -972,6 +1077,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual("PENDING", second.status)
             self.assertFalse(second.normal_terminal)
             self.assertEqual("failed", second.turn_status)
+            self.assertEqual(1, len(second.file_actions))
+            self.assertEqual(
+                "matched-not-verified",
+                second.file_actions[0].access,
+            )
             self.assertEqual((0, 0), engine.store.counters())
             self.assertTrue(
                 any(
@@ -1012,6 +1122,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual("PENDING", second.status)
             self.assertFalse(second.normal_terminal)
+            self.assertEqual(1, len(second.file_actions))
+            self.assertEqual(
+                "matched-not-verified",
+                second.file_actions[0].access,
+            )
             self.assertEqual((0, 0), engine.store.counters())
 
     async def test_machine_identity_and_wire_settings_are_exact(self) -> None:
@@ -1141,6 +1256,10 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(
                 "CodexRuntimeIdentityError",
                 result.error_type,
+            )
+            self.assertEqual(
+                "approval_identity_mismatch",
+                result.unsupported_reason,
             )
             self.assertIsNone(result.runtime_identity)
             self.assertFalse(adapter._settings_verified)
@@ -1298,6 +1417,10 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
                     self.assertEqual("UNSUPPORTED_MUTATION", result.status)
                     self.assertFalse(result.normal_terminal)
+                    self.assertEqual(
+                        "unsupported_file_change_shape",
+                        result.unsupported_reason,
+                    )
                     self.assertEqual([], engine.store.read_events())
                     responses = [
                         message["result"]["decision"]
@@ -1365,6 +1488,10 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual("UNSUPPORTED_MUTATION", result.status)
             self.assertIsNone(result.error_type)
+            self.assertEqual(
+                "unsupported_request_method:commandExecution",
+                result.unsupported_reason,
+            )
             self.assertEqual([], engine.store.read_events())
             self.assertEqual(
                 {"command-approval"},
@@ -1378,6 +1505,202 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(
                 {"decision": "decline"},
                 response["result"],
+            )
+
+    async def test_all_unsupported_item_types_are_bounded_and_fail_closed(
+        self,
+    ) -> None:
+        item_types = (
+            "collabAgentToolCall",
+            "commandExecution",
+            "dynamicToolCall",
+            "hookPrompt",
+            "imageGeneration",
+            "mcpToolCall",
+            "subAgentActivity",
+        )
+        for index, item_type in enumerate(item_types, start=1):
+            with self.subTest(item_type=item_type):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    thread_id = f"thread-{index}"
+                    turn_id = f"turn-{index}"
+                    messages = handshake_messages(
+                        repository,
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                    )
+                    messages.extend(
+                        [
+                            {
+                                "method": "item/started",
+                                "params": {
+                                    "item": {
+                                        "id": "PRIVATE_ITEM_ID",
+                                        "private": "PRIVATE_PAYLOAD",
+                                        "type": item_type,
+                                    },
+                                    "threadId": thread_id,
+                                    "turnId": turn_id,
+                                },
+                            },
+                            completed_turn(
+                                thread_id=thread_id,
+                                turn_id=turn_id,
+                            ),
+                        ]
+                    )
+                    factory = FakeTransportFactory([messages])
+                    engine, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: self.fail("must not prompt"),
+                    )
+
+                    result = await adapter.run("PRIVATE_PROMPT")
+
+                    self.assertEqual(
+                        "UNSUPPORTED_MUTATION",
+                        result.status,
+                    )
+                    self.assertFalse(result.normal_terminal)
+                    self.assertEqual(
+                        f"unsupported_item_type:{item_type}",
+                        result.unsupported_reason,
+                    )
+                    self.assertNotIn(
+                        "PRIVATE",
+                        result.unsupported_reason,
+                    )
+                    self.assertNotIn("PRIVATE", result.final_message)
+                    self.assertEqual([], engine.store.read_events())
+
+    async def test_unknown_request_method_uses_generic_bounded_reason(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    {
+                        "id": "PRIVATE_REQUEST_ID",
+                        "method": "PRIVATE_METHOD",
+                        "params": {
+                            "credential": "PRIVATE_CREDENTIAL",
+                            "itemId": "PRIVATE_ITEM_ID",
+                            "prompt": "PRIVATE_PROMPT",
+                            "threadId": "thread-1",
+                            "turnId": "turn-1",
+                        },
+                    },
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="PRIVATE_REQUEST_ID",
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("PRIVATE_PROMPT")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertEqual(
+                "unsupported_request_method:other",
+                result.unsupported_reason,
+            )
+            self.assertNotIn("PRIVATE", result.unsupported_reason)
+            self.assertNotIn("PRIVATE", result.final_message)
+            self.assertEqual([], engine.store.read_events())
+
+    async def test_unsupported_reason_resets_for_each_fresh_run(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            first_messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            first_messages.extend(
+                [
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="command-1",
+                        request_id="command-approval",
+                        method=(
+                            "item/commandExecution/requestApproval"
+                        ),
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="command-approval",
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            second_messages = handshake_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+            )
+            second_messages.extend(
+                [
+                    {
+                        "method": "item/started",
+                        "params": {
+                            "item": {
+                                "id": "dynamic-1",
+                                "type": "dynamicToolCall",
+                            },
+                            "threadId": "thread-2",
+                            "turnId": "turn-2",
+                        },
+                    },
+                    completed_turn(
+                        thread_id="thread-2",
+                        turn_id="turn-2",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory(
+                [first_messages, second_messages]
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            first = await adapter.run("first unsupported")
+            second = await adapter.run("second unsupported")
+
+            self.assertEqual(
+                "unsupported_request_method:commandExecution",
+                first.unsupported_reason,
+            )
+            self.assertEqual(
+                "unsupported_item_type:dynamicToolCall",
+                second.unsupported_reason,
             )
 
     async def test_image_generation_cannot_promote_pending_match(
@@ -1397,14 +1720,40 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 turn_id="turn-2",
                 item_id="file-2",
             )
+            secret_values = (
+                "PROMPT_SECRET",
+                "FILE_CONTENT_SECRET",
+                "PRIVATE_ITEM_ID",
+                "PRIVATE_COMMAND_ID",
+                "PRIVATE_REQUEST_ID",
+                "PRIVATE_PATH",
+                "CREDENTIAL_SECRET",
+                "RAW_JSON_SECRET",
+            )
             image_item = {
-                "id": "image-1",
-                "revisedPrompt": "generated artifact",
-                "savedPath": "generated.png",
+                "credential": "CREDENTIAL_SECRET",
+                "fileContent": "FILE_CONTENT_SECRET",
+                "id": "PRIVATE_ITEM_ID",
+                "rawPayload": "RAW_JSON_SECRET",
+                "revisedPrompt": "PROMPT_SECRET",
+                "savedPath": "PRIVATE_PATH",
                 "status": "completed",
                 "type": "imageGeneration",
             }
+            command_request = approval_request(
+                thread_id="thread-2",
+                turn_id="turn-2",
+                item_id="PRIVATE_COMMAND_ID",
+                request_id="PRIVATE_REQUEST_ID",
+                method="item/commandExecution/requestApproval",
+            )
+            command_request["params"]["credential"] = "CREDENTIAL_SECRET"
             second_messages[-1:-1] = [
+                completed_agent_message(
+                    thread_id="thread-2",
+                    turn_id="turn-2",
+                    text="Original Codex answer.",
+                ),
                 {
                     "method": "item/started",
                     "params": {
@@ -1421,6 +1770,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         "turnId": "turn-2",
                     },
                 },
+                command_request,
+                resolved_request(
+                    thread_id="thread-2",
+                    request_id="PRIVATE_REQUEST_ID",
+                ),
             ]
             factory = FakeTransportFactory(
                 [first_messages, second_messages]
@@ -1432,12 +1786,30 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             )
 
             first = await adapter.run("create default")
-            result = await adapter.run("unsupported image")
+            result = await adapter.run("PROMPT_SECRET")
 
             self.assertEqual("NORMAL_TERMINAL", first.status)
             self.assertEqual("UNSUPPORTED_MUTATION", result.status)
             self.assertFalse(result.normal_terminal)
             self.assertEqual("PENDING", result.checkpoint_outcomes[-1].status)
+            self.assertEqual(
+                "unsupported_item_type:imageGeneration",
+                result.unsupported_reason,
+            )
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual(
+                "matched-not-verified",
+                result.file_actions[0].access,
+            )
+            self.assertEqual(
+                "Original Codex answer.\n\n"
+                "Decision OS verification: not verified "
+                "(unsupported_item_type:imageGeneration).",
+                result.final_message,
+            )
+            for secret in secret_values:
+                self.assertNotIn(secret, result.unsupported_reason)
+                self.assertNotIn(secret, result.final_message)
             self.assertEqual((0, 0), engine.store.counters())
 
     async def test_completed_file_without_approval_is_unsupported(self) -> None:
@@ -1480,6 +1852,10 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual("UNSUPPORTED_MUTATION", result.status)
             self.assertFalse(result.normal_terminal)
+            self.assertEqual(
+                "unapproved_file_completion",
+                result.unsupported_reason,
+            )
             self.assertEqual([], engine.store.read_events())
 
     async def test_post_approval_patch_change_cannot_promote(self) -> None:

--- a/tests/test_acceleration_store.py
+++ b/tests/test_acceleration_store.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 import unittest
 
+from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.acceleration.model import (
     DecisionType,
     ScopeError,
@@ -194,6 +195,41 @@ class AccelerationStoreTest(unittest.TestCase):
             self.assertEqual([], store.read_events())
             with self.assertRaises(StateIntegrityError):
                 store.update_settings(minutes_per_reuse=0)
+
+    def test_active_defaults_are_enumerated_and_revoked_without_key_changes(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            (repository / "target.txt").write_text("one\n", encoding="utf-8")
+            engine = AccelerationEngine(repository)
+            run_id = engine.new_run_id()
+
+            outcome = engine.evaluate(
+                run_id=run_id,
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="./target.txt",
+                source_interrupt_id="enumeration-test",
+                choice_provider=lambda _identity: "2",
+            )
+            records = engine.store.active_defaults()
+
+            self.assertEqual(1, len(records))
+            record = records[0]
+            self.assertEqual(outcome.identity.decision_key, record.decision_key)
+            self.assertEqual(outcome.identity.rule_hash, record.rule_hash)
+            self.assertEqual("MODIFY_FILE", record.decision_type)
+            self.assertEqual("target.txt", record.normalized_scope)
+            self.assertEqual(run_id, record.created_run_id)
+            self.assertTrue(record.created_at.endswith("Z"))
+
+            engine.revoke(
+                run_id=engine.new_run_id(),
+                decision_key=record.decision_key,
+            )
+
+            self.assertEqual((), engine.store.active_defaults())
 
 
 if __name__ == "__main__":

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+from collections import deque
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import time
+import unittest
+from typing import Any
+
+from decision_os.acceleration.codex_adapter import (
+    CODEX_CLI_VERSION,
+    CODEX_MODEL,
+    CODEX_REASONING_EFFORT,
+    CODEX_SERVICE_TIER,
+    CodexAdapterFailure,
+    CodexApproval,
+    CodexFileAction,
+    CodexLifecycleEvent,
+    CodexRunResult,
+    CodexRuntimeIdentity,
+)
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import DecisionType
+from decision_os.companion.controller import (
+    ApprovalStateError,
+    CompanionController,
+    CompanionStateError,
+    RepositorySelectionError,
+    RunConflictError,
+)
+
+
+def create_repository(parent: Path, name: str = "repo") -> Path:
+    repository = parent / name
+    repository.mkdir()
+    completed = subprocess.run(
+        ("git", "init", "-q", str(repository)),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(completed.stderr)
+    (repository / "target.txt").write_text("before\n", encoding="utf-8")
+    return repository
+
+
+def runtime_identity() -> CodexRuntimeIdentity:
+    return CodexRuntimeIdentity(
+        model=CODEX_MODEL,
+        reasoning_effort=CODEX_REASONING_EFFORT,
+        service_tier=CODEX_SERVICE_TIER,
+        codex_cli_version=CODEX_CLI_VERSION,
+        account_type="chatgpt",
+    )
+
+
+class ScriptedAdapter:
+    def __init__(
+        self,
+        engine: AccelerationEngine,
+        approval_provider: Any,
+        lifecycle_sink: Any,
+        mode: str,
+    ) -> None:
+        self.engine = engine
+        self.approval_provider = approval_provider
+        self.lifecycle_sink = lifecycle_sink
+        self.mode = mode
+
+    async def run(self, prompt: str) -> CodexRunResult:
+        del prompt
+        self.lifecycle_sink(
+            CodexLifecycleEvent("runtime", "Starting the private Codex runtime.")
+        )
+        if self.mode == "malformed":
+            self.lifecycle_sink({"kind": "raw", "message": "<script>"})
+        if self.mode == "failure":
+            raise CodexAdapterFailure("sensitive raw adapter failure")
+        if self.mode == "read_only":
+            return CodexRunResult(
+                run_id=self.engine.new_run_id(),
+                normal_terminal=True,
+                status="NORMAL_TERMINAL",
+                error_type=None,
+                turn_status="completed",
+                runtime_identity=runtime_identity(),
+                checkpoint_outcomes=(),
+                final_message="Read-only result.",
+            )
+
+        run_id = self.engine.new_run_id()
+        outcome = self.engine.evaluate(
+            run_id=run_id,
+            iteration=1,
+            decision_type=DecisionType.MODIFY_FILE,
+            requested_scope="target.txt",
+            source_interrupt_id="private-test-item",
+            choice_provider=lambda identity: self.approval_provider(
+                CodexApproval(
+                    repository_name=self.engine.store.repository.name,
+                    action="Modify",
+                    normalized_scope=identity.normalized_scope,
+                    diff=(
+                        "--- a/target.txt\n"
+                        "+++ b/target.txt\n"
+                        "@@\n-before\n+after\n"
+                    ),
+                    reason="Apply the bounded update.",
+                )
+            ),
+        )
+        if not outcome.allowed:
+            return CodexRunResult(
+                run_id=run_id,
+                normal_terminal=False,
+                status="DENIED",
+                error_type=None,
+                turn_status="completed",
+                runtime_identity=runtime_identity(),
+                checkpoint_outcomes=(),
+                final_message="The change was denied.",
+                file_actions=(
+                    CodexFileAction(
+                        "Modify",
+                        "target.txt",
+                        "denied",
+                        "denied",
+                    ),
+                ),
+            )
+        checkpoint = self.engine.finish_checkpoint(
+            outcome,
+            normal_terminal=True,
+            checkpoint_id=f"companion-test:{run_id}",
+        )
+        access = {
+            "ALLOW_ONCE": "one-time",
+            "HUMAN_DEFAULT_CREATED": "newly-saved",
+            "DEFAULT_MATCHED": "reused",
+        }.get(outcome.status, "newly-saved")
+        status = checkpoint.status if checkpoint.verified else "NORMAL_TERMINAL"
+        return CodexRunResult(
+            run_id=run_id,
+            normal_terminal=True,
+            status=status,
+            error_type=None,
+            turn_status="completed",
+            runtime_identity=runtime_identity(),
+            checkpoint_outcomes=(checkpoint,),
+            final_message="Mutation result.",
+            file_actions=(
+                CodexFileAction(
+                    "Modify",
+                    "target.txt",
+                    access,
+                    "approved",
+                ),
+            ),
+        )
+
+
+class ScriptedFactory:
+    def __init__(self, *modes: str) -> None:
+        self.modes = deque(modes)
+
+    def __call__(
+        self,
+        engine: AccelerationEngine,
+        approval_provider: Any,
+        lifecycle_sink: Any,
+    ) -> ScriptedAdapter:
+        return ScriptedAdapter(
+            engine,
+            approval_provider,
+            lifecycle_sink,
+            self.modes.popleft(),
+        )
+
+
+def wait_for(
+    controller: CompanionController,
+    predicate: Any,
+    timeout: float = 4,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snapshot = controller.snapshot()
+        if predicate(snapshot):
+            return snapshot
+        time.sleep(0.01)
+    raise AssertionError(f"Timed out waiting for companion state: {snapshot!r}")
+
+
+class CompanionControllerTest(unittest.TestCase):
+    def make_controller(
+        self,
+        directory: Path,
+        factory: ScriptedFactory,
+        *,
+        picker_result: str | None = None,
+    ) -> CompanionController:
+        return CompanionController(
+            state_path=directory / "application-state" / "state.json",
+            picker_script=directory / "fixed-picker.applescript",
+            picker_runner=lambda _script: picker_result,
+            adapter_factory=factory,
+        )
+
+    def test_picker_validates_git_root_and_rejects_non_git(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root,
+                ScriptedFactory(),
+                picker_result=str(repository),
+            )
+
+            snapshot = controller.pick_repository()
+
+            self.assertEqual(
+                str(repository.resolve()),
+                snapshot["repository"]["path"],
+            )
+            non_git = root / "plain"
+            non_git.mkdir()
+            controller = self.make_controller(
+                root / "other",
+                ScriptedFactory(),
+                picker_result=str(non_git),
+            )
+            with self.assertRaises(RepositorySelectionError):
+                controller.pick_repository()
+
+    def test_state_file_is_0600_and_contains_only_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(root, ScriptedFactory())
+
+            controller.select_repository(repository)
+
+            state_path = root / "application-state" / "state.json"
+            self.assertEqual(
+                {"repository": str(repository.resolve())},
+                json.loads(state_path.read_text(encoding="utf-8")),
+            )
+            self.assertEqual(
+                0o600,
+                stat.S_IMODE(state_path.stat().st_mode),
+            )
+            invalid = root / "invalid-state.json"
+            invalid.write_text(
+                json.dumps(
+                    {
+                        "repository": str(repository),
+                        "prompt": "must not persist",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(CompanionStateError):
+                CompanionController(
+                    state_path=invalid,
+                    picker_runner=lambda _script: None,
+                )
+
+    def test_read_only_result_has_zero_verified_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root,
+                ScriptedFactory("read_only"),
+            )
+            controller.select_repository(repository)
+
+            controller.start_run("Read the target without changing it.")
+            snapshot = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "completed",
+            )
+
+            self.assertEqual("Read-only result.", snapshot["run"]["result"])
+            self.assertEqual(
+                {
+                    "estimated_minutes": 0.0,
+                    "estimated_money_jpy": 0.0,
+                    "estimated_tokens": None,
+                    "verified_reuses": 0,
+                    "verified_saves": 0,
+                },
+                snapshot["run"]["receipt_delta"],
+            )
+            self.assertEqual(0, snapshot["receipt"]["verified_saves"])
+
+    def test_allow_once_deny_and_repository_default_choices(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+
+            allow = self.make_controller(root / "allow", ScriptedFactory("mutation"))
+            allow.select_repository(repository)
+            allow.start_run("Modify target once.")
+            wait_for(allow, lambda state: state["run"]["approval"] is not None)
+            allow.submit_approval("allow_once")
+            allowed = wait_for(
+                allow,
+                lambda state: state["run"]["state"] == "completed",
+            )
+            self.assertEqual("one-time", allowed["run"]["file_actions"][0]["access"])
+            self.assertEqual([], allowed["defaults"])
+
+            deny = self.make_controller(root / "deny", ScriptedFactory("mutation"))
+            deny.select_repository(repository)
+            deny.start_run("Attempt a denied modification.")
+            wait_for(deny, lambda state: state["run"]["approval"] is not None)
+            deny.submit_approval("deny")
+            denied = wait_for(
+                deny,
+                lambda state: state["run"]["state"] == "denied",
+            )
+            self.assertEqual("denied", denied["run"]["file_actions"][0]["access"])
+
+            saved = self.make_controller(root / "saved", ScriptedFactory("mutation"))
+            saved.select_repository(repository)
+            saved.start_run("Save exact access.")
+            approval = wait_for(
+                saved,
+                lambda state: state["run"]["approval"] is not None,
+            )["run"]["approval"]
+            self.assertEqual(
+                {
+                    "action": "Modify",
+                    "diff": (
+                        "--- a/target.txt\n"
+                        "+++ b/target.txt\n"
+                        "@@\n-before\n+after\n"
+                    ),
+                    "path": "target.txt",
+                    "reason": "Apply the bounded update.",
+                    "repository": "repo",
+                },
+                approval,
+            )
+            saved.submit_approval("repository")
+            persisted = wait_for(
+                saved,
+                lambda state: state["run"]["state"] == "completed",
+            )
+            self.assertEqual(
+                "newly-saved",
+                persisted["run"]["file_actions"][0]["access"],
+            )
+            self.assertEqual(1, len(persisted["defaults"]))
+
+    def test_default_reuse_receipt_delta_enumeration_and_revoke(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root,
+                ScriptedFactory("mutation", "mutation"),
+            )
+            controller.select_repository(repository)
+            controller.start_run("Create exact saved access.")
+            wait_for(controller, lambda state: state["run"]["approval"] is not None)
+            controller.submit_approval("repository")
+            first = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "completed",
+            )
+            self.assertEqual(0, first["receipt"]["verified_saves"])
+            self.assertEqual(1, len(first["defaults"]))
+
+            controller.new_run()
+            controller.start_run("Reuse exact saved access.")
+            second = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "completed",
+            )
+
+            self.assertEqual(1, second["run"]["receipt_delta"]["verified_saves"])
+            self.assertEqual(1, second["run"]["receipt_delta"]["verified_reuses"])
+            self.assertEqual(7.5, second["run"]["receipt_delta"]["estimated_minutes"])
+            self.assertEqual(625.0, second["run"]["receipt_delta"]["estimated_money_jpy"])
+            self.assertIsNone(second["run"]["receipt_delta"]["estimated_tokens"])
+            self.assertEqual(1, second["receipt"]["verified_saves"])
+            self.assertEqual(1, second["receipt"]["verified_reuses"])
+            handle = second["defaults"][0]["handle"]
+
+            revoked = controller.revoke_default(handle)
+
+            self.assertEqual([], revoked["defaults"])
+            self.assertEqual(1, revoked["receipt"]["verified_saves"])
+            with self.assertRaises(ApprovalStateError):
+                controller.submit_approval("allow_once")
+
+    def test_one_active_run_and_browser_reconnect_to_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root,
+                ScriptedFactory("mutation"),
+            )
+            controller.select_repository(repository)
+            controller.start_run("Wait for approval.")
+            first = wait_for(
+                controller,
+                lambda state: state["run"]["approval"] is not None,
+            )
+
+            second = controller.snapshot()
+
+            self.assertEqual(first["run"]["approval"], second["run"]["approval"])
+            with self.assertRaises(RunConflictError):
+                controller.start_run("Overlapping Run.")
+            with self.assertRaises(RunConflictError):
+                controller.select_repository(repository)
+            controller.submit_approval("deny")
+            wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "denied",
+            )
+
+    def test_malformed_lifecycle_and_app_server_failure_are_sanitized(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root / "malformed",
+                ScriptedFactory("malformed"),
+            )
+            controller.select_repository(repository)
+            controller.start_run("Malformed lifecycle.")
+            malformed = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "needs_attention",
+            )
+            self.assertEqual(
+                "The companion received an invalid progress event.",
+                malformed["run"]["error"],
+            )
+            self.assertNotIn("<script>", json.dumps(malformed))
+
+            controller = self.make_controller(
+                root / "failure",
+                ScriptedFactory("failure"),
+            )
+            controller.select_repository(repository)
+            controller.start_run("Adapter failure.")
+            failed = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "needs_attention",
+            )
+            self.assertEqual(
+                "The bounded Codex Run failed closed.",
+                failed["run"]["error"],
+            )
+            self.assertNotIn("sensitive", json.dumps(failed))
+
+    def test_corrupted_event_chain_blocks_repository_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            engine = AccelerationEngine(repository)
+            outcome = engine.evaluate(
+                run_id=engine.new_run_id(),
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="corruption-setup",
+                choice_provider=lambda _identity: "2",
+            )
+            self.assertTrue(outcome.allowed)
+            events_path = engine.store.events_path
+            events_path.write_text("{}\n", encoding="utf-8")
+            controller = self.make_controller(root, ScriptedFactory())
+
+            with self.assertRaises(RepositorySelectionError):
+                controller.select_repository(repository)

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import http.client
+import json
+from pathlib import Path
+import tempfile
+import time
+import unittest
+from urllib.parse import urlsplit
+
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import DecisionType
+from decision_os.acceleration.store import StateIntegrityError
+from decision_os.companion.controller import CompanionController
+from decision_os.companion.server import CompanionServer
+from tests.test_companion_controller import (
+    ScriptedFactory,
+    create_repository,
+)
+
+
+class CompanionServerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.repository = create_repository(self.root, "repo<script>")
+        self.controller = CompanionController(
+            state_path=self.root / "state" / "state.json",
+            picker_script=self.root / "fixed-picker.applescript",
+            picker_runner=lambda _script: str(self.repository),
+            adapter_factory=ScriptedFactory("mutation"),
+        )
+        self.controller.select_repository(self.repository)
+        static_root = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+        )
+        self.server = CompanionServer(
+            self.controller,
+            static_root=static_root,
+        )
+        self.server.start_background()
+
+    def tearDown(self) -> None:
+        run = self.controller.snapshot()["run"]
+        if run["state"] == "running" and run["approval"] is not None:
+            self.controller.submit_approval("deny")
+        self.server.close()
+        self.temporary.cleanup()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, object] | None = None,
+        cookie: str | None = None,
+        csrf: str | None = None,
+        origin: str | None = None,
+        host: str | None = None,
+    ) -> tuple[int, dict[str, str], bytes]:
+        connection = http.client.HTTPConnection(
+            "127.0.0.1",
+            self.server.port,
+            timeout=5,
+        )
+        headers: dict[str, str] = {}
+        if host is not None:
+            headers["Host"] = host
+        if cookie is not None:
+            headers["Cookie"] = cookie
+        if csrf is not None:
+            headers["X-Decision-OS-CSRF"] = csrf
+        if origin is not None:
+            headers["Origin"] = origin
+        payload = None
+        if body is not None:
+            payload = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+            headers["Content-Length"] = str(len(payload))
+        connection.request(method, path, body=payload, headers=headers)
+        response = connection.getresponse()
+        raw = response.read()
+        result_headers = {
+            key.lower(): value for key, value in response.getheaders()
+        }
+        status = response.status
+        connection.close()
+        return status, result_headers, raw
+
+    def bootstrap(self) -> tuple[str, str]:
+        path = urlsplit(self.server.bootstrap_url).path
+        status, headers, _body = self.request("GET", path)
+        self.assertEqual(303, status)
+        cookie = headers["set-cookie"].split(";", 1)[0]
+        status, _headers, raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+        )
+        self.assertEqual(200, status)
+        csrf = json.loads(raw)["csrf"]
+        return cookie, csrf
+
+    def test_bootstrap_session_and_security_headers(self) -> None:
+        status, _headers, _raw = self.request("GET", "/api/state")
+        self.assertEqual(401, status)
+        status, _headers, _raw = self.request(
+            "GET",
+            "/api/state",
+            cookie="decision_os_session=invalid",
+        )
+        self.assertEqual(401, status)
+        wrong = "/bootstrap/not-the-private-token"
+        status, _headers, _raw = self.request("GET", wrong)
+        self.assertEqual(401, status)
+
+        path = urlsplit(self.server.bootstrap_url).path
+        status, headers, _raw = self.request("GET", path)
+
+        self.assertEqual(303, status)
+        self.assertIn("HttpOnly", headers["set-cookie"])
+        self.assertIn("SameSite=Strict", headers["set-cookie"])
+        cookie = headers["set-cookie"].split(";", 1)[0]
+        status, headers, _raw = self.request("GET", "/", cookie=cookie)
+        self.assertEqual(200, status)
+        self.assertEqual("no-store, max-age=0", headers["cache-control"])
+        self.assertEqual("DENY", headers["x-frame-options"])
+        self.assertIn("default-src 'none'", headers["content-security-policy"])
+        self.assertIn("frame-ancestors 'none'", headers["content-security-policy"])
+        status, _headers, _raw = self.request("GET", path)
+        self.assertEqual(401, status)
+
+    def test_host_origin_and_csrf_rejections(self) -> None:
+        cookie, csrf = self.bootstrap()
+        status, _headers, _raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+            host="attacker.invalid",
+        )
+        self.assertEqual(403, status)
+        status, _headers, _raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+            origin="http://attacker.invalid",
+        )
+        self.assertEqual(403, status)
+        status, _headers, _raw = self.request(
+            "POST",
+            "/api/new-run",
+            body={},
+            cookie=cookie,
+            csrf=csrf,
+            origin="http://attacker.invalid",
+        )
+        self.assertEqual(403, status)
+        status, _headers, _raw = self.request(
+            "POST",
+            "/api/new-run",
+            body={},
+            cookie=cookie,
+            origin=self.server.origin,
+        )
+        self.assertEqual(403, status)
+
+    def test_static_allowlist_blocks_traversal_and_arbitrary_files(self) -> None:
+        cookie, _csrf = self.bootstrap()
+        for path in (
+            "/../AGENTS.md",
+            "/%2e%2e/AGENTS.md",
+            "/etc/passwd",
+            "/decision_os/acceleration/store.py",
+            "/missing.js",
+        ):
+            status, _headers, raw = self.request(
+                "GET",
+                path,
+                cookie=cookie,
+            )
+            self.assertEqual(404, status)
+            self.assertNotIn(b"Agent Operating Rule", raw)
+
+    def test_json_and_dom_rendering_are_script_safe(self) -> None:
+        cookie, _csrf = self.bootstrap()
+        status, _headers, raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+        )
+        self.assertEqual(200, status)
+        self.assertIn(b"repo\\u003cscript\\u003e", raw)
+        self.assertNotIn(b"<script>", raw)
+        parsed = json.loads(raw)
+        self.assertEqual("repo<script>", parsed["repository"]["name"])
+
+        status, _headers, javascript = self.request(
+            "GET",
+            "/app.js",
+            cookie=cookie,
+        )
+        self.assertEqual(200, status)
+        self.assertIn(b"textContent", javascript)
+        self.assertNotIn(b"innerHTML", javascript)
+
+    def test_one_active_run_and_browser_reconnect(self) -> None:
+        cookie, csrf = self.bootstrap()
+        status, _headers, _raw = self.request(
+            "POST",
+            "/api/run",
+            body={"task": "Modify target.txt once."},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status)
+        deadline = time.monotonic() + 4
+        first = None
+        while time.monotonic() < deadline:
+            status, _headers, raw = self.request(
+                "GET",
+                "/api/state",
+                cookie=cookie,
+            )
+            self.assertEqual(200, status)
+            first = json.loads(raw)
+            if first["run"]["approval"] is not None:
+                break
+            time.sleep(0.01)
+        self.assertIsNotNone(first)
+        self.assertIsNotNone(first["run"]["approval"])
+
+        status, _headers, raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+        )
+        second = json.loads(raw)
+        self.assertEqual(first["run"]["approval"], second["run"]["approval"])
+
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/run",
+            body={"task": "Overlapping task."},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(409, status)
+        self.assertIn(b"already active", raw)
+
+        status, _headers, _raw = self.request(
+            "POST",
+            "/api/approval",
+            body={"choice": "deny"},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status)
+
+    def test_public_state_exposes_opaque_default_handle_only(self) -> None:
+        self.server.close()
+        engine = AccelerationEngine(self.repository)
+        engine.evaluate(
+            run_id=engine.new_run_id(),
+            iteration=1,
+            decision_type=DecisionType.MODIFY_FILE,
+            requested_scope="target.txt",
+            source_interrupt_id="server-default-setup",
+            choice_provider=lambda _identity: "2",
+        )
+        self.controller = CompanionController(
+            state_path=self.root / "second-state" / "state.json",
+            picker_runner=lambda _script: str(self.repository),
+            adapter_factory=ScriptedFactory(),
+        )
+        self.controller.select_repository(self.repository)
+        static_root = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+        )
+        self.server = CompanionServer(self.controller, static_root=static_root)
+        self.server.start_background()
+        cookie, _csrf = self.bootstrap()
+
+        status, _headers, raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+        )
+
+        self.assertEqual(200, status)
+        text = raw.decode("utf-8")
+        self.assertNotIn("decision_key", text)
+        self.assertNotIn("rule_hash", text)
+        self.assertNotIn("event_hash", text)
+        self.assertNotIn("request_id", text)
+        self.assertNotIn("credential", text)
+        state = json.loads(raw)
+        self.assertEqual(1, len(state["defaults"]))
+        self.assertEqual(
+            {"action", "created_at", "handle", "path"},
+            set(state["defaults"][0]),
+        )
+
+    def test_corrupted_repository_state_error_is_sanitized(self) -> None:
+        cookie, _csrf = self.bootstrap()
+        original_snapshot = self.controller.snapshot
+
+        def corrupted_snapshot() -> dict[str, object]:
+            raise StateIntegrityError("secret chain detail")
+
+        self.controller.snapshot = corrupted_snapshot  # type: ignore[method-assign]
+        try:
+            status, _headers, raw = self.request(
+                "GET",
+                "/api/state",
+                cookie=cookie,
+            )
+        finally:
+            self.controller.snapshot = original_snapshot  # type: ignore[method-assign]
+
+        self.assertEqual(409, status)
+        body = json.loads(raw)
+        self.assertEqual(
+            {"error": "Local companion state could not be read safely."},
+            body,
+        )
+        self.assertNotIn("secret", raw.decode("utf-8"))

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import http.client
 import json
 from pathlib import Path
+import shutil
+import subprocess
 import tempfile
+import textwrap
 import time
 import unittest
 from urllib.parse import urlsplit
@@ -333,3 +336,595 @@ class CompanionServerTest(unittest.TestCase):
             body,
         )
         self.assertNotIn("secret", raw.decode("utf-8"))
+
+
+class CompanionClientBehaviorTest(unittest.TestCase):
+    def test_disconnection_clears_and_disables_stale_ui_until_recovery(
+        self,
+    ) -> None:
+        node = shutil.which("node")
+        self.assertIsNotNone(node, "Node.js is required for client behavior tests.")
+        javascript = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+            / "app.js"
+        )
+        harness = textwrap.dedent(
+            r"""
+            "use strict";
+
+            const assert = require("assert");
+            const fs = require("fs");
+            const vm = require("vm");
+
+            const javascriptPath = process.argv[2];
+            const source = fs.readFileSync(javascriptPath, "utf8");
+            const disconnectedMessage =
+              "This companion session has ended. Close this tab and relaunch Decision OS Companion.app.";
+
+            class ClassList {
+              constructor(initial = []) {
+                this.values = new Set(initial);
+              }
+
+              contains(value) {
+                return this.values.has(value);
+              }
+
+              toggle(value, force) {
+                const enabled =
+                  force === undefined ? !this.values.has(value) : Boolean(force);
+                if (enabled) {
+                  this.values.add(value);
+                } else {
+                  this.values.delete(value);
+                }
+                return enabled;
+              }
+            }
+
+            class Element {
+              constructor(tagName = "div", id = "") {
+                this.tagName = tagName.toUpperCase();
+                this.id = id;
+                this.classList = new ClassList();
+                this.className = "";
+                this.dataset = {};
+                this.disabled = false;
+                this.value = "";
+                this.type = "";
+                this.children = [];
+                this.parentNode = null;
+                this.listeners = new Map();
+                this.ownText = "";
+              }
+
+              get textContent() {
+                return (
+                  this.ownText +
+                  this.children.map((child) => child.textContent).join("")
+                );
+              }
+
+              set textContent(value) {
+                this.ownText = value == null ? "" : String(value);
+                for (const child of this.children) {
+                  child.parentNode = null;
+                }
+                this.children = [];
+              }
+
+              append(...children) {
+                for (const child of children) {
+                  child.parentNode = this;
+                  this.children.push(child);
+                }
+              }
+
+              replaceChildren(...children) {
+                for (const child of this.children) {
+                  child.parentNode = null;
+                }
+                this.children = [];
+                this.ownText = "";
+                this.append(...children);
+              }
+
+              querySelectorAll(selector) {
+                const matches = [];
+                for (const child of this.children) {
+                  if (selector === "button" && child.tagName === "BUTTON") {
+                    matches.push(child);
+                  }
+                  matches.push(...child.querySelectorAll(selector));
+                }
+                return matches;
+              }
+
+              addEventListener(name, callback) {
+                const listeners = this.listeners.get(name) || [];
+                listeners.push(callback);
+                this.listeners.set(name, listeners);
+              }
+
+              async dispatch(name) {
+                for (const callback of this.listeners.get(name) || []) {
+                  await callback({ target: this });
+                }
+              }
+
+              focus() {}
+            }
+
+            const ids = [
+              "approval-action",
+              "approval-diff",
+              "approval-overlay",
+              "approval-path",
+              "approval-reason",
+              "approval-reason-label",
+              "approval-repository",
+              "choose-repository",
+              "claim-boundary",
+              "defaults",
+              "file-actions",
+              "global-error",
+              "new-run",
+              "progress",
+              "progress-card",
+              "receipt-status",
+              "repository-name",
+              "repository-path",
+              "repository-receipt",
+              "result",
+              "result-card",
+              "result-state",
+              "run",
+              "run-error",
+              "run-receipt",
+              "run-state",
+              "runtime",
+              "task",
+            ];
+            const elements = new Map(
+              ids.map((id) => [
+                id,
+                new Element(
+                  ["choose-repository", "new-run", "run"].includes(id)
+                    ? "button"
+                    : id === "task"
+                      ? "textarea"
+                      : "div",
+                  id,
+                ),
+              ]),
+            );
+            for (const id of [
+              "approval-overlay",
+              "approval-reason",
+              "approval-reason-label",
+              "global-error",
+              "progress-card",
+              "result-card",
+              "run-error",
+            ]) {
+              elements.get(id).classList.toggle("hidden", true);
+            }
+            elements.get("task").value = "Keep this bounded task";
+
+            const approvalButtons = [
+              "allow_once",
+              "repository",
+              "deny",
+            ].map((choice) => {
+              const button = new Element("button");
+              button.dataset.choice = choice;
+              return button;
+            });
+            const document = {
+              createElement(tagName) {
+                return new Element(tagName);
+              },
+              getElementById(id) {
+                assert(elements.has(id), `Unknown DOM id: ${id}`);
+                return elements.get(id);
+              },
+              querySelectorAll(selector) {
+                if (selector === "[data-choice]") {
+                  return approvalButtons;
+                }
+                return [];
+              },
+            };
+
+            const timers = [];
+            const fetchQueue = [];
+            const fetchCalls = [];
+            const window = {
+              confirm() {
+                return false;
+              },
+              setTimeout(callback) {
+                timers.push(callback);
+                return timers.length;
+              },
+            };
+            async function fetchMock(path, options = {}) {
+              fetchCalls.push({ path, options });
+              assert(fetchQueue.length > 0, `Unexpected fetch: ${path}`);
+              return fetchQueue.shift()();
+            }
+            function response(body, status = 200) {
+              return {
+                ok: status >= 200 && status < 300,
+                status,
+                async json() {
+                  return body;
+                },
+              };
+            }
+            function deferred() {
+              let resolve;
+              let reject;
+              const promise = new Promise((resolvePromise, rejectPromise) => {
+                resolve = resolvePromise;
+                reject = rejectPromise;
+              });
+              return { promise, reject, resolve };
+            }
+            function emptyRun(overrides = {}) {
+              return {
+                state: "idle",
+                progress: [],
+                result: "",
+                file_actions: [],
+                runtime: null,
+                receipt_delta: null,
+                approval: null,
+                error: null,
+                ...overrides,
+              };
+            }
+            const staleReceipt = {
+              status: "STALE_RECEIPT_STATUS",
+              verified_saves: 7,
+              verified_reuses: 8,
+              estimated_minutes: 90,
+              estimated_money_jpy: 12000,
+              estimated_tokens: 3456,
+              claim_boundary: "STALE_CLAIM_BOUNDARY",
+            };
+            const completedState = {
+              csrf: "csrf-one",
+              repository: {
+                name: "STALE_REPOSITORY_NAME",
+                path: "/tmp/STALE_REPOSITORY_PATH",
+              },
+              run: emptyRun({
+                state: "completed",
+                progress: ["STALE_PROGRESS"],
+                result: "STALE_RESULT",
+                file_actions: [
+                  {
+                    action: "Modify",
+                    path: "STALE_FILE_PATH",
+                    status: "approved",
+                    access: "one-time",
+                  },
+                ],
+                runtime: {
+                  authentication: "STALE_AUTH",
+                  model: "STALE_MODEL",
+                  reasoning_effort: "STALE_REASONING",
+                  service_tier: "STALE_TIER",
+                  codex_version: "STALE_VERSION",
+                },
+                receipt_delta: staleReceipt,
+              }),
+              defaults: [
+                {
+                  action: "Modify",
+                  path: "STALE_DEFAULT_PATH",
+                  handle: "opaque-handle",
+                },
+              ],
+              receipt: staleReceipt,
+            };
+            const approvalState = {
+              ...completedState,
+              csrf: "csrf-two",
+              run: emptyRun({
+                state: "running",
+                progress: ["WAITING_FOR_APPROVAL"],
+                approval: {
+                  repository: "STALE_APPROVAL_REPOSITORY",
+                  action: "Modify",
+                  path: "STALE_APPROVAL_PATH",
+                  diff: "STALE_APPROVAL_DIFF",
+                  reason: "STALE_APPROVAL_REASON",
+                },
+              }),
+            };
+            const recoveredState = {
+              csrf: "csrf-recovered",
+              repository: {
+                name: "FRESH_REPOSITORY_NAME",
+                path: "/tmp/FRESH_REPOSITORY_PATH",
+              },
+              run: emptyRun({
+                state: "completed",
+                progress: ["FRESH_PROGRESS"],
+                result: "FRESH_RESULT",
+              }),
+              defaults: [],
+              receipt: null,
+            };
+
+            function hidden(id) {
+              return elements.get(id).classList.contains("hidden");
+            }
+            async function settle() {
+              await new Promise((resolve) => setImmediate(resolve));
+              await new Promise((resolve) => setImmediate(resolve));
+            }
+            async function runNextTimer() {
+              assert(timers.length > 0, "Expected a scheduled refresh.");
+              await timers.shift()();
+              await settle();
+            }
+
+            async function main() {
+              fetchQueue.push(() => Promise.resolve(response(completedState)));
+              const sandbox = {
+                Boolean,
+                Error,
+                Intl,
+                JSON,
+                Promise,
+                String,
+                TypeError,
+                console,
+                document,
+                fetch: fetchMock,
+                window,
+              };
+              vm.createContext(sandbox);
+              vm.runInContext(source, sandbox, { filename: javascriptPath });
+              await settle();
+
+              assert.strictEqual(
+                elements.get("repository-name").textContent,
+                "STALE_REPOSITORY_NAME",
+              );
+              assert.strictEqual(
+                elements.get("repository-path").textContent,
+                "/tmp/STALE_REPOSITORY_PATH",
+              );
+              assert.strictEqual(elements.get("result").textContent, "STALE_RESULT");
+              assert.strictEqual(hidden("result-card"), false);
+              assert.strictEqual(hidden("global-error"), true);
+              assert.strictEqual(elements.get("choose-repository").disabled, false);
+              assert.strictEqual(elements.get("task").disabled, false);
+              assert.strictEqual(elements.get("run").disabled, false);
+              assert.strictEqual(elements.get("new-run").disabled, false);
+              const firstRevoke =
+                elements.get("defaults").children[0].children[1];
+              assert.strictEqual(firstRevoke.disabled, false);
+
+              fetchQueue.push(() => Promise.resolve(response(approvalState)));
+              await runNextTimer();
+              assert.strictEqual(hidden("approval-overlay"), false);
+              assert.strictEqual(
+                elements.get("approval-repository").textContent,
+                "STALE_APPROVAL_REPOSITORY",
+              );
+              for (const button of approvalButtons) {
+                assert.strictEqual(button.disabled, false);
+              }
+              const pendingRevoke =
+                elements.get("defaults").children[0].children[1];
+
+              fetchQueue.push(() =>
+                Promise.reject(new TypeError("fetch failed")),
+              );
+              await runNextTimer();
+
+              assert.strictEqual(
+                elements.get("repository-name").textContent,
+                "Companion disconnected",
+              );
+              assert.strictEqual(
+                elements.get("repository-path").textContent,
+                disconnectedMessage,
+              );
+              assert.strictEqual(
+                elements.get("global-error").textContent,
+                disconnectedMessage,
+              );
+              assert.strictEqual(hidden("global-error"), false);
+              assert.strictEqual(hidden("progress-card"), true);
+              assert.strictEqual(elements.get("progress").children.length, 0);
+              assert.strictEqual(elements.get("run-error").textContent, "");
+              assert.strictEqual(hidden("result-card"), true);
+              assert.strictEqual(elements.get("result").textContent, "");
+              assert.strictEqual(elements.get("file-actions").children.length, 0);
+              assert.strictEqual(elements.get("runtime").children.length, 0);
+              assert.strictEqual(elements.get("run-receipt").children.length, 0);
+              assert.strictEqual(
+                elements.get("repository-receipt").children.length,
+                0,
+              );
+              assert.strictEqual(
+                elements.get("receipt-status").textContent,
+                "Session ended",
+              );
+              assert.strictEqual(elements.get("claim-boundary").textContent, "");
+              assert.strictEqual(elements.get("defaults").children.length, 0);
+              assert.strictEqual(hidden("approval-overlay"), true);
+              for (const id of [
+                "approval-repository",
+                "approval-action",
+                "approval-path",
+                "approval-diff",
+                "approval-reason",
+              ]) {
+                assert.strictEqual(elements.get(id).textContent, "");
+              }
+              for (const id of [
+                "choose-repository",
+                "run",
+                "new-run",
+                "task",
+              ]) {
+                assert.strictEqual(elements.get(id).disabled, true, id);
+              }
+              for (const button of approvalButtons) {
+                assert.strictEqual(button.disabled, true);
+              }
+              assert.strictEqual(pendingRevoke.disabled, true);
+
+              elements.get("task").value = "Changed while disconnected";
+              await elements.get("task").dispatch("input");
+              assert.strictEqual(
+                elements.get("repository-path").textContent,
+                disconnectedMessage,
+              );
+              assert.strictEqual(elements.get("run").disabled, true);
+
+              fetchQueue.push(() => Promise.resolve(response(recoveredState)));
+              await runNextTimer();
+              assert.strictEqual(
+                elements.get("repository-name").textContent,
+                "FRESH_REPOSITORY_NAME",
+              );
+              assert.strictEqual(
+                elements.get("repository-path").textContent,
+                "/tmp/FRESH_REPOSITORY_PATH",
+              );
+              assert.strictEqual(elements.get("result").textContent, "FRESH_RESULT");
+              assert.strictEqual(hidden("global-error"), true);
+              assert.strictEqual(elements.get("choose-repository").disabled, false);
+              assert.strictEqual(elements.get("task").disabled, false);
+              assert.strictEqual(elements.get("run").disabled, false);
+              assert.strictEqual(elements.get("new-run").disabled, false);
+
+              const freshApprovalState = {
+                ...approvalState,
+                csrf: "csrf-approval",
+                repository: recoveredState.repository,
+              };
+              fetchQueue.push(() =>
+                Promise.resolve(response(freshApprovalState)),
+              );
+              await runNextTimer();
+              assert.strictEqual(hidden("approval-overlay"), false);
+              for (const button of approvalButtons) {
+                assert.strictEqual(button.disabled, false);
+              }
+
+              fetchQueue.push(() =>
+                Promise.reject(new TypeError("post fetch failed")),
+              );
+              await approvalButtons[0].dispatch("click");
+              await settle();
+              const approvalRequest = fetchCalls.at(-1);
+              assert.strictEqual(approvalRequest.path, "/api/approval");
+              assert.strictEqual(approvalRequest.options.method, "POST");
+              assert.strictEqual(
+                approvalRequest.options.headers["X-Decision-OS-CSRF"],
+                "csrf-approval",
+              );
+              assert.strictEqual(hidden("approval-overlay"), true);
+              assert.strictEqual(
+                elements.get("approval-repository").textContent,
+                "",
+              );
+              for (const button of approvalButtons) {
+                assert.strictEqual(button.disabled, true);
+              }
+              assert.strictEqual(elements.get("choose-repository").disabled, true);
+              assert.strictEqual(elements.get("task").disabled, true);
+
+              fetchQueue.push(() => Promise.resolve(response(recoveredState)));
+              await runNextTimer();
+              assert.strictEqual(
+                elements.get("repository-name").textContent,
+                "FRESH_REPOSITORY_NAME",
+              );
+              assert.strictEqual(hidden("approval-overlay"), true);
+              assert.strictEqual(elements.get("choose-repository").disabled, false);
+
+              fetchQueue.push(() =>
+                Promise.resolve(
+                  response({ error: "One bounded Run is already active." }, 409),
+                ),
+              );
+              await elements.get("run").dispatch("click");
+              await settle();
+              assert.strictEqual(
+                elements.get("global-error").textContent,
+                "One bounded Run is already active.",
+              );
+              assert.strictEqual(hidden("global-error"), false);
+              assert.strictEqual(
+                elements.get("repository-name").textContent,
+                "FRESH_REPOSITORY_NAME",
+              );
+              assert.strictEqual(elements.get("choose-repository").disabled, false);
+
+              const oldState = deferred();
+              fetchQueue.push(() => oldState.promise);
+              assert(timers.length > 0, "Expected a refresh for the race test.");
+              const oldRefresh = timers.shift()();
+              await settle();
+              assert.strictEqual(fetchCalls.at(-1).path, "/api/state");
+
+              fetchQueue.push(() =>
+                Promise.reject(new TypeError("racing post fetch failed")),
+              );
+              await elements.get("run").dispatch("click");
+              await settle();
+              assert.strictEqual(
+                elements.get("repository-path").textContent,
+                disconnectedMessage,
+              );
+
+              oldState.resolve(response(recoveredState));
+              await oldRefresh;
+              await settle();
+              assert.strictEqual(
+                elements.get("repository-path").textContent,
+                disconnectedMessage,
+              );
+              assert.strictEqual(elements.get("choose-repository").disabled, true);
+
+              fetchQueue.push(() => Promise.resolve(response(recoveredState)));
+              await runNextTimer();
+              assert.strictEqual(
+                elements.get("repository-name").textContent,
+                "FRESH_REPOSITORY_NAME",
+              );
+              assert.strictEqual(elements.get("choose-repository").disabled, false);
+            }
+
+            main().catch((error) => {
+              console.error(error.stack || error);
+              process.exitCode = 1;
+            });
+            """
+        )
+        completed = subprocess.run(
+            [node, "-", str(javascript)],
+            input=harness,
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(
+            0,
+            completed.returncode,
+            msg=f"Node client harness failed:\n{completed.stdout}{completed.stderr}",
+        )

--- a/validation/decision_os_companion_acceptance_run_001.md
+++ b/validation/decision_os_companion_acceptance_run_001.md
@@ -1,0 +1,321 @@
+# Decision OS Companion — Acceptance Run 001
+
+## Acceptance Identity
+
+```text
+Packet:
+V13-DECISION-OS-COMPANION-ACCEPTANCE-CLOSURE-001
+
+Product:
+Decision OS Companion v0.1
+
+Branch:
+codex/decision-os-companion-v0-1
+
+Draft PR:
+#37
+
+Approved pre-closure head:
+a04f1463fc1f4bf46196eeea1702c5b096fd36e2
+
+Acceptance date:
+2026-07-28
+
+Acceptance owner:
+Shin
+```
+
+## Classification
+
+```text
+FRESH_PROCESS_COMPANION_ACCEPTANCE:
+PASS
+
+TERMINAL_PROOF:
+PASS
+
+VERIFIED_SAVE:
+PASS
+
+VERIFIED_REUSE_COUNTER:
+1
+
+EXTERNAL_USER_ADOPTION:
+NOT ESTABLISHED
+
+NATIVE_CODEX_DESKTOP_INTEGRATION:
+NOT CLAIMED
+
+THIRD_PARTY_CERTIFICATION:
+NOT CLAIMED
+```
+
+This classification closes the previously observed matched-but-unverified
+acceptance failure. It applies only to Shin's fresh-process local use of the
+private Decision OS Companion.
+
+## Accepted Companion Surface
+
+```text
+Launch:
+rebuilt Decision OS Companion.app
+
+Terminal during normal launch and Run:
+not opened
+
+Repository:
+/Users/sn/Documents/v13/decision-os-v13-loopkit
+
+Authentication:
+ChatGPT
+
+Model:
+gpt-5.6-sol
+
+Reasoning effort:
+ultra
+
+Service tier:
+priority
+
+Client type:
+one-task Runner / not a true chat client
+
+Interaction surface:
+Companion localhost browser UI
+```
+
+The repository reopened correctly in the fresh Companion process. Normal use
+continued inside the Companion rather than inside Codex Desktop.
+
+## Shin-Owned Fresh-Process Run
+
+```text
+Approval card:
+not shown
+
+Saved exact repository access:
+matched and reused
+
+Requested file:
+companion_acceptance_trial.txt
+
+Requested change:
+stage: run-2 -> stage: run-3
+
+Other file modification:
+none observed
+
+Companion result:
+completed normally
+
+File action:
+approved / reused
+```
+
+The file action label `reused` was displayed only after the matching cross-Run
+checkpoint completed with verified terminal proof. This is the corrected
+semantic boundary introduced at the approved pre-closure head.
+
+## Repository Event-Chain Evidence
+
+The canonical repository event chain contains 11 valid events. The successful
+fresh-process Run ends with:
+
+```text
+DECISION_CHECK
+DEFAULT_MATCHED
+INTERRUPT_SKIPPED
+CHECKPOINT_PASSED
+VERIFIED_SAVE
+```
+
+```text
+Verified Save counter:
+1
+
+Verified Reuse counter:
+1
+
+Active Repository Defaults:
+1
+
+Event-chain head:
+840f263accae0a2093f9aa5baa60e4aaa5b75448825f97ad96f63285ec45f491
+```
+
+The earlier failed acceptance ended at `CHECKPOINT_PENDING` and did not
+increment either hard counter. The fresh-process Run passed the checkpoint and
+recorded the first verified cross-Run use as `VERIFIED_SAVE`, which yields one
+Verified Save and one Verified Reuse in the authoritative Receipt.
+
+## Correction Chronology
+
+1. The first repository-selection acceptance used a stale browser page whose
+   localhost server had already ended. A1 corrected the disconnected-state
+   presentation; it did not change picker, launcher, or server protocol.
+2. Repository-picker acceptance then passed.
+3. The initial human access Run created a Repository Default. A later Run
+   matched that default and skipped approval, but ended
+   `CHECKPOINT_PENDING / PENDING_ABNORMAL_TERMINAL`; its zero Receipt was
+   authoritative and it was not claimed verified.
+4. A2 made file-action labels terminal-aware and added bounded sanitized
+   unsupported-reason observability without relaxing the fail-closed boundary.
+5. The rebuilt app then performed the accepted fresh-process Run recorded
+   here, ending `CHECKPOINT_PASSED / VERIFIED_SAVE`.
+
+This is not a claim that the final build passed one uninterrupted clean-room
+two-Run trial. It is a closure of the preserved correction sequence followed
+by one successful fresh-process verification Run.
+
+## Authoritative Receipt
+
+```text
+VERIFIED
+
+1 Verified Save
+1 Verified Reuse
+
+7.5 estimated recovered minutes
+¥625 estimated human-time value
+UNKNOWN tokens
+```
+
+The time and money values are estimates derived from the configured local
+defaults. They are not measured elapsed time, realized income, provider
+pricing, or third-party valuation. Token value remains `UNKNOWN`.
+
+## Claim Boundary
+
+This record establishes:
+
+- Shin-owned local acceptance;
+- one fresh-process private Companion Run without Terminal;
+- one exact saved repository access match without a repeated approval card;
+- one normal terminal checkpoint;
+- one locally recorded Verified Save and one Verified Reuse counter.
+
+This record does not establish:
+
+- external-user adoption;
+- native Codex Desktop integration or interception;
+- third-party certification;
+- public installer, signing, notarization, or release readiness;
+- measured recovered time or realized human-time value;
+- a token value.
+
+Decision OS Companion remains a local one-task Runner, not a true multi-turn
+chat client.
+
+## Separate macOS Automation Observation
+
+The earlier macOS `Codex Computer Use` automation prompt was a separate,
+noncausal observation. It was not emitted by the Companion terminal-proof
+path, did not create or promote the Verified Save, and was not required for
+the successful fresh-process verified Run.
+
+## Validation Receipt
+
+```text
+Focused Companion tests:
+16 / 16 PASS
+
+Focused Codex adapter tests:
+31 / 31 PASS
+
+Full repository suite:
+244 / 244 PASS
+
+Protected v0.1 blob/mode guard:
+PASS
+
+Changed Markdown heading/fence validation:
+PASS
+
+Introduced local-link validation:
+PASS
+
+Exact closure file boundary:
+PASS / 3 files
+
+Cumulative Draft PR boundary:
+PASS / 18 files
+
+git diff --check:
+PASS
+```
+
+No product source, test, UI, launcher, build, README, release, or public-post
+surface changed in this closure.
+
+## Exact Closure File Boundary
+
+### Create
+
+1. `validation/decision_os_companion_acceptance_run_001.md`
+
+### Update
+
+1. `docs/current_signal.md`
+2. `handoff/current_codex_handoff.md`
+
+The closure boundary is exactly these three Markdown evidence files.
+
+## Temporary Acceptance Artifact Cleanup
+
+Before deletion, the untracked temporary acceptance file was verified as one
+regular 13-byte file with exact content:
+
+```text
+stage: run-3
+```
+
+`companion_acceptance_trial.txt` was then deleted as Codex-owned acceptance
+cleanup. It was never staged, committed, or pushed. No other untracked or
+modified worktree file remained before the three authorized closure records
+were staged.
+
+## Git and Draft PR State
+
+```text
+Draft PR:
+#37 / OPEN / DRAFT
+
+Approved pre-closure head:
+a04f1463fc1f4bf46196eeea1702c5b096fd36e2
+
+Merge:
+NOT AUTHORIZED / NOT PERFORMED
+
+Ready-for-review:
+NOT AUTHORIZED / NOT PERFORMED
+```
+
+The closure commit's final head is reported after commit and push rather than
+embedded self-referentially in this record.
+
+## Canonical Restart Surfaces
+
+- [Current Signal](../docs/current_signal.md)
+- [Current Codex Handoff](../handoff/current_codex_handoff.md)
+- [Draft PR #37](https://github.com/shin4141/decision-os-v13-loopkit/pull/37)
+
+## Final Merge Gate
+
+```text
+V12 State:
+DELAY — Shin-owned fresh-process local Companion acceptance passed;
+external-user adoption remains unobserved and no external adoption claim is made
+
+V13 Next Loop Gate:
+HOLD — Draft PR review / no merge authority
+
+Merge Authority:
+NONE
+
+Next Authorized Action:
+none unless Shin explicitly authorizes review-state or merge work
+
+Decision Owner:
+Shin
+```


### PR DESCRIPTION
## Objective

Add the smallest private macOS companion for one bounded Decision OS task per fresh Codex app-server Run, without requiring Terminal during normal use.

## User experience

- Double-click `Decision OS Companion.app`.
- Choose or reopen one local Git repository.
- Enter one bounded task and press **Run**.
- See sanitized progress and final text, never raw JSONL.
- For one exact create/modify action, choose **Allow once**, **Use for this repository**, or **Deny**.
- See current and cumulative Verified Save receipts, recovered-minute/value estimates, and token estimate or `UNKNOWN`.
- Press **New Run** for the next fresh Run.
- Review and revoke saved repository defaults from the companion.

This is a one-task Runner, not a true multi-turn chat client. Shin remains inside the companion browser UI during use; it does not continue inside Codex Desktop.

## Runtime lock

- ChatGPT authentication
- `gpt-5.6-sol`
- `reasoning_effort=ultra`
- `service_tier=priority`
- expected bundled Codex app-server `0.146.0-alpha.3.1`

## Safety boundary

- Binds only to `127.0.0.1` on an ephemeral port.
- Uses bootstrap/session/CSRF tokens, strict cookie and origin/host checks, a static allowlist, no-cache and browser hardening headers.
- Stores only local companion state with owner-only permissions.
- Persists repository-scoped decisions through opaque handles and exposes explicit revoke controls.
- Supports one exact single-file create/modify action.
- Fails closed as **Unsupported** for command/shell execution, dependencies, multi-file actions, delete/rename, dynamic tools, hooks, MCP, subagents, and other out-of-bound behavior.
- Existing terminal adapter behavior remains backward compatible.

## Shin-owned local acceptance — PASS

On 2026-07-28 JST, Shin completed the private fresh-process acceptance flow against implementation head `a04f1463fc1f4bf46196eeea1702c5b096fd36e2` on his Mac:

- A fresh double-click launch opened the rebuilt Companion without Terminal.
- The selected repository reopened as `/Users/sn/Documents/v13/decision-os-v13-loopkit`.
- The fresh bounded Run used ChatGPT / `gpt-5.6-sol` / `ultra` / `priority`.
- A repository-scoped default previously created with **Use for this repository** matched the exact action and path; no repeated approval card appeared.
- `companion_acceptance_trial.txt` changed from `stage: run-2` to `stage: run-3`, and no other file was modified.
- The Run completed normally and displayed `approved · reused`.
- The terminal event sequence ended `DECISION_CHECK` → `DEFAULT_MATCHED` → `INTERRUPT_SKIPPED` → `CHECKPOINT_PASSED` → `VERIFIED_SAVE`.
- The authoritative local Receipt displayed **VERIFIED**, 1 Verified Save, 1 Verified Reuse, 7.5 estimated recovered minutes, ¥625 estimated human-time value, and token estimate `UNKNOWN`.
- The earlier macOS `Codex Computer Use` automation prompt was a separate, noncausal observation and was not required for this successful verified Run.
- The temporary acceptance file was deleted after evidence capture and was never staged, committed, or pushed.

This is Shin-owned local acceptance only. It is not external-user adoption, native Codex Desktop integration, or third-party certification. Recovered time and money remain estimates, and token value remains `UNKNOWN`.

## Final supported / unsupported boundary

Supported by this private v0.1 evidence:

- one local repository at a time;
- one bounded task per fresh Run;
- normal launch and use without Terminal;
- local repository selection/reopen, task input, Run, New Run, sanitized progress/result, Receipt, and visible revoke controls;
- one exact typed single-file create/modify approval and exact repository-default reuse;
- verification only after a normal terminal checkpoint and authoritative local event-chain receipt.

Unsupported or not established:

- a true multi-turn chat client or native Codex Desktop interception/integration;
- command/shell execution, dependencies, multi-file actions, delete/rename, dynamic tools, hooks, MCP, subagents, or other out-of-bound behavior;
- mobile, remote server, telemetry, provider pricing tables, model switching, multi-repository dashboard, public installer, signing, notarization, or release work;
- external-user adoption, third-party certification, measured recovered time, realized monetary value, or a known token value.

A matched action that does not pass its terminal checkpoint remains unverified and must not increment the hard Receipt.

## Validation

Closure validation at head `dc00d5c0367b5bfcd934ad097e3e81b5dfc2007f`:

- Focused Companion/server suite: 16 tests passed.
- Focused Codex adapter suite: 31 tests passed.
- Full deterministic repository suite: 244 tests passed, 0 failures, 0 errors.
- Protected v0.1 blob/mode guard passed.
- Changed-Markdown heading/fence validation and introduced local-link validation passed.
- Exact closure boundary confirmed: 3 Markdown evidence files.
- Cumulative Draft PR boundary confirmed: 18 files.
- `git diff --check` passed.

Prior implementation validation also established:

- Python AST parse passed for 46 Python files.
- `node --check` and `sh -n` passed.
- Private app built at `/Users/sn/Applications/Decision OS Companion.app`; compiler-produced local ad-hoc signature verified with `codesign --verify --deep --strict`.
- Live app bound only to localhost and opened Chrome without opening Terminal.
- Live no-tool read-only Run completed with sanitized result `READ_ONLY_OK` and a zero receipt.
- Live single-file modification reached the three-choice approval card; **Deny** was exercised and the file remained unchanged.

## Observed limitation to review

A read-only prompt that led Codex to inspect the repository through internal `commandExecution` returned useful final text but was marked **Unsupported** by the companion. This is the intended fail-closed shell/command boundary, but it also means v0.1 only completes read-only tasks that do not require command execution. The Draft state preserves that limitation for review.

## Private packaging

The build script compiles a stay-open AppleScript `.app`, installs a private runtime under `~/Library/Application Support/Decision OS Companion/runtime`, and installs the app under `~/Applications`. No app bundle, signing, notarization, public installer, or release artifact is committed or published.
