### PR TITLE
Docs: add Stage 5 Audit Coverage Ledger v0.1

### DIFF
--- a/docs/audit/v13_stage5_audit_coverage_ledger_v0_1.md
+++ b/docs/audit/v13_stage5_audit_coverage_ledger_v0_1.md
@@ -1,0 +1,877 @@
+# V13 Stage 5 Audit Coverage Ledger v0.1
+
+**Ledger ID:** `V13-S5-AUDIT-COVERAGE-LEDGER-v0.1`
+**Current Layer:** V13 Stage 5
+**Decision Owner:** Shin
+**Ledger Status:** `FIXED AS-OF / FORWARD-ONLY`
+**Audited As-of:** `719bb0699cda7db9ef587320bdf1c676181bf41c`
+**Source PR:** `#46 Stage 5 v0.1: implement intelligence transplant loop`
+**Approved Implementation Head:** `bc8e98f6736b875511b3e2ed39419fcb11a2046f`
+**Merge Commit:** `719bb0699cda7db9ef587320bdf1c676181bf41c`
+
+PR #46は`CLOSED / MERGED / Draft=false`で、上記merge commitへ固定されている。
+
+---
+
+## 1. Purpose
+
+このLedgerは、Stage 5 v0.1について次を区別する。
+
+1. 独立監査で明示的に反例を当てて確認した領域
+2. 独立再実行・回帰テストで確認した領域
+3. 実装とテストは存在するが、独立した敵対的監査までは行っていない領域
+4. 未確立または対象外の領域
+5. 将来の変更によって再監査が必要になる条件
+
+古い監査結果を後から書き換えない。
+
+変更によって監査の前提が失われた場合は、旧結果を`STALE`とし、新しいcommitを対象にForward-onlyで監査記録を追加する。
+
+---
+
+## 2. Coverage Classes
+
+| Class                    | Meaning                                    |
+| ------------------------ | ------------------------------------------ |
+| `A — ADVERSARIAL`        | 独立監査役が具体的反例を提示し、修理後に同じ反例を再実行して閉じた          |
+| `B — INDEPENDENT REPLAY` | 独立Contextで実装・回帰・cross-layer behaviorを再実行した |
+| `C — TEST COVERED`       | 実装とテストは存在するが、独立した敵対的反例監査までは確認していない         |
+| `N — NOT ESTABLISHED`    | 本監査では成立を確認していない、または明示的に対象外                 |
+
+---
+
+## 3. Validity States
+
+| State                 | Meaning               |
+| --------------------- | --------------------- |
+| `VALID`               | 指定As-ofと固定された前提の範囲で有効 |
+| `VALID WITH BOUNDARY` | 一部の条件・環境・故障境界に限定して有効  |
+| `STALE`               | 後続変更によって監査前提が失われた     |
+| `RE-AUDIT REQUIRED`   | 変更が失効条件に該当し、再監査が必要    |
+| `NOT ESTABLISHED`     | 成立を主張できない             |
+
+---
+
+# 4. Audit Coverage Matrix
+
+## A-01 — Delta Maturity State Transition
+
+**Audit Surface:**
+`NONE → CANDIDATE → IMPLEMENTED → REUSED`
+
+**Covered Claim:**
+必要なEvidenceを欠いた状態で、成熟度が上位Stateへ進まない。
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+
+* E1のみで`CANDIDATE`にならない
+* E2 `REJECT`後、実質的に同じE1を並べ替えただけでは新しいlineageにならない
+* E3成立前に`CANDIDATE`にならない
+* E4なしで`IMPLEMENTED`にならない
+* E5なしで`REUSED`にならない
+* top-level Run StateとCompanion panelが同じfresh projectionから導出される
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* reducerまたはmaturity projectionの変更
+* E1–E5 dependency graphの変更
+* `CANDIDATE / IMPLEMENTED / REUSED`成立条件の変更
+* cached stateをauthority sourceとして使用する変更
+
+**Required Re-audit Scope:**
+全State Transitionと古いEvidence chainのreplay。
+
+**Residual UNKNOWN:**
+実際のFormal Run 001による運用成立は未確認。
+
+---
+
+## A-02 — Post-REJECT E1 Novelty Canonicalization
+
+**Audit Surface:**
+棄却済みDiscoveryを、表面変更だけで新規Discoveryとして再登録する経路。
+
+**Covered Claim:**
+次の変更だけでは、materially new E1にならない。
+
+* anchor順序
+* list順序
+* word順序
+* 大文字・小文字
+* 空白
+* 句読点
+* Unicode compatibility form
+* invisible/control character
+* combining grapheme joiner `U+034F`
+* variation selector
+* `U+FE0F`
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+
+* order-only E1によるfalse `CANDIDATE`反例
+* `U+FE0F`反例
+* `U+034F`反例
+* standard variation selectors 256個の確認
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* semantic signature生成処理の変更
+* Unicode normalization処理の変更
+* tokenizationまたはlexical inventoryの変更
+* E1 novelty fieldの追加・削除
+* Category-M文字の扱い変更
+
+**Required Re-audit Scope:**
+Unicode corpus、invisible character、reordering、semantic-preserving mutation。
+
+**Residual UNKNOWN:**
+全言語・全Unicode組合せに対する意味同一性判定は未確立。
+
+---
+
+## A-03 — E2 Independent Counter-Structure Audit Binding
+
+**Audit Surface:**
+DiscoveryとAuditの独立性、固定E1への監査binding。
+
+**Covered Claim:**
+
+* E2は固定済みE1 ID/hashを対象にする
+* DiscoveryとAuditは異なるSeatおよびContextを使用する
+* 同じ会話内でRole名だけを変更しても独立監査にならない
+* verdictは`SURVIVE / REVISE / REJECT`
+* Audit Input ManifestとCompletion Receiptが必要
+
+**Coverage Class:** `B — INDEPENDENT REPLAY`
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* Seat Assignment Receipt schemaの変更
+* context identity判定の変更
+* Audit Input Manifestの変更
+* verdict enumの変更
+* fresh context条件の緩和
+
+**Required Re-audit Scope:**
+same-context role relabel、stale E1、cross-run E1 substitution。
+
+**Residual UNKNOWN:**
+現実世界のモデル・人物Identityを暗号学的に認証するものではない。
+
+---
+
+## A-04 — E3 Accepted / Revised Discovery Binding
+
+**Audit Surface:**
+E1とE2の差分を、実装可能なFailure Structureへ固定する部分。
+
+**Covered Claim:**
+
+* `REJECT`はE3へ進めない
+* `SURVIVE`はaccepted claimsを保持する
+* `REVISE`はrequired audit deltaを一対一で反映する
+* accepted claims、excluded claims、implementation requirements、scope、forbidden overclaimsを明示する
+* `GENERALIZED_TRANSPLANT_NOT_ESTABLISHED`を保持する
+
+**Coverage Class:** `C — TEST COVERED`
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* E3 schemaの変更
+* required audit delta mappingの変更
+* accepted/excluded claim semanticsの変更
+* generalized claim boundaryの変更
+
+**Required Re-audit Scope:**
+partial revision、missing delta、contradictory accepted/excluded claims。
+
+**Residual UNKNOWN:**
+Formal Run 001で人間が実際にE1/E2差分を正しく解消できるかは未確認。
+
+---
+
+## A-05 — E4 Complete Consumption of E3 Requirements
+
+**Audit Surface:**
+E3の要求を一部だけ実装し、全体を`IMPLEMENTED`として扱う経路。
+
+**Covered Claim:**
+
+E4は以下を完全に消費しなければならない。
+
+* accepted claim
+* implementation requirement
+* implementation scope path
+* required control behavior
+* concrete asset
+* behavioral activation verification
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+E4がE3 requirementsまたはscope pathを無視しても通過する反例を検出し、修理後に閉鎖。
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* E3–E4 mapping構造の変更
+* implementation requirement fieldの変更
+* scope path bindingの変更
+* behavioral verification typeの変更
+
+**Required Re-audit Scope:**
+missing requirement、orphan scope、unmapped accepted claim、unrelated changed path。
+
+**Residual UNKNOWN:**
+Control Asset自体の外部的な有効性は、E4だけでは成立しない。
+
+---
+
+## A-06 — E4 Active Asset Claim Binding
+
+**Audit Surface:**
+実装commit内に存在するだけのassetを、claimを守るactive assetとして扱う経路。
+
+**Covered Claim:**
+
+* E4 assetはaccepted claimと一対一で結合される
+* assetの存在だけでは不十分
+* passing testだけでは不十分
+* runtime interception、adversarial trigger、controlled contrastなどのbehavioral activationが必要
+* unrelated changed filesを同じE4に隠せない
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* active asset selection logicの変更
+* claim binding schemaの変更
+* activation verification enumの変更
+* changed path accountingの変更
+
+**Required Re-audit Scope:**
+unbound asset、unused validator、pass-only test、hidden unrelated changes。
+
+**Residual UNKNOWN:**
+本番公開ワークフロー上でassetが確実に呼び出されるかはFormal Run 001で確認する。
+
+---
+
+## A-07 — Lower-Run Context Independence
+
+**Audit Surface:**
+Upper DiscoveryまたはImplementation ContextをLower-Runとして再利用する経路。
+
+**Covered Claim:**
+
+Lower-Run runtime contextは次と異なる必要がある。
+
+* Discovery Context
+* Audit Context
+* Implementation Context
+
+また、Seat Assignment、Trial Manifest、Completion Receiptが同じLower-Run Contextをbindする。
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+Implementation contextをLower-Runとして再利用できる反例を検出し、修理後に閉鎖。
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* context identity比較の変更
+* Lower-Run Seat Assignment変更
+* Trial Manifest input model変更
+* Completion Receipt context field変更
+
+**Required Re-audit Scope:**
+same-session、shared memory、implementation-context reuse、context relabel。
+
+**Residual UNKNOWN:**
+外部サービス側の非公開Memoryやhidden system contextの不存在は証明しない。
+
+---
+
+## A-08 — Exact E4 Asset Reuse in E5
+
+**Audit Surface:**
+E4でclaim-boundではないassetを、E5で再利用成功として登録する経路。
+
+**Covered Claim:**
+
+以下が同一のasset identity、version、hashを参照する。
+
+* E4 claim binding
+* Lower-Run Trial Manifest
+* Lower-Run Completion Receipt
+* activation trace
+* E5 record
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+`changed_artifacts`に存在するだけでclaim-unboundなassetをE5で使用できる反例を閉鎖。
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* asset identity/version/hash modelの変更
+* E4 active asset selection変更
+* manifestまたはreceipt binding変更
+* multi-asset E5の導入
+
+**Required Re-audit Scope:**
+unbound asset、stale asset hash、manifest/completion mismatch、asset substitution。
+
+**Residual UNKNOWN:**
+複数Control Assetの合成再利用は未確立。
+
+---
+
+## A-09 — E5 Causal Proof and Human Rescue Boundary
+
+**Audit Surface:**
+偶然正しい結果、assetの存在、単なるtest pass、人間修正を`REUSED`として扱う経路。
+
+**Covered Claim:**
+
+E5のcausal proofは次のいずれかに限定される。
+
+* `INTERCEPTION_TRACE`
+* `CONTROLLED_CONTRAST`
+
+次はE5を成立させない。
+
+* assetが存在するだけ
+* assetを読み込んだだけ
+* testがpassしただけ
+* 偶然正しい回答
+* `human_rescue = PRESENT`
+* `human_rescue = INTERRUPTED`
+
+**Coverage Class:** `C — TEST COVERED`
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* causal proof mode追加
+* human rescue semantics変更
+* controlled contrast条件変更
+* interception trace schema変更
+
+**Required Re-audit Scope:**
+accidental pass、human correction、post-hoc validation、asset-loaded-only。
+
+**Residual UNKNOWN:**
+Formal Run 001で実際のclaim interceptionを記録できるかは未確認。
+
+---
+
+## A-10 — Forward-Only E5 Revocation and Recovery
+
+**Audit Surface:**
+E5をrevokeした後、古いtrialまたはrecordを再利用して`REUSED`へ戻す経路。
+
+**Covered Claim:**
+
+* revoked E5の直接replayは禁止
+* 新しいpre-frozen Lower-Run Manifestが必要
+* 新しいCompletion Receiptが必要
+* task/input/result evidenceがmaterially differentである必要がある
+* ID、timestamp、context label、referenceの付け替えだけでは復活できない
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+direct E5 revocation replay反例を検出し、修理後に閉鎖。
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* revoke/supersession処理の変更
+* material novelty判定変更
+* manifest reuse条件変更
+* detached E5の導入
+
+**Required Re-audit Scope:**
+ID relabel、timestamp relabel、detached E5、old receipt reuse。
+
+**Residual UNKNOWN:**
+複数回の長期的なE5累積・一般化昇格は未設計。
+
+---
+
+## A-11 — Git Evidence Integrity
+
+**Audit Surface:**
+Gitの置換・設定・外部object storeを利用し、偽のE4またはrollback evidenceを成立させる経路。
+
+**Covered Claim:**
+
+次の状態ではfail closedする。
+
+* replace refs
+* legacy grafts
+* alternate object stores
+* unsafe local/worktree config
+* ambient Git environment contamination
+* non-SHA-1 object format
+* blob/hash mismatch
+* ancestry mismatch
+* repository HEAD drift
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+Git replace/graftによるfalse `IMPLEMENTED`反例を検出し、config-neutral raw Git verificationへ修理。
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* Git command wrapper変更
+* repository format対応追加
+* SHA-256 Git repository対応
+* ancestry/blob verification変更
+* rollback evidence model変更
+
+**Required Re-audit Scope:**
+replace refs、grafts、alternates、local config、environment poisoning、object-format transition。
+
+**Residual UNKNOWN:**
+SHA-256 object-format repositoryは未対応であり、fail closed対象。
+
+---
+
+## A-12 — Publication HEAD Drift Fail-Closed
+
+**Audit Surface:**
+Evidence append中にrepository HEADが変わり、異なる状態を一つのEvidenceとして公開する経路。
+
+**Covered Claim:**
+
+* append開始時と終了時にHEADを確認
+* publication中は`IN_PROGRESS`
+* driftまたは中断時は読み取り不能
+* expected HEADが維持された場合のみmarkerをclear
+* cached projectionではなくverified chainから再構成する
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* publication marker処理変更
+* opening/closing HEAD check変更
+* append transaction順序変更
+* concurrent writer model変更
+
+**Required Re-audit Scope:**
+pre-append drift、post-append drift、event-head update race、marker deletion race。
+
+**Residual UNKNOWN:**
+複数process・複数machine間のdistributed transactionは未確立。
+
+---
+
+## A-13 — Crash/Reopen Fail-Closed
+
+**Audit Surface:**
+process crash後にpartial stateを正常なEvidenceとして読み取る経路。
+
+**Covered Crash Points:**
+
+1. `IN_PROGRESS`作成後
+2. event append後
+3. event-head publication後
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+subprocessを強制終了し、再open時にすべてfail closedすることを独立確認。
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* atomic write処理変更
+* event append順序変更
+* publication marker変更
+* reopen recovery処理追加
+
+**Required Re-audit Scope:**
+各commit pointでのSIGKILL、truncated event、missing event-head、uncleared marker。
+
+**Residual UNKNOWN:**
+OS process crash境界は確認済みだが、全電源断・storage controller failureは未確立。
+
+---
+
+## A-14 — Atomic Replacement Parent Directory Durability
+
+**Audit Surface:**
+file replacementは成功したが、親directory entryがdurableでない経路。
+
+**Covered Claim:**
+Stage 5 `_atomic_write` replacement後、対象parent directoryをfsyncする。
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* atomic write utility変更
+* directory creation flow変更
+* marker deletion flow変更
+* cross-platform filesystem対応追加
+
+**Required Re-audit Scope:**
+replacement、new file、marker deletion、nested directory creation。
+
+**Residual UNKNOWN:**
+新しく作られたdirectory hierarchy全体のfull power-loss durabilityは未確立。
+
+---
+
+## A-15 — Event Chain and Corruption Fail-Closed
+
+**Audit Surface:**
+store破損時に古いvalid stateへ黙って戻る経路。
+
+**Covered Claim:**
+
+* event chainをgenesisから検証
+* event-headがtruncationを検出
+* structured blobとtransport bytesを再hash
+* corruption時はfail closed
+* writable maturity fieldをauthority sourceにしない
+
+**Coverage Class:** `B — INDEPENDENT REPLAY`
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* event format変更
+* event ID生成変更
+* event-head structure変更
+* store recovery機構追加
+* snapshot/compaction導入
+
+**Required Re-audit Scope:**
+truncation、reordering、blob substitution、event-head mismatch、stale snapshot recovery。
+
+**Residual UNKNOWN:**
+same-OS full-store rewrite攻撃はv0.1の成立範囲外。
+
+---
+
+## A-16 — Companion Projection and Private Cache Consistency
+
+**Audit Surface:**
+fresh verified stateとcached Run/UI panelが矛盾する経路。
+
+**Covered Claim:**
+
+* top-level Run
+* UI panel
+* private Stage 5 `_run` cache
+
+が、fresh verifiedまたはfail-closed projectionへ同期する。
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Evidence:**
+
+* top-level Run/panel contradictionを修理
+* later snapshots/operationsでprivate cacheが同期されることを再確認
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* Companion projection変更
+* `_run` cache構造変更
+* UI route変更
+* read pathへの新しいcache追加
+
+**Required Re-audit Scope:**
+stale cache、fail-closed transition、later snapshot、concurrent read。
+
+**Residual UNKNOWN:**
+外部クライアント側の独自cacheは対象外。
+
+---
+
+## A-17 — Repository Sibling Isolation
+
+**Audit Surface:**
+Stage 5 store corruptionまたはfail-closed処理が、Companion内の他のRepository stateを壊す経路。
+
+**Covered Claim:**
+Stage 5 corruption中もRepository siblingを保持し、対象Runだけをfail closedする。
+
+**Coverage Class:** `A — ADVERSARIAL`
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* Companion root state変更
+* Repository sibling structure変更
+* corruption handling変更
+* shared cache導入
+
+**Required Re-audit Scope:**
+single-run corruption、multi-repository state、cache replacement、error projection。
+
+**Residual UNKNOWN:**
+大量Repositoryを持つ長時間運用でのresource isolationは未確認。
+
+---
+
+## A-18 — Manual Authority and Identity Boundary
+
+**Audit Surface:**
+manual receiptを暗号学的な人物認証として誤解する経路。
+
+**Covered Claim:**
+
+```text
+Authority Provenance: MANUAL OWNER ATTESTED
+Cryptographic Provenance: NOT ESTABLISHED
+Generalized Transplant: NOT ESTABLISHED
+```
+
+**Coverage Class:** `C — TEST COVERED`
+
+**Current Status:** `VALID WITH BOUNDARY`
+
+**Invalidation Triggers:**
+
+* authentication導入
+* signature導入
+* federated identity導入
+* authority wording変更
+* browser session claim変更
+
+**Required Re-audit Scope:**
+identity claim、operator claim、hidden input claim、federated provenance claim。
+
+**Residual UNKNOWN:**
+
+* real-world operator identity
+* external identity
+* hidden input absence
+* federated provenance
+* cryptographic attestation
+
+はいずれも未確立。
+
+---
+
+## A-19 — Legacy V13 Compatibility
+
+**Audit Surface:**
+Stage 5追加によって既存V13機能が破壊されていないか。
+
+**Covered Areas:**
+
+* legacy Manual Bridge six-role order
+* Golden manifest bytes
+* Structural Replay semantics
+* Guided Intake exact-key schema
+* existing Role Contract
+* `v13_loop_record.schema.json`
+* bounded-task Runner behavior
+
+**Coverage Class:** `B — INDEPENDENT REPLAY`
+
+**Evidence:**
+
+* Required regression suites: `206 PASS`
+* Full suite: `577 PASS`
+* Focused Stage 5 suites: `77 PASS`
+* `git diff --check`: PASS
+* JavaScript syntax: PASS
+* JSON parsing: PASS
+* `git fsck --full --strict`: PASS
+
+**Current Status:** `VALID`
+
+**Invalidation Triggers:**
+
+* legacy Bridge code変更
+* shared schema変更
+* Guided Intake変更
+* Runner state contract変更
+* common persistence layer変更
+
+**Required Re-audit Scope:**
+関連するlegacy suiteとStage 5 focused suite。
+
+**Residual UNKNOWN:**
+未テストの外部integrationまたは独自fork互換性は未確立。
+
+---
+
+## A-20 — Formal Run 001 Operational Proof
+
+**Audit Surface:**
+実際の公開文章タスクで、E1からE5まで成立するか。
+
+**Coverage Class:** `N — NOT ESTABLISHED`
+
+**Current Status:** `NOT ESTABLISHED`
+
+**Reason:**
+
+* Formal Run 001は未開始
+* E1 Pro Discoveryは未成立
+* E2 Counter-Structure Auditは未成立
+* E3 Accepted / Revised Discoveryは未成立
+* E4 Control Assetは未成立
+* E5 Lower-Run Reuseは未成立
+
+**Invalidation Trigger:**
+なし。まだ成立していないため失効対象がない。
+
+**Required Audit Scope:**
+固定Charterに従ったFormal Run 001全体。
+
+---
+
+# 5. Residual UNKNOWN Register
+
+| ID     | Residual UNKNOWN                                 | Current Treatment             |
+| ------ | ------------------------------------------------ | ----------------------------- |
+| `U-01` | Cryptographic operator identity                  | `NOT ESTABLISHED`             |
+| `U-02` | Hidden inputが存在しなかったことの証明                        | `NOT ESTABLISHED`             |
+| `U-03` | Federated provenance                             | `NOT ESTABLISHED`             |
+| `U-04` | Generalized Intelligence Transplant              | `NOT ESTABLISHED`             |
+| `U-05` | 複数Lower-Run・複数モデルへの一般化                           | `NOT ESTABLISHED`             |
+| `U-06` | 新規directory hierarchyのfull power-loss durability | `NOT ESTABLISHED`             |
+| `U-07` | same-OS full-store rewrite耐性                     | `OUT OF v0.1 SCOPE`           |
+| `U-08` | Git SHA-256 object-format対応                      | `NOT SUPPORTED / FAIL CLOSED` |
+| `U-09` | distributed multi-machine transaction            | `NOT ESTABLISHED`             |
+| `U-10` | Formal Run 001 E1–E5                             | `NOT STARTED`                 |
+| `U-11` | 外部利用者による再現・採用                                    | `NOT ESTABLISHED`             |
+| `U-12` | 公開Claim Guardの実運用有効性                             | `NOT ESTABLISHED`             |
+
+---
+
+# 6. Change-to-Audit Mapping
+
+今後は変更ファイル数ではなく、変更された**invariant**によって再監査範囲を決定する。
+
+| Changed Surface                       | Minimum Re-audit      |
+| ------------------------------------- | --------------------- |
+| E1 novelty / canonicalization         | A-01、A-02             |
+| E2 Seat / Context / Audit Manifest    | A-03                  |
+| E3 schema / revision mapping          | A-04、A-05             |
+| E4 claim binding / Git evidence       | A-05、A-06、A-11        |
+| E5 manifest / context / asset binding | A-07、A-08、A-09、A-10   |
+| revoke / rollback / supersession      | A-10、A-11、A-15        |
+| store / event chain / atomic write    | A-12、A-13、A-14、A-15   |
+| Companion cache / UI projection       | A-16、A-17             |
+| authority / identity wording          | A-18                  |
+| shared legacy code / schemas          | A-19                  |
+| README・release note・投稿Claim Guard     | A-20およびFormal Run 001 |
+
+---
+
+# 7. Re-audit Rules
+
+1. `VALID`は指定commitに対してのみ有効。
+2. 関連invariantが変更された場合、旧結果を削除しない。
+3. 旧結果を`STALE`または`RE-AUDIT REQUIRED`へ変更する。
+4. 新しいcommit、反例、監査Context、結果を新規行として追加する。
+5. unrelated changeだけで全面監査へ戻さない。
+6. trust boundary、state reducer、store、shared schema変更時のみ広域回帰を行う。
+7. test passだけを独立敵対監査として数えない。
+8. 未監査領域を「暗黙にPASS」と扱わない。
+9. `NOT ESTABLISHED`を失敗や欠陥と混同しない。
+10. 新しい監査結果を過去commitへ遡及適用しない。
+
+---
+
+# 8. Current Gate
+
+```text
+PASS — STAGE 5 v0.1 AUDIT COVERAGE RECORDED
+PASS — PR #46 IMPLEMENTATION MERGED
+HOLD — FORMAL RUN 001 NOT STARTED
+```
+
+---
+
+# 9. Completion Line
+
+以下をAs-of付きで固定した。
+
+* 明示的に敵対監査された領域
+* 独立再実行された領域
+* test coverageのみの領域
+* 未確立領域
+* residual UNKNOWN
+* 監査失効条件
+* 変更に対応する最小再監査範囲
+
+**Completion State:**
+`PASS — AUDIT COVERAGE LEDGER v0.1 CREATED`
+
+---
+
+# 10. Missing Closure
+
+実装監査の後始末は残っていない。
+
+残るのは別Loopである。
+
+```text
+Formal Run 001
+E1 → E2 → E3 → E4 → E5
+```
+
+これは既存実装の再監査ではなく、Stage 5を実タスクで使用する運用実証。
+
+---
+
+# 11. Next Authorized Action
+
+```text
+V13-S5-FR-001 Source Input Manifest v0.1を作成する。
+```
+
+まだ許可されないもの：
+
+```text
+NO EXTERNAL MODEL INVOCATION
+NO SOURCE TASK EXECUTION
+NO CODEX
+NO CODE / BRANCH / PR
+NO RELEASE
+NO PUBLICATION
+```


### PR DESCRIPTION
## Summary

- add `docs/audit/v13_stage5_audit_coverage_ledger_v0_1.md`
- preserve the supplied Ledger text byte-for-byte, including its audit classes, As-of commit, validity states, invalidation triggers, and Formal Run 001 boundary
- keep the change docs-only; no README, implementation, schema, test, release, or publication changes are included

## Why

Fix the already-created V13 Stage 5 Audit Coverage Ledger v0.1 in the repository as a reviewable audit asset anchored to merged Stage 5 commit `719bb0699cda7db9ef587320bdf1c676181bf41c`.

## Impact

Documentation and audit provenance only. Runtime behavior is unchanged, and Formal Run 001 is not started.

## Validation

- attachment and repository file SHA-256 match: `7e534f95cea51ba367795035df90c5831754f42950c3bac4ce846766ec5bf654`
- Markdown structure: 11 numbered sections, A-01 through A-20, U-01 through U-12, balanced fenced blocks, and consistent table widths
- internal audit references: no undefined A-series references; no Markdown links to resolve
- PR #46 metadata, head, merge commit, and recorded test counts checked against the merged PR
- `git diff --check HEAD`: pass
- final diff: one new Markdown file, 877 additions
