### PR TITLE
Add role-bound specialist contracts for Stage 4

### DIFF
--- a/decision_os/role_contract.py
+++ b/decision_os/role_contract.py
@@ -1,0 +1,784 @@
+"""Fail-closed validation for Stage 4 role-bound specialist contracts.
+
+This module is deliberately read-only.  It validates one fixed Role Contract
+against one requested operation and returns a decision; it never assigns a
+role, invokes a specialist, repairs a target, or advances a stage.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+
+RESULT_ACTIVE = "ACTIVE"
+RESULT_HOLD = "HOLD"
+RESULT_BLOCK = "BLOCK"
+RESULT_INVALID = "INVALID"
+
+ROLE_BUILDER = "BUILDER"
+ROLE_AUDITOR = "AUDITOR"
+SUPPORTED_ROLES = frozenset((ROLE_BUILDER, ROLE_AUDITOR))
+
+ROLE_CONTEXT_VALUES = frozenset(
+    (
+        "SAME_CONTEXT_ALLOWED",
+        "FRESH_CONTEXT_REQUIRED",
+        "DISTINCT_TRUSTED_CONTEXT_REQUIRED",
+    )
+)
+SOURCE_REVIEW_VALUES = frozenset(
+    (
+        "FULL_PRIOR_CONTEXT_ALLOWED",
+        "FIXED_ARTIFACTS_ONLY",
+        "INDEPENDENT_EVIDENCE_SELECTION_REQUIRED",
+    )
+)
+RUNTIME_EXECUTION_VALUES = frozenset(
+    (
+        "NOT_REQUIRED",
+        "REQUIRED_NOT_ESTABLISHED",
+        "READ_ONLY_REEXECUTION_REQUIRED",
+        "SEPARATE_ENV_REEXECUTION_REQUIRED",
+        "ESTABLISHED",
+    )
+)
+MODEL_DIVERSITY_VALUES = frozenset(
+    ("SAME_MODEL_ALLOWED", "DIFFERENT_MODEL_REQUIRED")
+)
+
+OPERATION_VALUES = frozenset(
+    (
+        "IMPLEMENT_DESIGN",
+        "READ_TARGET",
+        "AUDIT_TARGET",
+        "VERIFY_TARGET_IMMUTABILITY",
+        "RUN_TESTS",
+        "RUN_READ_ONLY_TESTS",
+        "PRODUCE_EXIT_RECEIPT",
+        "GENERATE_COVERAGE_GAP_RECOMMENDATION",
+        "SELF_AUDIT",
+        "MODIFY_TARGET",
+        "REPAIR_IMPLEMENTATION",
+        "ASSUME_BUILDER_ROLE",
+        "MODIFY_ROLE_GRANT",
+        "MODIFY_SPECIALIST_LENS",
+        "MODIFY_OUTSIDE_TARGET",
+        "MERGE",
+        "POST",
+        "INVOKE_SPECIALIST",
+        "START_STAGE_5",
+    )
+)
+
+BUILDER_ALLOWED = frozenset(
+    (
+        "IMPLEMENT_DESIGN",
+        "READ_TARGET",
+        "RUN_TESTS",
+        "PRODUCE_EXIT_RECEIPT",
+        "GENERATE_COVERAGE_GAP_RECOMMENDATION",
+    )
+)
+AUDITOR_ALLOWED = frozenset(
+    (
+        "READ_TARGET",
+        "AUDIT_TARGET",
+        "VERIFY_TARGET_IMMUTABILITY",
+        "RUN_READ_ONLY_TESTS",
+        "PRODUCE_EXIT_RECEIPT",
+        "GENERATE_COVERAGE_GAP_RECOMMENDATION",
+    )
+)
+BUILDER_REQUIRED_FORBIDDEN = frozenset(
+    (
+        "AUDIT_TARGET",
+        "SELF_AUDIT",
+        "MODIFY_ROLE_GRANT",
+        "MODIFY_SPECIALIST_LENS",
+        "MODIFY_OUTSIDE_TARGET",
+        "MERGE",
+        "POST",
+        "INVOKE_SPECIALIST",
+        "START_STAGE_5",
+    )
+)
+AUDITOR_REQUIRED_FORBIDDEN = frozenset(
+    (
+        "MODIFY_TARGET",
+        "REPAIR_IMPLEMENTATION",
+        "ASSUME_BUILDER_ROLE",
+        "MODIFY_ROLE_GRANT",
+        "MODIFY_SPECIALIST_LENS",
+        "MODIFY_OUTSIDE_TARGET",
+        "MERGE",
+        "POST",
+        "INVOKE_SPECIALIST",
+        "START_STAGE_5",
+    )
+)
+
+TOP_LEVEL_FIELDS = frozenset(
+    (
+        "contract_identity",
+        "assignment",
+        "owned_responsibility",
+        "operations",
+        "task_artifact_packet",
+        "specialist_lens",
+        "independence_profile",
+        "completion",
+        "lifecycle",
+        "coverage_gap_recommendation",
+    )
+)
+SECTION_FIELDS = {
+    "contract_identity": frozenset(("contract_id", "version", "contract_hash")),
+    "assignment": frozenset(
+        (
+            "task_id",
+            "role_id",
+            "grant_type",
+            "assignment_authority",
+            "shin_gate_reference",
+            "assignee_identity",
+            "execution_context_identity",
+            "role_acceptance",
+        )
+    ),
+    "owned_responsibility": frozenset(
+        ("responsibility", "exact_target", "next_owner")
+    ),
+    "operations": frozenset(("allowed_operations", "forbidden_operations")),
+    "task_artifact_packet": frozenset(
+        ("repo", "head", "paths", "artifact_hashes", "as_of")
+    ),
+    "specialist_lens": frozenset(("lens_id", "lens_version", "lens_hash")),
+    "independence_profile": frozenset(
+        (
+            "role_context_independence",
+            "source_review_independence",
+            "runtime_execution_independence",
+            "model_diversity",
+        )
+    ),
+    "completion": frozenset(
+        ("completion_line", "required_exit_receipt", "coverage_gap_required")
+    ),
+    "lifecycle": frozenset(
+        ("issued_at", "expires_at", "revocation_reference", "status")
+    ),
+    "coverage_gap_recommendation": frozenset(
+        (
+            "coverage_completed",
+            "coverage_gap",
+            "recommended_specialist",
+            "reason",
+            "exact_target",
+            "required_evidence",
+            "urgency",
+            "assignment_authority_required",
+            "automatic_invocation",
+        )
+    ),
+}
+
+REQUEST_FIELDS = frozenset(
+    (
+        "operation",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "task_artifact_packet",
+        "specialist_lens",
+        "independence_evidence",
+        "prior_role_bindings",
+        "target_immutability",
+        "coverage_gap_recommendation",
+    )
+)
+INDEPENDENCE_EVIDENCE_FIELDS = frozenset(
+    (
+        "role_context_independence",
+        "source_review_independence",
+        "runtime_execution_independence",
+        "model_diversity",
+        "model_identity",
+        "source_review_evidence_reference",
+        "runtime_execution_evidence_reference",
+    )
+)
+PRIOR_BINDING_FIELDS = frozenset(
+    (
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "model_identity",
+    )
+)
+TARGET_IMMUTABILITY_FIELDS = frozenset(
+    (
+        "before_head",
+        "after_head",
+        "before_artifact_hashes",
+        "after_artifact_hashes",
+    )
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GIT_HEAD_RE = re.compile(r"^[0-9a-f]{40}$")
+_UNKNOWN_VALUES = frozenset(("", "UNKNOWN", "UNVERIFIABLE", "NONE"))
+
+
+@dataclass(frozen=True)
+class RoleContractAssessment:
+    """One deterministic Stage 4 role-operation assessment."""
+
+    result: str
+    issue_codes: tuple[str, ...]
+
+    @property
+    def decision_line(self) -> str:
+        if self.result == RESULT_ACTIVE:
+            return "ACTIVE — ROLE CONTRACT SATISFIED"
+        issue = self.issue_codes[0] if self.issue_codes else "UNSPECIFIED"
+        return f"{self.result} — {issue.replace('_', ' ')}"
+
+
+def _assessment(result: str, *issue_codes: str) -> RoleContractAssessment:
+    return RoleContractAssessment(result, tuple(dict.fromkeys(issue_codes)))
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and value.strip() not in _UNKNOWN_VALUES
+
+
+def _is_string_sequence(value: Any, *, nonempty: bool = True) -> bool:
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and (bool(value) or not nonempty)
+        and all(_is_nonempty_string(item) for item in value)
+    )
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def compute_contract_hash(contract: Mapping[str, Any]) -> str:
+    """Return the canonical SHA-256 with ``contract_hash`` blanked."""
+
+    canonical = deepcopy(dict(contract))
+    identity = canonical.get("contract_identity")
+    if not isinstance(identity, Mapping):
+        raise ValueError("contract_identity is required")
+    canonical["contract_identity"] = dict(identity)
+    canonical["contract_identity"]["contract_hash"] = ""
+    encoded = json.dumps(
+        canonical,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def contract_with_hash(contract: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a JSON-compatible copy with its canonical hash populated."""
+
+    value = deepcopy(dict(contract))
+    identity = value.get("contract_identity")
+    if not isinstance(identity, Mapping):
+        raise ValueError("contract_identity is required")
+    value["contract_identity"] = dict(identity)
+    value["contract_identity"]["contract_hash"] = compute_contract_hash(value)
+    return value
+
+
+def _contract_shape_issue(contract: Any) -> str | None:
+    if not isinstance(contract, Mapping):
+        return "ROLE_CONTRACT_REQUIRED"
+    if set(contract) != TOP_LEVEL_FIELDS:
+        return "INVALID_CONTRACT_STRUCTURE"
+    for section_name, fields in SECTION_FIELDS.items():
+        section = contract.get(section_name)
+        if not isinstance(section, Mapping) or set(section) != fields:
+            return "INVALID_CONTRACT_STRUCTURE"
+    return None
+
+
+def _request_shape_issue(request: Any) -> str | None:
+    if not isinstance(request, Mapping):
+        return "OPERATION_REQUEST_REQUIRED"
+    if not set(request).issubset(REQUEST_FIELDS):
+        return "INVALID_OPERATION_REQUEST"
+    required = REQUEST_FIELDS - {
+        "coverage_gap_recommendation",
+        "target_immutability",
+    }
+    if not required.issubset(request):
+        return "OPERATION_REQUEST_INCOMPLETE"
+    return None
+
+
+def _valid_coverage_gap(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    if set(value) != SECTION_FIELDS["coverage_gap_recommendation"]:
+        return False
+    if (
+        not isinstance(value.get("coverage_completed"), bool)
+        or not _is_nonempty_string(value.get("coverage_gap"))
+        or value.get("recommended_specialist")
+        not in ("NONE", ROLE_BUILDER, ROLE_AUDITOR)
+        or not _is_nonempty_string(value.get("reason"))
+        or not _is_string_sequence(value.get("exact_target"))
+        or not _is_string_sequence(value.get("required_evidence"))
+        or value.get("urgency") not in ("LOW", "MEDIUM", "HIGH", "NONE")
+        or value.get("assignment_authority_required") is not True
+        or value.get("automatic_invocation") is not False
+    ):
+        return False
+    return True
+
+
+def _packet_valid(packet: Any) -> bool:
+    if not isinstance(packet, Mapping):
+        return False
+    if set(packet) != SECTION_FIELDS["task_artifact_packet"]:
+        return False
+    paths = packet.get("paths")
+    hashes = packet.get("artifact_hashes")
+    if (
+        not _is_nonempty_string(packet.get("repo"))
+        or not isinstance(packet.get("head"), str)
+        or _GIT_HEAD_RE.fullmatch(packet["head"]) is None
+        or not _is_string_sequence(paths)
+        or len(paths) != len(set(paths))
+        or not isinstance(hashes, Mapping)
+        or set(hashes) != set(paths)
+        or not all(
+            isinstance(digest, str) and _SHA256_RE.fullmatch(digest)
+            for digest in hashes.values()
+        )
+        or _parse_timestamp(packet.get("as_of")) is None
+    ):
+        return False
+    return True
+
+
+def _lens_valid(lens: Any) -> bool:
+    return (
+        isinstance(lens, Mapping)
+        and set(lens) == SECTION_FIELDS["specialist_lens"]
+        and _is_nonempty_string(lens.get("lens_id"))
+        and _is_nonempty_string(lens.get("lens_version"))
+        and isinstance(lens.get("lens_hash"), str)
+        and _SHA256_RE.fullmatch(lens["lens_hash"]) is not None
+    )
+
+
+def _profile_valid(profile: Any) -> bool:
+    return (
+        isinstance(profile, Mapping)
+        and set(profile) == SECTION_FIELDS["independence_profile"]
+        and profile.get("role_context_independence") in ROLE_CONTEXT_VALUES
+        and profile.get("source_review_independence") in SOURCE_REVIEW_VALUES
+        and profile.get("runtime_execution_independence")
+        in RUNTIME_EXECUTION_VALUES
+        and profile.get("model_diversity") in MODEL_DIVERSITY_VALUES
+    )
+
+
+def _contract_semantic_issue(contract: Mapping[str, Any]) -> str | None:
+    identity = contract["contract_identity"]
+    assignment = contract["assignment"]
+    ownership = contract["owned_responsibility"]
+    operations = contract["operations"]
+    packet = contract["task_artifact_packet"]
+    lens = contract["specialist_lens"]
+    profile = contract["independence_profile"]
+    completion = contract["completion"]
+    lifecycle = contract["lifecycle"]
+    coverage = contract["coverage_gap_recommendation"]
+
+    if (
+        not _is_nonempty_string(identity["contract_id"])
+        or identity["version"] != "0.1"
+        or not isinstance(identity["contract_hash"], str)
+        or _SHA256_RE.fullmatch(identity["contract_hash"]) is None
+    ):
+        return "INVALID_CONTRACT_IDENTITY"
+    try:
+        expected_hash = compute_contract_hash(contract)
+    except (TypeError, ValueError):
+        return "INVALID_CONTRACT_IDENTITY"
+    if identity["contract_hash"] != expected_hash:
+        return "CONTRACT_HASH_MISMATCH"
+
+    role = assignment["role_id"]
+    if role not in SUPPORTED_ROLES:
+        return "UNSUPPORTED_ROLE"
+    if assignment["grant_type"] != "EXPLICIT_ROLE_GRANT":
+        return "EXPLICIT_ROLE_GRANT_REQUIRED"
+    if assignment["assignment_authority"] != "Shin":
+        return "ASSIGNMENT_AUTHORITY_REQUIRED"
+    if not _is_nonempty_string(assignment["shin_gate_reference"]):
+        return "SHIN_GATE_REFERENCE_REQUIRED"
+    if (
+        not _is_nonempty_string(assignment["task_id"])
+        or not _is_nonempty_string(assignment["assignee_identity"])
+        or not _is_nonempty_string(assignment["execution_context_identity"])
+    ):
+        return "ASSIGNMENT_BINDING_REQUIRED"
+    if assignment["role_acceptance"] != "ACCEPTED":
+        return "ROLE_ACCEPTANCE_REQUIRED"
+
+    if (
+        not _is_nonempty_string(ownership["responsibility"])
+        or not _is_string_sequence(ownership["exact_target"])
+        or not _is_nonempty_string(ownership["next_owner"])
+    ):
+        return "INVALID_OWNED_RESPONSIBILITY"
+    if not _packet_valid(packet):
+        return "TASK_ARTIFACT_PACKET_REQUIRED"
+    if tuple(ownership["exact_target"]) != tuple(packet["paths"]):
+        return "TARGET_SCOPE_MISMATCH"
+    if not _lens_valid(lens):
+        return "SPECIALIST_LENS_REQUIRED"
+    if not _profile_valid(profile):
+        return "INDEPENDENCE_PROFILE_INVALID"
+    if role == ROLE_AUDITOR and (
+        profile["role_context_independence"]
+        != "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+    ):
+        return "AUDITOR_DISTINCT_CONTEXT_REQUIRED"
+
+    allowed = operations["allowed_operations"]
+    forbidden = operations["forbidden_operations"]
+    if (
+        not _is_string_sequence(allowed)
+        or not _is_string_sequence(forbidden)
+        or len(allowed) != len(set(allowed))
+        or len(forbidden) != len(set(forbidden))
+        or not set((*allowed, *forbidden)).issubset(OPERATION_VALUES)
+        or set(allowed) & set(forbidden)
+    ):
+        return "INVALID_OPERATION_BOUNDARY"
+    role_allowed = BUILDER_ALLOWED if role == ROLE_BUILDER else AUDITOR_ALLOWED
+    role_forbidden = (
+        BUILDER_REQUIRED_FORBIDDEN
+        if role == ROLE_BUILDER
+        else AUDITOR_REQUIRED_FORBIDDEN
+    )
+    if not set(allowed).issubset(role_allowed) or not role_forbidden.issubset(
+        forbidden
+    ):
+        return "ROLE_OPERATION_BOUNDARY_INCOMPLETE"
+
+    if (
+        not _is_nonempty_string(completion["completion_line"])
+        or completion["required_exit_receipt"] is not True
+        or completion["coverage_gap_required"] is not True
+    ):
+        return "COMPLETION_CONTRACT_INCOMPLETE"
+    issued = _parse_timestamp(lifecycle["issued_at"])
+    expires = _parse_timestamp(lifecycle["expires_at"])
+    if issued is None or expires is None or issued >= expires:
+        return "INVALID_LIFECYCLE"
+    if lifecycle["status"] not in ("ACTIVE", "EXPIRED", "REVOKED"):
+        return "INVALID_LIFECYCLE"
+    revocation = lifecycle["revocation_reference"]
+    if revocation is not None and not _is_nonempty_string(revocation):
+        return "INVALID_LIFECYCLE"
+    if not _valid_coverage_gap(coverage):
+        return "COVERAGE_RECOMMENDATION_NOT_INERT"
+    if tuple(coverage["exact_target"]) != tuple(packet["paths"]):
+        return "COVERAGE_TARGET_MISMATCH"
+    if coverage["coverage_gap"] == "NONE DETECTED" and (
+        coverage["coverage_completed"] is not True
+        or coverage["recommended_specialist"] != "NONE"
+        or coverage["urgency"] != "NONE"
+    ):
+        return "COVERAGE_RECOMMENDATION_INCONSISTENT"
+    if coverage["coverage_gap"] != "NONE DETECTED" and (
+        coverage["recommended_specialist"] == "NONE"
+        or coverage["urgency"] == "NONE"
+    ):
+        return "COVERAGE_RECOMMENDATION_INCONSISTENT"
+    return None
+
+
+def _independence_assessment(
+    contract: Mapping[str, Any],
+    request: Mapping[str, Any],
+) -> RoleContractAssessment | None:
+    assignment = contract["assignment"]
+    required = contract["independence_profile"]
+    evidence = request["independence_evidence"]
+    bindings = request["prior_role_bindings"]
+    if (
+        not isinstance(evidence, Mapping)
+        or set(evidence) != INDEPENDENCE_EVIDENCE_FIELDS
+        or not isinstance(bindings, Sequence)
+        or isinstance(bindings, (str, bytes, bytearray))
+    ):
+        return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
+    if (
+        evidence.get("role_context_independence") not in ROLE_CONTEXT_VALUES
+        or evidence.get("source_review_independence")
+        not in SOURCE_REVIEW_VALUES
+        or evidence.get("runtime_execution_independence")
+        not in RUNTIME_EXECUTION_VALUES
+        or evidence.get("model_diversity") not in MODEL_DIVERSITY_VALUES
+        or not _is_nonempty_string(evidence.get("model_identity"))
+        or not _is_nonempty_string(
+            evidence.get("source_review_evidence_reference")
+        )
+        or not _is_nonempty_string(
+            evidence.get("runtime_execution_evidence_reference")
+        )
+    ):
+        return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
+
+    normalized_bindings: list[Mapping[str, Any]] = []
+    for binding in bindings:
+        if (
+            not isinstance(binding, Mapping)
+            or set(binding) != PRIOR_BINDING_FIELDS
+            or binding.get("role_id") not in SUPPORTED_ROLES
+            or not all(
+                _is_nonempty_string(binding.get(field))
+                for field in PRIOR_BINDING_FIELDS - {"role_id"}
+            )
+        ):
+            return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
+        normalized_bindings.append(binding)
+
+    same_task = [
+        binding
+        for binding in normalized_bindings
+        if binding["task_id"] == assignment["task_id"]
+    ]
+    builder_bindings = [
+        binding
+        for binding in same_task
+        if binding["role_id"] == ROLE_BUILDER
+    ]
+    current_context = assignment["execution_context_identity"]
+    current_assignee = assignment["assignee_identity"]
+    role_requirement = required["role_context_independence"]
+
+    if (
+        role_requirement != "SAME_CONTEXT_ALLOWED"
+        and evidence["role_context_independence"] != role_requirement
+    ):
+        return _assessment(
+            RESULT_HOLD,
+            "CONTEXT_INDEPENDENCE_NOT_ESTABLISHED",
+        )
+    if role_requirement in (
+        "FRESH_CONTEXT_REQUIRED",
+        "DISTINCT_TRUSTED_CONTEXT_REQUIRED",
+    ) and any(
+        binding["execution_context_identity"] == current_context
+        for binding in same_task
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "CONTEXT_INDEPENDENCE_VIOLATION",
+        )
+    if (
+        assignment["role_id"] == ROLE_AUDITOR
+        and not builder_bindings
+    ):
+        return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
+    if assignment["role_id"] == ROLE_AUDITOR and any(
+        binding["assignee_identity"] == current_assignee
+        for binding in builder_bindings
+    ):
+        return _assessment(RESULT_BLOCK, "BUILDER_AUDITOR_ROLE_COLLISION")
+
+    source_required = required["source_review_independence"]
+    source_observed = evidence["source_review_independence"]
+    source_satisfies = {
+        "FULL_PRIOR_CONTEXT_ALLOWED": SOURCE_REVIEW_VALUES,
+        "FIXED_ARTIFACTS_ONLY": frozenset(
+            (
+                "FIXED_ARTIFACTS_ONLY",
+                "INDEPENDENT_EVIDENCE_SELECTION_REQUIRED",
+            )
+        ),
+        "INDEPENDENT_EVIDENCE_SELECTION_REQUIRED": frozenset(
+            ("INDEPENDENT_EVIDENCE_SELECTION_REQUIRED",)
+        ),
+    }
+    if source_observed not in source_satisfies[source_required]:
+        return _assessment(
+            RESULT_HOLD,
+            "SOURCE_REVIEW_INDEPENDENCE_NOT_ESTABLISHED",
+        )
+
+    runtime_required = required["runtime_execution_independence"]
+    runtime_observed = evidence["runtime_execution_independence"]
+    if runtime_required == "REQUIRED_NOT_ESTABLISHED":
+        return _assessment(
+            RESULT_HOLD,
+            "RUNTIME_EXECUTION_INDEPENDENCE_NOT_ESTABLISHED",
+        )
+    if (
+        runtime_required != "NOT_REQUIRED"
+        and runtime_observed != runtime_required
+    ):
+        return _assessment(
+            RESULT_HOLD,
+            "RUNTIME_EXECUTION_INDEPENDENCE_NOT_ESTABLISHED",
+        )
+
+    model_required = required["model_diversity"]
+    if model_required == "DIFFERENT_MODEL_REQUIRED":
+        if not builder_bindings or any(
+            binding["model_identity"] == evidence["model_identity"]
+            for binding in builder_bindings
+        ):
+            return _assessment(
+                RESULT_HOLD,
+                "MODEL_DIVERSITY_NOT_ESTABLISHED",
+            )
+    return None
+
+
+def _target_immutability_satisfied(
+    contract: Mapping[str, Any],
+    request: Mapping[str, Any],
+) -> bool:
+    evidence = request.get("target_immutability")
+    packet = contract["task_artifact_packet"]
+    return (
+        isinstance(evidence, Mapping)
+        and set(evidence) == TARGET_IMMUTABILITY_FIELDS
+        and evidence.get("before_head") == packet["head"]
+        and evidence.get("after_head") == packet["head"]
+        and evidence.get("before_artifact_hashes")
+        == packet["artifact_hashes"]
+        and evidence.get("after_artifact_hashes")
+        == packet["artifact_hashes"]
+    )
+
+
+def validate_role_operation(
+    contract: Mapping[str, Any] | None,
+    request: Mapping[str, Any] | None,
+    *,
+    now: datetime | None = None,
+) -> RoleContractAssessment:
+    """Validate one operation without producing any assignment or side effect."""
+
+    shape_issue = _contract_shape_issue(contract)
+    if shape_issue is not None:
+        return _assessment(RESULT_INVALID, shape_issue)
+    assert contract is not None
+    semantic_issue = _contract_semantic_issue(contract)
+    if semantic_issue is not None:
+        result = (
+            RESULT_BLOCK
+            if semantic_issue
+            in (
+                "EXPLICIT_ROLE_GRANT_REQUIRED",
+                "ASSIGNMENT_AUTHORITY_REQUIRED",
+                "SHIN_GATE_REFERENCE_REQUIRED",
+                "ROLE_ACCEPTANCE_REQUIRED",
+                "COVERAGE_RECOMMENDATION_NOT_INERT",
+            )
+            else RESULT_INVALID
+        )
+        return _assessment(result, semantic_issue)
+
+    request_issue = _request_shape_issue(request)
+    if request_issue is not None:
+        return _assessment(RESULT_INVALID, request_issue)
+    assert request is not None
+
+    assignment = contract["assignment"]
+    if (
+        request["task_id"] != assignment["task_id"]
+        or request["role_id"] != assignment["role_id"]
+        or request["assignee_identity"] != assignment["assignee_identity"]
+        or request["execution_context_identity"]
+        != assignment["execution_context_identity"]
+    ):
+        return _assessment(RESULT_BLOCK, "ASSIGNMENT_BINDING_MISMATCH")
+    if request["task_artifact_packet"] != contract["task_artifact_packet"]:
+        return _assessment(RESULT_BLOCK, "TASK_ARTIFACT_PACKET_MISMATCH")
+    if request["specialist_lens"] != contract["specialist_lens"]:
+        return _assessment(RESULT_BLOCK, "SPECIALIST_LENS_MISMATCH")
+
+    operation = request["operation"]
+    if (
+        operation not in OPERATION_VALUES
+        or operation not in contract["operations"]["allowed_operations"]
+        or operation in contract["operations"]["forbidden_operations"]
+    ):
+        return _assessment(RESULT_BLOCK, "OPERATION_NOT_ALLOWED")
+    if (
+        assignment["role_id"] == ROLE_AUDITOR
+        and not _target_immutability_satisfied(contract, request)
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "TARGET_IMMUTABILITY_NOT_ESTABLISHED",
+        )
+
+    lifecycle = contract["lifecycle"]
+    current = now or datetime.now(timezone.utc)
+    if not isinstance(current, datetime) or current.tzinfo is None:
+        return _assessment(RESULT_INVALID, "CURRENT_TIME_UNVERIFIABLE")
+    current = current.astimezone(timezone.utc)
+    expires = _parse_timestamp(lifecycle["expires_at"])
+    issued = _parse_timestamp(lifecycle["issued_at"])
+    assert expires is not None and issued is not None
+    if (
+        lifecycle["status"] == "REVOKED"
+        or lifecycle["revocation_reference"] is not None
+    ):
+        return _assessment(RESULT_BLOCK, "ROLE_GRANT_REVOKED")
+    if lifecycle["status"] == "EXPIRED" or current >= expires:
+        return _assessment(RESULT_BLOCK, "ROLE_GRANT_EXPIRED")
+    if lifecycle["status"] != "ACTIVE" or current < issued:
+        return _assessment(RESULT_HOLD, "ROLE_GRANT_NOT_ACTIVE")
+
+    independence = _independence_assessment(contract, request)
+    if independence is not None:
+        return independence
+
+    if contract["completion"]["coverage_gap_required"]:
+        recommendation = request.get("coverage_gap_recommendation")
+        if not _valid_coverage_gap(recommendation):
+            return _assessment(
+                RESULT_BLOCK,
+                "COVERAGE_RECOMMENDATION_NOT_INERT",
+            )
+        if recommendation != contract["coverage_gap_recommendation"]:
+            return _assessment(
+                RESULT_BLOCK,
+                "COVERAGE_RECOMMENDATION_MISMATCH",
+            )
+
+    return _assessment(RESULT_ACTIVE)

--- a/decision_os/role_contract.py
+++ b/decision_os/role_contract.py
@@ -205,6 +205,11 @@ REQUEST_FIELDS = frozenset(
 )
 INDEPENDENCE_EVIDENCE_FIELDS = frozenset(
     (
+        "evidence_identity",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
         "role_context_independence",
         "source_review_independence",
         "runtime_execution_independence",
@@ -216,6 +221,7 @@ INDEPENDENCE_EVIDENCE_FIELDS = frozenset(
 )
 PRIOR_BINDING_FIELDS = frozenset(
     (
+        "evidence_identity",
         "task_id",
         "role_id",
         "assignee_identity",
@@ -242,6 +248,18 @@ TRUSTED_ROLE_GRANT_FIELDS = frozenset(
         "shin_gate_reference",
         "assignee_identity",
         "execution_context_identity",
+    )
+)
+TRUSTED_ROLE_ACCEPTANCE_FIELDS = frozenset(
+    (
+        "contract_id",
+        "contract_hash",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "role_acceptance",
+        "accepted_at",
     )
 )
 
@@ -539,39 +557,42 @@ def _contract_semantic_issue(contract: Mapping[str, Any]) -> str | None:
     return None
 
 
-def _independence_assessment(
-    contract: Mapping[str, Any],
-    request: Mapping[str, Any],
-) -> RoleContractAssessment | None:
-    assignment = contract["assignment"]
-    required = contract["independence_profile"]
-    evidence = request["independence_evidence"]
-    bindings = request["prior_role_bindings"]
+def _independence_evidence_valid(evidence: Any) -> bool:
+    return (
+        isinstance(evidence, Mapping)
+        and set(evidence) == INDEPENDENCE_EVIDENCE_FIELDS
+        and evidence.get("role_id") in SUPPORTED_ROLES
+        and all(
+            _is_nonempty_string(evidence.get(field))
+            for field in (
+                "evidence_identity",
+                "task_id",
+                "assignee_identity",
+                "execution_context_identity",
+                "model_identity",
+                "source_review_evidence_reference",
+                "runtime_execution_evidence_reference",
+            )
+        )
+        and evidence.get("role_context_independence")
+        in ROLE_CONTEXT_VALUES
+        and evidence.get("source_review_independence")
+        in SOURCE_REVIEW_VALUES
+        and evidence.get("runtime_execution_independence")
+        in RUNTIME_EXECUTION_VALUES
+        and evidence.get("model_diversity") in MODEL_DIVERSITY_VALUES
+    )
+
+
+def _prior_binding_map(
+    bindings: Any,
+) -> dict[str, Mapping[str, Any]] | None:
     if (
-        not isinstance(evidence, Mapping)
-        or set(evidence) != INDEPENDENCE_EVIDENCE_FIELDS
-        or not isinstance(bindings, Sequence)
+        not isinstance(bindings, Sequence)
         or isinstance(bindings, (str, bytes, bytearray))
     ):
-        return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
-    if (
-        evidence.get("role_context_independence") not in ROLE_CONTEXT_VALUES
-        or evidence.get("source_review_independence")
-        not in SOURCE_REVIEW_VALUES
-        or evidence.get("runtime_execution_independence")
-        not in RUNTIME_EXECUTION_VALUES
-        or evidence.get("model_diversity") not in MODEL_DIVERSITY_VALUES
-        or not _is_nonempty_string(evidence.get("model_identity"))
-        or not _is_nonempty_string(
-            evidence.get("source_review_evidence_reference")
-        )
-        or not _is_nonempty_string(
-            evidence.get("runtime_execution_evidence_reference")
-        )
-    ):
-        return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
-
-    normalized_bindings: list[Mapping[str, Any]] = []
+        return None
+    normalized: dict[str, Mapping[str, Any]] = {}
     for binding in bindings:
         if (
             not isinstance(binding, Mapping)
@@ -582,12 +603,91 @@ def _independence_assessment(
                 for field in PRIOR_BINDING_FIELDS - {"role_id"}
             )
         ):
-            return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
-        normalized_bindings.append(binding)
+            return None
+        evidence_identity = binding["evidence_identity"]
+        if evidence_identity in normalized:
+            return None
+        normalized[evidence_identity] = binding
+    return normalized
+
+
+def _independence_assessment(
+    contract: Mapping[str, Any],
+    request: Mapping[str, Any],
+    trusted_independence_evidence: Any,
+    trusted_prior_role_bindings: Any,
+) -> RoleContractAssessment | None:
+    assignment = contract["assignment"]
+    required = contract["independence_profile"]
+    claimed_evidence = request["independence_evidence"]
+    claimed_bindings = request["prior_role_bindings"]
+
+    if not _independence_evidence_valid(trusted_independence_evidence):
+        return _assessment(
+            RESULT_HOLD,
+            "TRUSTED_INDEPENDENCE_EVIDENCE_REQUIRED",
+        )
+    evidence = trusted_independence_evidence
+    evidence_binding = {
+        "task_id": assignment["task_id"],
+        "role_id": assignment["role_id"],
+        "assignee_identity": assignment["assignee_identity"],
+        "execution_context_identity": assignment[
+            "execution_context_identity"
+        ],
+    }
+    if any(
+        evidence[field] != expected
+        for field, expected in evidence_binding.items()
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+        )
+
+    trusted_binding_map = _prior_binding_map(trusted_prior_role_bindings)
+    if trusted_binding_map is None:
+        return _assessment(
+            RESULT_HOLD,
+            "TRUSTED_PRIOR_ROLE_BINDINGS_REQUIRED",
+        )
+    if evidence["evidence_identity"] in trusted_binding_map:
+        return _assessment(
+            RESULT_HOLD,
+            "TRUSTED_EVIDENCE_IDENTITY_COLLISION",
+        )
+
+    evidence_claim_mismatch = (
+        not _independence_evidence_valid(claimed_evidence)
+        or dict(claimed_evidence) != dict(evidence)
+    )
+    claimed_binding_map = _prior_binding_map(claimed_bindings)
+    binding_claim_mismatch = claimed_binding_map is None or (
+        {
+            identity: dict(binding)
+            for identity, binding in claimed_binding_map.items()
+        }
+        != {
+            identity: dict(binding)
+            for identity, binding in trusted_binding_map.items()
+        }
+    )
+    claim_mismatch_codes = (
+        *(
+            ("TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",)
+            if evidence_claim_mismatch
+            else ()
+        ),
+        *(
+            ("TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",)
+            if binding_claim_mismatch
+            else ()
+        ),
+    )
 
     same_task = [
         binding
-        for binding in normalized_bindings
+        for binding in trusted_binding_map.values()
         if binding["task_id"] == assignment["task_id"]
     ]
     builder_bindings = [
@@ -617,17 +717,33 @@ def _independence_assessment(
         return _assessment(
             RESULT_BLOCK,
             "CONTEXT_INDEPENDENCE_VIOLATION",
+            *claim_mismatch_codes,
+        )
+    if assignment["role_id"] == ROLE_AUDITOR and any(
+        binding["assignee_identity"] == current_assignee
+        for binding in builder_bindings
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "BUILDER_AUDITOR_ROLE_COLLISION",
+            *claim_mismatch_codes,
+        )
+    if evidence_claim_mismatch:
+        return _assessment(
+            RESULT_BLOCK,
+            "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+            *claim_mismatch_codes,
+        )
+    if binding_claim_mismatch:
+        return _assessment(
+            RESULT_BLOCK,
+            "TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",
         )
     if (
         assignment["role_id"] == ROLE_AUDITOR
         and not builder_bindings
     ):
         return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
-    if assignment["role_id"] == ROLE_AUDITOR and any(
-        binding["assignee_identity"] == current_assignee
-        for binding in builder_bindings
-    ):
-        return _assessment(RESULT_BLOCK, "BUILDER_AUDITOR_ROLE_COLLISION")
 
     source_required = required["source_review_independence"]
     source_observed = evidence["source_review_independence"]
@@ -725,14 +841,72 @@ def _trusted_role_grant_assessment(
     return None
 
 
+def _trusted_role_acceptance_assessment(
+    contract: Mapping[str, Any],
+    trusted_role_acceptance: Any,
+    current: datetime,
+) -> RoleContractAssessment | None:
+    if (
+        not isinstance(trusted_role_acceptance, Mapping)
+        or set(trusted_role_acceptance) != TRUSTED_ROLE_ACCEPTANCE_FIELDS
+    ):
+        return _assessment(RESULT_HOLD, "TRUSTED_ROLE_ACCEPTANCE_REQUIRED")
+
+    identity = contract["contract_identity"]
+    assignment = contract["assignment"]
+    expected_binding = {
+        "contract_id": identity["contract_id"],
+        "contract_hash": identity["contract_hash"],
+        "task_id": assignment["task_id"],
+        "role_id": assignment["role_id"],
+        "assignee_identity": assignment["assignee_identity"],
+        "execution_context_identity": assignment[
+            "execution_context_identity"
+        ],
+    }
+    if any(
+        trusted_role_acceptance[field] != expected
+        for field, expected in expected_binding.items()
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "TRUSTED_ROLE_ACCEPTANCE_MISMATCH",
+        )
+    if trusted_role_acceptance["role_acceptance"] != "ACCEPTED":
+        return _assessment(
+            RESULT_BLOCK,
+            "TRUSTED_ROLE_ACCEPTANCE_NOT_ACCEPTED",
+        )
+
+    accepted_at = _parse_timestamp(trusted_role_acceptance["accepted_at"])
+    if accepted_at is None:
+        return _assessment(
+            RESULT_HOLD,
+            "TRUSTED_ROLE_ACCEPTANCE_UNVERIFIABLE",
+        )
+    lifecycle = contract["lifecycle"]
+    issued = _parse_timestamp(lifecycle["issued_at"])
+    expires = _parse_timestamp(lifecycle["expires_at"])
+    assert issued is not None and expires is not None
+    if accepted_at < issued or accepted_at >= expires or accepted_at > current:
+        return _assessment(
+            RESULT_BLOCK,
+            "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+        )
+    return None
+
+
 def validate_role_operation(
     contract: Mapping[str, Any] | None,
     request: Mapping[str, Any] | None,
     *,
     trusted_role_grant: Mapping[str, Any] | None = None,
+    trusted_role_acceptance: Mapping[str, Any] | None = None,
+    trusted_independence_evidence: Mapping[str, Any] | None = None,
+    trusted_prior_role_bindings: Sequence[Mapping[str, Any]] | None = None,
     now: datetime | None = None,
 ) -> RoleContractAssessment:
-    """Validate one operation against an out-of-band trusted Role Grant."""
+    """Validate one operation against independently supplied trusted records."""
 
     shape_issue = _contract_shape_issue(contract)
     if shape_issue is not None:
@@ -814,7 +988,20 @@ def validate_role_operation(
     if lifecycle["status"] != "ACTIVE" or current < issued:
         return _assessment(RESULT_HOLD, "ROLE_GRANT_NOT_ACTIVE")
 
-    independence = _independence_assessment(contract, request)
+    acceptance = _trusted_role_acceptance_assessment(
+        contract,
+        trusted_role_acceptance,
+        current,
+    )
+    if acceptance is not None:
+        return acceptance
+
+    independence = _independence_assessment(
+        contract,
+        request,
+        trusted_independence_evidence,
+        trusted_prior_role_bindings,
+    )
     if independence is not None:
         return independence
 

--- a/decision_os/role_contract.py
+++ b/decision_os/role_contract.py
@@ -231,6 +231,19 @@ TARGET_IMMUTABILITY_FIELDS = frozenset(
         "after_artifact_hashes",
     )
 )
+TRUSTED_ROLE_GRANT_FIELDS = frozenset(
+    (
+        "contract_id",
+        "contract_hash",
+        "task_id",
+        "role_id",
+        "grant_type",
+        "assignment_authority",
+        "shin_gate_reference",
+        "assignee_identity",
+        "execution_context_identity",
+    )
+)
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _GIT_HEAD_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -683,13 +696,43 @@ def _target_immutability_satisfied(
     )
 
 
+def _trusted_role_grant_assessment(
+    contract: Mapping[str, Any],
+    trusted_role_grant: Any,
+) -> RoleContractAssessment | None:
+    if (
+        not isinstance(trusted_role_grant, Mapping)
+        or set(trusted_role_grant) != TRUSTED_ROLE_GRANT_FIELDS
+    ):
+        return _assessment(RESULT_HOLD, "TRUSTED_ROLE_GRANT_REQUIRED")
+    identity = contract["contract_identity"]
+    assignment = contract["assignment"]
+    expected = {
+        "contract_id": identity["contract_id"],
+        "contract_hash": identity["contract_hash"],
+        "task_id": assignment["task_id"],
+        "role_id": assignment["role_id"],
+        "grant_type": assignment["grant_type"],
+        "assignment_authority": assignment["assignment_authority"],
+        "shin_gate_reference": assignment["shin_gate_reference"],
+        "assignee_identity": assignment["assignee_identity"],
+        "execution_context_identity": assignment[
+            "execution_context_identity"
+        ],
+    }
+    if dict(trusted_role_grant) != expected:
+        return _assessment(RESULT_BLOCK, "TRUSTED_ROLE_GRANT_MISMATCH")
+    return None
+
+
 def validate_role_operation(
     contract: Mapping[str, Any] | None,
     request: Mapping[str, Any] | None,
     *,
+    trusted_role_grant: Mapping[str, Any] | None = None,
     now: datetime | None = None,
 ) -> RoleContractAssessment:
-    """Validate one operation without producing any assignment or side effect."""
+    """Validate one operation against an out-of-band trusted Role Grant."""
 
     shape_issue = _contract_shape_issue(contract)
     if shape_issue is not None:
@@ -710,6 +753,13 @@ def validate_role_operation(
             else RESULT_INVALID
         )
         return _assessment(result, semantic_issue)
+
+    grant_assessment = _trusted_role_grant_assessment(
+        contract,
+        trusted_role_grant,
+    )
+    if grant_assessment is not None:
+        return grant_assessment
 
     request_issue = _request_shape_issue(request)
     if request_issue is not None:

--- a/decision_os/role_contract.py
+++ b/decision_os/role_contract.py
@@ -1,8 +1,9 @@
-"""Fail-closed validation for Stage 4 role-bound specialist contracts.
+"""Validator-level fail-closed checks for Stage 4 Role Contracts.
 
 This module is deliberately read-only.  It validates one fixed Role Contract
-against one requested operation and returns a decision; it never assigns a
-role, invokes a specialist, repairs a target, or advances a stage.
+against one requested operation and supplied records, then returns a decision.
+It does not issue or authenticate records, assign a role, invoke a specialist,
+repair a target, persist replay state, or advance a stage.
 """
 
 from __future__ import annotations
@@ -29,7 +30,7 @@ ROLE_CONTEXT_VALUES = frozenset(
     (
         "SAME_CONTEXT_ALLOWED",
         "FRESH_CONTEXT_REQUIRED",
-        "DISTINCT_TRUSTED_CONTEXT_REQUIRED",
+        "DISTINCT_CONTEXT_REQUIRED",
     )
 )
 SOURCE_REVIEW_VALUES = frozenset(
@@ -45,7 +46,7 @@ RUNTIME_EXECUTION_VALUES = frozenset(
         "REQUIRED_NOT_ESTABLISHED",
         "READ_ONLY_REEXECUTION_REQUIRED",
         "SEPARATE_ENV_REEXECUTION_REQUIRED",
-        "ESTABLISHED",
+        "EXECUTION_RECORD_SUPPLIED",
     )
 )
 MODEL_DIVERSITY_VALUES = frozenset(
@@ -205,7 +206,7 @@ REQUEST_FIELDS = frozenset(
 )
 INDEPENDENCE_EVIDENCE_FIELDS = frozenset(
     (
-        "evidence_identity",
+        "record_identity",
         "task_id",
         "role_id",
         "assignee_identity",
@@ -221,12 +222,15 @@ INDEPENDENCE_EVIDENCE_FIELDS = frozenset(
 )
 PRIOR_BINDING_FIELDS = frozenset(
     (
-        "evidence_identity",
+        "record_identity",
         "task_id",
         "role_id",
         "assignee_identity",
         "execution_context_identity",
         "model_identity",
+        "bound_at",
+        "ended_at",
+        "binding_state",
     )
 )
 TARGET_IMMUTABILITY_FIELDS = frozenset(
@@ -237,7 +241,17 @@ TARGET_IMMUTABILITY_FIELDS = frozenset(
         "after_artifact_hashes",
     )
 )
-TRUSTED_ROLE_GRANT_FIELDS = frozenset(
+SUPPLIED_RECORD_STATE_FIELDS = frozenset(
+    (
+        "record_identity",
+        "snapshot_identity",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference",
+    )
+)
+SUPPLIED_ROLE_GRANT_FIELDS = frozenset(
     (
         "contract_id",
         "contract_hash",
@@ -249,8 +263,8 @@ TRUSTED_ROLE_GRANT_FIELDS = frozenset(
         "assignee_identity",
         "execution_context_identity",
     )
-)
-TRUSTED_ROLE_ACCEPTANCE_FIELDS = frozenset(
+) | SUPPLIED_RECORD_STATE_FIELDS
+SUPPLIED_ROLE_ACCEPTANCE_FIELDS = frozenset(
     (
         "contract_id",
         "contract_hash",
@@ -260,8 +274,52 @@ TRUSTED_ROLE_ACCEPTANCE_FIELDS = frozenset(
         "execution_context_identity",
         "role_acceptance",
         "accepted_at",
+        "grant_record_identity",
+    )
+) | SUPPLIED_RECORD_STATE_FIELDS
+SUPPLIED_INDEPENDENCE_EVIDENCE_FIELDS = (
+    INDEPENDENCE_EVIDENCE_FIELDS
+    | SUPPLIED_RECORD_STATE_FIELDS
+    | frozenset(
+        (
+            "contract_id",
+            "contract_hash",
+            "prior_role_bindings_snapshot_identity",
+            "prior_role_bindings_snapshot_hash",
+        )
     )
 )
+SUPPLIED_PRIOR_BINDING_FIELDS = (
+    PRIOR_BINDING_FIELDS | SUPPLIED_RECORD_STATE_FIELDS
+)
+SUPPLIED_PRIOR_BINDING_SNAPSHOT_FIELDS = frozenset(
+    (
+        "snapshot_identity",
+        "snapshot_hash",
+        "contract_id",
+        "contract_hash",
+        "task_id",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference",
+        "completeness_boundary",
+        "bindings",
+    )
+)
+COMPLETENESS_BOUNDARY_FIELDS = frozenset(
+    (
+        "scope",
+        "task_id",
+        "from",
+        "through",
+        "included_roles",
+        "state",
+        "expected_record_identities",
+    )
+)
+
+REVOCATION_STATES = frozenset(("NOT_REVOKED", "REVOKED", "UNKNOWN"))
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _GIT_HEAD_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -278,7 +336,7 @@ class RoleContractAssessment:
     @property
     def decision_line(self) -> str:
         if self.result == RESULT_ACTIVE:
-            return "ACTIVE — ROLE CONTRACT SATISFIED"
+            return "ACTIVE — VALIDATOR CONDITIONS SATISFIED"
         issue = self.issue_codes[0] if self.issue_codes else "UNSPECIFIED"
         return f"{self.result} — {issue.replace('_', ' ')}"
 
@@ -341,6 +399,25 @@ def contract_with_hash(contract: Mapping[str, Any]) -> dict[str, Any]:
     value["contract_identity"] = dict(identity)
     value["contract_identity"]["contract_hash"] = compute_contract_hash(value)
     return value
+
+
+def compute_prior_role_bindings_snapshot_hash(
+    snapshot: Mapping[str, Any],
+) -> str:
+    """Return the canonical SHA-256 with ``snapshot_hash`` blanked."""
+
+    canonical = deepcopy(dict(snapshot))
+    if "snapshot_hash" not in canonical:
+        raise ValueError("snapshot_hash is required")
+    canonical["snapshot_hash"] = ""
+    encoded = json.dumps(
+        canonical,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _contract_shape_issue(contract: Any) -> str | None:
@@ -498,7 +575,7 @@ def _contract_semantic_issue(contract: Mapping[str, Any]) -> str | None:
         return "INDEPENDENCE_PROFILE_INVALID"
     if role == ROLE_AUDITOR and (
         profile["role_context_independence"]
-        != "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+        != "DISTINCT_CONTEXT_REQUIRED"
     ):
         return "AUDITOR_DISTINCT_CONTEXT_REQUIRED"
 
@@ -557,7 +634,7 @@ def _contract_semantic_issue(contract: Mapping[str, Any]) -> str | None:
     return None
 
 
-def _independence_evidence_valid(evidence: Any) -> bool:
+def _claim_independence_evidence_valid(evidence: Any) -> bool:
     return (
         isinstance(evidence, Mapping)
         and set(evidence) == INDEPENDENCE_EVIDENCE_FIELDS
@@ -565,7 +642,7 @@ def _independence_evidence_valid(evidence: Any) -> bool:
         and all(
             _is_nonempty_string(evidence.get(field))
             for field in (
-                "evidence_identity",
+                "record_identity",
                 "task_id",
                 "assignee_identity",
                 "execution_context_identity",
@@ -584,7 +661,7 @@ def _independence_evidence_valid(evidence: Any) -> bool:
     )
 
 
-def _prior_binding_map(
+def _claim_prior_binding_map(
     bindings: Any,
 ) -> dict[str, Mapping[str, Any]] | None:
     if (
@@ -598,37 +675,517 @@ def _prior_binding_map(
             not isinstance(binding, Mapping)
             or set(binding) != PRIOR_BINDING_FIELDS
             or binding.get("role_id") not in SUPPORTED_ROLES
+            or binding.get("binding_state") not in ("ACTIVE", "ENDED")
             or not all(
                 _is_nonempty_string(binding.get(field))
-                for field in PRIOR_BINDING_FIELDS - {"role_id"}
+                for field in (
+                    "record_identity",
+                    "task_id",
+                    "assignee_identity",
+                    "execution_context_identity",
+                    "model_identity",
+                )
             )
         ):
             return None
-        evidence_identity = binding["evidence_identity"]
-        if evidence_identity in normalized:
+        bound_at = _parse_timestamp(binding.get("bound_at"))
+        ended_at = _parse_timestamp(binding.get("ended_at"))
+        if (
+            bound_at is None
+            or (
+                binding["binding_state"] == "ACTIVE"
+                and binding.get("ended_at") is not None
+            )
+            or (
+                binding["binding_state"] == "ENDED"
+                and (ended_at is None or ended_at <= bound_at)
+            )
+        ):
             return None
-        normalized[evidence_identity] = binding
+        record_identity = binding["record_identity"]
+        if record_identity in normalized:
+            return None
+        normalized[record_identity] = binding
     return normalized
+
+
+def _supplied_record_state_assessment(
+    record: Mapping[str, Any],
+    prefix: str,
+    current: datetime,
+) -> RoleContractAssessment | None:
+    if (
+        not _is_nonempty_string(record.get("record_identity"))
+        or not _is_nonempty_string(record.get("snapshot_identity"))
+    ):
+        return _assessment(RESULT_HOLD, f"{prefix}_REQUIRED")
+    as_of = _parse_timestamp(record.get("as_of"))
+    if as_of is None:
+        return _assessment(RESULT_HOLD, f"{prefix}_AS_OF_UNVERIFIABLE")
+    if as_of < current:
+        return _assessment(RESULT_HOLD, f"{prefix}_STALE")
+    if as_of > current:
+        return _assessment(RESULT_BLOCK, f"{prefix}_TIME_INVALID")
+
+    state = record.get("revocation_state")
+    revoked_at = record.get("revoked_at")
+    reference = record.get("revocation_reference")
+    if state not in REVOCATION_STATES or state == "UNKNOWN":
+        return _assessment(
+            RESULT_HOLD,
+            f"{prefix}_REVOCATION_UNVERIFIABLE",
+        )
+    if state == "REVOKED":
+        revoked_at_value = _parse_timestamp(revoked_at)
+        if (
+            revoked_at_value is None
+            or revoked_at_value > as_of
+            or not _is_nonempty_string(reference)
+        ):
+            return _assessment(
+                RESULT_HOLD,
+                f"{prefix}_REVOCATION_UNVERIFIABLE",
+            )
+        return _assessment(RESULT_BLOCK, f"{prefix}_REVOKED")
+    if revoked_at is not None or reference is not None:
+        return _assessment(
+            RESULT_HOLD,
+            f"{prefix}_REVOCATION_UNVERIFIABLE",
+        )
+    return None
+
+
+def _supplied_role_grant_assessment(
+    contract: Mapping[str, Any],
+    supplied_role_grant: Any,
+    current: datetime,
+) -> RoleContractAssessment | None:
+    if (
+        not isinstance(supplied_role_grant, Mapping)
+        or set(supplied_role_grant) != SUPPLIED_ROLE_GRANT_FIELDS
+    ):
+        return _assessment(RESULT_HOLD, "SUPPLIED_ROLE_GRANT_REQUIRED")
+    identity = contract["contract_identity"]
+    assignment = contract["assignment"]
+    expected = {
+        "contract_id": identity["contract_id"],
+        "contract_hash": identity["contract_hash"],
+        "task_id": assignment["task_id"],
+        "role_id": assignment["role_id"],
+        "grant_type": assignment["grant_type"],
+        "assignment_authority": assignment["assignment_authority"],
+        "shin_gate_reference": assignment["shin_gate_reference"],
+        "assignee_identity": assignment["assignee_identity"],
+        "execution_context_identity": assignment[
+            "execution_context_identity"
+        ],
+    }
+    if any(
+        supplied_role_grant[field] != expected_value
+        for field, expected_value in expected.items()
+    ):
+        return _assessment(RESULT_BLOCK, "SUPPLIED_ROLE_GRANT_MISMATCH")
+    return _supplied_record_state_assessment(
+        supplied_role_grant,
+        "SUPPLIED_ROLE_GRANT",
+        current,
+    )
+
+
+def _supplied_role_acceptance_assessment(
+    contract: Mapping[str, Any],
+    supplied_role_acceptance: Any,
+    supplied_role_grant: Mapping[str, Any],
+    current: datetime,
+) -> RoleContractAssessment | None:
+    if (
+        not isinstance(supplied_role_acceptance, Mapping)
+        or set(supplied_role_acceptance)
+        != SUPPLIED_ROLE_ACCEPTANCE_FIELDS
+    ):
+        return _assessment(
+            RESULT_HOLD,
+            "SUPPLIED_ROLE_ACCEPTANCE_REQUIRED",
+        )
+
+    identity = contract["contract_identity"]
+    assignment = contract["assignment"]
+    expected_binding = {
+        "contract_id": identity["contract_id"],
+        "contract_hash": identity["contract_hash"],
+        "task_id": assignment["task_id"],
+        "role_id": assignment["role_id"],
+        "assignee_identity": assignment["assignee_identity"],
+        "execution_context_identity": assignment[
+            "execution_context_identity"
+        ],
+        "grant_record_identity": supplied_role_grant["record_identity"],
+    }
+    if any(
+        supplied_role_acceptance[field] != expected
+        for field, expected in expected_binding.items()
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "SUPPLIED_ROLE_ACCEPTANCE_MISMATCH",
+        )
+    if supplied_role_acceptance["role_acceptance"] != "ACCEPTED":
+        return _assessment(
+            RESULT_BLOCK,
+            "SUPPLIED_ROLE_ACCEPTANCE_NOT_ACCEPTED",
+        )
+    state_assessment = _supplied_record_state_assessment(
+        supplied_role_acceptance,
+        "SUPPLIED_ROLE_ACCEPTANCE",
+        current,
+    )
+    if state_assessment is not None:
+        return state_assessment
+
+    accepted_at = _parse_timestamp(supplied_role_acceptance["accepted_at"])
+    if accepted_at is None:
+        return _assessment(
+            RESULT_HOLD,
+            "SUPPLIED_ROLE_ACCEPTANCE_UNVERIFIABLE",
+        )
+    lifecycle = contract["lifecycle"]
+    issued = _parse_timestamp(lifecycle["issued_at"])
+    expires = _parse_timestamp(lifecycle["expires_at"])
+    as_of = _parse_timestamp(supplied_role_acceptance["as_of"])
+    assert issued is not None and expires is not None and as_of is not None
+    if accepted_at < issued or accepted_at >= expires or accepted_at > as_of:
+        return _assessment(
+            RESULT_BLOCK,
+            "SUPPLIED_ROLE_ACCEPTANCE_TIME_INVALID",
+        )
+    return None
+
+
+def _supplied_prior_role_bindings_assessment(
+    contract: Mapping[str, Any],
+    supplied_prior_role_bindings: Any,
+    current: datetime,
+) -> tuple[
+    RoleContractAssessment | None,
+    dict[str, Mapping[str, Any]] | None,
+]:
+    if (
+        not isinstance(supplied_prior_role_bindings, Mapping)
+        or set(supplied_prior_role_bindings)
+        != SUPPLIED_PRIOR_BINDING_SNAPSHOT_FIELDS
+    ):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            ),
+            None,
+        )
+    snapshot = supplied_prior_role_bindings
+    identity = contract["contract_identity"]
+    assignment = contract["assignment"]
+    if (
+        snapshot.get("contract_id") != identity["contract_id"]
+        or snapshot.get("contract_hash") != identity["contract_hash"]
+        or snapshot.get("task_id") != assignment["task_id"]
+    ):
+        return (
+            _assessment(
+                RESULT_BLOCK,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_SNAPSHOT_MISMATCH",
+            ),
+            None,
+        )
+    if (
+        not _is_nonempty_string(snapshot.get("snapshot_identity"))
+        or not isinstance(snapshot.get("snapshot_hash"), str)
+        or _SHA256_RE.fullmatch(snapshot["snapshot_hash"]) is None
+    ):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            ),
+            None,
+        )
+
+    snapshot_as_of = _parse_timestamp(snapshot.get("as_of"))
+    if snapshot_as_of is None:
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_AS_OF_UNVERIFIABLE",
+            ),
+            None,
+        )
+    if snapshot_as_of < current:
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_STALE",
+            ),
+            None,
+        )
+    if snapshot_as_of > current:
+        return (
+            _assessment(
+                RESULT_BLOCK,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_TIME_INVALID",
+            ),
+            None,
+        )
+    state = snapshot.get("revocation_state")
+    if state not in REVOCATION_STATES or state == "UNKNOWN":
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REVOCATION_UNVERIFIABLE",
+            ),
+            None,
+        )
+    if state == "REVOKED":
+        revoked_at_value = _parse_timestamp(snapshot.get("revoked_at"))
+        if (
+            revoked_at_value is None
+            or revoked_at_value > snapshot_as_of
+            or not _is_nonempty_string(
+                snapshot.get("revocation_reference")
+            )
+        ):
+            return (
+                _assessment(
+                    RESULT_HOLD,
+                    "SUPPLIED_PRIOR_ROLE_BINDINGS_REVOCATION_UNVERIFIABLE",
+                ),
+                None,
+            )
+        return (
+            _assessment(
+                RESULT_BLOCK,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REVOKED",
+            ),
+            None,
+        )
+    if (
+        snapshot.get("revoked_at") is not None
+        or snapshot.get("revocation_reference") is not None
+    ):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REVOCATION_UNVERIFIABLE",
+            ),
+            None,
+        )
+
+    try:
+        expected_hash = compute_prior_role_bindings_snapshot_hash(snapshot)
+    except (TypeError, ValueError):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            ),
+            None,
+        )
+    if snapshot["snapshot_hash"] != expected_hash:
+        return (
+            _assessment(
+                RESULT_BLOCK,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_SNAPSHOT_HASH_MISMATCH",
+            ),
+            None,
+        )
+
+    boundary = snapshot.get("completeness_boundary")
+    if (
+        not isinstance(boundary, Mapping)
+        or set(boundary) != COMPLETENESS_BOUNDARY_FIELDS
+        or boundary.get("scope") != "ALL_PRIOR_ROLE_BINDINGS_FOR_TASK"
+        or boundary.get("task_id") != assignment["task_id"]
+        or boundary.get("from") != "TASK_INCEPTION"
+        or boundary.get("through") != snapshot["as_of"]
+        or not isinstance(boundary.get("included_roles"), list)
+        or len(boundary["included_roles"]) != 2
+        or set(boundary["included_roles"]) != SUPPORTED_ROLES
+        or boundary.get("state") != "COMPLETE"
+        or not _is_string_sequence(
+            boundary.get("expected_record_identities"),
+            nonempty=False,
+        )
+        or len(boundary["expected_record_identities"])
+        != len(set(boundary["expected_record_identities"]))
+    ):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_INCOMPLETE",
+            ),
+            None,
+        )
+
+    bindings = snapshot.get("bindings")
+    if (
+        not isinstance(bindings, Sequence)
+        or isinstance(bindings, (str, bytes, bytearray))
+    ):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            ),
+            None,
+        )
+    normalized: dict[str, Mapping[str, Any]] = {}
+    for binding in bindings:
+        if (
+            not isinstance(binding, Mapping)
+            or set(binding) != SUPPLIED_PRIOR_BINDING_FIELDS
+            or binding.get("role_id") not in SUPPORTED_ROLES
+            or binding.get("binding_state") not in ("ACTIVE", "ENDED")
+            or not all(
+                _is_nonempty_string(binding.get(field))
+                for field in (
+                    "record_identity",
+                    "snapshot_identity",
+                    "task_id",
+                    "assignee_identity",
+                    "execution_context_identity",
+                    "model_identity",
+                )
+            )
+        ):
+            return (
+                _assessment(
+                    RESULT_HOLD,
+                    "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
+                ),
+                None,
+            )
+        if (
+            binding["snapshot_identity"] != snapshot["snapshot_identity"]
+            or binding["task_id"] != assignment["task_id"]
+        ):
+            return (
+                _assessment(
+                    RESULT_BLOCK,
+                    "SUPPLIED_PRIOR_ROLE_BINDINGS_SNAPSHOT_MISMATCH",
+                ),
+                None,
+            )
+        state_assessment = _supplied_record_state_assessment(
+            binding,
+            "SUPPLIED_PRIOR_ROLE_BINDING",
+            current,
+        )
+        if state_assessment is not None:
+            return state_assessment, None
+        bound_at = _parse_timestamp(binding.get("bound_at"))
+        ended_at = _parse_timestamp(binding.get("ended_at"))
+        if (
+            bound_at is None
+            or bound_at > snapshot_as_of
+            or (
+                binding["binding_state"] == "ACTIVE"
+                and binding.get("ended_at") is not None
+            )
+            or (
+                binding["binding_state"] == "ENDED"
+                and (
+                    ended_at is None
+                    or ended_at <= bound_at
+                    or ended_at > snapshot_as_of
+                )
+            )
+        ):
+            return (
+                _assessment(
+                    RESULT_HOLD,
+                    "SUPPLIED_PRIOR_ROLE_BINDING_TIME_UNVERIFIABLE",
+                ),
+                None,
+            )
+        record_identity = binding["record_identity"]
+        if record_identity in normalized:
+            return (
+                _assessment(
+                    RESULT_BLOCK,
+                    "SUPPLIED_RECORD_IDENTITY_REPLAY",
+                ),
+                None,
+            )
+        normalized[record_identity] = binding
+
+    expected_identities = set(boundary["expected_record_identities"])
+    if expected_identities != set(normalized):
+        return (
+            _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_INCOMPLETE",
+            ),
+            None,
+        )
+    return None, normalized
+
+
+def _supplied_independence_evidence_shape_valid(evidence: Any) -> bool:
+    return (
+        isinstance(evidence, Mapping)
+        and set(evidence) == SUPPLIED_INDEPENDENCE_EVIDENCE_FIELDS
+        and evidence.get("role_id") in SUPPORTED_ROLES
+        and all(
+            _is_nonempty_string(evidence.get(field))
+            for field in (
+                "record_identity",
+                "snapshot_identity",
+                "contract_id",
+                "contract_hash",
+                "task_id",
+                "assignee_identity",
+                "execution_context_identity",
+                "model_identity",
+                "source_review_evidence_reference",
+                "runtime_execution_evidence_reference",
+                "prior_role_bindings_snapshot_identity",
+                "prior_role_bindings_snapshot_hash",
+            )
+        )
+        and evidence.get("role_context_independence")
+        in ROLE_CONTEXT_VALUES
+        and evidence.get("source_review_independence")
+        in SOURCE_REVIEW_VALUES
+        and evidence.get("runtime_execution_independence")
+        in RUNTIME_EXECUTION_VALUES
+        and evidence.get("model_diversity") in MODEL_DIVERSITY_VALUES
+    )
 
 
 def _independence_assessment(
     contract: Mapping[str, Any],
     request: Mapping[str, Any],
-    trusted_independence_evidence: Any,
-    trusted_prior_role_bindings: Any,
+    supplied_role_acceptance: Mapping[str, Any],
+    supplied_independence_evidence: Any,
+    supplied_prior_role_bindings: Mapping[str, Any],
+    supplied_binding_map: Mapping[str, Mapping[str, Any]],
+    current: datetime,
 ) -> RoleContractAssessment | None:
     assignment = contract["assignment"]
     required = contract["independence_profile"]
     claimed_evidence = request["independence_evidence"]
     claimed_bindings = request["prior_role_bindings"]
 
-    if not _independence_evidence_valid(trusted_independence_evidence):
+    if not _supplied_independence_evidence_shape_valid(
+        supplied_independence_evidence
+    ):
         return _assessment(
             RESULT_HOLD,
-            "TRUSTED_INDEPENDENCE_EVIDENCE_REQUIRED",
+            "SUPPLIED_INDEPENDENCE_EVIDENCE_REQUIRED",
         )
-    evidence = trusted_independence_evidence
+    evidence = supplied_independence_evidence
+    identity = contract["contract_identity"]
     evidence_binding = {
+        "contract_id": identity["contract_id"],
+        "contract_hash": identity["contract_hash"],
         "task_id": assignment["task_id"],
         "role_id": assignment["role_id"],
         "assignee_identity": assignment["assignee_identity"],
@@ -642,44 +1199,57 @@ def _independence_assessment(
     ):
         return _assessment(
             RESULT_BLOCK,
-            "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+            "SUPPLIED_INDEPENDENCE_EVIDENCE_MISMATCH",
         )
-
-    trusted_binding_map = _prior_binding_map(trusted_prior_role_bindings)
-    if trusted_binding_map is None:
-        return _assessment(
-            RESULT_HOLD,
-            "TRUSTED_PRIOR_ROLE_BINDINGS_REQUIRED",
-        )
-    if evidence["evidence_identity"] in trusted_binding_map:
-        return _assessment(
-            RESULT_HOLD,
-            "TRUSTED_EVIDENCE_IDENTITY_COLLISION",
-        )
-
-    evidence_claim_mismatch = (
-        not _independence_evidence_valid(claimed_evidence)
-        or dict(claimed_evidence) != dict(evidence)
+    state_assessment = _supplied_record_state_assessment(
+        evidence,
+        "SUPPLIED_INDEPENDENCE_EVIDENCE",
+        current,
     )
-    claimed_binding_map = _prior_binding_map(claimed_bindings)
+    if state_assessment is not None:
+        return state_assessment
+
+    snapshot_identity = supplied_prior_role_bindings["snapshot_identity"]
+    snapshot_hash = supplied_prior_role_bindings["snapshot_hash"]
+    if (
+        evidence["prior_role_bindings_snapshot_identity"]
+        != snapshot_identity
+        or evidence["prior_role_bindings_snapshot_hash"] != snapshot_hash
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_SNAPSHOT_MISMATCH",
+        )
+
+    supplied_projection = {
+        field: evidence[field] for field in INDEPENDENCE_EVIDENCE_FIELDS
+    }
+    evidence_claim_mismatch = (
+        not _claim_independence_evidence_valid(claimed_evidence)
+        or dict(claimed_evidence) != supplied_projection
+    )
+    claimed_binding_map = _claim_prior_binding_map(claimed_bindings)
+    supplied_binding_projection = {
+        record_identity: {
+            field: binding[field] for field in PRIOR_BINDING_FIELDS
+        }
+        for record_identity, binding in supplied_binding_map.items()
+    }
     binding_claim_mismatch = claimed_binding_map is None or (
         {
-            identity: dict(binding)
-            for identity, binding in claimed_binding_map.items()
+            record_identity: dict(binding)
+            for record_identity, binding in claimed_binding_map.items()
         }
-        != {
-            identity: dict(binding)
-            for identity, binding in trusted_binding_map.items()
-        }
+        != supplied_binding_projection
     )
     claim_mismatch_codes = (
         *(
-            ("TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",)
+            ("SUPPLIED_INDEPENDENCE_EVIDENCE_CLAIM_MISMATCH",)
             if evidence_claim_mismatch
             else ()
         ),
         *(
-            ("TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",)
+            ("SUPPLIED_PRIOR_ROLE_BINDINGS_CLAIM_MISMATCH",)
             if binding_claim_mismatch
             else ()
         ),
@@ -687,7 +1257,7 @@ def _independence_assessment(
 
     same_task = [
         binding
-        for binding in trusted_binding_map.values()
+        for binding in supplied_binding_map.values()
         if binding["task_id"] == assignment["task_id"]
     ]
     builder_bindings = [
@@ -695,6 +1265,37 @@ def _independence_assessment(
         for binding in same_task
         if binding["role_id"] == ROLE_BUILDER
     ]
+    if assignment["role_id"] == ROLE_AUDITOR:
+        if not builder_bindings:
+            return _assessment(
+                RESULT_HOLD,
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_INCOMPLETE",
+            )
+        if any(
+            binding["binding_state"] != "ENDED"
+            or binding["ended_at"] is None
+            for binding in builder_bindings
+        ):
+            return _assessment(
+                RESULT_HOLD,
+                "BUILDER_ROLE_END_NOT_ESTABLISHED",
+            )
+        accepted_at = _parse_timestamp(supplied_role_acceptance["accepted_at"])
+        builder_ends = [
+            _parse_timestamp(binding["ended_at"])
+            for binding in builder_bindings
+        ]
+        assert accepted_at is not None and all(
+            ended_at is not None for ended_at in builder_ends
+        )
+        if accepted_at <= max(
+            ended_at for ended_at in builder_ends if ended_at is not None
+        ):
+            return _assessment(
+                RESULT_BLOCK,
+                "AUDITOR_ACCEPTANCE_BEFORE_BUILDER_END",
+            )
+
     current_context = assignment["execution_context_identity"]
     current_assignee = assignment["assignee_identity"]
     role_requirement = required["role_context_independence"]
@@ -709,7 +1310,7 @@ def _independence_assessment(
         )
     if role_requirement in (
         "FRESH_CONTEXT_REQUIRED",
-        "DISTINCT_TRUSTED_CONTEXT_REQUIRED",
+        "DISTINCT_CONTEXT_REQUIRED",
     ) and any(
         binding["execution_context_identity"] == current_context
         for binding in same_task
@@ -731,19 +1332,14 @@ def _independence_assessment(
     if evidence_claim_mismatch:
         return _assessment(
             RESULT_BLOCK,
-            "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+            "SUPPLIED_INDEPENDENCE_EVIDENCE_CLAIM_MISMATCH",
             *claim_mismatch_codes,
         )
     if binding_claim_mismatch:
         return _assessment(
             RESULT_BLOCK,
-            "TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_CLAIM_MISMATCH",
         )
-    if (
-        assignment["role_id"] == ROLE_AUDITOR
-        and not builder_bindings
-    ):
-        return _assessment(RESULT_HOLD, "INDEPENDENCE_UNVERIFIABLE")
 
     source_required = required["source_review_independence"]
     source_observed = evidence["source_review_independence"]
@@ -812,101 +1408,17 @@ def _target_immutability_satisfied(
     )
 
 
-def _trusted_role_grant_assessment(
-    contract: Mapping[str, Any],
-    trusted_role_grant: Any,
-) -> RoleContractAssessment | None:
-    if (
-        not isinstance(trusted_role_grant, Mapping)
-        or set(trusted_role_grant) != TRUSTED_ROLE_GRANT_FIELDS
-    ):
-        return _assessment(RESULT_HOLD, "TRUSTED_ROLE_GRANT_REQUIRED")
-    identity = contract["contract_identity"]
-    assignment = contract["assignment"]
-    expected = {
-        "contract_id": identity["contract_id"],
-        "contract_hash": identity["contract_hash"],
-        "task_id": assignment["task_id"],
-        "role_id": assignment["role_id"],
-        "grant_type": assignment["grant_type"],
-        "assignment_authority": assignment["assignment_authority"],
-        "shin_gate_reference": assignment["shin_gate_reference"],
-        "assignee_identity": assignment["assignee_identity"],
-        "execution_context_identity": assignment[
-            "execution_context_identity"
-        ],
-    }
-    if dict(trusted_role_grant) != expected:
-        return _assessment(RESULT_BLOCK, "TRUSTED_ROLE_GRANT_MISMATCH")
-    return None
-
-
-def _trusted_role_acceptance_assessment(
-    contract: Mapping[str, Any],
-    trusted_role_acceptance: Any,
-    current: datetime,
-) -> RoleContractAssessment | None:
-    if (
-        not isinstance(trusted_role_acceptance, Mapping)
-        or set(trusted_role_acceptance) != TRUSTED_ROLE_ACCEPTANCE_FIELDS
-    ):
-        return _assessment(RESULT_HOLD, "TRUSTED_ROLE_ACCEPTANCE_REQUIRED")
-
-    identity = contract["contract_identity"]
-    assignment = contract["assignment"]
-    expected_binding = {
-        "contract_id": identity["contract_id"],
-        "contract_hash": identity["contract_hash"],
-        "task_id": assignment["task_id"],
-        "role_id": assignment["role_id"],
-        "assignee_identity": assignment["assignee_identity"],
-        "execution_context_identity": assignment[
-            "execution_context_identity"
-        ],
-    }
-    if any(
-        trusted_role_acceptance[field] != expected
-        for field, expected in expected_binding.items()
-    ):
-        return _assessment(
-            RESULT_BLOCK,
-            "TRUSTED_ROLE_ACCEPTANCE_MISMATCH",
-        )
-    if trusted_role_acceptance["role_acceptance"] != "ACCEPTED":
-        return _assessment(
-            RESULT_BLOCK,
-            "TRUSTED_ROLE_ACCEPTANCE_NOT_ACCEPTED",
-        )
-
-    accepted_at = _parse_timestamp(trusted_role_acceptance["accepted_at"])
-    if accepted_at is None:
-        return _assessment(
-            RESULT_HOLD,
-            "TRUSTED_ROLE_ACCEPTANCE_UNVERIFIABLE",
-        )
-    lifecycle = contract["lifecycle"]
-    issued = _parse_timestamp(lifecycle["issued_at"])
-    expires = _parse_timestamp(lifecycle["expires_at"])
-    assert issued is not None and expires is not None
-    if accepted_at < issued or accepted_at >= expires or accepted_at > current:
-        return _assessment(
-            RESULT_BLOCK,
-            "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
-        )
-    return None
-
-
 def validate_role_operation(
     contract: Mapping[str, Any] | None,
     request: Mapping[str, Any] | None,
     *,
-    trusted_role_grant: Mapping[str, Any] | None = None,
-    trusted_role_acceptance: Mapping[str, Any] | None = None,
-    trusted_independence_evidence: Mapping[str, Any] | None = None,
-    trusted_prior_role_bindings: Sequence[Mapping[str, Any]] | None = None,
+    supplied_role_grant: Mapping[str, Any] | None = None,
+    supplied_role_acceptance: Mapping[str, Any] | None = None,
+    supplied_independence_evidence: Mapping[str, Any] | None = None,
+    supplied_prior_role_bindings: Mapping[str, Any] | None = None,
     now: datetime | None = None,
 ) -> RoleContractAssessment:
-    """Validate one operation against independently supplied trusted records."""
+    """Validate one operation against unauthenticated supplied records."""
 
     shape_issue = _contract_shape_issue(contract)
     if shape_issue is not None:
@@ -928,12 +1440,33 @@ def validate_role_operation(
         )
         return _assessment(result, semantic_issue)
 
-    grant_assessment = _trusted_role_grant_assessment(
+    current = now or datetime.now(timezone.utc)
+    if not isinstance(current, datetime) or current.tzinfo is None:
+        return _assessment(RESULT_INVALID, "CURRENT_TIME_UNVERIFIABLE")
+    current = current.astimezone(timezone.utc)
+
+    lifecycle = contract["lifecycle"]
+    expires = _parse_timestamp(lifecycle["expires_at"])
+    issued = _parse_timestamp(lifecycle["issued_at"])
+    assert expires is not None and issued is not None
+    if (
+        lifecycle["status"] == "REVOKED"
+        or lifecycle["revocation_reference"] is not None
+    ):
+        return _assessment(RESULT_BLOCK, "ROLE_GRANT_REVOKED")
+    if lifecycle["status"] == "EXPIRED" or current >= expires:
+        return _assessment(RESULT_BLOCK, "ROLE_GRANT_EXPIRED")
+    if lifecycle["status"] != "ACTIVE" or current < issued:
+        return _assessment(RESULT_HOLD, "ROLE_GRANT_NOT_ACTIVE")
+
+    grant_assessment = _supplied_role_grant_assessment(
         contract,
-        trusted_role_grant,
+        supplied_role_grant,
+        current,
     )
     if grant_assessment is not None:
         return grant_assessment
+    assert supplied_role_grant is not None
 
     request_issue = _request_shape_issue(request)
     if request_issue is not None:
@@ -970,37 +1503,81 @@ def validate_role_operation(
             "TARGET_IMMUTABILITY_NOT_ESTABLISHED",
         )
 
-    lifecycle = contract["lifecycle"]
-    current = now or datetime.now(timezone.utc)
-    if not isinstance(current, datetime) or current.tzinfo is None:
-        return _assessment(RESULT_INVALID, "CURRENT_TIME_UNVERIFIABLE")
-    current = current.astimezone(timezone.utc)
-    expires = _parse_timestamp(lifecycle["expires_at"])
-    issued = _parse_timestamp(lifecycle["issued_at"])
-    assert expires is not None and issued is not None
-    if (
-        lifecycle["status"] == "REVOKED"
-        or lifecycle["revocation_reference"] is not None
-    ):
-        return _assessment(RESULT_BLOCK, "ROLE_GRANT_REVOKED")
-    if lifecycle["status"] == "EXPIRED" or current >= expires:
-        return _assessment(RESULT_BLOCK, "ROLE_GRANT_EXPIRED")
-    if lifecycle["status"] != "ACTIVE" or current < issued:
-        return _assessment(RESULT_HOLD, "ROLE_GRANT_NOT_ACTIVE")
-
-    acceptance = _trusted_role_acceptance_assessment(
+    acceptance = _supplied_role_acceptance_assessment(
         contract,
-        trusted_role_acceptance,
+        supplied_role_acceptance,
+        supplied_role_grant,
         current,
     )
     if acceptance is not None:
         return acceptance
+    assert supplied_role_acceptance is not None
+
+    snapshot_assessment, supplied_binding_map = (
+        _supplied_prior_role_bindings_assessment(
+            contract,
+            supplied_prior_role_bindings,
+            current,
+        )
+    )
+    if snapshot_assessment is not None:
+        return snapshot_assessment
+    assert supplied_prior_role_bindings is not None
+    assert supplied_binding_map is not None
+
+    if not _supplied_independence_evidence_shape_valid(
+        supplied_independence_evidence
+    ):
+        return _assessment(
+            RESULT_HOLD,
+            "SUPPLIED_INDEPENDENCE_EVIDENCE_REQUIRED",
+        )
+    assert supplied_independence_evidence is not None
+
+    supplied_records = (
+        supplied_role_grant,
+        supplied_role_acceptance,
+        supplied_independence_evidence,
+    )
+    snapshot_identity = supplied_prior_role_bindings["snapshot_identity"]
+    snapshot_as_of = _parse_timestamp(
+        supplied_prior_role_bindings["as_of"]
+    )
+    assert snapshot_as_of is not None
+    if any(
+        record["snapshot_identity"] != snapshot_identity
+        for record in supplied_records
+    ):
+        return _assessment(
+            RESULT_BLOCK,
+            "SUPPLIED_RECORD_SNAPSHOT_MISMATCH",
+        )
+    if any(
+        _parse_timestamp(record["as_of"]) != snapshot_as_of
+        for record in supplied_records
+    ):
+        return _assessment(RESULT_HOLD, "SUPPLIED_RECORDS_AS_OF_MISMATCH")
+
+    record_identities = [
+        supplied_role_grant["record_identity"],
+        supplied_role_acceptance["record_identity"],
+        supplied_independence_evidence["record_identity"],
+        *supplied_binding_map,
+    ]
+    if len(record_identities) != len(set(record_identities)):
+        return _assessment(
+            RESULT_BLOCK,
+            "SUPPLIED_RECORD_IDENTITY_REPLAY",
+        )
 
     independence = _independence_assessment(
         contract,
         request,
-        trusted_independence_evidence,
-        trusted_prior_role_bindings,
+        supplied_role_acceptance,
+        supplied_independence_evidence,
+        supplied_prior_role_bindings,
+        supplied_binding_map,
+        current,
     )
     if independence is not None:
         return independence

--- a/docs/role_bound_specialist_system_v0_1.md
+++ b/docs/role_bound_specialist_system_v0_1.md
@@ -1,0 +1,145 @@
+# Role-Bound Specialist System v0.1
+
+## Boundary
+
+This is the minimal V13 Stage 4 implementation. Stage 4 covers explicit Role
+assignment, Role-bound work, a fixed Specialist Lens, and an inert Coverage
+Gap Recommendation. Only `BUILDER` and `AUDITOR` exist in v0.1. Scout,
+Architect, Companion integration, Runner integration, automatic specialist
+invocation, and all Stage 5 decisions are outside this implementation.
+
+```text
+Stage 4:
+Role assignment
+Role-bound work
+Specialist Lens
+Coverage Gap Recommendation
+
+Stage 5:
+GO / HOLD / CAP / BLOCK the recommended specialist loop
+```
+
+```text
+Recommendation: ALLOWED
+Automatic Assignment: PROHIBITED
+Automatic Invocation: PROHIBITED
+```
+
+## Authority and activation
+
+A Role originates only from Shin's authority. An AI cannot assign itself a
+Role. A Role name, artifact declaration, `producer_role`,
+`builder_generated`, different artifact bytes, specialist recommendation, or
+model self-description is never sufficient.
+
+A Role is Active only when all of the following are established:
+
+1. an `EXPLICIT_ROLE_GRANT` exists;
+2. `assignment_authority` is `Shin`;
+3. a non-placeholder Shin Gate reference exists;
+4. the assignee identity is fixed;
+5. the trusted execution context identity is fixed;
+6. Role Acceptance is `ACCEPTED`;
+7. the complete Role Contract and its canonical hash are fixed;
+8. the Task Artifact Packet is fixed;
+9. the Specialist Lens identity, version, and hash are fixed;
+10. every required independence dimension is independently satisfied;
+11. the grant has not expired; and
+12. the grant has not been revoked.
+
+Missing, unknown, or unverifiable state never becomes Active. A new Role,
+authority, operation, target, or Lens requires a new Shin Gate.
+
+## Contract identity
+
+The schema is
+[`schema/v13_role_contract.schema.json`](../schema/v13_role_contract.schema.json).
+It separates contract identity, assignment, owned responsibility, operations,
+Task Artifact Packet, Specialist Lens, independence profile, completion,
+lifecycle, and Coverage Gap Recommendation.
+
+`contract_hash` is the lowercase SHA-256 of canonical JSON with these rules:
+
+1. replace `contract_identity.contract_hash` with the empty string;
+2. encode JSON as UTF-8 with sorted keys, no insignificant whitespace, and
+   non-ASCII characters preserved; and
+3. hash the resulting bytes.
+
+`decision_os.role_contract.compute_contract_hash` is the reference
+implementation.
+
+## Builder
+
+Builder owns only implementation of the specified Design at the specified
+paths and head under the specified Completion Line. It cannot self-audit,
+change a Role Grant or Specialist Lens, change anything outside the exact
+target, merge, post, invoke a specialist, or start Stage 5.
+
+## Auditor
+
+Auditor owns only read-only inspection of the fixed head, artifacts, evidence,
+Role Contract conformity, and target immutability. It cannot change the
+target, implement a repair, also act as Builder, merge, post, invoke a
+specialist, or start Stage 5.
+
+An Auditor must use a trusted execution context distinct from Builder's.
+The same base model is allowed only when the Role Contract says
+`SAME_MODEL_ALLOWED`. Model diversity never substitutes for context
+independence.
+
+## Independent dimensions
+
+The four independence fields are separate and non-substitutable:
+
+- `role_context_independence`
+- `source_review_independence`
+- `runtime_execution_independence`
+- `model_diversity`
+
+A different model is not a different context. A different context is not an
+independent runtime execution. An independent runtime execution is not
+independent evidence selection. `REQUIRED_NOT_ESTABLISHED`, missing evidence,
+and unknown evidence remain HOLD.
+
+## Specialist Lens
+
+[`templates/v13_specialist_lens.md`](../templates/v13_specialist_lens.md)
+defines the required Lens sections. The Role Grant selects the Lens; the
+assignee cannot self-select it. Identity or hash absence or mismatch keeps the
+Role inactive.
+
+## Coverage Gap Recommendation
+
+Every Role Exit Receipt includes the coverage result. No-gap receipts say
+exactly `Coverage Gap: NONE DETECTED`. The recommendation records completed
+coverage, the gap, recommended specialist, reason, exact target, required
+evidence, urgency, and the two fixed controls:
+
+```json
+{
+  "assignment_authority_required": true,
+  "automatic_invocation": false
+}
+```
+
+The recommendation is data only. Creating or validating it produces no Role
+Assignment event, Runner/Codex/agent invocation, or Stage 5 decision.
+
+## Semantic validation
+
+`decision_os.role_contract.validate_role_operation` validates the complete
+contract and one requested operation. It is deterministic and read-only. It
+checks explicit authority and Gate binding, assignee/context binding, Role
+Acceptance, exact packet and Lens identities, scope and path identity,
+role-specific forbidden operations, lifecycle, each independence dimension,
+and recommendation inertness.
+
+The first closed attack is same-context false division: a trusted context
+cannot create Builder artifact A, create different Audit artifact B, omit
+producer metadata, and become Auditor. The trusted context binding produces:
+
+```text
+BLOCK — CONTEXT INDEPENDENCE VIOLATION
+```
+
+No automatic assignment or invocation function exists in this module.

--- a/docs/role_bound_specialist_system_v0_1.md
+++ b/docs/role_bound_specialist_system_v0_1.md
@@ -1,17 +1,18 @@
 # Role-Bound Specialist System v0.1
 
-## Boundary
+## Implementation boundary
 
-This is the minimal V13 Stage 4 implementation. Stage 4 covers explicit Role
-assignment, Role-bound work, a fixed Specialist Lens, and an inert Coverage
-Gap Recommendation. Only `BUILDER` and `AUDITOR` exist in v0.1. Scout,
-Architect, Companion integration, Runner integration, automatic specialist
-invocation, and all Stage 5 decisions are outside this implementation.
+This is the minimal V13 Stage 4 validator implementation. It defines a Role
+Contract, a fixed Specialist Lens, supplied-record validation, and an inert
+Coverage Gap Recommendation for `BUILDER` and `AUDITOR`. It does not issue,
+authenticate, transport, discover, or persist Role records. It does not assign
+a Role, invoke a specialist, perform Role-bound work, or establish real-world
+Role separation.
 
 ```text
 Stage 4:
-Role assignment
-Role-bound work
+Role assignment contract
+Role-bound operation validation
 Specialist Lens
 Coverage Gap Recommendation
 
@@ -19,93 +20,257 @@ Stage 5:
 GO / HOLD / CAP / BLOCK the recommended specialist loop
 ```
 
+Scout, Architect, Companion integration, Runner integration, automatic
+specialist invocation, and every Stage 5 decision remain outside this
+implementation.
+
 ```text
 Recommendation: ALLOWED
 Automatic Assignment: PROHIBITED
 Automatic Invocation: PROHIBITED
 ```
 
-## Authority and activation
-
-A Role originates only from Shin's authority. An AI cannot assign itself a
-Role. A Role name, artifact declaration, `producer_role`,
-`builder_generated`, different artifact bytes, specialist recommendation, or
-model self-description is never sufficient.
-
-A Role is Active only when all of the following are established:
-
-1. an `EXPLICIT_ROLE_GRANT` exists;
-2. `assignment_authority` is `Shin`;
-3. a non-placeholder Shin Gate reference exists;
-4. the assignee identity is fixed;
-5. the trusted execution context identity is fixed;
-6. the Contract claims Role Acceptance and a receiver-side trusted Role
-   Acceptance record establishes `ACCEPTED`;
-7. the complete Role Contract and its canonical hash are fixed;
-8. the Task Artifact Packet is fixed;
-9. the Specialist Lens identity, version, and hash are fixed;
-10. every required independence dimension is independently satisfied;
-11. the grant has not expired; and
-12. the grant has not been revoked.
-
-Missing, unknown, or unverifiable state never becomes Active. A new Role,
-authority, operation, target, or Lens requires a new Shin Gate.
-
-The Role Contract's own authority fields are declarations, not proof of their
-provenance. `validate_role_operation` therefore requires a
-`trusted_role_grant` supplied independently of the Role Contract and operation
-request. The trusted grant must bind the exact contract ID/hash, task, Role,
-Grant type, Shin authority and Gate reference, assignee, and trusted execution
-context. Contract self-declaration without this out-of-band evidence is HOLD.
-
-The same separation applies to acceptance and independence.
-`validate_role_operation` requires all four trusted inputs independently of
-the claimant-controlled operation request:
+The implementation boundary is fixed:
 
 ```text
-trusted_role_grant
-trusted_role_acceptance
-trusted_independence_evidence
-trusted_prior_role_bindings
+Role Separation Enforcement: VALIDATOR-LEVEL ONLY
+Record Issuer / Authentication / Transport: NOT IMPLEMENTED
+Role Independence: NOT ESTABLISHED
+End-to-End False-Division Prevention: NOT ESTABLISHED
 ```
 
-The request's `independence_evidence` and `prior_role_bindings` remain claims.
-They must match the trusted records, but they are never the source of truth.
-The trusted independence record binds its evidence identity to the exact task,
-Role, assignee, execution context, and model. Every trusted prior-Role binding
-does the same. Evidence identities must be unique, and the trusted binding
-source must supply the complete same-task binding set. An adapter must not
-construct a `trusted_*` input by copying claimant payload.
+## Authority declarations and validator-level ACTIVE
 
-The receiver-side Role Acceptance record is also separate from the Contract
-and request:
+The governing rule is that a Role originates only from Shin's authority and an
+AI cannot assign itself a Role. This validator does not authenticate Shin or
+prove that an assignment event occurred. It checks that supplied fields carry
+the required authority value and Gate binding.
+
+A Role name, artifact declaration, `producer_role`, `builder_generated`,
+different artifact bytes, specialist recommendation, or model
+self-description is insufficient even at the validator boundary.
+
+`ACTIVE` is only a validator result. It means that, at the supplied validation
+time, the Contract, request, and separately supplied records satisfy the
+implemented structural, binding, timestamp, declared revocation-state,
+snapshot, and ordering checks. It does not establish that a Role was actually
+granted or accepted, that any record is authentic, that a supplied snapshot is
+complete in the real world, or that Role independence exists.
+
+The validator can return `ACTIVE` only when:
+
+1. the Contract declares `EXPLICIT_ROLE_GRANT`,
+   `assignment_authority: Shin`, and a non-placeholder Shin Gate reference;
+2. the Contract binds task, Role, assignee, execution context, exact target,
+   Task Artifact Packet, Specialist Lens, operations, lifecycle, and
+   completion;
+3. the Contract's canonical hash is valid;
+4. the operation request matches the Contract;
+5. all required separately supplied records are present and internally valid;
+6. all supplied records bind to the required Contract, task, Role, assignee,
+   context, model, snapshot, and related record identities;
+7. every supplied record is current for the same validation snapshot and has
+   an admissible declared revocation state;
+8. the supplied prior-Role snapshot carries a valid hash and a declared
+   complete same-task boundary;
+9. the supplied values satisfy each required validator-level independence
+   condition; and
+10. the requested operation remains inside the Stage 4 Role boundary.
+
+Missing, unknown, malformed, incomplete, or stale input never becomes
+`ACTIVE`. Mismatched, revoked, or observably conflicting input is rejected.
+A new Role, authority, operation, target, or Lens requires a new Shin Gate,
+but this validator does not create that Gate or the corresponding records.
+
+## Separately supplied validator inputs
+
+`validate_role_operation` accepts four separately supplied record inputs in
+addition to the Role Contract and claimant-controlled operation request:
+
+```text
+supplied_role_grant
+supplied_role_acceptance
+supplied_independence_evidence
+supplied_prior_role_bindings
+```
+
+The names describe how the values enter the validator API. They do not assert
+that the values came from an independent party or channel. The implementation
+cannot determine whether an adapter copied, fabricated, or coherently rewrote
+them.
+
+The request's `independence_evidence` and `prior_role_bindings` remain
+claimant-controlled claims. The validator compares them with the separately
+supplied inputs. Neither input is treated as authenticated truth, and a
+successful comparison proves only internal consistency.
+
+## Common record snapshot and lifecycle fields
+
+The supplied Role Grant, Role Acceptance, and independence evidence records
+carry these common fields:
+
+```text
+record_identity
+snapshot_identity
+as_of
+revocation_state
+revoked_at
+revocation_reference
+```
+
+The prior-Role snapshot uses `snapshot_identity` as its own identity and
+carries the same `as_of` and revocation fields.
+
+All `as_of` values must be timezone-aware and coherent with the normalized
+validator time and shared snapshot identity. The normalized `now` value is the
+validation snapshot time, and every supplied `as_of` must equal it. An earlier
+record is stale and results in HOLD; a future record is rejected as
+time-invalid; skew between supplied records results in HOLD rather than
+`ACTIVE`.
+
+Revocation state is explicit:
+
+- `NOT_REVOKED` requires both `revoked_at` and `revocation_reference` to be
+  null.
+- `REVOKED` is rejected; its supplied timestamp and reference do not
+  authenticate the revocation source.
+- `UNKNOWN`, missing, or internally inconsistent revocation state results in
+  HOLD.
+
+Record identities must be unique within one validation bundle. A duplicate
+identity, a record bound to an old Contract hash, or another replay indicator
+visible in the supplied bundle is rejected. This is not a cross-validation
+replay ledger. An exact replay at an indistinguishable evaluation point cannot
+be detected by this stateless implementation.
+
+## Supplied Role Grant
+
+`supplied_role_grant` binds:
+
+- record and snapshot identities;
+- Contract ID and canonical hash;
+- task and Role;
+- Grant type;
+- declared assignment authority and Shin Gate reference;
+- assignee and execution context; and
+- `as_of` and explicit revocation state.
+
+The Contract's assignment fields are declarations, not provenance evidence.
+The supplied Role Grant is a separate validator input, not an authenticated
+grant. Matching values establish only that the two supplied representations
+are consistent.
+
+## Supplied Role Acceptance
+
+The Contract's `role_acceptance: ACCEPTED` remains a hashed requirement claim.
+Validator-level `ACTIVE` also requires `supplied_role_acceptance`, containing:
 
 ```json
 {
+  "record_identity": "acceptance-record-001",
+  "snapshot_identity": "validation-snapshot-001",
+  "grant_record_identity": "grant-record-001",
   "contract_id": "contract-auditor-001",
   "contract_hash": "<canonical SHA-256>",
   "task_id": "task-stage4-001",
   "role_id": "AUDITOR",
   "assignee_identity": "auditor-assignee",
-  "execution_context_identity": "trusted-auditor-context",
+  "execution_context_identity": "auditor-context-001",
   "role_acceptance": "ACCEPTED",
-  "accepted_at": "2026-07-29T00:01:00Z"
+  "accepted_at": "2026-07-29T00:03:00Z",
+  "as_of": "2026-07-29T12:00:00Z",
+  "revocation_state": "NOT_REVOKED",
+  "revoked_at": null,
+  "revocation_reference": null
 }
 ```
 
-It must match the exact Contract ID/hash, task, Role, assignee, and execution
-context. `accepted_at` must be timezone-aware, no earlier than issuance,
-earlier than expiry, and no later than validation time. The Contract's own
-`role_acceptance: ACCEPTED` is a hashed requirement claim, not receiver-side
-proof.
+The record must bind the exact Contract ID/hash, task, Role, assignee,
+execution context, Grant record, and validation snapshot. `accepted_at` must
+be timezone-aware, no earlier than Contract issuance, no later than the
+record's `as_of`, and earlier than Contract expiry. These checks validate a
+supplied acceptance claim; they do not authenticate the receiver or record
+issuer.
+
+For an Auditor, every supplied Builder binding for the same task must be
+`ENDED` with a valid `ended_at`. An active Builder or a Builder without a
+verifiable end keeps the result on HOLD. Auditor `accepted_at` must be strictly
+later than the latest Builder `ended_at`; acceptance at or before that boundary
+is rejected.
+
+## Supplied prior-Role binding snapshot
+
+`supplied_prior_role_bindings` is a snapshot envelope, not a bare list. Its
+fields are:
+
+```text
+snapshot_identity
+snapshot_hash
+contract_id
+contract_hash
+task_id
+as_of
+revocation_state
+revoked_at
+revocation_reference
+completeness_boundary
+bindings
+```
+
+`completeness_boundary` contains:
+
+```text
+scope
+task_id
+from
+through
+included_roles
+state
+expected_record_identities
+```
+
+For validator-level `ACTIVE`, the boundary must declare
+`scope: ALL_PRIOR_ROLE_BINDINGS_FOR_TASK`, bind the same task, cover the
+required time range from `TASK_INCEPTION` through the snapshot `as_of`,
+include the required Role set, use
+`state: COMPLETE`, and list exactly the record identities present in
+`bindings`. A missing boundary, `INCOMPLETE` or `UNKNOWN` state, manifest
+mismatch, stale boundary, omitted required Builder history, or unverifiable
+Builder end results in HOLD.
+
+Each binding records:
+
+```text
+record_identity
+snapshot_identity
+task_id
+role_id
+assignee_identity
+execution_context_identity
+model_identity
+bound_at
+ended_at
+binding_state
+as_of
+revocation_state
+revoked_at
+revocation_reference
+```
+
+`snapshot_hash` is the canonical SHA-256 of the supplied snapshot with its own
+hash field blanked. The validator rejects supplied contents that no longer
+match that hash, including changes to the envelope, completeness declaration,
+identity manifest, or bindings. It does not authenticate the snapshot producer
+or prove that the declared manifest contains every real-world binding.
 
 ## Contract identity
 
 The schema is
 [`schema/v13_role_contract.schema.json`](../schema/v13_role_contract.schema.json).
-It separates contract identity, assignment, owned responsibility, operations,
+It separates Contract identity, assignment, owned responsibility, operations,
 Task Artifact Packet, Specialist Lens, independence profile, completion,
-lifecycle, and Coverage Gap Recommendation.
+lifecycle, and Coverage Gap Recommendation. Its `$defs` also describe the
+separately supplied validator records.
 
 `contract_hash` is the lowercase SHA-256 of canonical JSON with these rules:
 
@@ -117,26 +282,29 @@ lifecycle, and Coverage Gap Recommendation.
 `decision_os.role_contract.compute_contract_hash` is the reference
 implementation.
 
-## Builder
+## Builder boundary
 
-Builder owns only implementation of the specified Design at the specified
-paths and head under the specified Completion Line. It cannot self-audit,
-change a Role Grant or Specialist Lens, change anything outside the exact
-target, merge, post, invoke a specialist, or start Stage 5.
+A Builder Contract can permit only implementation of the specified Design at
+the specified paths and head under the specified Completion Line. The
+validator rejects Builder requests to self-audit, change a Role Grant or
+Specialist Lens, change anything outside the exact target, merge, post, invoke
+a specialist, or start Stage 5.
 
-## Auditor
+## Auditor boundary
 
-Auditor owns only read-only inspection of the fixed head, artifacts, evidence,
-Role Contract conformity, and target immutability. It cannot change the
-target, implement a repair, also act as Builder, merge, post, invoke a
-specialist, or start Stage 5.
+An Auditor Contract can permit only read-only inspection of the fixed head,
+artifacts, supplied evidence, Contract conformity, and target immutability.
+The validator rejects Auditor requests to change the target, implement a
+repair, also act as Builder, merge, post, invoke a specialist, or start
+Stage 5.
 
-An Auditor must use a trusted execution context distinct from Builder's.
-The same base model is allowed only when the Role Contract says
-`SAME_MODEL_ALLOWED`. Model diversity never substitutes for context
-independence.
+An Auditor Contract requires `DISTINCT_CONTEXT_REQUIRED`. The validator
+compares its execution-context identity with the Builder bindings present in
+the supplied current snapshot. The same base model is allowed only when the
+Contract says `SAME_MODEL_ALLOWED`. Model diversity never substitutes for a
+distinct context.
 
-## Independent dimensions
+## Independence dimensions
 
 The four independence fields are separate and non-substitutable:
 
@@ -145,22 +313,28 @@ The four independence fields are separate and non-substitutable:
 - `runtime_execution_independence`
 - `model_diversity`
 
-A different model is not a different context. A different context is not an
-independent runtime execution. An independent runtime execution is not
+A different model is not a different context. A different context is not a
+separate runtime execution. A supplied runtime execution record is not
 independent evidence selection. `REQUIRED_NOT_ESTABLISHED`, missing evidence,
-and unknown evidence remain HOLD. Independence decisions use only the trusted
-out-of-band evidence and binding set. Claim/trusted mismatches are BLOCK.
+and unknown evidence remain HOLD. `EXECUTION_RECORD_SUPPLIED` means only that
+the required record value was supplied and passed validator checks; it does
+not establish real-world runtime independence.
+
+The independence record also binds the Contract ID/hash and the prior-Role
+snapshot identity/hash. The validator checks those bindings and declared
+values. Role independence remains NOT ESTABLISHED outside this validator-level
+assessment.
 
 ## Specialist Lens
 
 [`templates/v13_specialist_lens.md`](../templates/v13_specialist_lens.md)
-defines the required Lens sections. The Role Grant selects the Lens; the
-assignee cannot self-select it. Identity or hash absence or mismatch keeps the
-Role inactive.
+defines the required Lens sections. The Contract selects the Lens identity and
+hash. The validator rejects a missing or mismatched Lens; it does not assign
+the Lens or invoke a specialist.
 
 ## Coverage Gap Recommendation
 
-Every Role Exit Receipt includes the coverage result. No-gap receipts say
+Every Role Exit Receipt includes the coverage result. A no-gap receipt says
 exactly `Coverage Gap: NONE DETECTED`. The recommendation records completed
 coverage, the gap, recommended specialist, reason, exact target, required
 evidence, urgency, and the two fixed controls:
@@ -172,31 +346,33 @@ evidence, urgency, and the two fixed controls:
 }
 ```
 
-The recommendation is data only. Creating or validating it produces no Role
+The recommendation is inert data. Creating or validating it produces no Role
 Assignment event, Runner/Codex/agent invocation, or Stage 5 decision.
 
-## Semantic validation
+## Observable adversarial behavior
 
-`decision_os.role_contract.validate_role_operation` validates the complete
-contract, one independently supplied trusted Role Grant, one receiver-side
-trusted Role Acceptance record, trusted independence evidence, the complete
-trusted prior-Role binding set, and one requested operation. It is
-deterministic and read-only. It checks explicit authority and Gate binding,
-assignee/context binding, receiver acceptance, exact packet and Lens
-identities, scope and path identity, role-specific forbidden operations,
-lifecycle, each independence dimension, and recommendation inertness.
-
-The first closed attack is same-context false division: a trusted context
-cannot create Builder artifact A, create different Audit artifact B, omit
-producer metadata, and become Auditor. The trusted context binding produces:
+When the supplied current snapshot contains a same-context Builder binding for
+an Auditor request, the validator returns:
 
 ```text
 BLOCK — CONTEXT INDEPENDENCE VIOLATION
 ```
 
-Omitting that true same-context Builder binding from the request and replacing
-it with a forged different-context binding does not help: the complete trusted
-binding set still exposes the collision, and the claim/trusted mismatch is
-also recorded.
+Replacing the request's binding claim does not override a conflicting binding
+that remains present in the supplied snapshot. Missing, incomplete, stale, or
+internally incoherent snapshot state returns HOLD rather than `ACTIVE`.
+
+The validator also rejects observable revoked records, duplicate identities,
+snapshot-hash or identity-manifest mismatches, and Auditor acceptance at or
+before Builder completion. It holds on timestamp skew, stale records, unknown
+revocation state, an active or unended Builder, and other unverifiable input.
+
+These are validator responses to supplied data, not end-to-end attack
+prevention. A caller that fabricates a coherent snapshot, falsely declares it
+complete, and recomputes its hash may evade these checks. Likewise, a
+stateless validator cannot detect an exact cross-call replay, and independently
+loaded records are not an atomic snapshot merely because their `as_of` values
+match. Record authentication, authoritative history lookup, atomic transport,
+and replay consumption state are not implemented.
 
 No automatic assignment or invocation function exists in this module.

--- a/docs/role_bound_specialist_system_v0_1.md
+++ b/docs/role_bound_specialist_system_v0_1.md
@@ -50,6 +50,13 @@ A Role is Active only when all of the following are established:
 Missing, unknown, or unverifiable state never becomes Active. A new Role,
 authority, operation, target, or Lens requires a new Shin Gate.
 
+The Role Contract's own authority fields are declarations, not proof of their
+provenance. `validate_role_operation` therefore requires a
+`trusted_role_grant` supplied independently of the Role Contract and operation
+request. The trusted grant must bind the exact contract ID/hash, task, Role,
+Grant type, Shin authority and Gate reference, assignee, and trusted execution
+context. Contract self-declaration without this out-of-band evidence is HOLD.
+
 ## Contract identity
 
 The schema is
@@ -128,11 +135,11 @@ Assignment event, Runner/Codex/agent invocation, or Stage 5 decision.
 ## Semantic validation
 
 `decision_os.role_contract.validate_role_operation` validates the complete
-contract and one requested operation. It is deterministic and read-only. It
-checks explicit authority and Gate binding, assignee/context binding, Role
-Acceptance, exact packet and Lens identities, scope and path identity,
-role-specific forbidden operations, lifecycle, each independence dimension,
-and recommendation inertness.
+contract, one independently supplied trusted Role Grant, and one requested
+operation. It is deterministic and read-only. It checks explicit authority
+and Gate binding, assignee/context binding, Role Acceptance, exact packet and
+Lens identities, scope and path identity, role-specific forbidden operations,
+lifecycle, each independence dimension, and recommendation inertness.
 
 The first closed attack is same-context false division: a trusted context
 cannot create Builder artifact A, create different Audit artifact B, omit

--- a/docs/role_bound_specialist_system_v0_1.md
+++ b/docs/role_bound_specialist_system_v0_1.md
@@ -39,7 +39,8 @@ A Role is Active only when all of the following are established:
 3. a non-placeholder Shin Gate reference exists;
 4. the assignee identity is fixed;
 5. the trusted execution context identity is fixed;
-6. Role Acceptance is `ACCEPTED`;
+6. the Contract claims Role Acceptance and a receiver-side trusted Role
+   Acceptance record establishes `ACCEPTED`;
 7. the complete Role Contract and its canonical hash are fixed;
 8. the Task Artifact Packet is fixed;
 9. the Specialist Lens identity, version, and hash are fixed;
@@ -56,6 +57,47 @@ provenance. `validate_role_operation` therefore requires a
 request. The trusted grant must bind the exact contract ID/hash, task, Role,
 Grant type, Shin authority and Gate reference, assignee, and trusted execution
 context. Contract self-declaration without this out-of-band evidence is HOLD.
+
+The same separation applies to acceptance and independence.
+`validate_role_operation` requires all four trusted inputs independently of
+the claimant-controlled operation request:
+
+```text
+trusted_role_grant
+trusted_role_acceptance
+trusted_independence_evidence
+trusted_prior_role_bindings
+```
+
+The request's `independence_evidence` and `prior_role_bindings` remain claims.
+They must match the trusted records, but they are never the source of truth.
+The trusted independence record binds its evidence identity to the exact task,
+Role, assignee, execution context, and model. Every trusted prior-Role binding
+does the same. Evidence identities must be unique, and the trusted binding
+source must supply the complete same-task binding set. An adapter must not
+construct a `trusted_*` input by copying claimant payload.
+
+The receiver-side Role Acceptance record is also separate from the Contract
+and request:
+
+```json
+{
+  "contract_id": "contract-auditor-001",
+  "contract_hash": "<canonical SHA-256>",
+  "task_id": "task-stage4-001",
+  "role_id": "AUDITOR",
+  "assignee_identity": "auditor-assignee",
+  "execution_context_identity": "trusted-auditor-context",
+  "role_acceptance": "ACCEPTED",
+  "accepted_at": "2026-07-29T00:01:00Z"
+}
+```
+
+It must match the exact Contract ID/hash, task, Role, assignee, and execution
+context. `accepted_at` must be timezone-aware, no earlier than issuance,
+earlier than expiry, and no later than validation time. The Contract's own
+`role_acceptance: ACCEPTED` is a hashed requirement claim, not receiver-side
+proof.
 
 ## Contract identity
 
@@ -106,7 +148,8 @@ The four independence fields are separate and non-substitutable:
 A different model is not a different context. A different context is not an
 independent runtime execution. An independent runtime execution is not
 independent evidence selection. `REQUIRED_NOT_ESTABLISHED`, missing evidence,
-and unknown evidence remain HOLD.
+and unknown evidence remain HOLD. Independence decisions use only the trusted
+out-of-band evidence and binding set. Claim/trusted mismatches are BLOCK.
 
 ## Specialist Lens
 
@@ -135,10 +178,12 @@ Assignment event, Runner/Codex/agent invocation, or Stage 5 decision.
 ## Semantic validation
 
 `decision_os.role_contract.validate_role_operation` validates the complete
-contract, one independently supplied trusted Role Grant, and one requested
-operation. It is deterministic and read-only. It checks explicit authority
-and Gate binding, assignee/context binding, Role Acceptance, exact packet and
-Lens identities, scope and path identity, role-specific forbidden operations,
+contract, one independently supplied trusted Role Grant, one receiver-side
+trusted Role Acceptance record, trusted independence evidence, the complete
+trusted prior-Role binding set, and one requested operation. It is
+deterministic and read-only. It checks explicit authority and Gate binding,
+assignee/context binding, receiver acceptance, exact packet and Lens
+identities, scope and path identity, role-specific forbidden operations,
 lifecycle, each independence dimension, and recommendation inertness.
 
 The first closed attack is same-context false division: a trusted context
@@ -148,5 +193,10 @@ producer metadata, and become Auditor. The trusted context binding produces:
 ```text
 BLOCK — CONTEXT INDEPENDENCE VIOLATION
 ```
+
+Omitting that true same-context Builder binding from the request and replacing
+it with a forged different-context binding does not help: the complete trusted
+binding set still exposes the collision, and the claim/trusted mismatch is
+also recorded.
 
 No automatic assignment or invocation function exists in this module.

--- a/examples/role_contract.v0_1.json
+++ b/examples/role_contract.v0_1.json
@@ -1,0 +1,92 @@
+{
+  "contract_identity": {
+    "contract_id": "stage4-example-builder-001",
+    "version": "0.1",
+    "contract_hash": "bb4527beddf6fb882032201bd2586714c54513779c5cab93a4435d77e421e531"
+  },
+  "assignment": {
+    "task_id": "stage4-example-task-001",
+    "role_id": "BUILDER",
+    "grant_type": "EXPLICIT_ROLE_GRANT",
+    "assignment_authority": "Shin",
+    "shin_gate_reference": "GO — STAGE 4 v0.1 EXAMPLE BUILDER",
+    "assignee_identity": "example-builder",
+    "execution_context_identity": "trusted-context-example-builder-001",
+    "role_acceptance": "ACCEPTED"
+  },
+  "owned_responsibility": {
+    "responsibility": "Implement only the fixed example target.",
+    "exact_target": [
+      "README.md"
+    ],
+    "next_owner": "Shin"
+  },
+  "operations": {
+    "allowed_operations": [
+      "IMPLEMENT_DESIGN",
+      "READ_TARGET",
+      "RUN_TESTS",
+      "PRODUCE_EXIT_RECEIPT",
+      "GENERATE_COVERAGE_GAP_RECOMMENDATION"
+    ],
+    "forbidden_operations": [
+      "AUDIT_TARGET",
+      "SELF_AUDIT",
+      "MODIFY_ROLE_GRANT",
+      "MODIFY_SPECIALIST_LENS",
+      "MODIFY_OUTSIDE_TARGET",
+      "MERGE",
+      "POST",
+      "INVOKE_SPECIALIST",
+      "START_STAGE_5"
+    ]
+  },
+  "task_artifact_packet": {
+    "repo": "shin4141/decision-os-v13-loopkit",
+    "head": "fe7d51806ac06ae6b4110d7443521abc351d7e87",
+    "paths": [
+      "README.md"
+    ],
+    "artifact_hashes": {
+      "README.md": "d1ec370e2b44b3df732204ccf4e78b0d14b82591163911da1b7854227cf5460a"
+    },
+    "as_of": "2026-07-29T00:00:00Z"
+  },
+  "specialist_lens": {
+    "lens_id": "v13-stage4-specialist-lens",
+    "lens_version": "0.1",
+    "lens_hash": "3a1200f872a1c89c93ebebf099cfa63d2721ea765e992adb3ad0b3dd82730bcc"
+  },
+  "independence_profile": {
+    "role_context_independence": "SAME_CONTEXT_ALLOWED",
+    "source_review_independence": "FULL_PRIOR_CONTEXT_ALLOWED",
+    "runtime_execution_independence": "NOT_REQUIRED",
+    "model_diversity": "SAME_MODEL_ALLOWED"
+  },
+  "completion": {
+    "completion_line": "The fixed example target is implemented and its Role Exit Receipt is complete.",
+    "required_exit_receipt": true,
+    "coverage_gap_required": true
+  },
+  "lifecycle": {
+    "issued_at": "2026-07-29T00:00:00Z",
+    "expires_at": "2026-07-30T00:00:00Z",
+    "revocation_reference": null,
+    "status": "ACTIVE"
+  },
+  "coverage_gap_recommendation": {
+    "coverage_completed": true,
+    "coverage_gap": "NONE DETECTED",
+    "recommended_specialist": "NONE",
+    "reason": "The fixed Builder responsibility is fully covered.",
+    "exact_target": [
+      "README.md"
+    ],
+    "required_evidence": [
+      "Role Exit Receipt"
+    ],
+    "urgency": "NONE",
+    "assignment_authority_required": true,
+    "automatic_invocation": false
+  }
+}

--- a/examples/role_contract.v0_1.json
+++ b/examples/role_contract.v0_1.json
@@ -2,7 +2,7 @@
   "contract_identity": {
     "contract_id": "stage4-example-builder-001",
     "version": "0.1",
-    "contract_hash": "bb4527beddf6fb882032201bd2586714c54513779c5cab93a4435d77e421e531"
+    "contract_hash": "d8754357fff5c86d9b196972608aeaaaf82a9065a1dacb4bb051e1dacc0dad9b"
   },
   "assignment": {
     "task_id": "stage4-example-task-001",
@@ -55,7 +55,7 @@
   "specialist_lens": {
     "lens_id": "v13-stage4-specialist-lens",
     "lens_version": "0.1",
-    "lens_hash": "3a1200f872a1c89c93ebebf099cfa63d2721ea765e992adb3ad0b3dd82730bcc"
+    "lens_hash": "f40ca45c96fc115a4cbd58f5ddb1bb21049e6df3564452061868960c7289a964"
   },
   "independence_profile": {
     "role_context_independence": "SAME_CONTEXT_ALLOWED",

--- a/examples/role_contract.v0_1.json
+++ b/examples/role_contract.v0_1.json
@@ -2,7 +2,7 @@
   "contract_identity": {
     "contract_id": "stage4-example-builder-001",
     "version": "0.1",
-    "contract_hash": "d8754357fff5c86d9b196972608aeaaaf82a9065a1dacb4bb051e1dacc0dad9b"
+    "contract_hash": "6dd126cd5a557c9d2f07d059ca50b6e3c05040934a6dd881c5e6620115734f33"
   },
   "assignment": {
     "task_id": "stage4-example-task-001",
@@ -11,7 +11,7 @@
     "assignment_authority": "Shin",
     "shin_gate_reference": "GO — STAGE 4 v0.1 EXAMPLE BUILDER",
     "assignee_identity": "example-builder",
-    "execution_context_identity": "trusted-context-example-builder-001",
+    "execution_context_identity": "context-example-builder-001",
     "role_acceptance": "ACCEPTED"
   },
   "owned_responsibility": {
@@ -55,7 +55,7 @@
   "specialist_lens": {
     "lens_id": "v13-stage4-specialist-lens",
     "lens_version": "0.1",
-    "lens_hash": "f40ca45c96fc115a4cbd58f5ddb1bb21049e6df3564452061868960c7289a964"
+    "lens_hash": "5e1636a7c576112450d36c4b5fa935d24cb44af741576a111421f0bfba12aa8d"
   },
   "independence_profile": {
     "role_context_independence": "SAME_CONTEXT_ALLOWED",

--- a/schema/v13_role_contract.schema.json
+++ b/schema/v13_role_contract.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/v13-role-contract.schema.json",
   "title": "Decision-OS V13 Stage 4 Role Contract v0.1",
-  "description": "A human-granted, role-bound contract for Builder or Auditor work. The artifact does not assign or invoke a role.",
+  "description": "A human-granted, role-bound contract for Builder or Auditor work. The artifact does not assign or invoke a role, and its claims require separately supplied trusted records.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -49,7 +49,10 @@
         "shin_gate_reference": {"type": "string", "minLength": 1},
         "assignee_identity": {"type": "string", "minLength": 1},
         "execution_context_identity": {"type": "string", "minLength": 1},
-        "role_acceptance": {"const": "ACCEPTED"}
+        "role_acceptance": {
+          "const": "ACCEPTED",
+          "description": "A contract claim, not receiver-side proof. ACTIVE validation also requires a separate trustedRoleAcceptanceRecord."
+        }
       }
     },
     "owned_responsibility": {
@@ -215,6 +218,122 @@
         "INVOKE_SPECIALIST",
         "START_STAGE_5"
       ]
+    },
+    "trustedRoleAcceptanceRecord": {
+      "description": "Receiver-side out-of-band acceptance evidence. This record is a separate validator input, not part of the Role Contract or operation request.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_id",
+        "contract_hash",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "role_acceptance",
+        "accepted_at"
+      ],
+      "properties": {
+        "contract_id": {"type": "string", "minLength": 1},
+        "contract_hash": {"$ref": "#/$defs/sha256"},
+        "task_id": {"type": "string", "minLength": 1},
+        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
+        "assignee_identity": {"type": "string", "minLength": 1},
+        "execution_context_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role_acceptance": {"const": "ACCEPTED"},
+        "accepted_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "trustedPriorRoleBinding": {
+      "description": "One record from the trusted, complete same-task role-binding set. A claimant-supplied copy is not trusted evidence.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_identity",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "model_identity"
+      ],
+      "properties": {
+        "evidence_identity": {"type": "string", "minLength": 1},
+        "task_id": {"type": "string", "minLength": 1},
+        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
+        "assignee_identity": {"type": "string", "minLength": 1},
+        "execution_context_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_identity": {"type": "string", "minLength": 1}
+      }
+    },
+    "trustedIndependenceEvidenceRecord": {
+      "description": "Out-of-band independence evidence bound to the current task, Role, assignee, execution context, model, and evidence identity.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_identity",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "role_context_independence",
+        "source_review_independence",
+        "runtime_execution_independence",
+        "model_diversity",
+        "model_identity",
+        "source_review_evidence_reference",
+        "runtime_execution_evidence_reference"
+      ],
+      "properties": {
+        "evidence_identity": {"type": "string", "minLength": 1},
+        "task_id": {"type": "string", "minLength": 1},
+        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
+        "assignee_identity": {"type": "string", "minLength": 1},
+        "execution_context_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role_context_independence": {
+          "enum": [
+            "SAME_CONTEXT_ALLOWED",
+            "FRESH_CONTEXT_REQUIRED",
+            "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+          ]
+        },
+        "source_review_independence": {
+          "enum": [
+            "FULL_PRIOR_CONTEXT_ALLOWED",
+            "FIXED_ARTIFACTS_ONLY",
+            "INDEPENDENT_EVIDENCE_SELECTION_REQUIRED"
+          ]
+        },
+        "runtime_execution_independence": {
+          "enum": [
+            "NOT_REQUIRED",
+            "REQUIRED_NOT_ESTABLISHED",
+            "READ_ONLY_REEXECUTION_REQUIRED",
+            "SEPARATE_ENV_REEXECUTION_REQUIRED",
+            "ESTABLISHED"
+          ]
+        },
+        "model_diversity": {
+          "enum": ["SAME_MODEL_ALLOWED", "DIFFERENT_MODEL_REQUIRED"]
+        },
+        "model_identity": {"type": "string", "minLength": 1},
+        "source_review_evidence_reference": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime_execution_evidence_reference": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     },
     "coverageGapRecommendation": {
       "type": "object",

--- a/schema/v13_role_contract.schema.json
+++ b/schema/v13_role_contract.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/v13-role-contract.schema.json",
   "title": "Decision-OS V13 Stage 4 Role Contract v0.1",
-  "description": "A human-granted, role-bound contract for Builder or Auditor work. The artifact does not assign or invoke a role, and its claims require separately supplied trusted records.",
+  "description": "A human-granted, role-bound contract for Builder or Auditor work. The artifact does not assign or invoke a role. Separately supplied records are validator inputs only and are not authenticated by this schema.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -51,7 +51,7 @@
         "execution_context_identity": {"type": "string", "minLength": 1},
         "role_acceptance": {
           "const": "ACCEPTED",
-          "description": "A contract claim, not receiver-side proof. ACTIVE validation also requires a separate trustedRoleAcceptanceRecord."
+          "description": "A contract claim, not receiver-side proof. ACTIVE validation also requires a separate suppliedRoleAcceptanceRecord."
         }
       }
     },
@@ -124,7 +124,7 @@
           "enum": [
             "SAME_CONTEXT_ALLOWED",
             "FRESH_CONTEXT_REQUIRED",
-            "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+            "DISTINCT_CONTEXT_REQUIRED"
           ]
         },
         "source_review_independence": {
@@ -140,7 +140,7 @@
             "REQUIRED_NOT_ESTABLISHED",
             "READ_ONLY_REEXECUTION_REQUIRED",
             "SEPARATE_ENV_REEXECUTION_REQUIRED",
-            "ESTABLISHED"
+            "EXECUTION_RECORD_SUPPLIED"
           ]
         },
         "model_diversity": {
@@ -219,23 +219,83 @@
         "START_STAGE_5"
       ]
     },
-    "trustedRoleAcceptanceRecord": {
-      "description": "Receiver-side out-of-band acceptance evidence. This record is a separate validator input, not part of the Role Contract or operation request.",
+    "suppliedRoleGrantRecord": {
+      "description": "A standalone Role Grant record supplied to the validator. The schema checks declared structure and bindings only; it does not authenticate an issuer, transport, or provenance.",
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "record_identity",
+        "snapshot_identity",
         "contract_id",
         "contract_hash",
+        "task_id",
+        "role_id",
+        "grant_type",
+        "assignment_authority",
+        "shin_gate_reference",
+        "assignee_identity",
+        "execution_context_identity",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference"
+      ],
+      "properties": {
+        "record_identity": {"type": "string", "minLength": 1},
+        "snapshot_identity": {"type": "string", "minLength": 1},
+        "contract_id": {"type": "string", "minLength": 1},
+        "contract_hash": {"$ref": "#/$defs/sha256"},
+        "task_id": {"type": "string", "minLength": 1},
+        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
+        "grant_type": {"const": "EXPLICIT_ROLE_GRANT"},
+        "assignment_authority": {"const": "Shin"},
+        "shin_gate_reference": {"type": "string", "minLength": 1},
+        "assignee_identity": {"type": "string", "minLength": 1},
+        "execution_context_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "as_of": {"type": "string", "format": "date-time"},
+        "revocation_state": {
+          "enum": ["NOT_REVOKED", "REVOKED", "UNKNOWN"]
+        },
+        "revoked_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "revocation_reference": {
+          "type": ["string", "null"],
+          "minLength": 1
+        }
+      }
+    },
+    "suppliedRoleAcceptanceRecord": {
+      "description": "A standalone receiver Role Acceptance record supplied to the validator. Its declared identity and lifecycle are validated without authenticating the receiver or record source.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "record_identity",
+        "snapshot_identity",
+        "contract_id",
+        "contract_hash",
+        "grant_record_identity",
         "task_id",
         "role_id",
         "assignee_identity",
         "execution_context_identity",
         "role_acceptance",
-        "accepted_at"
+        "accepted_at",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference"
       ],
       "properties": {
+        "record_identity": {"type": "string", "minLength": 1},
+        "snapshot_identity": {"type": "string", "minLength": 1},
         "contract_id": {"type": "string", "minLength": 1},
         "contract_hash": {"$ref": "#/$defs/sha256"},
+        "grant_record_identity": {"type": "string", "minLength": 1},
         "task_id": {"type": "string", "minLength": 1},
         "role_id": {"enum": ["BUILDER", "AUDITOR"]},
         "assignee_identity": {"type": "string", "minLength": 1},
@@ -243,40 +303,33 @@
           "type": "string",
           "minLength": 1
         },
-        "role_acceptance": {"const": "ACCEPTED"},
-        "accepted_at": {"type": "string", "format": "date-time"}
-      }
-    },
-    "trustedPriorRoleBinding": {
-      "description": "One record from the trusted, complete same-task role-binding set. A claimant-supplied copy is not trusted evidence.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "evidence_identity",
-        "task_id",
-        "role_id",
-        "assignee_identity",
-        "execution_context_identity",
-        "model_identity"
-      ],
-      "properties": {
-        "evidence_identity": {"type": "string", "minLength": 1},
-        "task_id": {"type": "string", "minLength": 1},
-        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
-        "assignee_identity": {"type": "string", "minLength": 1},
-        "execution_context_identity": {
-          "type": "string",
-          "minLength": 1
+        "role_acceptance": {
+          "enum": ["ACCEPTED", "DECLINED", "UNKNOWN"]
         },
-        "model_identity": {"type": "string", "minLength": 1}
+        "accepted_at": {"type": "string", "format": "date-time"},
+        "as_of": {"type": "string", "format": "date-time"},
+        "revocation_state": {
+          "enum": ["NOT_REVOKED", "REVOKED", "UNKNOWN"]
+        },
+        "revoked_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "revocation_reference": {
+          "type": ["string", "null"],
+          "minLength": 1
+        }
       }
     },
-    "trustedIndependenceEvidenceRecord": {
-      "description": "Out-of-band independence evidence bound to the current task, Role, assignee, execution context, model, and evidence identity.",
+    "suppliedIndependenceEvidenceRecord": {
+      "description": "A standalone independence record supplied to the validator. It carries declared contract, task, Role, assignee, context, model, and prior-binding snapshot identities without authenticating those declarations.",
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "evidence_identity",
+        "record_identity",
+        "snapshot_identity",
+        "contract_id",
+        "contract_hash",
         "task_id",
         "role_id",
         "assignee_identity",
@@ -287,10 +340,19 @@
         "model_diversity",
         "model_identity",
         "source_review_evidence_reference",
-        "runtime_execution_evidence_reference"
+        "runtime_execution_evidence_reference",
+        "prior_role_bindings_snapshot_identity",
+        "prior_role_bindings_snapshot_hash",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference"
       ],
       "properties": {
-        "evidence_identity": {"type": "string", "minLength": 1},
+        "record_identity": {"type": "string", "minLength": 1},
+        "snapshot_identity": {"type": "string", "minLength": 1},
+        "contract_id": {"type": "string", "minLength": 1},
+        "contract_hash": {"$ref": "#/$defs/sha256"},
         "task_id": {"type": "string", "minLength": 1},
         "role_id": {"enum": ["BUILDER", "AUDITOR"]},
         "assignee_identity": {"type": "string", "minLength": 1},
@@ -302,7 +364,7 @@
           "enum": [
             "SAME_CONTEXT_ALLOWED",
             "FRESH_CONTEXT_REQUIRED",
-            "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+            "DISTINCT_CONTEXT_REQUIRED"
           ]
         },
         "source_review_independence": {
@@ -318,7 +380,7 @@
             "REQUIRED_NOT_ESTABLISHED",
             "READ_ONLY_REEXECUTION_REQUIRED",
             "SEPARATE_ENV_REEXECUTION_REQUIRED",
-            "ESTABLISHED"
+            "EXECUTION_RECORD_SUPPLIED"
           ]
         },
         "model_diversity": {
@@ -332,6 +394,152 @@
         "runtime_execution_evidence_reference": {
           "type": "string",
           "minLength": 1
+        },
+        "prior_role_bindings_snapshot_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prior_role_bindings_snapshot_hash": {
+          "$ref": "#/$defs/sha256"
+        },
+        "as_of": {"type": "string", "format": "date-time"},
+        "revocation_state": {
+          "enum": ["NOT_REVOKED", "REVOKED", "UNKNOWN"]
+        },
+        "revoked_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "revocation_reference": {
+          "type": ["string", "null"],
+          "minLength": 1
+        }
+      }
+    },
+    "suppliedPriorRoleBinding": {
+      "description": "One prior Role binding supplied inside a declared snapshot. Its identity, state, and timestamps are validator inputs, not authenticated facts.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "record_identity",
+        "snapshot_identity",
+        "task_id",
+        "role_id",
+        "assignee_identity",
+        "execution_context_identity",
+        "model_identity",
+        "bound_at",
+        "ended_at",
+        "binding_state",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference"
+      ],
+      "properties": {
+        "record_identity": {"type": "string", "minLength": 1},
+        "snapshot_identity": {"type": "string", "minLength": 1},
+        "task_id": {"type": "string", "minLength": 1},
+        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
+        "assignee_identity": {"type": "string", "minLength": 1},
+        "execution_context_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_identity": {"type": "string", "minLength": 1},
+        "bound_at": {"type": "string", "format": "date-time"},
+        "ended_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "binding_state": {"enum": ["ACTIVE", "ENDED", "UNKNOWN"]},
+        "as_of": {"type": "string", "format": "date-time"},
+        "revocation_state": {
+          "enum": ["NOT_REVOKED", "REVOKED", "UNKNOWN"]
+        },
+        "revoked_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "revocation_reference": {
+          "type": ["string", "null"],
+          "minLength": 1
+        }
+      }
+    },
+    "suppliedPriorRoleBindingSnapshot": {
+      "description": "A supplied snapshot of declared prior Role bindings. The validator can check its hash, manifest, temporal coherence, and completeness assertion but cannot authenticate source completeness.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "snapshot_identity",
+        "snapshot_hash",
+        "contract_id",
+        "contract_hash",
+        "task_id",
+        "as_of",
+        "revocation_state",
+        "revoked_at",
+        "revocation_reference",
+        "completeness_boundary",
+        "bindings"
+      ],
+      "properties": {
+        "snapshot_identity": {"type": "string", "minLength": 1},
+        "snapshot_hash": {
+          "$ref": "#/$defs/sha256",
+          "description": "Canonical SHA-256 of this snapshot with snapshot_hash replaced by the empty string."
+        },
+        "contract_id": {"type": "string", "minLength": 1},
+        "contract_hash": {"$ref": "#/$defs/sha256"},
+        "task_id": {"type": "string", "minLength": 1},
+        "as_of": {"type": "string", "format": "date-time"},
+        "revocation_state": {
+          "enum": ["NOT_REVOKED", "REVOKED", "UNKNOWN"]
+        },
+        "revoked_at": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "revocation_reference": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "completeness_boundary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope",
+            "task_id",
+            "from",
+            "through",
+            "included_roles",
+            "state",
+            "expected_record_identities"
+          ],
+          "properties": {
+            "scope": {"const": "ALL_PRIOR_ROLE_BINDINGS_FOR_TASK"},
+            "task_id": {"type": "string", "minLength": 1},
+            "from": {"const": "TASK_INCEPTION"},
+            "through": {"type": "string", "format": "date-time"},
+            "included_roles": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {"enum": ["BUILDER", "AUDITOR"]}
+            },
+            "state": {"enum": ["COMPLETE", "INCOMPLETE", "UNKNOWN"]},
+            "expected_record_identities": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        "bindings": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/suppliedPriorRoleBinding"}
         }
       }
     },

--- a/schema/v13_role_contract.schema.json
+++ b/schema/v13_role_contract.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/v13-role-contract.schema.json",
+  "title": "Decision-OS V13 Stage 4 Role Contract v0.1",
+  "description": "A human-granted, role-bound contract for Builder or Auditor work. The artifact does not assign or invoke a role.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_identity",
+    "assignment",
+    "owned_responsibility",
+    "operations",
+    "task_artifact_packet",
+    "specialist_lens",
+    "independence_profile",
+    "completion",
+    "lifecycle",
+    "coverage_gap_recommendation"
+  ],
+  "properties": {
+    "contract_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_id", "version", "contract_hash"],
+      "properties": {
+        "contract_id": {"type": "string", "minLength": 1},
+        "version": {"const": "0.1"},
+        "contract_hash": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "assignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "task_id",
+        "role_id",
+        "grant_type",
+        "assignment_authority",
+        "shin_gate_reference",
+        "assignee_identity",
+        "execution_context_identity",
+        "role_acceptance"
+      ],
+      "properties": {
+        "task_id": {"type": "string", "minLength": 1},
+        "role_id": {"enum": ["BUILDER", "AUDITOR"]},
+        "grant_type": {"const": "EXPLICIT_ROLE_GRANT"},
+        "assignment_authority": {"const": "Shin"},
+        "shin_gate_reference": {"type": "string", "minLength": 1},
+        "assignee_identity": {"type": "string", "minLength": 1},
+        "execution_context_identity": {"type": "string", "minLength": 1},
+        "role_acceptance": {"const": "ACCEPTED"}
+      }
+    },
+    "owned_responsibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["responsibility", "exact_target", "next_owner"],
+      "properties": {
+        "responsibility": {"type": "string", "minLength": 1},
+        "exact_target": {"$ref": "#/$defs/nonEmptyUniqueStrings"},
+        "next_owner": {"type": "string", "minLength": 1}
+      }
+    },
+    "operations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed_operations", "forbidden_operations"],
+      "properties": {
+        "allowed_operations": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/operation"}
+        },
+        "forbidden_operations": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/operation"}
+        }
+      }
+    },
+    "task_artifact_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "head", "paths", "artifact_hashes", "as_of"],
+      "properties": {
+        "repo": {"type": "string", "minLength": 1},
+        "head": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "paths": {"$ref": "#/$defs/nonEmptyUniqueStrings"},
+        "artifact_hashes": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"$ref": "#/$defs/sha256"}
+        },
+        "as_of": {"type": "string", "format": "date-time"}
+      }
+    },
+    "specialist_lens": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lens_id", "lens_version", "lens_hash"],
+      "properties": {
+        "lens_id": {"type": "string", "minLength": 1},
+        "lens_version": {"type": "string", "minLength": 1},
+        "lens_hash": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "independence_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role_context_independence",
+        "source_review_independence",
+        "runtime_execution_independence",
+        "model_diversity"
+      ],
+      "properties": {
+        "role_context_independence": {
+          "enum": [
+            "SAME_CONTEXT_ALLOWED",
+            "FRESH_CONTEXT_REQUIRED",
+            "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+          ]
+        },
+        "source_review_independence": {
+          "enum": [
+            "FULL_PRIOR_CONTEXT_ALLOWED",
+            "FIXED_ARTIFACTS_ONLY",
+            "INDEPENDENT_EVIDENCE_SELECTION_REQUIRED"
+          ]
+        },
+        "runtime_execution_independence": {
+          "enum": [
+            "NOT_REQUIRED",
+            "REQUIRED_NOT_ESTABLISHED",
+            "READ_ONLY_REEXECUTION_REQUIRED",
+            "SEPARATE_ENV_REEXECUTION_REQUIRED",
+            "ESTABLISHED"
+          ]
+        },
+        "model_diversity": {
+          "enum": ["SAME_MODEL_ALLOWED", "DIFFERENT_MODEL_REQUIRED"]
+        }
+      }
+    },
+    "completion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completion_line",
+        "required_exit_receipt",
+        "coverage_gap_required"
+      ],
+      "properties": {
+        "completion_line": {"type": "string", "minLength": 1},
+        "required_exit_receipt": {"const": true},
+        "coverage_gap_required": {"const": true}
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issued_at",
+        "expires_at",
+        "revocation_reference",
+        "status"
+      ],
+      "properties": {
+        "issued_at": {"type": "string", "format": "date-time"},
+        "expires_at": {"type": "string", "format": "date-time"},
+        "revocation_reference": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "status": {"enum": ["ACTIVE", "EXPIRED", "REVOKED"]}
+      }
+    },
+    "coverage_gap_recommendation": {
+      "$ref": "#/$defs/coverageGapRecommendation"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nonEmptyUniqueStrings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "operation": {
+      "enum": [
+        "IMPLEMENT_DESIGN",
+        "READ_TARGET",
+        "AUDIT_TARGET",
+        "VERIFY_TARGET_IMMUTABILITY",
+        "RUN_TESTS",
+        "RUN_READ_ONLY_TESTS",
+        "PRODUCE_EXIT_RECEIPT",
+        "GENERATE_COVERAGE_GAP_RECOMMENDATION",
+        "SELF_AUDIT",
+        "MODIFY_TARGET",
+        "REPAIR_IMPLEMENTATION",
+        "ASSUME_BUILDER_ROLE",
+        "MODIFY_ROLE_GRANT",
+        "MODIFY_SPECIALIST_LENS",
+        "MODIFY_OUTSIDE_TARGET",
+        "MERGE",
+        "POST",
+        "INVOKE_SPECIALIST",
+        "START_STAGE_5"
+      ]
+    },
+    "coverageGapRecommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage_completed",
+        "coverage_gap",
+        "recommended_specialist",
+        "reason",
+        "exact_target",
+        "required_evidence",
+        "urgency",
+        "assignment_authority_required",
+        "automatic_invocation"
+      ],
+      "properties": {
+        "coverage_completed": {"type": "boolean"},
+        "coverage_gap": {"type": "string", "minLength": 1},
+        "recommended_specialist": {
+          "enum": ["NONE", "BUILDER", "AUDITOR"]
+        },
+        "reason": {"type": "string", "minLength": 1},
+        "exact_target": {"$ref": "#/$defs/nonEmptyUniqueStrings"},
+        "required_evidence": {"$ref": "#/$defs/nonEmptyUniqueStrings"},
+        "urgency": {"enum": ["NONE", "LOW", "MEDIUM", "HIGH"]},
+        "assignment_authority_required": {"const": true},
+        "automatic_invocation": {"const": false}
+      }
+    }
+  }
+}

--- a/templates/v13_specialist_lens.md
+++ b/templates/v13_specialist_lens.md
@@ -1,0 +1,72 @@
+# V13 Stage 4 Specialist Lens v0.1
+
+## Lens Identity
+
+```text
+Lens ID:
+Lens Version: 0.1
+Lens SHA-256:
+Assigned Role: BUILDER / AUDITOR
+Role Contract ID:
+Shin Gate Reference:
+```
+
+The Role Grant must explicitly select this Lens identity and exact hash.
+An assignee cannot select, replace, or amend its own Lens. A missing or
+mismatched identity or hash keeps the Role inactive.
+
+## Purpose
+
+State the narrow specialist judgment this Lens contributes to the assigned
+Builder or Auditor responsibility. The Lens supplies a bounded review
+perspective; it grants no authority and creates no additional Role.
+
+## Primary Risks
+
+- Identify risks inside the Role Contract's exact target.
+- Keep Builder implementation risk separate from Auditor conformity risk.
+- Treat unknown, stale, or unfixed evidence as a HOLD condition.
+- Do not expand to Scout, Architect, Stage 5, or an ungranted specialist.
+
+## Required Evidence
+
+- Exact Role Contract identity and canonical hash.
+- Exact Task Artifact Packet repository, head, paths, hashes, and as-of time.
+- Exact Lens identity, version, and SHA-256.
+- Assignee and trusted execution context identities.
+- Independence evidence required by each independent profile field.
+- Before/after target identity when immutability is required.
+
+## Common Failure Patterns
+
+- Treating a Role name or self-description as a Role Grant.
+- Treating different artifact bytes as independent authorship or review.
+- Omitting `producer_role` or `builder_generated` metadata to conceal a
+  same-context Builder/Auditor collision.
+- Treating a different model as a different trusted execution context.
+- Treating a recommendation as an assignment or invocation.
+
+## Escalation Conditions
+
+Return HOLD or BLOCK when authority, Gate, identity, target, Lens, lifecycle,
+or independence is missing, unknown, expired, revoked, inconsistent, or
+unverifiable. Any new Role, authority, target, operation, or Lens requires a
+new Shin Gate.
+
+## Output Contract
+
+Produce only the contracted Role output and a Role Exit Receipt. The receipt
+must state either a concrete Coverage Gap Recommendation or:
+
+```text
+Coverage Gap:
+NONE DETECTED
+```
+
+Every recommendation remains inert:
+
+```text
+Recommendation: ALLOWED
+Automatic Assignment: PROHIBITED
+Automatic Invocation: PROHIBITED
+```

--- a/templates/v13_specialist_lens.md
+++ b/templates/v13_specialist_lens.md
@@ -33,12 +33,20 @@ perspective; it grants no authority and creates no additional Role.
 - Exact Role Contract identity and canonical hash.
 - Exact Task Artifact Packet repository, head, paths, hashes, and as-of time.
 - Exact Lens identity, version, and SHA-256.
-- Assignee and trusted execution context identities.
-- Receiver-side trusted Role Acceptance bound to the exact Contract ID/hash,
-  task, Role, assignee, execution context, and acceptance time.
-- Trusted independence evidence and complete prior-Role binding records,
-  including task, Role, assignee, context, model, and evidence identities.
+- Assignee and execution context identities.
+- A separately supplied Role Grant record and receiver Role Acceptance record
+  bound to the Contract ID/hash, task, Role, assignee, execution context,
+  shared snapshot, as-of time, and explicit revocation state.
+- A supplied independence record bound to the declared prior-Role binding
+  snapshot identity and hash.
+- A supplied prior-Role binding snapshot with its identity, canonical hash,
+  as-of time, completeness boundary, expected record-identity manifest,
+  binding lifecycle times, and explicit revocation states.
 - Before/after target identity when immutability is required.
+
+Supplied records are validator inputs. Their names and internally consistent
+fields do not authenticate an issuer, receiver, execution context, transport,
+record store, provenance, completeness assertion, or revocation truth.
 
 ## Common Failure Patterns
 
@@ -47,17 +55,21 @@ perspective; it grants no authority and creates no additional Role.
 - Omitting `producer_role` or `builder_generated` metadata to conceal a
   same-context Builder/Auditor collision.
 - Omitting a true same-context binding and substituting a claimant-controlled
-  forged different-context binding.
+  different-context binding.
 - Treating Contract-local `role_acceptance: ACCEPTED` as receiver proof.
-- Treating a different model as a different trusted execution context.
+- Reusing a stale or different-snapshot record.
+- Mixing record as-of times across one validation snapshot.
+- Accepting an Auditor before every supplied Builder binding has ended.
+- Treating a different model as a different execution context.
 - Treating a recommendation as an assignment or invocation.
 
 ## Escalation Conditions
 
 Return HOLD or BLOCK when authority, Gate, identity, target, Lens, lifecycle,
-or independence is missing, unknown, expired, revoked, inconsistent, or
-unverifiable. Any new Role, authority, target, operation, or Lens requires a
-new Shin Gate.
+snapshot freshness, completeness boundary, record manifest, revocation state,
+Builder end time, or independence claim is missing, unknown, expired, stale,
+revoked, inconsistent, or unverifiable. Any new Role, authority, target,
+operation, or Lens requires a new Shin Gate.
 
 ## Output Contract
 
@@ -76,3 +88,18 @@ Recommendation: ALLOWED
 Automatic Assignment: PROHIBITED
 Automatic Invocation: PROHIBITED
 ```
+
+Every Role Exit Receipt must also preserve this implementation boundary
+exactly:
+
+```text
+Role Separation Enforcement: VALIDATOR-LEVEL ONLY
+Record Issuer / Authentication / Transport: NOT IMPLEMENTED
+Role Independence: NOT ESTABLISHED
+End-to-End False-Division Prevention: NOT ESTABLISHED
+```
+
+An internally consistent supplied snapshot may satisfy validator conditions,
+but it does not establish record authenticity, real-world completeness, Role
+independence, or end-to-end false-division prevention. No automatic Role
+assignment, specialist invocation, or Stage 5 decision follows.

--- a/templates/v13_specialist_lens.md
+++ b/templates/v13_specialist_lens.md
@@ -34,7 +34,10 @@ perspective; it grants no authority and creates no additional Role.
 - Exact Task Artifact Packet repository, head, paths, hashes, and as-of time.
 - Exact Lens identity, version, and SHA-256.
 - Assignee and trusted execution context identities.
-- Independence evidence required by each independent profile field.
+- Receiver-side trusted Role Acceptance bound to the exact Contract ID/hash,
+  task, Role, assignee, execution context, and acceptance time.
+- Trusted independence evidence and complete prior-Role binding records,
+  including task, Role, assignee, context, model, and evidence identities.
 - Before/after target identity when immutability is required.
 
 ## Common Failure Patterns
@@ -43,6 +46,9 @@ perspective; it grants no authority and creates no additional Role.
 - Treating different artifact bytes as independent authorship or review.
 - Omitting `producer_role` or `builder_generated` metadata to conceal a
   same-context Builder/Auditor collision.
+- Omitting a true same-context binding and substituting a claimant-controlled
+  forged different-context binding.
+- Treating Contract-local `role_acceptance: ACCEPTED` as receiver proof.
 - Treating a different model as a different trusted execution context.
 - Treating a recommendation as an assignment or invocation.
 

--- a/tests/test_decision_os_role_contract.py
+++ b/tests/test_decision_os_role_contract.py
@@ -214,7 +214,7 @@ class RoleContractV01Test(unittest.TestCase):
         }
         return contract_with_hash(value)
 
-    def _request(
+    def _independence_evidence(
         self,
         contract: dict[str, object],
     ) -> dict[str, object]:
@@ -222,6 +222,54 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertIsInstance(assignment, dict)
         profile = contract["independence_profile"]
         self.assertIsInstance(profile, dict)
+        role = assignment["role_id"]
+        return {
+            "evidence_identity": f"trusted-{role.lower()}-evidence-001",
+            "task_id": assignment["task_id"],
+            "role_id": role,
+            "assignee_identity": assignment["assignee_identity"],
+            "execution_context_identity": assignment[
+                "execution_context_identity"
+            ],
+            **deepcopy(profile),
+            "model_identity": "same-base-model",
+            "source_review_evidence_reference": (
+                "trusted fixed-artifact review receipt"
+                if role == "AUDITOR"
+                else "trusted full-context allowance record"
+            ),
+            "runtime_execution_evidence_reference": (
+                "trusted read-only reexecution receipt"
+                if role == "AUDITOR"
+                else "trusted not-required record"
+            ),
+        }
+
+    def _prior_role_bindings(
+        self,
+        contract: dict[str, object],
+    ) -> list[dict[str, object]]:
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        if assignment["role_id"] == "BUILDER":
+            return []
+        return [
+            {
+                "evidence_identity": "trusted-builder-binding-001",
+                "task_id": assignment["task_id"],
+                "role_id": "BUILDER",
+                "assignee_identity": "builder-assignee",
+                "execution_context_identity": "trusted-builder-context",
+                "model_identity": "same-base-model",
+            }
+        ]
+
+    def _request(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, object]:
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
         role = assignment["role_id"]
         return {
             "operation": (
@@ -237,35 +285,8 @@ class RoleContractV01Test(unittest.TestCase):
                 contract["task_artifact_packet"]
             ),
             "specialist_lens": deepcopy(contract["specialist_lens"]),
-            "independence_evidence": {
-                **deepcopy(profile),
-                "model_identity": "same-base-model",
-                "source_review_evidence_reference": (
-                    "fixed Task Artifact Packet"
-                    if role == "AUDITOR"
-                    else "Role Contract declaration"
-                ),
-                "runtime_execution_evidence_reference": (
-                    "read-only reexecution receipt"
-                    if role == "AUDITOR"
-                    else "not required by Role Contract"
-                ),
-            },
-            "prior_role_bindings": (
-                []
-                if role == "BUILDER"
-                else [
-                    {
-                        "task_id": assignment["task_id"],
-                        "role_id": "BUILDER",
-                        "assignee_identity": "builder-assignee",
-                        "execution_context_identity": (
-                            "trusted-builder-context"
-                        ),
-                        "model_identity": "same-base-model",
-                    }
-                ]
-            ),
+            "independence_evidence": self._independence_evidence(contract),
+            "prior_role_bindings": self._prior_role_bindings(contract),
             **(
                 {}
                 if role == "BUILDER"
@@ -322,6 +343,27 @@ class RoleContractV01Test(unittest.TestCase):
             ],
         }
 
+    def _trusted_acceptance(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, object]:
+        identity = contract["contract_identity"]
+        assignment = contract["assignment"]
+        self.assertIsInstance(identity, dict)
+        self.assertIsInstance(assignment, dict)
+        return {
+            "contract_id": identity["contract_id"],
+            "contract_hash": identity["contract_hash"],
+            "task_id": assignment["task_id"],
+            "role_id": assignment["role_id"],
+            "assignee_identity": assignment["assignee_identity"],
+            "execution_context_identity": assignment[
+                "execution_context_identity"
+            ],
+            "role_acceptance": "ACCEPTED",
+            "accepted_at": "2026-07-29T00:01:00Z",
+        }
+
     def _validate(
         self,
         contract: dict[str, object],
@@ -331,6 +373,11 @@ class RoleContractV01Test(unittest.TestCase):
             contract,
             request or self._request(contract),
             trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            trusted_independence_evidence=self._independence_evidence(
+                contract
+            ),
+            trusted_prior_role_bindings=self._prior_role_bindings(contract),
             now=FIXED_NOW,
         )
 
@@ -354,6 +401,40 @@ class RoleContractV01Test(unittest.TestCase):
                 "coverage_gap_recommendation",
             },
             set(schema["required"]),
+        )
+        self.assertEqual(
+            {
+                "contract_id",
+                "contract_hash",
+                "task_id",
+                "role_id",
+                "assignee_identity",
+                "execution_context_identity",
+                "role_acceptance",
+                "accepted_at",
+            },
+            set(
+                schema["$defs"]["trustedRoleAcceptanceRecord"]["required"]
+            ),
+        )
+        trusted_identity_fields = {
+            "evidence_identity",
+            "task_id",
+            "role_id",
+            "assignee_identity",
+            "execution_context_identity",
+            "model_identity",
+        }
+        self.assertEqual(
+            trusted_identity_fields,
+            set(schema["$defs"]["trustedPriorRoleBinding"]["required"]),
+        )
+        self.assertTrue(
+            trusted_identity_fields.issubset(
+                schema["$defs"]["trustedIndependenceEvidenceRecord"][
+                    "required"
+                ]
+            )
         )
         example = json.loads(
             (REPO_ROOT / "examples" / "role_contract.v0_1.json").read_text(
@@ -412,17 +493,129 @@ class RoleContractV01Test(unittest.TestCase):
         bindings = request["prior_role_bindings"]
         self.assertIsInstance(bindings, list)
         bindings[0]["execution_context_identity"] = "shared-trusted-context"
+        trusted_evidence = self._independence_evidence(contract)
+        trusted_bindings = self._prior_role_bindings(contract)
+        trusted_bindings[0][
+            "execution_context_identity"
+        ] = "shared-trusted-context"
         self.assertNotEqual(self._hash("builder.txt"), self._hash("audit.txt"))
         self.assertNotIn("producer_role", request)
         self.assertNotIn("builder_generated", request)
 
-        result = self._validate(contract, request)
+        result = validate_role_operation(
+            contract,
+            request,
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            trusted_independence_evidence=trusted_evidence,
+            trusted_prior_role_bindings=trusted_bindings,
+            now=FIXED_NOW,
+        )
 
         self.assertEqual(RESULT_BLOCK, result.result)
         self.assertEqual(
             "BLOCK — CONTEXT INDEPENDENCE VIOLATION",
             result.decision_line,
         )
+
+    def test_claimant_cannot_replace_true_same_context_binding(self) -> None:
+        contract = self._contract("AUDITOR")
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["execution_context_identity"] = "shared-trusted-context"
+        self._rehash(contract)
+
+        request = self._request(contract)
+        request["execution_context_identity"] = "shared-trusted-context"
+        claimed_bindings = request["prior_role_bindings"]
+        self.assertIsInstance(claimed_bindings, list)
+        claimed_bindings[0] = {
+            "evidence_identity": "forged-builder-binding-002",
+            "task_id": assignment["task_id"],
+            "role_id": "BUILDER",
+            "assignee_identity": "builder-assignee",
+            "execution_context_identity": "fake-distinct-context",
+            "model_identity": "same-base-model",
+        }
+
+        trusted_bindings = self._prior_role_bindings(contract)
+        trusted_bindings[0][
+            "execution_context_identity"
+        ] = "shared-trusted-context"
+        result = validate_role_operation(
+            contract,
+            request,
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            trusted_independence_evidence=self._independence_evidence(
+                contract
+            ),
+            trusted_prior_role_bindings=trusted_bindings,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertEqual(
+            (
+                "CONTEXT_INDEPENDENCE_VIOLATION",
+                "TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",
+            ),
+            result.issue_codes,
+        )
+
+    def test_malformed_claims_cannot_downgrade_trusted_context_block(
+        self,
+    ) -> None:
+        contract = self._contract("AUDITOR")
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["execution_context_identity"] = "shared-trusted-context"
+        self._rehash(contract)
+        trusted_evidence = self._independence_evidence(contract)
+        trusted_bindings = self._prior_role_bindings(contract)
+        trusted_bindings[0][
+            "execution_context_identity"
+        ] = "shared-trusted-context"
+
+        malformed_requests = []
+        malformed_evidence = self._request(contract)
+        malformed_evidence["independence_evidence"] = {}
+        malformed_requests.append(
+            (
+                "malformed evidence",
+                malformed_evidence,
+                "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+            )
+        )
+        duplicate_bindings = self._request(contract)
+        binding_claims = duplicate_bindings["prior_role_bindings"]
+        self.assertIsInstance(binding_claims, list)
+        binding_claims.append(deepcopy(binding_claims[0]))
+        malformed_requests.append(
+            (
+                "duplicate binding identity",
+                duplicate_bindings,
+                "TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",
+            )
+        )
+
+        for label, request, mismatch_issue in malformed_requests:
+            with self.subTest(label=label):
+                result = validate_role_operation(
+                    contract,
+                    request,
+                    trusted_role_grant=self._trusted_grant(contract),
+                    trusted_role_acceptance=self._trusted_acceptance(contract),
+                    trusted_independence_evidence=trusted_evidence,
+                    trusted_prior_role_bindings=trusted_bindings,
+                    now=FIXED_NOW,
+                )
+                self.assertEqual(RESULT_BLOCK, result.result)
+                self.assertEqual(
+                    "CONTEXT_INDEPENDENCE_VIOLATION",
+                    result.issue_codes[0],
+                )
+                self.assertIn(mismatch_issue, result.issue_codes)
 
     def test_builder_cannot_audit_itself(self) -> None:
         contract = self._contract()
@@ -490,6 +683,113 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertEqual(RESULT_BLOCK, result.result)
         self.assertIn("TRUSTED_ROLE_GRANT_MISMATCH", result.issue_codes)
 
+    def test_request_only_independence_claims_are_not_trusted(self) -> None:
+        contract = self._contract()
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            now=FIXED_NOW,
+        )
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn(
+            "TRUSTED_INDEPENDENCE_EVIDENCE_REQUIRED",
+            result.issue_codes,
+        )
+
+    def test_trusted_independence_evidence_binds_all_identities(self) -> None:
+        replacements = {
+            "task_id": "different-task",
+            "role_id": "AUDITOR",
+            "assignee_identity": "different-assignee",
+            "execution_context_identity": "different-context",
+            "model_identity": "different-model",
+            "evidence_identity": "different-evidence",
+        }
+        for field, replacement in replacements.items():
+            with self.subTest(field=field):
+                contract = self._contract()
+                trusted_evidence = self._independence_evidence(contract)
+                trusted_evidence[field] = replacement
+                result = validate_role_operation(
+                    contract,
+                    self._request(contract),
+                    trusted_role_grant=self._trusted_grant(contract),
+                    trusted_role_acceptance=self._trusted_acceptance(contract),
+                    trusted_independence_evidence=trusted_evidence,
+                    trusted_prior_role_bindings=[],
+                    now=FIXED_NOW,
+                )
+                self.assertEqual(RESULT_BLOCK, result.result)
+                self.assertIn(
+                    "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+                    result.issue_codes,
+                )
+
+    def test_trusted_prior_role_bindings_are_required_and_unique(self) -> None:
+        contract = self._contract("AUDITOR")
+        common = {
+            "trusted_role_grant": self._trusted_grant(contract),
+            "trusted_role_acceptance": self._trusted_acceptance(contract),
+            "trusted_independence_evidence": (
+                self._independence_evidence(contract)
+            ),
+            "now": FIXED_NOW,
+        }
+        missing = validate_role_operation(
+            contract,
+            self._request(contract),
+            **common,
+        )
+        self.assertEqual(RESULT_HOLD, missing.result)
+        self.assertIn(
+            "TRUSTED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            missing.issue_codes,
+        )
+
+        binding = self._prior_role_bindings(contract)[0]
+        duplicate = validate_role_operation(
+            contract,
+            self._request(contract),
+            trusted_prior_role_bindings=[
+                deepcopy(binding),
+                deepcopy(binding),
+            ],
+            **common,
+        )
+        self.assertEqual(RESULT_HOLD, duplicate.result)
+        self.assertIn(
+            "TRUSTED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            duplicate.issue_codes,
+        )
+
+    def test_trusted_evidence_identities_are_globally_unique(self) -> None:
+        contract = self._contract("AUDITOR")
+        trusted_evidence = self._independence_evidence(contract)
+        trusted_bindings = self._prior_role_bindings(contract)
+        trusted_evidence["evidence_identity"] = trusted_bindings[0][
+            "evidence_identity"
+        ]
+        request = self._request(contract)
+        request["independence_evidence"] = deepcopy(trusted_evidence)
+
+        result = validate_role_operation(
+            contract,
+            request,
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            trusted_independence_evidence=trusted_evidence,
+            trusted_prior_role_bindings=trusted_bindings,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn(
+            "TRUSTED_EVIDENCE_IDENTITY_COLLISION",
+            result.issue_codes,
+        )
+
     def test_explicit_assignment_authority_is_required(self) -> None:
         contract = self._contract()
         assignment = contract["assignment"]
@@ -529,6 +829,115 @@ class RoleContractV01Test(unittest.TestCase):
         result = self._validate(contract)
         self.assertEqual(RESULT_BLOCK, result.result)
         self.assertIn("ROLE_ACCEPTANCE_REQUIRED", result.issue_codes)
+
+    def test_contract_acceptance_claim_needs_trusted_receiver_record(
+        self,
+    ) -> None:
+        contract = self._contract()
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        self.assertEqual("ACCEPTED", assignment["role_acceptance"])
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_independence_evidence=self._independence_evidence(
+                contract
+            ),
+            trusted_prior_role_bindings=[],
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn("TRUSTED_ROLE_ACCEPTANCE_REQUIRED", result.issue_codes)
+
+    def test_trusted_role_acceptance_binds_receiver_and_contract(
+        self,
+    ) -> None:
+        replacements = {
+            "contract_id": "different-contract",
+            "contract_hash": "f" * 64,
+            "task_id": "different-task",
+            "role_id": "AUDITOR",
+            "assignee_identity": "different-assignee",
+            "execution_context_identity": "different-context",
+        }
+        for field, replacement in replacements.items():
+            with self.subTest(field=field):
+                contract = self._contract()
+                acceptance = self._trusted_acceptance(contract)
+                acceptance[field] = replacement
+                result = validate_role_operation(
+                    contract,
+                    self._request(contract),
+                    trusted_role_grant=self._trusted_grant(contract),
+                    trusted_role_acceptance=acceptance,
+                    trusted_independence_evidence=(
+                        self._independence_evidence(contract)
+                    ),
+                    trusted_prior_role_bindings=[],
+                    now=FIXED_NOW,
+                )
+                self.assertEqual(RESULT_BLOCK, result.result)
+                self.assertIn(
+                    "TRUSTED_ROLE_ACCEPTANCE_MISMATCH",
+                    result.issue_codes,
+                )
+
+    def test_trusted_role_acceptance_status_and_time_fail_closed(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "role_acceptance",
+                "DECLINED",
+                RESULT_BLOCK,
+                "TRUSTED_ROLE_ACCEPTANCE_NOT_ACCEPTED",
+            ),
+            (
+                "accepted_at",
+                "UNKNOWN",
+                RESULT_HOLD,
+                "TRUSTED_ROLE_ACCEPTANCE_UNVERIFIABLE",
+            ),
+            (
+                "accepted_at",
+                "2026-07-28T23:59:59Z",
+                RESULT_BLOCK,
+                "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+            ),
+            (
+                "accepted_at",
+                "2026-07-30T00:00:00Z",
+                RESULT_BLOCK,
+                "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+            ),
+            (
+                "accepted_at",
+                "2026-07-29T13:00:00Z",
+                RESULT_BLOCK,
+                "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+            ),
+        )
+        for field, replacement, expected_result, expected_issue in cases:
+            with self.subTest(field=field, replacement=replacement):
+                contract = self._contract()
+                acceptance = self._trusted_acceptance(contract)
+                acceptance[field] = replacement
+                result = validate_role_operation(
+                    contract,
+                    self._request(contract),
+                    trusted_role_grant=self._trusted_grant(contract),
+                    trusted_role_acceptance=acceptance,
+                    trusted_independence_evidence=(
+                        self._independence_evidence(contract)
+                    ),
+                    trusted_prior_role_bindings=[],
+                    now=FIXED_NOW,
+                )
+                self.assertEqual(expected_result, result.result)
+                self.assertIn(expected_issue, result.issue_codes)
 
     def test_role_contract_is_required(self) -> None:
         result = validate_role_operation(None, None, now=FIXED_NOW)
@@ -628,12 +1037,22 @@ class RoleContractV01Test(unittest.TestCase):
     def test_unknown_independence_does_not_become_pass(self) -> None:
         contract = self._contract()
         request = self._request(contract)
-        evidence = request["independence_evidence"]
-        self.assertIsInstance(evidence, dict)
-        evidence["runtime_execution_independence"] = "UNKNOWN"
-        result = self._validate(contract, request)
+        trusted_evidence = self._independence_evidence(contract)
+        trusted_evidence["runtime_execution_independence"] = "UNKNOWN"
+        result = validate_role_operation(
+            contract,
+            request,
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            trusted_independence_evidence=trusted_evidence,
+            trusted_prior_role_bindings=[],
+            now=FIXED_NOW,
+        )
         self.assertEqual(RESULT_HOLD, result.result)
-        self.assertIn("INDEPENDENCE_UNVERIFIABLE", result.issue_codes)
+        self.assertIn(
+            "TRUSTED_INDEPENDENCE_EVIDENCE_REQUIRED",
+            result.issue_codes,
+        )
 
     def test_different_model_name_does_not_establish_context_independence(
         self,
@@ -652,8 +1071,18 @@ class RoleContractV01Test(unittest.TestCase):
         bindings = request["prior_role_bindings"]
         self.assertIsInstance(bindings, list)
         bindings[0]["execution_context_identity"] = "shared-trusted-context"
+        trusted_evidence = deepcopy(evidence)
+        trusted_bindings = deepcopy(bindings)
 
-        result = self._validate(contract, request)
+        result = validate_role_operation(
+            contract,
+            request,
+            trusted_role_grant=self._trusted_grant(contract),
+            trusted_role_acceptance=self._trusted_acceptance(contract),
+            trusted_independence_evidence=trusted_evidence,
+            trusted_prior_role_bindings=trusted_bindings,
+            now=FIXED_NOW,
+        )
 
         self.assertEqual(RESULT_BLOCK, result.result)
         self.assertIn(

--- a/tests/test_decision_os_role_contract.py
+++ b/tests/test_decision_os_role_contract.py
@@ -300,6 +300,28 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertIsInstance(identity, dict)
         identity["contract_hash"] = compute_contract_hash(contract)
 
+    def _trusted_grant(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, object]:
+        identity = contract["contract_identity"]
+        assignment = contract["assignment"]
+        self.assertIsInstance(identity, dict)
+        self.assertIsInstance(assignment, dict)
+        return {
+            "contract_id": identity["contract_id"],
+            "contract_hash": identity["contract_hash"],
+            "task_id": assignment["task_id"],
+            "role_id": assignment["role_id"],
+            "grant_type": assignment["grant_type"],
+            "assignment_authority": assignment["assignment_authority"],
+            "shin_gate_reference": assignment["shin_gate_reference"],
+            "assignee_identity": assignment["assignee_identity"],
+            "execution_context_identity": assignment[
+                "execution_context_identity"
+            ],
+        }
+
     def _validate(
         self,
         contract: dict[str, object],
@@ -308,6 +330,7 @@ class RoleContractV01Test(unittest.TestCase):
         return validate_role_operation(
             contract,
             request or self._request(contract),
+            trusted_role_grant=self._trusted_grant(contract),
             now=FIXED_NOW,
         )
 
@@ -439,8 +462,33 @@ class RoleContractV01Test(unittest.TestCase):
             {"role_id": "BUILDER"},
             now=FIXED_NOW,
         )
-        self.assertEqual(RESULT_INVALID, result.result)
-        self.assertIn("OPERATION_REQUEST_INCOMPLETE", result.issue_codes)
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn("TRUSTED_ROLE_GRANT_REQUIRED", result.issue_codes)
+
+    def test_contract_self_declaration_is_not_a_trusted_role_grant(
+        self,
+    ) -> None:
+        contract = self._contract()
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            now=FIXED_NOW,
+        )
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn("TRUSTED_ROLE_GRANT_REQUIRED", result.issue_codes)
+
+    def test_trusted_role_grant_must_bind_contract_and_context(self) -> None:
+        contract = self._contract()
+        grant = self._trusted_grant(contract)
+        grant["execution_context_identity"] = "different-context"
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            trusted_role_grant=grant,
+            now=FIXED_NOW,
+        )
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("TRUSTED_ROLE_GRANT_MISMATCH", result.issue_codes)
 
     def test_explicit_assignment_authority_is_required(self) -> None:
         contract = self._contract()

--- a/tests/test_decision_os_role_contract.py
+++ b/tests/test_decision_os_role_contract.py
@@ -1,0 +1,618 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from decision_os.role_contract import (
+    RESULT_ACTIVE,
+    RESULT_BLOCK,
+    RESULT_HOLD,
+    RESULT_INVALID,
+    RoleContractAssessment,
+    compute_contract_hash,
+    contract_with_hash,
+    validate_role_operation,
+)
+from tests.test_decision_os_checks import tree_digest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXED_NOW = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+
+
+def _git(root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ("git", "-C", str(root), *arguments),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(completed.stderr)
+    return completed.stdout.strip()
+
+
+class RoleContractV01Test(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary.name) / "target"
+        self.repository.mkdir()
+        _git(self.repository, "init", "-b", "main")
+        _git(self.repository, "config", "user.name", "Stage 4 Test")
+        _git(
+            self.repository,
+            "config",
+            "user.email",
+            "stage4@example.invalid",
+        )
+        (self.repository / "builder.txt").write_text(
+            "builder artifact A\n",
+            encoding="utf-8",
+        )
+        (self.repository / "audit.txt").write_text(
+            "different audit artifact B\n",
+            encoding="utf-8",
+        )
+        _git(self.repository, "add", ".")
+        _git(self.repository, "commit", "-m", "fixture")
+        self.head = _git(self.repository, "rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _hash(self, path: str) -> str:
+        return hashlib.sha256(
+            (self.repository / path).read_bytes()
+        ).hexdigest()
+
+    def _coverage(self, target: str) -> dict[str, object]:
+        return {
+            "coverage_completed": True,
+            "coverage_gap": "NONE DETECTED",
+            "recommended_specialist": "NONE",
+            "reason": "The fixed responsibility is fully covered.",
+            "exact_target": [target],
+            "required_evidence": ["Role Exit Receipt"],
+            "urgency": "NONE",
+            "assignment_authority_required": True,
+            "automatic_invocation": False,
+        }
+
+    def _contract(self, role: str = "BUILDER") -> dict[str, object]:
+        target = "builder.txt" if role == "BUILDER" else "audit.txt"
+        is_builder = role == "BUILDER"
+        value: dict[str, object] = {
+            "contract_identity": {
+                "contract_id": f"contract-{role.lower()}-001",
+                "version": "0.1",
+                "contract_hash": "",
+            },
+            "assignment": {
+                "task_id": "task-stage4-001",
+                "role_id": role,
+                "grant_type": "EXPLICIT_ROLE_GRANT",
+                "assignment_authority": "Shin",
+                "shin_gate_reference": "GO — STAGE 4 TEST",
+                "assignee_identity": (
+                    "builder-assignee" if is_builder else "auditor-assignee"
+                ),
+                "execution_context_identity": (
+                    "trusted-builder-context"
+                    if is_builder
+                    else "trusted-auditor-context"
+                ),
+                "role_acceptance": "ACCEPTED",
+            },
+            "owned_responsibility": {
+                "responsibility": (
+                    "Implement the fixed target."
+                    if is_builder
+                    else "Audit the fixed target read-only."
+                ),
+                "exact_target": [target],
+                "next_owner": "Shin",
+            },
+            "operations": {
+                "allowed_operations": (
+                    [
+                        "IMPLEMENT_DESIGN",
+                        "READ_TARGET",
+                        "RUN_TESTS",
+                        "PRODUCE_EXIT_RECEIPT",
+                        "GENERATE_COVERAGE_GAP_RECOMMENDATION",
+                    ]
+                    if is_builder
+                    else [
+                        "READ_TARGET",
+                        "AUDIT_TARGET",
+                        "VERIFY_TARGET_IMMUTABILITY",
+                        "RUN_READ_ONLY_TESTS",
+                        "PRODUCE_EXIT_RECEIPT",
+                        "GENERATE_COVERAGE_GAP_RECOMMENDATION",
+                    ]
+                ),
+                "forbidden_operations": (
+                    [
+                        "AUDIT_TARGET",
+                        "SELF_AUDIT",
+                        "MODIFY_ROLE_GRANT",
+                        "MODIFY_SPECIALIST_LENS",
+                        "MODIFY_OUTSIDE_TARGET",
+                        "MERGE",
+                        "POST",
+                        "INVOKE_SPECIALIST",
+                        "START_STAGE_5",
+                    ]
+                    if is_builder
+                    else [
+                        "MODIFY_TARGET",
+                        "REPAIR_IMPLEMENTATION",
+                        "ASSUME_BUILDER_ROLE",
+                        "MODIFY_ROLE_GRANT",
+                        "MODIFY_SPECIALIST_LENS",
+                        "MODIFY_OUTSIDE_TARGET",
+                        "MERGE",
+                        "POST",
+                        "INVOKE_SPECIALIST",
+                        "START_STAGE_5",
+                    ]
+                ),
+            },
+            "task_artifact_packet": {
+                "repo": str(self.repository.resolve()),
+                "head": self.head,
+                "paths": [target],
+                "artifact_hashes": {target: self._hash(target)},
+                "as_of": "2026-07-29T00:00:00Z",
+            },
+            "specialist_lens": {
+                "lens_id": f"lens-{role.lower()}",
+                "lens_version": "0.1",
+                "lens_hash": hashlib.sha256(
+                    f"fixed {role} lens".encode()
+                ).hexdigest(),
+            },
+            "independence_profile": {
+                "role_context_independence": (
+                    "SAME_CONTEXT_ALLOWED"
+                    if is_builder
+                    else "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+                ),
+                "source_review_independence": (
+                    "FULL_PRIOR_CONTEXT_ALLOWED"
+                    if is_builder
+                    else "FIXED_ARTIFACTS_ONLY"
+                ),
+                "runtime_execution_independence": (
+                    "NOT_REQUIRED"
+                    if is_builder
+                    else "READ_ONLY_REEXECUTION_REQUIRED"
+                ),
+                "model_diversity": "SAME_MODEL_ALLOWED",
+            },
+            "completion": {
+                "completion_line": "Fixed Role work and receipt are complete.",
+                "required_exit_receipt": True,
+                "coverage_gap_required": True,
+            },
+            "lifecycle": {
+                "issued_at": "2026-07-29T00:00:00Z",
+                "expires_at": "2026-07-30T00:00:00Z",
+                "revocation_reference": None,
+                "status": "ACTIVE",
+            },
+            "coverage_gap_recommendation": self._coverage(target),
+        }
+        return contract_with_hash(value)
+
+    def _request(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, object]:
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        profile = contract["independence_profile"]
+        self.assertIsInstance(profile, dict)
+        role = assignment["role_id"]
+        return {
+            "operation": (
+                "IMPLEMENT_DESIGN" if role == "BUILDER" else "AUDIT_TARGET"
+            ),
+            "task_id": assignment["task_id"],
+            "role_id": role,
+            "assignee_identity": assignment["assignee_identity"],
+            "execution_context_identity": assignment[
+                "execution_context_identity"
+            ],
+            "task_artifact_packet": deepcopy(
+                contract["task_artifact_packet"]
+            ),
+            "specialist_lens": deepcopy(contract["specialist_lens"]),
+            "independence_evidence": {
+                **deepcopy(profile),
+                "model_identity": "same-base-model",
+                "source_review_evidence_reference": (
+                    "fixed Task Artifact Packet"
+                    if role == "AUDITOR"
+                    else "Role Contract declaration"
+                ),
+                "runtime_execution_evidence_reference": (
+                    "read-only reexecution receipt"
+                    if role == "AUDITOR"
+                    else "not required by Role Contract"
+                ),
+            },
+            "prior_role_bindings": (
+                []
+                if role == "BUILDER"
+                else [
+                    {
+                        "task_id": assignment["task_id"],
+                        "role_id": "BUILDER",
+                        "assignee_identity": "builder-assignee",
+                        "execution_context_identity": (
+                            "trusted-builder-context"
+                        ),
+                        "model_identity": "same-base-model",
+                    }
+                ]
+            ),
+            **(
+                {}
+                if role == "BUILDER"
+                else {
+                    "target_immutability": {
+                        "before_head": contract["task_artifact_packet"][
+                            "head"
+                        ],
+                        "after_head": contract["task_artifact_packet"][
+                            "head"
+                        ],
+                        "before_artifact_hashes": deepcopy(
+                            contract["task_artifact_packet"][
+                                "artifact_hashes"
+                            ]
+                        ),
+                        "after_artifact_hashes": deepcopy(
+                            contract["task_artifact_packet"][
+                                "artifact_hashes"
+                            ]
+                        ),
+                    }
+                }
+            ),
+            "coverage_gap_recommendation": deepcopy(
+                contract["coverage_gap_recommendation"]
+            ),
+        }
+
+    def _rehash(self, contract: dict[str, object]) -> None:
+        identity = contract["contract_identity"]
+        self.assertIsInstance(identity, dict)
+        identity["contract_hash"] = compute_contract_hash(contract)
+
+    def _validate(
+        self,
+        contract: dict[str, object],
+        request: dict[str, object] | None = None,
+    ) -> RoleContractAssessment:
+        return validate_role_operation(
+            contract,
+            request or self._request(contract),
+            now=FIXED_NOW,
+        )
+
+    def test_schema_example_hash_and_lens_hash_are_fixed(self) -> None:
+        schema = json.loads(
+            (REPO_ROOT / "schema" / "v13_role_contract.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(
+            {
+                "contract_identity",
+                "assignment",
+                "owned_responsibility",
+                "operations",
+                "task_artifact_packet",
+                "specialist_lens",
+                "independence_profile",
+                "completion",
+                "lifecycle",
+                "coverage_gap_recommendation",
+            },
+            set(schema["required"]),
+        )
+        example = json.loads(
+            (REPO_ROOT / "examples" / "role_contract.v0_1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(
+            example["contract_identity"]["contract_hash"],
+            compute_contract_hash(example),
+        )
+        lens_hash = hashlib.sha256(
+            (
+                REPO_ROOT / "templates" / "v13_specialist_lens.md"
+            ).read_bytes()
+        ).hexdigest()
+        self.assertEqual(example["specialist_lens"]["lens_hash"], lens_hash)
+        self.assertEqual(
+            hashlib.sha256((REPO_ROOT / "README.md").read_bytes()).hexdigest(),
+            example["task_artifact_packet"]["artifact_hashes"]["README.md"],
+        )
+        lens_text = (
+            REPO_ROOT / "templates" / "v13_specialist_lens.md"
+        ).read_text(encoding="utf-8")
+        for section in (
+            "Lens Identity",
+            "Purpose",
+            "Primary Risks",
+            "Required Evidence",
+            "Common Failure Patterns",
+            "Escalation Conditions",
+            "Output Contract",
+        ):
+            self.assertIn(f"## {section}\n", lens_text)
+
+    def test_valid_builder_is_active_deterministic_and_read_only(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        before = tree_digest(self.repository)
+
+        first = self._validate(contract, request)
+        second = self._validate(contract, request)
+
+        self.assertEqual(RoleContractAssessment(RESULT_ACTIVE, ()), first)
+        self.assertEqual(first, second)
+        self.assertEqual("ACTIVE — ROLE CONTRACT SATISFIED", first.decision_line)
+        self.assertEqual(before, tree_digest(self.repository))
+
+    def test_first_attack_same_context_false_division_is_blocked(self) -> None:
+        contract = self._contract("AUDITOR")
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["execution_context_identity"] = "shared-trusted-context"
+        self._rehash(contract)
+        request = self._request(contract)
+        request["execution_context_identity"] = "shared-trusted-context"
+        bindings = request["prior_role_bindings"]
+        self.assertIsInstance(bindings, list)
+        bindings[0]["execution_context_identity"] = "shared-trusted-context"
+        self.assertNotEqual(self._hash("builder.txt"), self._hash("audit.txt"))
+        self.assertNotIn("producer_role", request)
+        self.assertNotIn("builder_generated", request)
+
+        result = self._validate(contract, request)
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertEqual(
+            "BLOCK — CONTEXT INDEPENDENCE VIOLATION",
+            result.decision_line,
+        )
+
+    def test_builder_cannot_audit_itself(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        request["operation"] = "AUDIT_TARGET"
+        self.assertEqual(
+            RoleContractAssessment(RESULT_BLOCK, ("OPERATION_NOT_ALLOWED",)),
+            self._validate(contract, request),
+        )
+
+    def test_auditor_cannot_modify_target(self) -> None:
+        contract = self._contract("AUDITOR")
+        request = self._request(contract)
+        request["operation"] = "MODIFY_TARGET"
+        before = tree_digest(self.repository)
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("OPERATION_NOT_ALLOWED", result.issue_codes)
+        self.assertEqual(before, tree_digest(self.repository))
+
+    def test_auditor_requires_unchanged_head_and_artifact_hashes(self) -> None:
+        contract = self._contract("AUDITOR")
+        request = self._request(contract)
+        immutability = request["target_immutability"]
+        self.assertIsInstance(immutability, dict)
+        immutability["after_head"] = "f" * 40
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "TARGET_IMMUTABILITY_NOT_ESTABLISHED",
+            result.issue_codes,
+        )
+
+    def test_role_identity_alone_is_insufficient(self) -> None:
+        result = validate_role_operation(
+            self._contract(),
+            {"role_id": "BUILDER"},
+            now=FIXED_NOW,
+        )
+        self.assertEqual(RESULT_INVALID, result.result)
+        self.assertIn("OPERATION_REQUEST_INCOMPLETE", result.issue_codes)
+
+    def test_explicit_assignment_authority_is_required(self) -> None:
+        contract = self._contract()
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["assignment_authority"] = "AI"
+        self._rehash(contract)
+        result = self._validate(contract)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("ASSIGNMENT_AUTHORITY_REQUIRED", result.issue_codes)
+
+    def test_explicit_role_grant_is_required(self) -> None:
+        contract = self._contract()
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["grant_type"] = "SELF_ASSIGNED"
+        self._rehash(contract)
+        result = self._validate(contract)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("EXPLICIT_ROLE_GRANT_REQUIRED", result.issue_codes)
+
+    def test_shin_gate_reference_is_required(self) -> None:
+        contract = self._contract()
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["shin_gate_reference"] = "UNKNOWN"
+        self._rehash(contract)
+        result = self._validate(contract)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("SHIN_GATE_REFERENCE_REQUIRED", result.issue_codes)
+
+    def test_role_acceptance_is_required(self) -> None:
+        contract = self._contract()
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["role_acceptance"] = "DECLINED"
+        self._rehash(contract)
+        result = self._validate(contract)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("ROLE_ACCEPTANCE_REQUIRED", result.issue_codes)
+
+    def test_role_contract_is_required(self) -> None:
+        result = validate_role_operation(None, None, now=FIXED_NOW)
+        self.assertEqual(
+            RoleContractAssessment(
+                RESULT_INVALID,
+                ("ROLE_CONTRACT_REQUIRED",),
+            ),
+            result,
+        )
+
+    def test_specialist_lens_identity_and_hash_are_required(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        lens = request["specialist_lens"]
+        self.assertIsInstance(lens, dict)
+        lens["lens_hash"] = "0" * 64
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("SPECIALIST_LENS_MISMATCH", result.issue_codes)
+
+    def test_task_artifact_packet_identity_is_required(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        packet = request["task_artifact_packet"]
+        self.assertIsInstance(packet, dict)
+        packet["head"] = "f" * 40
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("TASK_ARTIFACT_PACKET_MISMATCH", result.issue_codes)
+
+    def test_expired_role_cannot_operate(self) -> None:
+        contract = self._contract()
+        lifecycle = contract["lifecycle"]
+        self.assertIsInstance(lifecycle, dict)
+        lifecycle["expires_at"] = "2026-07-29T11:59:59Z"
+        self._rehash(contract)
+        result = self._validate(contract)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("ROLE_GRANT_EXPIRED", result.issue_codes)
+
+    def test_revoked_role_cannot_operate(self) -> None:
+        contract = self._contract()
+        lifecycle = contract["lifecycle"]
+        self.assertIsInstance(lifecycle, dict)
+        lifecycle["status"] = "REVOKED"
+        lifecycle["revocation_reference"] = "Shin revocation 2026-07-29"
+        self._rehash(contract)
+        result = self._validate(contract)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn("ROLE_GRANT_REVOKED", result.issue_codes)
+
+    def test_coverage_gap_recommendation_cannot_invoke_role(self) -> None:
+        contract = self._contract()
+        coverage = contract["coverage_gap_recommendation"]
+        self.assertIsInstance(coverage, dict)
+        coverage["automatic_invocation"] = True
+        self._rehash(contract)
+        request = self._request(contract)
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "COVERAGE_RECOMMENDATION_NOT_INERT",
+            result.issue_codes,
+        )
+
+    def test_recommendation_does_not_generate_assignment_event(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        before = tree_digest(self.repository)
+        with mock.patch("subprocess.run") as run, mock.patch(
+            "os.system"
+        ) as system:
+            result = self._validate(contract, request)
+        self.assertEqual(RESULT_ACTIVE, result.result)
+        run.assert_not_called()
+        system.assert_not_called()
+        self.assertFalse(hasattr(result, "assignment_event"))
+        self.assertEqual(before, tree_digest(self.repository))
+
+    def test_assignment_event_field_makes_recommendation_non_inert(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        coverage = request["coverage_gap_recommendation"]
+        self.assertIsInstance(coverage, dict)
+        coverage["assignment_event"] = {
+            "role_id": "AUDITOR",
+            "invoke": True,
+        }
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "COVERAGE_RECOMMENDATION_NOT_INERT",
+            result.issue_codes,
+        )
+
+    def test_unknown_independence_does_not_become_pass(self) -> None:
+        contract = self._contract()
+        request = self._request(contract)
+        evidence = request["independence_evidence"]
+        self.assertIsInstance(evidence, dict)
+        evidence["runtime_execution_independence"] = "UNKNOWN"
+        result = self._validate(contract, request)
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn("INDEPENDENCE_UNVERIFIABLE", result.issue_codes)
+
+    def test_different_model_name_does_not_establish_context_independence(
+        self,
+    ) -> None:
+        contract = self._contract("AUDITOR")
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["execution_context_identity"] = "shared-trusted-context"
+        self._rehash(contract)
+        request = self._request(contract)
+        request["execution_context_identity"] = "shared-trusted-context"
+        evidence = request["independence_evidence"]
+        self.assertIsInstance(evidence, dict)
+        evidence["model_identity"] = "different-model-name"
+        evidence["model_diversity"] = "DIFFERENT_MODEL_REQUIRED"
+        bindings = request["prior_role_bindings"]
+        self.assertIsInstance(bindings, list)
+        bindings[0]["execution_context_identity"] = "shared-trusted-context"
+
+        result = self._validate(contract, request)
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "CONTEXT_INDEPENDENCE_VIOLATION",
+            result.issue_codes,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_role_contract.py
+++ b/tests/test_decision_os_role_contract.py
@@ -17,6 +17,7 @@ from decision_os.role_contract import (
     RESULT_INVALID,
     RoleContractAssessment,
     compute_contract_hash,
+    compute_prior_role_bindings_snapshot_hash,
     contract_with_hash,
     validate_role_operation,
 )
@@ -25,6 +26,7 @@ from tests.test_decision_os_checks import tree_digest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXED_NOW = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+FIXED_AS_OF = "2026-07-29T12:00:00Z"
 
 
 def _git(root: Path, *arguments: str) -> str:
@@ -106,9 +108,9 @@ class RoleContractV01Test(unittest.TestCase):
                     "builder-assignee" if is_builder else "auditor-assignee"
                 ),
                 "execution_context_identity": (
-                    "trusted-builder-context"
+                    "builder-context"
                     if is_builder
-                    else "trusted-auditor-context"
+                    else "auditor-context"
                 ),
                 "role_acceptance": "ACCEPTED",
             },
@@ -185,7 +187,7 @@ class RoleContractV01Test(unittest.TestCase):
                 "role_context_independence": (
                     "SAME_CONTEXT_ALLOWED"
                     if is_builder
-                    else "DISTINCT_TRUSTED_CONTEXT_REQUIRED"
+                    else "DISTINCT_CONTEXT_REQUIRED"
                 ),
                 "source_review_independence": (
                     "FULL_PRIOR_CONTEXT_ALLOWED"
@@ -224,7 +226,9 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertIsInstance(profile, dict)
         role = assignment["role_id"]
         return {
-            "evidence_identity": f"trusted-{role.lower()}-evidence-001",
+            "record_identity": (
+                f"supplied-{role.lower()}-independence-001"
+            ),
             "task_id": assignment["task_id"],
             "role_id": role,
             "assignee_identity": assignment["assignee_identity"],
@@ -234,14 +238,14 @@ class RoleContractV01Test(unittest.TestCase):
             **deepcopy(profile),
             "model_identity": "same-base-model",
             "source_review_evidence_reference": (
-                "trusted fixed-artifact review receipt"
+                "supplied fixed-artifact review receipt"
                 if role == "AUDITOR"
-                else "trusted full-context allowance record"
+                else "supplied full-context allowance record"
             ),
             "runtime_execution_evidence_reference": (
-                "trusted read-only reexecution receipt"
+                "supplied read-only reexecution receipt"
                 if role == "AUDITOR"
-                else "trusted not-required record"
+                else "supplied not-required record"
             ),
         }
 
@@ -255,12 +259,15 @@ class RoleContractV01Test(unittest.TestCase):
             return []
         return [
             {
-                "evidence_identity": "trusted-builder-binding-001",
+                "record_identity": "supplied-builder-binding-001",
                 "task_id": assignment["task_id"],
                 "role_id": "BUILDER",
                 "assignee_identity": "builder-assignee",
-                "execution_context_identity": "trusted-builder-context",
+                "execution_context_identity": "builder-context",
                 "model_identity": "same-base-model",
+                "bound_at": "2026-07-29T00:00:00Z",
+                "ended_at": "2026-07-29T00:02:00Z",
+                "binding_state": "ENDED",
             }
         ]
 
@@ -321,7 +328,18 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertIsInstance(identity, dict)
         identity["contract_hash"] = compute_contract_hash(contract)
 
-    def _trusted_grant(
+    def _snapshot_identity(
+        self,
+        contract: dict[str, object],
+    ) -> str:
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        return (
+            f"snapshot-{str(assignment['role_id']).lower()}-"
+            "20260729T120000Z"
+        )
+
+    def _supplied_grant(
         self,
         contract: dict[str, object],
     ) -> dict[str, object]:
@@ -330,6 +348,14 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertIsInstance(identity, dict)
         self.assertIsInstance(assignment, dict)
         return {
+            "record_identity": (
+                f"supplied-{str(assignment['role_id']).lower()}-grant-001"
+            ),
+            "snapshot_identity": self._snapshot_identity(contract),
+            "as_of": FIXED_AS_OF,
+            "revocation_state": "NOT_REVOKED",
+            "revoked_at": None,
+            "revocation_reference": None,
             "contract_id": identity["contract_id"],
             "contract_hash": identity["contract_hash"],
             "task_id": assignment["task_id"],
@@ -343,15 +369,26 @@ class RoleContractV01Test(unittest.TestCase):
             ],
         }
 
-    def _trusted_acceptance(
+    def _supplied_acceptance(
         self,
         contract: dict[str, object],
+        grant: dict[str, object] | None = None,
     ) -> dict[str, object]:
         identity = contract["contract_identity"]
         assignment = contract["assignment"]
         self.assertIsInstance(identity, dict)
         self.assertIsInstance(assignment, dict)
+        supplied_grant = grant or self._supplied_grant(contract)
         return {
+            "record_identity": (
+                "supplied-"
+                f"{str(assignment['role_id']).lower()}-acceptance-001"
+            ),
+            "snapshot_identity": self._snapshot_identity(contract),
+            "as_of": FIXED_AS_OF,
+            "revocation_state": "NOT_REVOKED",
+            "revoked_at": None,
+            "revocation_reference": None,
             "contract_id": identity["contract_id"],
             "contract_hash": identity["contract_hash"],
             "task_id": assignment["task_id"],
@@ -361,8 +398,141 @@ class RoleContractV01Test(unittest.TestCase):
                 "execution_context_identity"
             ],
             "role_acceptance": "ACCEPTED",
-            "accepted_at": "2026-07-29T00:01:00Z",
+            "accepted_at": (
+                "2026-07-29T00:01:00Z"
+                if assignment["role_id"] == "BUILDER"
+                else "2026-07-29T00:03:00Z"
+            ),
+            "grant_record_identity": supplied_grant["record_identity"],
         }
+
+    def _supplied_prior_role_bindings(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, object]:
+        identity = contract["contract_identity"]
+        assignment = contract["assignment"]
+        self.assertIsInstance(identity, dict)
+        self.assertIsInstance(assignment, dict)
+        snapshot_identity = self._snapshot_identity(contract)
+        bindings = [
+            {
+                **deepcopy(binding),
+                "snapshot_identity": snapshot_identity,
+                "as_of": FIXED_AS_OF,
+                "revocation_state": "NOT_REVOKED",
+                "revoked_at": None,
+                "revocation_reference": None,
+            }
+            for binding in self._prior_role_bindings(contract)
+        ]
+        snapshot: dict[str, object] = {
+            "snapshot_identity": snapshot_identity,
+            "snapshot_hash": "",
+            "contract_id": identity["contract_id"],
+            "contract_hash": identity["contract_hash"],
+            "task_id": assignment["task_id"],
+            "as_of": FIXED_AS_OF,
+            "revocation_state": "NOT_REVOKED",
+            "revoked_at": None,
+            "revocation_reference": None,
+            "completeness_boundary": {
+                "scope": "ALL_PRIOR_ROLE_BINDINGS_FOR_TASK",
+                "task_id": assignment["task_id"],
+                "from": "TASK_INCEPTION",
+                "through": FIXED_AS_OF,
+                "included_roles": ["BUILDER", "AUDITOR"],
+                "state": "COMPLETE",
+                "expected_record_identities": [
+                    binding["record_identity"] for binding in bindings
+                ],
+            },
+            "bindings": bindings,
+        }
+        snapshot["snapshot_hash"] = (
+            compute_prior_role_bindings_snapshot_hash(snapshot)
+        )
+        return snapshot
+
+    def _supplied_independence_evidence(
+        self,
+        contract: dict[str, object],
+        snapshot: dict[str, object],
+    ) -> dict[str, object]:
+        identity = contract["contract_identity"]
+        self.assertIsInstance(identity, dict)
+        return {
+            **self._independence_evidence(contract),
+            "snapshot_identity": snapshot["snapshot_identity"],
+            "as_of": FIXED_AS_OF,
+            "revocation_state": "NOT_REVOKED",
+            "revoked_at": None,
+            "revocation_reference": None,
+            "contract_id": identity["contract_id"],
+            "contract_hash": identity["contract_hash"],
+            "prior_role_bindings_snapshot_identity": snapshot[
+                "snapshot_identity"
+            ],
+            "prior_role_bindings_snapshot_hash": snapshot["snapshot_hash"],
+        }
+
+    def _supplied_inputs(
+        self,
+        contract: dict[str, object],
+    ) -> dict[str, object]:
+        grant = self._supplied_grant(contract)
+        snapshot = self._supplied_prior_role_bindings(contract)
+        return {
+            "supplied_role_grant": grant,
+            "supplied_role_acceptance": self._supplied_acceptance(
+                contract,
+                grant,
+            ),
+            "supplied_independence_evidence": (
+                self._supplied_independence_evidence(contract, snapshot)
+            ),
+            "supplied_prior_role_bindings": snapshot,
+        }
+
+    def _rehash_supplied_snapshot(
+        self,
+        supplied_inputs: dict[str, object],
+    ) -> None:
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        evidence = supplied_inputs["supplied_independence_evidence"]
+        self.assertIsInstance(snapshot, dict)
+        self.assertIsInstance(evidence, dict)
+        snapshot["snapshot_hash"] = (
+            compute_prior_role_bindings_snapshot_hash(snapshot)
+        )
+        evidence["prior_role_bindings_snapshot_hash"] = snapshot[
+            "snapshot_hash"
+        ]
+
+    def _set_supplied_as_of(
+        self,
+        supplied_inputs: dict[str, object],
+        as_of: str,
+    ) -> None:
+        for record_name in (
+            "supplied_role_grant",
+            "supplied_role_acceptance",
+            "supplied_independence_evidence",
+        ):
+            record = supplied_inputs[record_name]
+            self.assertIsInstance(record, dict)
+            record["as_of"] = as_of
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        snapshot["as_of"] = as_of
+        boundary = snapshot["completeness_boundary"]
+        bindings = snapshot["bindings"]
+        self.assertIsInstance(boundary, dict)
+        self.assertIsInstance(bindings, list)
+        boundary["through"] = as_of
+        for binding in bindings:
+            binding["as_of"] = as_of
+        self._rehash_supplied_snapshot(supplied_inputs)
 
     def _validate(
         self,
@@ -372,12 +542,7 @@ class RoleContractV01Test(unittest.TestCase):
         return validate_role_operation(
             contract,
             request or self._request(contract),
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
-            trusted_independence_evidence=self._independence_evidence(
-                contract
-            ),
-            trusted_prior_role_bindings=self._prior_role_bindings(contract),
+            **self._supplied_inputs(contract),
             now=FIXED_NOW,
         )
 
@@ -404,37 +569,57 @@ class RoleContractV01Test(unittest.TestCase):
         )
         self.assertEqual(
             {
+                "record_identity",
+                "snapshot_identity",
                 "contract_id",
                 "contract_hash",
+                "grant_record_identity",
                 "task_id",
                 "role_id",
                 "assignee_identity",
                 "execution_context_identity",
                 "role_acceptance",
                 "accepted_at",
+                "as_of",
+                "revocation_state",
+                "revoked_at",
+                "revocation_reference",
             },
             set(
-                schema["$defs"]["trustedRoleAcceptanceRecord"]["required"]
+                schema["$defs"]["suppliedRoleAcceptanceRecord"]["required"]
             ),
         )
-        trusted_identity_fields = {
-            "evidence_identity",
+        supplied_identity_fields = {
+            "record_identity",
+            "snapshot_identity",
             "task_id",
             "role_id",
             "assignee_identity",
             "execution_context_identity",
             "model_identity",
         }
-        self.assertEqual(
-            trusted_identity_fields,
-            set(schema["$defs"]["trustedPriorRoleBinding"]["required"]),
+        self.assertTrue(
+            supplied_identity_fields.issubset(
+                schema["$defs"]["suppliedPriorRoleBinding"]["required"]
+            )
         )
         self.assertTrue(
-            trusted_identity_fields.issubset(
-                schema["$defs"]["trustedIndependenceEvidenceRecord"][
+            supplied_identity_fields.issubset(
+                schema["$defs"]["suppliedIndependenceEvidenceRecord"][
                     "required"
                 ]
             )
+        )
+        boundary = schema["$defs"]["suppliedPriorRoleBindingSnapshot"][
+            "properties"
+        ]["completeness_boundary"]
+        self.assertEqual(
+            "ALL_PRIOR_ROLE_BINDINGS_FOR_TASK",
+            boundary["properties"]["scope"]["const"],
+        )
+        self.assertEqual(
+            "TASK_INCEPTION",
+            boundary["properties"]["from"]["const"],
         )
         example = json.loads(
             (REPO_ROOT / "examples" / "role_contract.v0_1.json").read_text(
@@ -468,8 +653,24 @@ class RoleContractV01Test(unittest.TestCase):
             "Output Contract",
         ):
             self.assertIn(f"## {section}\n", lens_text)
+        implementation_boundary = "\n".join(
+            (
+                "Role Separation Enforcement: VALIDATOR-LEVEL ONLY",
+                "Record Issuer / Authentication / Transport: "
+                "NOT IMPLEMENTED",
+                "Role Independence: NOT ESTABLISHED",
+                "End-to-End False-Division Prevention: NOT ESTABLISHED",
+            )
+        )
+        docs_text = (
+            REPO_ROOT / "docs" / "role_bound_specialist_system_v0_1.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(implementation_boundary, lens_text)
+        self.assertIn(implementation_boundary, docs_text)
 
-    def test_valid_builder_is_active_deterministic_and_read_only(self) -> None:
+    def test_matching_supplied_records_return_active_validator_result(
+        self,
+    ) -> None:
         contract = self._contract()
         request = self._request(contract)
         before = tree_digest(self.repository)
@@ -479,25 +680,76 @@ class RoleContractV01Test(unittest.TestCase):
 
         self.assertEqual(RoleContractAssessment(RESULT_ACTIVE, ()), first)
         self.assertEqual(first, second)
-        self.assertEqual("ACTIVE — ROLE CONTRACT SATISFIED", first.decision_line)
+        self.assertEqual(
+            "ACTIVE — VALIDATOR CONDITIONS SATISFIED",
+            first.decision_line,
+        )
         self.assertEqual(before, tree_digest(self.repository))
 
-    def test_first_attack_same_context_false_division_is_blocked(self) -> None:
+    def test_subsecond_validation_snapshot_is_not_truncated(self) -> None:
+        contract = self._contract()
+        supplied_inputs = self._supplied_inputs(contract)
+        self._set_supplied_as_of(
+            supplied_inputs,
+            "2026-07-29T12:00:00.500000Z",
+        )
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=datetime(
+                2026,
+                7,
+                29,
+                12,
+                0,
+                0,
+                500000,
+                tzinfo=timezone.utc,
+            ),
+        )
+
+        self.assertEqual(RESULT_ACTIVE, result.result)
+
+    def test_equivalent_timezone_as_of_values_are_coherent(self) -> None:
+        contract = self._contract()
+        supplied_inputs = self._supplied_inputs(contract)
+        grant = supplied_inputs["supplied_role_grant"]
+        self.assertIsInstance(grant, dict)
+        grant["as_of"] = "2026-07-29T21:00:00+09:00"
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_ACTIVE, result.result)
+
+    def test_supplied_snapshot_same_context_collision_returns_block(
+        self,
+    ) -> None:
         contract = self._contract("AUDITOR")
         assignment = contract["assignment"]
         self.assertIsInstance(assignment, dict)
-        assignment["execution_context_identity"] = "shared-trusted-context"
+        assignment["execution_context_identity"] = "shared-supplied-context"
         self._rehash(contract)
         request = self._request(contract)
-        request["execution_context_identity"] = "shared-trusted-context"
+        request["execution_context_identity"] = "shared-supplied-context"
         bindings = request["prior_role_bindings"]
         self.assertIsInstance(bindings, list)
-        bindings[0]["execution_context_identity"] = "shared-trusted-context"
-        trusted_evidence = self._independence_evidence(contract)
-        trusted_bindings = self._prior_role_bindings(contract)
-        trusted_bindings[0][
-            "execution_context_identity"
-        ] = "shared-trusted-context"
+        bindings[0]["execution_context_identity"] = "shared-supplied-context"
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        supplied_bindings = snapshot["bindings"]
+        self.assertIsInstance(supplied_bindings, list)
+        supplied_bindings[0]["execution_context_identity"] = (
+            "shared-supplied-context"
+        )
+        self._rehash_supplied_snapshot(supplied_inputs)
         self.assertNotEqual(self._hash("builder.txt"), self._hash("audit.txt"))
         self.assertNotIn("producer_role", request)
         self.assertNotIn("builder_generated", request)
@@ -505,10 +757,7 @@ class RoleContractV01Test(unittest.TestCase):
         result = validate_role_operation(
             contract,
             request,
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
-            trusted_independence_evidence=trusted_evidence,
-            trusted_prior_role_bindings=trusted_bindings,
+            **supplied_inputs,
             now=FIXED_NOW,
         )
 
@@ -518,39 +767,39 @@ class RoleContractV01Test(unittest.TestCase):
             result.decision_line,
         )
 
-    def test_claimant_cannot_replace_true_same_context_binding(self) -> None:
+    def test_claim_replacement_does_not_override_supplied_collision(
+        self,
+    ) -> None:
         contract = self._contract("AUDITOR")
         assignment = contract["assignment"]
         self.assertIsInstance(assignment, dict)
-        assignment["execution_context_identity"] = "shared-trusted-context"
+        assignment["execution_context_identity"] = "shared-supplied-context"
         self._rehash(contract)
 
         request = self._request(contract)
-        request["execution_context_identity"] = "shared-trusted-context"
+        request["execution_context_identity"] = "shared-supplied-context"
         claimed_bindings = request["prior_role_bindings"]
         self.assertIsInstance(claimed_bindings, list)
-        claimed_bindings[0] = {
-            "evidence_identity": "forged-builder-binding-002",
-            "task_id": assignment["task_id"],
-            "role_id": "BUILDER",
-            "assignee_identity": "builder-assignee",
-            "execution_context_identity": "fake-distinct-context",
-            "model_identity": "same-base-model",
-        }
+        claimed_bindings[0]["record_identity"] = (
+            "forged-builder-binding-002"
+        )
+        claimed_bindings[0]["execution_context_identity"] = (
+            "fake-distinct-context"
+        )
 
-        trusted_bindings = self._prior_role_bindings(contract)
-        trusted_bindings[0][
-            "execution_context_identity"
-        ] = "shared-trusted-context"
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        supplied_bindings = snapshot["bindings"]
+        self.assertIsInstance(supplied_bindings, list)
+        supplied_bindings[0]["execution_context_identity"] = (
+            "shared-supplied-context"
+        )
+        self._rehash_supplied_snapshot(supplied_inputs)
         result = validate_role_operation(
             contract,
             request,
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
-            trusted_independence_evidence=self._independence_evidence(
-                contract
-            ),
-            trusted_prior_role_bindings=trusted_bindings,
+            **supplied_inputs,
             now=FIXED_NOW,
         )
 
@@ -558,24 +807,28 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertEqual(
             (
                 "CONTEXT_INDEPENDENCE_VIOLATION",
-                "TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_CLAIM_MISMATCH",
             ),
             result.issue_codes,
         )
 
-    def test_malformed_claims_cannot_downgrade_trusted_context_block(
+    def test_malformed_claims_do_not_downgrade_supplied_context_block(
         self,
     ) -> None:
         contract = self._contract("AUDITOR")
         assignment = contract["assignment"]
         self.assertIsInstance(assignment, dict)
-        assignment["execution_context_identity"] = "shared-trusted-context"
+        assignment["execution_context_identity"] = "shared-supplied-context"
         self._rehash(contract)
-        trusted_evidence = self._independence_evidence(contract)
-        trusted_bindings = self._prior_role_bindings(contract)
-        trusted_bindings[0][
-            "execution_context_identity"
-        ] = "shared-trusted-context"
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        supplied_bindings = snapshot["bindings"]
+        self.assertIsInstance(supplied_bindings, list)
+        supplied_bindings[0]["execution_context_identity"] = (
+            "shared-supplied-context"
+        )
+        self._rehash_supplied_snapshot(supplied_inputs)
 
         malformed_requests = []
         malformed_evidence = self._request(contract)
@@ -584,7 +837,7 @@ class RoleContractV01Test(unittest.TestCase):
             (
                 "malformed evidence",
                 malformed_evidence,
-                "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+                "SUPPLIED_INDEPENDENCE_EVIDENCE_CLAIM_MISMATCH",
             )
         )
         duplicate_bindings = self._request(contract)
@@ -595,7 +848,7 @@ class RoleContractV01Test(unittest.TestCase):
             (
                 "duplicate binding identity",
                 duplicate_bindings,
-                "TRUSTED_PRIOR_ROLE_BINDINGS_MISMATCH",
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_CLAIM_MISMATCH",
             )
         )
 
@@ -604,10 +857,7 @@ class RoleContractV01Test(unittest.TestCase):
                 result = validate_role_operation(
                     contract,
                     request,
-                    trusted_role_grant=self._trusted_grant(contract),
-                    trusted_role_acceptance=self._trusted_acceptance(contract),
-                    trusted_independence_evidence=trusted_evidence,
-                    trusted_prior_role_bindings=trusted_bindings,
+                    **supplied_inputs,
                     now=FIXED_NOW,
                 )
                 self.assertEqual(RESULT_BLOCK, result.result)
@@ -656,9 +906,9 @@ class RoleContractV01Test(unittest.TestCase):
             now=FIXED_NOW,
         )
         self.assertEqual(RESULT_HOLD, result.result)
-        self.assertIn("TRUSTED_ROLE_GRANT_REQUIRED", result.issue_codes)
+        self.assertIn("SUPPLIED_ROLE_GRANT_REQUIRED", result.issue_codes)
 
-    def test_contract_self_declaration_is_not_a_trusted_role_grant(
+    def test_contract_self_declaration_is_not_a_supplied_role_grant(
         self,
     ) -> None:
         contract = self._contract()
@@ -668,127 +918,495 @@ class RoleContractV01Test(unittest.TestCase):
             now=FIXED_NOW,
         )
         self.assertEqual(RESULT_HOLD, result.result)
-        self.assertIn("TRUSTED_ROLE_GRANT_REQUIRED", result.issue_codes)
+        self.assertIn("SUPPLIED_ROLE_GRANT_REQUIRED", result.issue_codes)
 
-    def test_trusted_role_grant_must_bind_contract_and_context(self) -> None:
+    def test_supplied_role_grant_must_bind_contract_and_context(self) -> None:
         contract = self._contract()
-        grant = self._trusted_grant(contract)
+        grant = self._supplied_grant(contract)
         grant["execution_context_identity"] = "different-context"
         result = validate_role_operation(
             contract,
             self._request(contract),
-            trusted_role_grant=grant,
+            supplied_role_grant=grant,
             now=FIXED_NOW,
         )
         self.assertEqual(RESULT_BLOCK, result.result)
-        self.assertIn("TRUSTED_ROLE_GRANT_MISMATCH", result.issue_codes)
+        self.assertIn("SUPPLIED_ROLE_GRANT_MISMATCH", result.issue_codes)
 
-    def test_request_only_independence_claims_are_not_trusted(self) -> None:
+    def test_request_only_independence_claims_do_not_replace_supplied_record(
+        self,
+    ) -> None:
         contract = self._contract()
+        supplied_inputs = self._supplied_inputs(contract)
+        supplied_inputs.pop("supplied_independence_evidence")
         result = validate_role_operation(
             contract,
             self._request(contract),
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
+            **supplied_inputs,
             now=FIXED_NOW,
         )
         self.assertEqual(RESULT_HOLD, result.result)
         self.assertIn(
-            "TRUSTED_INDEPENDENCE_EVIDENCE_REQUIRED",
+            "SUPPLIED_INDEPENDENCE_EVIDENCE_REQUIRED",
             result.issue_codes,
         )
 
-    def test_trusted_independence_evidence_binds_all_identities(self) -> None:
+    def test_supplied_independence_evidence_binds_all_identities(self) -> None:
         replacements = {
             "task_id": "different-task",
             "role_id": "AUDITOR",
             "assignee_identity": "different-assignee",
             "execution_context_identity": "different-context",
             "model_identity": "different-model",
-            "evidence_identity": "different-evidence",
+            "record_identity": "different-record",
         }
         for field, replacement in replacements.items():
             with self.subTest(field=field):
                 contract = self._contract()
-                trusted_evidence = self._independence_evidence(contract)
-                trusted_evidence[field] = replacement
+                supplied_inputs = self._supplied_inputs(contract)
+                supplied_evidence = supplied_inputs[
+                    "supplied_independence_evidence"
+                ]
+                self.assertIsInstance(supplied_evidence, dict)
+                supplied_evidence[field] = replacement
                 result = validate_role_operation(
                     contract,
                     self._request(contract),
-                    trusted_role_grant=self._trusted_grant(contract),
-                    trusted_role_acceptance=self._trusted_acceptance(contract),
-                    trusted_independence_evidence=trusted_evidence,
-                    trusted_prior_role_bindings=[],
+                    **supplied_inputs,
                     now=FIXED_NOW,
                 )
                 self.assertEqual(RESULT_BLOCK, result.result)
                 self.assertIn(
-                    "TRUSTED_INDEPENDENCE_EVIDENCE_MISMATCH",
+                    (
+                        "SUPPLIED_INDEPENDENCE_EVIDENCE_CLAIM_MISMATCH"
+                        if field in ("model_identity", "record_identity")
+                        else "SUPPLIED_INDEPENDENCE_EVIDENCE_MISMATCH"
+                    ),
                     result.issue_codes,
                 )
 
-    def test_trusted_prior_role_bindings_are_required_and_unique(self) -> None:
+    def test_supplied_prior_role_bindings_require_snapshot_wrapper(
+        self,
+    ) -> None:
         contract = self._contract("AUDITOR")
-        common = {
-            "trusted_role_grant": self._trusted_grant(contract),
-            "trusted_role_acceptance": self._trusted_acceptance(contract),
-            "trusted_independence_evidence": (
-                self._independence_evidence(contract)
-            ),
-            "now": FIXED_NOW,
-        }
+        common = self._supplied_inputs(contract)
+        common.pop("supplied_prior_role_bindings")
         missing = validate_role_operation(
             contract,
             self._request(contract),
             **common,
+            now=FIXED_NOW,
         )
         self.assertEqual(RESULT_HOLD, missing.result)
         self.assertIn(
-            "TRUSTED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
             missing.issue_codes,
         )
 
         binding = self._prior_role_bindings(contract)[0]
-        duplicate = validate_role_operation(
+        bare_sequence = validate_role_operation(
             contract,
             self._request(contract),
-            trusted_prior_role_bindings=[
+            supplied_prior_role_bindings=[
                 deepcopy(binding),
                 deepcopy(binding),
             ],
             **common,
+            now=FIXED_NOW,
         )
-        self.assertEqual(RESULT_HOLD, duplicate.result)
+        self.assertEqual(RESULT_HOLD, bare_sequence.result)
         self.assertIn(
-            "TRUSTED_PRIOR_ROLE_BINDINGS_REQUIRED",
-            duplicate.issue_codes,
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_REQUIRED",
+            bare_sequence.issue_codes,
         )
 
-    def test_trusted_evidence_identities_are_globally_unique(self) -> None:
+    def test_duplicate_record_identity_in_validation_bundle_is_blocked(
+        self,
+    ) -> None:
         contract = self._contract("AUDITOR")
-        trusted_evidence = self._independence_evidence(contract)
-        trusted_bindings = self._prior_role_bindings(contract)
-        trusted_evidence["evidence_identity"] = trusted_bindings[0][
-            "evidence_identity"
+        supplied_inputs = self._supplied_inputs(contract)
+        supplied_evidence = supplied_inputs[
+            "supplied_independence_evidence"
+        ]
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(supplied_evidence, dict)
+        self.assertIsInstance(snapshot, dict)
+        supplied_bindings = snapshot["bindings"]
+        self.assertIsInstance(supplied_bindings, list)
+        supplied_evidence["record_identity"] = supplied_bindings[0][
+            "record_identity"
         ]
         request = self._request(contract)
-        request["independence_evidence"] = deepcopy(trusted_evidence)
+        request["independence_evidence"] = deepcopy(supplied_evidence)
+        request_evidence = request["independence_evidence"]
+        self.assertIsInstance(request_evidence, dict)
+        for field in (
+            "snapshot_identity",
+            "as_of",
+            "revocation_state",
+            "revoked_at",
+            "revocation_reference",
+            "contract_id",
+            "contract_hash",
+            "prior_role_bindings_snapshot_identity",
+            "prior_role_bindings_snapshot_hash",
+        ):
+            request_evidence.pop(field)
 
         result = validate_role_operation(
             contract,
             request,
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
-            trusted_independence_evidence=trusted_evidence,
-            trusted_prior_role_bindings=trusted_bindings,
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "SUPPLIED_RECORD_IDENTITY_REPLAY",
+            result.issue_codes,
+        )
+
+    def test_incomplete_prior_binding_snapshot_is_hold(self) -> None:
+        contract = self._contract("AUDITOR")
+        cases = ("declared incomplete", "manifest omission")
+        for case in cases:
+            with self.subTest(case=case):
+                supplied_inputs = self._supplied_inputs(contract)
+                snapshot = supplied_inputs["supplied_prior_role_bindings"]
+                self.assertIsInstance(snapshot, dict)
+                boundary = snapshot["completeness_boundary"]
+                bindings = snapshot["bindings"]
+                self.assertIsInstance(boundary, dict)
+                self.assertIsInstance(bindings, list)
+                if case == "declared incomplete":
+                    boundary["state"] = "INCOMPLETE"
+                else:
+                    bindings.clear()
+                self._rehash_supplied_snapshot(supplied_inputs)
+
+                result = validate_role_operation(
+                    contract,
+                    self._request(contract),
+                    **supplied_inputs,
+                    now=FIXED_NOW,
+                )
+
+                self.assertEqual(RESULT_HOLD, result.result)
+                self.assertIn(
+                    "SUPPLIED_PRIOR_ROLE_BINDINGS_INCOMPLETE",
+                    result.issue_codes,
+                )
+
+    def test_omission_substitution_with_stale_manifest_is_hold(
+        self,
+    ) -> None:
+        contract = self._contract("AUDITOR")
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["execution_context_identity"] = "shared-context"
+        self._rehash(contract)
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        bindings = snapshot["bindings"]
+        self.assertIsInstance(bindings, list)
+        true_binding = bindings[0]
+        true_binding["execution_context_identity"] = "shared-context"
+        fake_binding = deepcopy(true_binding)
+        fake_binding["record_identity"] = "fake-distinct-binding-002"
+        fake_binding["execution_context_identity"] = "fake-distinct-context"
+        bindings[0] = fake_binding
+        self._rehash_supplied_snapshot(supplied_inputs)
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
             now=FIXED_NOW,
         )
 
         self.assertEqual(RESULT_HOLD, result.result)
         self.assertIn(
-            "TRUSTED_EVIDENCE_IDENTITY_COLLISION",
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_INCOMPLETE",
             result.issue_codes,
         )
+
+    def test_coherent_snapshot_fabrication_is_not_detectable(self) -> None:
+        contract = self._contract("AUDITOR")
+        assignment = contract["assignment"]
+        self.assertIsInstance(assignment, dict)
+        assignment["execution_context_identity"] = "shared-context"
+        self._rehash(contract)
+        request = self._request(contract)
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        boundary = snapshot["completeness_boundary"]
+        supplied_bindings = snapshot["bindings"]
+        claimed_bindings = request["prior_role_bindings"]
+        self.assertIsInstance(boundary, dict)
+        self.assertIsInstance(supplied_bindings, list)
+        self.assertIsInstance(claimed_bindings, list)
+
+        supplied_bindings[0]["record_identity"] = (
+            "fabricated-distinct-binding-002"
+        )
+        supplied_bindings[0]["execution_context_identity"] = (
+            "fabricated-distinct-context"
+        )
+        boundary["expected_record_identities"] = [
+            supplied_bindings[0]["record_identity"]
+        ]
+        claimed_bindings[0] = {
+            field: supplied_bindings[0][field]
+            for field in (
+                "record_identity",
+                "task_id",
+                "role_id",
+                "assignee_identity",
+                "execution_context_identity",
+                "model_identity",
+                "bound_at",
+                "ended_at",
+                "binding_state",
+            )
+        }
+        self._rehash_supplied_snapshot(supplied_inputs)
+
+        result = validate_role_operation(
+            contract,
+            request,
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_ACTIVE, result.result)
+
+    def test_stale_acceptance_record_is_hold(self) -> None:
+        contract = self._contract()
+        supplied_inputs = self._supplied_inputs(contract)
+        acceptance = supplied_inputs["supplied_role_acceptance"]
+        self.assertIsInstance(acceptance, dict)
+        acceptance["as_of"] = "2026-07-29T11:59:59Z"
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn("SUPPLIED_ROLE_ACCEPTANCE_STALE", result.issue_codes)
+
+    def test_stale_prior_binding_snapshot_is_hold(self) -> None:
+        contract = self._contract("AUDITOR")
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        evidence = supplied_inputs["supplied_independence_evidence"]
+        self.assertIsInstance(snapshot, dict)
+        self.assertIsInstance(evidence, dict)
+        snapshot["as_of"] = "2026-07-29T11:59:59Z"
+        boundary = snapshot["completeness_boundary"]
+        bindings = snapshot["bindings"]
+        self.assertIsInstance(boundary, dict)
+        self.assertIsInstance(bindings, list)
+        boundary["through"] = snapshot["as_of"]
+        for binding in bindings:
+            binding["as_of"] = snapshot["as_of"]
+        self._rehash_supplied_snapshot(supplied_inputs)
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn(
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_STALE",
+            result.issue_codes,
+        )
+
+    def test_cross_snapshot_acceptance_replay_indicator_is_blocked(
+        self,
+    ) -> None:
+        contract = self._contract()
+        supplied_inputs = self._supplied_inputs(contract)
+        acceptance = supplied_inputs["supplied_role_acceptance"]
+        self.assertIsInstance(acceptance, dict)
+        acceptance["snapshot_identity"] = "previous-snapshot-identity"
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "SUPPLIED_RECORD_SNAPSHOT_MISMATCH",
+            result.issue_codes,
+        )
+
+    def test_revoked_supplied_records_never_return_active(self) -> None:
+        contract = self._contract("AUDITOR")
+        cases = {
+            "grant": (
+                "supplied_role_grant",
+                "SUPPLIED_ROLE_GRANT_REVOKED",
+            ),
+            "acceptance": (
+                "supplied_role_acceptance",
+                "SUPPLIED_ROLE_ACCEPTANCE_REVOKED",
+            ),
+            "independence": (
+                "supplied_independence_evidence",
+                "SUPPLIED_INDEPENDENCE_EVIDENCE_REVOKED",
+            ),
+            "snapshot": (
+                "supplied_prior_role_bindings",
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REVOKED",
+            ),
+            "binding": (
+                "binding",
+                "SUPPLIED_PRIOR_ROLE_BINDING_REVOKED",
+            ),
+        }
+        for case, (target_name, expected_issue) in cases.items():
+            with self.subTest(case=case):
+                supplied_inputs = self._supplied_inputs(contract)
+                if target_name == "binding":
+                    snapshot = supplied_inputs[
+                        "supplied_prior_role_bindings"
+                    ]
+                    self.assertIsInstance(snapshot, dict)
+                    bindings = snapshot["bindings"]
+                    self.assertIsInstance(bindings, list)
+                    target = bindings[0]
+                else:
+                    target = supplied_inputs[target_name]
+                self.assertIsInstance(target, dict)
+                target["revocation_state"] = "REVOKED"
+                target["revoked_at"] = "2026-07-29T11:59:00Z"
+                target["revocation_reference"] = "revocation-record-001"
+                if target_name in (
+                    "binding",
+                    "supplied_prior_role_bindings",
+                ):
+                    self._rehash_supplied_snapshot(supplied_inputs)
+
+                result = validate_role_operation(
+                    contract,
+                    self._request(contract),
+                    **supplied_inputs,
+                    now=FIXED_NOW,
+                )
+
+                self.assertEqual(RESULT_BLOCK, result.result)
+                self.assertIn(expected_issue, result.issue_codes)
+
+    def test_malformed_revoked_metadata_is_hold(self) -> None:
+        cases = (
+            (
+                "grant",
+                "SUPPLIED_ROLE_GRANT_REVOCATION_UNVERIFIABLE",
+            ),
+            (
+                "snapshot",
+                "SUPPLIED_PRIOR_ROLE_BINDINGS_REVOCATION_UNVERIFIABLE",
+            ),
+        )
+        for case, expected_issue in cases:
+            with self.subTest(case=case):
+                contract = self._contract()
+                supplied_inputs = self._supplied_inputs(contract)
+                target = (
+                    supplied_inputs["supplied_role_grant"]
+                    if case == "grant"
+                    else supplied_inputs["supplied_prior_role_bindings"]
+                )
+                self.assertIsInstance(target, dict)
+                target["revocation_state"] = "REVOKED"
+                target["revoked_at"] = None
+                target["revocation_reference"] = None
+
+                result = validate_role_operation(
+                    contract,
+                    self._request(contract),
+                    **supplied_inputs,
+                    now=FIXED_NOW,
+                )
+
+                self.assertEqual(RESULT_HOLD, result.result)
+                self.assertIn(expected_issue, result.issue_codes)
+
+    def test_toctou_snapshot_mutation_after_hash_binding_is_blocked(
+        self,
+    ) -> None:
+        contract = self._contract("AUDITOR")
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        bindings = snapshot["bindings"]
+        self.assertIsInstance(bindings, list)
+        bindings[0]["execution_context_identity"] = "changed-after-hash"
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "SUPPLIED_PRIOR_ROLE_BINDINGS_SNAPSHOT_HASH_MISMATCH",
+            result.issue_codes,
+        )
+
+    def test_auditor_acceptance_before_builder_end_is_blocked(self) -> None:
+        contract = self._contract("AUDITOR")
+        supplied_inputs = self._supplied_inputs(contract)
+        acceptance = supplied_inputs["supplied_role_acceptance"]
+        self.assertIsInstance(acceptance, dict)
+        acceptance["accepted_at"] = "2026-07-29T00:01:00Z"
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_BLOCK, result.result)
+        self.assertIn(
+            "AUDITOR_ACCEPTANCE_BEFORE_BUILDER_END",
+            result.issue_codes,
+        )
+
+    def test_active_builder_keeps_auditor_on_hold(self) -> None:
+        contract = self._contract("AUDITOR")
+        supplied_inputs = self._supplied_inputs(contract)
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(snapshot, dict)
+        bindings = snapshot["bindings"]
+        self.assertIsInstance(bindings, list)
+        bindings[0]["binding_state"] = "ACTIVE"
+        bindings[0]["ended_at"] = None
+        self._rehash_supplied_snapshot(supplied_inputs)
+
+        result = validate_role_operation(
+            contract,
+            self._request(contract),
+            **supplied_inputs,
+            now=FIXED_NOW,
+        )
+
+        self.assertEqual(RESULT_HOLD, result.result)
+        self.assertIn("BUILDER_ROLE_END_NOT_ESTABLISHED", result.issue_codes)
 
     def test_explicit_assignment_authority_is_required(self) -> None:
         contract = self._contract()
@@ -830,7 +1448,7 @@ class RoleContractV01Test(unittest.TestCase):
         self.assertEqual(RESULT_BLOCK, result.result)
         self.assertIn("ROLE_ACCEPTANCE_REQUIRED", result.issue_codes)
 
-    def test_contract_acceptance_claim_needs_trusted_receiver_record(
+    def test_contract_acceptance_claim_needs_supplied_receiver_record(
         self,
     ) -> None:
         contract = self._contract()
@@ -841,18 +1459,18 @@ class RoleContractV01Test(unittest.TestCase):
         result = validate_role_operation(
             contract,
             self._request(contract),
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_independence_evidence=self._independence_evidence(
+            supplied_role_grant=self._supplied_grant(contract),
+            supplied_independence_evidence=self._independence_evidence(
                 contract
             ),
-            trusted_prior_role_bindings=[],
+            supplied_prior_role_bindings=[],
             now=FIXED_NOW,
         )
 
         self.assertEqual(RESULT_HOLD, result.result)
-        self.assertIn("TRUSTED_ROLE_ACCEPTANCE_REQUIRED", result.issue_codes)
+        self.assertIn("SUPPLIED_ROLE_ACCEPTANCE_REQUIRED", result.issue_codes)
 
-    def test_trusted_role_acceptance_binds_receiver_and_contract(
+    def test_supplied_role_acceptance_binds_receiver_and_contract(
         self,
     ) -> None:
         replacements = {
@@ -866,26 +1484,26 @@ class RoleContractV01Test(unittest.TestCase):
         for field, replacement in replacements.items():
             with self.subTest(field=field):
                 contract = self._contract()
-                acceptance = self._trusted_acceptance(contract)
+                acceptance = self._supplied_acceptance(contract)
                 acceptance[field] = replacement
                 result = validate_role_operation(
                     contract,
                     self._request(contract),
-                    trusted_role_grant=self._trusted_grant(contract),
-                    trusted_role_acceptance=acceptance,
-                    trusted_independence_evidence=(
+                    supplied_role_grant=self._supplied_grant(contract),
+                    supplied_role_acceptance=acceptance,
+                    supplied_independence_evidence=(
                         self._independence_evidence(contract)
                     ),
-                    trusted_prior_role_bindings=[],
+                    supplied_prior_role_bindings=[],
                     now=FIXED_NOW,
                 )
                 self.assertEqual(RESULT_BLOCK, result.result)
                 self.assertIn(
-                    "TRUSTED_ROLE_ACCEPTANCE_MISMATCH",
+                    "SUPPLIED_ROLE_ACCEPTANCE_MISMATCH",
                     result.issue_codes,
                 )
 
-    def test_trusted_role_acceptance_status_and_time_fail_closed(
+    def test_supplied_role_acceptance_status_and_time_fail_closed(
         self,
     ) -> None:
         cases = (
@@ -893,47 +1511,47 @@ class RoleContractV01Test(unittest.TestCase):
                 "role_acceptance",
                 "DECLINED",
                 RESULT_BLOCK,
-                "TRUSTED_ROLE_ACCEPTANCE_NOT_ACCEPTED",
+                "SUPPLIED_ROLE_ACCEPTANCE_NOT_ACCEPTED",
             ),
             (
                 "accepted_at",
                 "UNKNOWN",
                 RESULT_HOLD,
-                "TRUSTED_ROLE_ACCEPTANCE_UNVERIFIABLE",
+                "SUPPLIED_ROLE_ACCEPTANCE_UNVERIFIABLE",
             ),
             (
                 "accepted_at",
                 "2026-07-28T23:59:59Z",
                 RESULT_BLOCK,
-                "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+                "SUPPLIED_ROLE_ACCEPTANCE_TIME_INVALID",
             ),
             (
                 "accepted_at",
                 "2026-07-30T00:00:00Z",
                 RESULT_BLOCK,
-                "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+                "SUPPLIED_ROLE_ACCEPTANCE_TIME_INVALID",
             ),
             (
                 "accepted_at",
                 "2026-07-29T13:00:00Z",
                 RESULT_BLOCK,
-                "TRUSTED_ROLE_ACCEPTANCE_TIME_INVALID",
+                "SUPPLIED_ROLE_ACCEPTANCE_TIME_INVALID",
             ),
         )
         for field, replacement, expected_result, expected_issue in cases:
             with self.subTest(field=field, replacement=replacement):
                 contract = self._contract()
-                acceptance = self._trusted_acceptance(contract)
+                acceptance = self._supplied_acceptance(contract)
                 acceptance[field] = replacement
                 result = validate_role_operation(
                     contract,
                     self._request(contract),
-                    trusted_role_grant=self._trusted_grant(contract),
-                    trusted_role_acceptance=acceptance,
-                    trusted_independence_evidence=(
+                    supplied_role_grant=self._supplied_grant(contract),
+                    supplied_role_acceptance=acceptance,
+                    supplied_independence_evidence=(
                         self._independence_evidence(contract)
                     ),
-                    trusted_prior_role_bindings=[],
+                    supplied_prior_role_bindings=[],
                     now=FIXED_NOW,
                 )
                 self.assertEqual(expected_result, result.result)
@@ -1037,20 +1655,21 @@ class RoleContractV01Test(unittest.TestCase):
     def test_unknown_independence_does_not_become_pass(self) -> None:
         contract = self._contract()
         request = self._request(contract)
-        trusted_evidence = self._independence_evidence(contract)
-        trusted_evidence["runtime_execution_independence"] = "UNKNOWN"
+        supplied_inputs = self._supplied_inputs(contract)
+        supplied_evidence = supplied_inputs[
+            "supplied_independence_evidence"
+        ]
+        self.assertIsInstance(supplied_evidence, dict)
+        supplied_evidence["runtime_execution_independence"] = "UNKNOWN"
         result = validate_role_operation(
             contract,
             request,
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
-            trusted_independence_evidence=trusted_evidence,
-            trusted_prior_role_bindings=[],
+            **supplied_inputs,
             now=FIXED_NOW,
         )
         self.assertEqual(RESULT_HOLD, result.result)
         self.assertIn(
-            "TRUSTED_INDEPENDENCE_EVIDENCE_REQUIRED",
+            "SUPPLIED_INDEPENDENCE_EVIDENCE_REQUIRED",
             result.issue_codes,
         )
 
@@ -1060,27 +1679,37 @@ class RoleContractV01Test(unittest.TestCase):
         contract = self._contract("AUDITOR")
         assignment = contract["assignment"]
         self.assertIsInstance(assignment, dict)
-        assignment["execution_context_identity"] = "shared-trusted-context"
+        assignment["execution_context_identity"] = "shared-supplied-context"
         self._rehash(contract)
         request = self._request(contract)
-        request["execution_context_identity"] = "shared-trusted-context"
+        request["execution_context_identity"] = "shared-supplied-context"
         evidence = request["independence_evidence"]
         self.assertIsInstance(evidence, dict)
         evidence["model_identity"] = "different-model-name"
         evidence["model_diversity"] = "DIFFERENT_MODEL_REQUIRED"
         bindings = request["prior_role_bindings"]
         self.assertIsInstance(bindings, list)
-        bindings[0]["execution_context_identity"] = "shared-trusted-context"
-        trusted_evidence = deepcopy(evidence)
-        trusted_bindings = deepcopy(bindings)
+        bindings[0]["execution_context_identity"] = "shared-supplied-context"
+        supplied_inputs = self._supplied_inputs(contract)
+        supplied_evidence = supplied_inputs[
+            "supplied_independence_evidence"
+        ]
+        snapshot = supplied_inputs["supplied_prior_role_bindings"]
+        self.assertIsInstance(supplied_evidence, dict)
+        self.assertIsInstance(snapshot, dict)
+        supplied_evidence["model_identity"] = "different-model-name"
+        supplied_evidence["model_diversity"] = "DIFFERENT_MODEL_REQUIRED"
+        supplied_bindings = snapshot["bindings"]
+        self.assertIsInstance(supplied_bindings, list)
+        supplied_bindings[0]["execution_context_identity"] = (
+            "shared-supplied-context"
+        )
+        self._rehash_supplied_snapshot(supplied_inputs)
 
         result = validate_role_operation(
             contract,
             request,
-            trusted_role_grant=self._trusted_grant(contract),
-            trusted_role_acceptance=self._trusted_acceptance(contract),
-            trusted_independence_evidence=trusted_evidence,
-            trusted_prior_role_bindings=trusted_bindings,
+            **supplied_inputs,
             now=FIXED_NOW,
         )
 


### PR DESCRIPTION
## Summary

This PR implements V13 Stage 4 Role Contract validation as a deterministic,
read-only validator for separately supplied records.

`trusted_*` naming and authenticated/closed-attack claims have been removed.
The public validator inputs are now:

- `supplied_role_grant`
- `supplied_role_acceptance`
- `supplied_independence_evidence`
- `supplied_prior_role_bindings`

`ACTIVE` means only `ACTIVE — VALIDATOR CONDITIONS SATISFIED`.

## Honest implementation boundary

```text
Role Separation Enforcement: VALIDATOR-LEVEL ONLY
Record Issuer / Authentication / Transport: NOT IMPLEMENTED
Role Independence: NOT ESTABLISHED
End-to-End False-Division Prevention: NOT ESTABLISHED
```

The validator does not issue, authenticate, transport, discover, or persist
records. It does not establish real-world assignment, receiver acceptance,
snapshot completeness, Role separation, or independence.

## Validator behavior

- Every supplied Grant, Acceptance, independence record, prior-binding
  snapshot, and prior binding carries an `as_of` value and explicit revocation
  state.
- The supplied Role Acceptance binds the exact Contract ID/hash, task, Role,
  assignee, execution context, Grant record identity, shared snapshot, and
  `accepted_at`.
- `supplied_prior_role_bindings` is a snapshot envelope with snapshot
  identity/hash, Contract/task binding, `as_of`, revocation fields, a
  `TASK_INCEPTION` completeness boundary, exact record-identity manifest, and
  binding lifecycle records.
- Missing, incomplete, stale, or internally inconsistent prior-binding
  snapshot state returns HOLD rather than `ACTIVE`.
- Declared cross-snapshot reuse, duplicate identities, explicit revoked
  records, snapshot-hash mutation, mixed timing, and invalid Builder/Auditor
  ordering are non-permitted.
- Auditor acceptance must be strictly later than the latest supplied Builder
  end. An active or unended Builder keeps the result on HOLD.

The snapshot hash and manifest detect only inconsistencies visible in the
supplied bundle. A caller can fabricate a coherent complete-looking snapshot,
rewrite its manifest, and recompute its hash. The stateless validator cannot
detect that fabrication or an indistinguishable cross-call replay. Atomic
record acquisition and a replay-consumption ledger are not implemented.

## Adversarial validator coverage

Focused tests cover:

- incomplete completeness state and manifest/list omission;
- claimant replacement versus a same-context binding still present in the
  supplied snapshot;
- a coherently fabricated/rehashed snapshot remaining outside validator
  detection;
- stale Acceptance and stale prior-binding snapshots;
- declared cross-snapshot replay and duplicate record identities;
- revoked and malformed-revocation records;
- mutation after snapshot hash binding (observable TOCTOU mismatch);
- Auditor acceptance before Builder end and an active/unended Builder;
- subsecond validation times and equivalent timezone representations.

## Scope boundary

Exactly six files are changed:

- `decision_os/role_contract.py`
- `docs/role_bound_specialist_system_v0_1.md`
- `examples/role_contract.v0_1.json`
- `schema/v13_role_contract.schema.json`
- `templates/v13_specialist_lens.md`
- `tests/test_decision_os_role_contract.py`

Stage 5 is not implemented. Coverage Gap Recommendations remain inert.
Automatic Role assignment and automatic specialist invocation remain
prohibited.

## Validation

- Focused: `python3 -B -m unittest tests.test_decision_os_role_contract -v`
  — 45/45 PASS
- Full: `python3 -B -m unittest discover -s tests -v`
  — 490/490 PASS
- `git diff --check` — PASS

## Current gate

```text
PR State: DRAFT
Review Gate: HOLD — AWAITING SHIN / OPUS RE-REVIEW
Merge: NOT PERFORMED
Stage 5: NOT IMPLEMENTED
Automatic Specialist Invocation: NOT IMPLEMENTED
```

Completion Receipt:

```text
Role Separation Enforcement: VALIDATOR-LEVEL ONLY
Record Issuer / Authentication / Transport: NOT IMPLEMENTED
Role Independence: NOT ESTABLISHED
End-to-End False-Division Prevention: NOT ESTABLISHED
```
