### PR TITLE
[13-49] Repair Companion contract import

### DIFF
--- a/decision_os/companion/static/app.css
+++ b/decision_os/companion/static/app.css
@@ -28,6 +28,8 @@ body {
 }
 
 button,
+input,
+select,
 textarea {
   font: inherit;
 }
@@ -119,6 +121,7 @@ h3 {
   border-radius: 18px;
   box-shadow: var(--shadow);
   margin-top: 1rem;
+  min-width: 0;
   padding: 1.35rem;
 }
 
@@ -128,6 +131,12 @@ h3 {
   gap: 1rem;
   justify-content: space-between;
   margin-bottom: 1rem;
+}
+
+.section-heading > *,
+.file-action > *,
+.default-row > * {
+  min-width: 0;
 }
 
 .step {
@@ -142,6 +151,7 @@ h3 {
   font-size: 1.12rem;
   font-weight: 700;
   margin-bottom: 0.25rem;
+  overflow-wrap: anywhere;
 }
 
 .path-value {
@@ -150,6 +160,15 @@ h3 {
   overflow-wrap: anywhere;
 }
 
+label {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 650;
+  margin: 0.9rem 0 0.35rem;
+}
+
+input:not([type="checkbox"]):not([type="radio"]),
+select,
 textarea {
   background: #fbfbfc;
   border: 1px solid var(--line);
@@ -157,12 +176,34 @@ textarea {
   color: var(--ink);
   display: block;
   line-height: 1.5;
+  max-width: 100%;
+  min-width: 0;
   padding: 0.9rem;
-  resize: vertical;
   width: 100%;
 }
 
+textarea {
+  resize: vertical;
+}
+
+input[type="file"] {
+  padding: 0.7rem;
+}
+
+label > input[type="checkbox"],
+label > input[type="radio"] {
+  margin-right: 0.45rem;
+}
+
+label + input,
+label + select,
+label + textarea {
+  margin-bottom: 0.85rem;
+}
+
 textarea:focus,
+input:focus,
+select:focus,
 button:focus-visible {
   outline: 3px solid rgba(37, 87, 214, 0.25);
   outline-offset: 2px;
@@ -230,6 +271,28 @@ button:focus-visible {
   word-break: break-word;
 }
 
+.contract-preview {
+  background: #f7f8fb;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  color: var(--ink);
+  font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  margin: 0.85rem 0 0;
+  max-height: 18rem;
+  max-width: 100%;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.contract-full-content {
+  display: none;
+}
+
 .file-action,
 .default-row {
   align-items: center;
@@ -241,7 +304,8 @@ button:focus-visible {
 }
 
 .file-action code,
-.default-row code {
+.default-row code,
+.default-row span {
   overflow-wrap: anywhere;
 }
 

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -13,8 +13,12 @@ let guidedRepositoryPath = null;
 let guidedInputError = "";
 let guidedPurgeConfirmationIdentity = null;
 let guidedPurgedInputClearedIdentity = null;
+let importedContract = null;
+let contractImportGeneration = 0;
 
 const MAX_BRIDGE_ARTIFACT_BYTES = 1024 * 1024;
+const CONTRACT_PREVIEW_CHARACTERS = 4096;
+const CONTRACT_EXTENSIONS = [".md", ".txt"];
 const GUIDED_INTAKE_AUTHORITY_CLAIM =
   "INTERPRETATION ONLY — NO EXECUTION AUTHORITY";
 const MANUAL_OWNER_AUTHORITY = "MANUAL OWNER ATTESTED";
@@ -32,6 +36,52 @@ function setText(id, value) {
 
 function setHidden(id, hidden) {
   byId(id).classList.toggle("hidden", hidden);
+}
+
+function selectedContractFile() {
+  return byId("contract-file").files?.[0] || null;
+}
+
+function supportedContractFile(file) {
+  if (!file || typeof file.name !== "string") {
+    return false;
+  }
+  const normalized = file.name.toLowerCase();
+  return CONTRACT_EXTENSIONS.some((extension) =>
+    normalized.endsWith(extension),
+  );
+}
+
+function resetContractImport({ clearFile = false } = {}) {
+  importedContract = null;
+  if (clearFile) {
+    byId("contract-file").value = "";
+  }
+  byId("contract-full-content").value = "";
+  setText("contract-import-state", "No contract");
+  setText("contract-file-name", "No Contract imported");
+  setText(
+    "contract-preview-status",
+    "Select a supported local file to preview it.",
+  );
+  setText("contract-preview", "");
+  setHidden("contract-preview", true);
+  setText("contract-import-error", "");
+  setHidden("contract-import-error", true);
+}
+
+function renderContractImportControls() {
+  byId("contract-file").disabled = !connected;
+  byId("contract-import").disabled =
+    !connected || selectedContractFile() === null;
+}
+
+function showContractImportError(message) {
+  resetContractImport();
+  setText("contract-import-state", "Rejected");
+  setText("contract-import-error", message);
+  setHidden("contract-import-error", false);
+  renderContractImportControls();
 }
 
 function statusLabel(state) {
@@ -856,6 +906,7 @@ function render(state) {
     "repository-path",
     repository ? repository.path : "Select one local Git repository.",
   );
+  renderContractImportControls();
 
   const run =
     state.run && typeof state.run === "object"
@@ -922,6 +973,8 @@ function render(state) {
 
 function disableStateChangingControls() {
   byId("choose-repository").disabled = true;
+  byId("contract-file").disabled = true;
+  byId("contract-import").disabled = true;
   byId("run").disabled = true;
   byId("new-run").disabled = true;
   byId("task").disabled = true;
@@ -946,6 +999,8 @@ function enterDisconnected() {
   csrfToken = "";
   bridgeRepositoryPath = null;
   guidedRepositoryPath = null;
+  contractImportGeneration += 1;
+  resetContractImport({ clearFile: true });
   resetBridgeDrafts();
   resetGuidedIntakeDrafts();
   disableStateChangingControls();
@@ -1055,6 +1110,79 @@ async function postJSON(path, value) {
     requestActive = false;
   }
 }
+
+function contractFileSelectionChanged() {
+  contractImportGeneration += 1;
+  resetContractImport();
+  renderContractImportControls();
+}
+
+byId("contract-file").addEventListener("input", contractFileSelectionChanged);
+byId("contract-file").addEventListener("change", contractFileSelectionChanged);
+
+byId("contract-import").addEventListener("click", async () => {
+  const file = selectedContractFile();
+  const generation = ++contractImportGeneration;
+  if (!file) {
+    showContractImportError("Choose one Product Contract file first.");
+    return;
+  }
+  if (!supportedContractFile(file)) {
+    showContractImportError(
+      "Only .md and .txt Product Contract files are supported.",
+    );
+    return;
+  }
+  if (typeof file.text !== "function") {
+    showContractImportError("The Product Contract could not be read locally.");
+    return;
+  }
+
+  let content;
+  try {
+    content = await file.text();
+  } catch (_error) {
+    if (
+      !connected ||
+      generation !== contractImportGeneration ||
+      selectedContractFile() !== file
+    ) {
+      return;
+    }
+    showContractImportError("The Product Contract could not be read locally.");
+    return;
+  }
+  if (
+    !connected ||
+    generation !== contractImportGeneration ||
+    selectedContractFile() !== file
+  ) {
+    return;
+  }
+  if (typeof content !== "string") {
+    showContractImportError("The Product Contract could not be read locally.");
+    return;
+  }
+
+  importedContract = { filename: file.name, content };
+  byId("contract-full-content").value = importedContract.content;
+  setText("contract-import-state", "Imported locally");
+  setText("contract-file-name", importedContract.filename);
+  setText(
+    "contract-preview-status",
+    content.length > CONTRACT_PREVIEW_CHARACTERS
+      ? `Showing first ${CONTRACT_PREVIEW_CHARACTERS} of ${content.length} characters. Full content is retained locally.`
+      : `Showing all ${content.length} characters. Full content is retained locally.`,
+  );
+  setText(
+    "contract-preview",
+    content.slice(0, CONTRACT_PREVIEW_CHARACTERS),
+  );
+  setHidden("contract-preview", false);
+  setText("contract-import-error", "");
+  setHidden("contract-import-error", true);
+  renderContractImportControls();
+});
 
 byId("task").addEventListener("input", () => {
   if (connected && latestState) {

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -36,6 +36,57 @@
       </p>
     </section>
 
+    <section
+      id="contract-import-card"
+      class="card"
+      aria-labelledby="contract-import-heading"
+    >
+      <div class="section-heading">
+        <div>
+          <p class="step">C</p>
+          <h2 id="contract-import-heading">Import Contract</h2>
+        </div>
+        <span
+          id="contract-import-state"
+          class="status"
+          role="status"
+          aria-live="polite"
+        >No contract</span>
+      </div>
+      <p class="boundary">
+        Load one approved Product Contract from this device as Markdown or
+        plain text. The file stays in this local tab. Import does not start a
+        Run, implement anything, or send the Contract anywhere.
+      </p>
+      <label for="contract-file">Product Contract (.md or .txt)</label>
+      <input id="contract-file" type="file" accept=".md,.txt">
+      <button id="contract-import" class="secondary" type="button" disabled>
+        Import Contract
+      </button>
+      <p id="contract-file-name" class="primary-value">
+        No Contract imported
+      </p>
+      <p id="contract-preview-status" class="path-value">
+        Select a supported local file to preview it.
+      </p>
+      <pre
+        id="contract-preview"
+        class="contract-preview hidden"
+      ></pre>
+      <textarea
+        id="contract-full-content"
+        class="contract-full-content"
+        readonly
+        hidden
+        aria-hidden="true"
+      ></textarea>
+      <p
+        id="contract-import-error"
+        class="error hidden"
+        role="alert"
+      ></p>
+    </section>
+
     <section id="bounded-task-card" class="card" aria-labelledby="task-heading">
       <div class="section-heading">
         <div>

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -5,6 +5,7 @@ import hashlib
 import http.client
 import json
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tempfile
@@ -1272,6 +1273,75 @@ class CompanionServerTest(unittest.TestCase):
         self.assertIn(b"textContent", javascript)
         self.assertNotIn(b"innerHTML", javascript)
 
+    def test_contract_import_dom_is_local_only_and_layout_is_bounded(
+        self,
+    ) -> None:
+        cookie, _csrf = self.bootstrap()
+        status, _headers, html = self.request("GET", "/", cookie=cookie)
+        self.assertEqual(200, status)
+        for element_id in (
+            "contract-import-card",
+            "contract-import-heading",
+            "contract-import-state",
+            "contract-file",
+            "contract-import",
+            "contract-file-name",
+            "contract-preview-status",
+            "contract-preview",
+            "contract-full-content",
+            "contract-import-error",
+        ):
+            with self.subTest(element_id=element_id):
+                self.assertIn(f'id="{element_id}"'.encode("utf-8"), html)
+        self.assertIn(b'accept=".md,.txt"', html)
+        self.assertIn(b"Import Contract", html)
+        normalized_html = " ".join(html.decode("utf-8").split())
+        self.assertIn(
+            (
+                "The file stays in this local tab. Import does not start a "
+                "Run, implement anything, or send the Contract anywhere."
+            ),
+            normalized_html,
+        )
+        full_content_tag = normalized_html.split(
+            'id="contract-full-content"',
+            1,
+        )[1].split(">", 1)[0]
+        self.assertIn("readonly", full_content_tag)
+        self.assertIn("hidden", full_content_tag)
+        self.assertNotIn("maxlength", full_content_tag)
+
+        status, _headers, javascript = self.request(
+            "GET",
+            "/app.js",
+            cookie=cookie,
+        )
+        self.assertEqual(200, status)
+        contract_handler = javascript.split(
+            b'byId("contract-import").addEventListener',
+            1,
+        )[1].split(b'byId("task").addEventListener', 1)[0]
+        self.assertIn(b"await file.text()", contract_handler)
+        self.assertIn(b"content.slice(0, CONTRACT_PREVIEW_CHARACTERS)", contract_handler)
+        self.assertNotIn(b"postJSON", contract_handler)
+        self.assertNotIn(b"fetch(", contract_handler)
+
+        status, _headers, stylesheet = self.request(
+            "GET",
+            "/app.css",
+            cookie=cookie,
+        )
+        self.assertEqual(200, status)
+        self.assertIn(
+            b'input:not([type="checkbox"]):not([type="radio"])',
+            stylesheet,
+        )
+        self.assertIn(b".default-row span", stylesheet)
+        self.assertIn(b".primary-value", stylesheet)
+        self.assertIn(b".contract-preview", stylesheet)
+        self.assertIn(b"max-height: 18rem", stylesheet)
+        self.assertIn(b"overflow-wrap: anywhere", stylesheet)
+
     def test_guided_intake_dom_and_authority_boundary_are_present(self) -> None:
         cookie, _csrf = self.bootstrap()
         status, _headers, html = self.request("GET", "/", cookie=cookie)
@@ -1649,6 +1719,140 @@ class CompanionServerTest(unittest.TestCase):
 
 
 class CompanionClientBehaviorTest(unittest.TestCase):
+    def test_desktop_layout_contains_long_contract_without_overflow(
+        self,
+    ) -> None:
+        chrome_candidates = (
+            shutil.which("google-chrome"),
+            shutil.which("chromium"),
+            shutil.which("chromium-browser"),
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        )
+        chrome = next(
+            (
+                candidate
+                for candidate in chrome_candidates
+                if candidate and Path(candidate).is_file()
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            chrome,
+            "Chrome or Chromium is required for desktop layout verification.",
+        )
+
+        static_root = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+        )
+        html = (static_root / "index.html").read_text(encoding="utf-8")
+        html = html.replace(
+            '<link rel="stylesheet" href="/app.css">',
+            f'<link rel="stylesheet" href="{(static_root / "app.css").as_uri()}">',
+        )
+        long_filename = ("contract-" * 80) + ".md"
+        long_content = "A" * 20000
+        layout_probe = textwrap.dedent(
+            f"""
+            <script>
+              const longFilename = {json.dumps(long_filename)};
+              const longContent = {json.dumps(long_content)};
+              const filename = document.getElementById("contract-file-name");
+              const preview = document.getElementById("contract-preview");
+              const full = document.getElementById("contract-full-content");
+              filename.textContent = longFilename;
+              preview.textContent = longContent.slice(0, 4096);
+              preview.classList.remove("hidden");
+              full.value = longContent;
+              const root = document.documentElement;
+              const control = document.getElementById("bridge-as-of-commit");
+              document.body.dataset.viewportWidth = String(window.innerWidth);
+              document.body.dataset.viewportHeight = String(window.innerHeight);
+              document.body.dataset.horizontalOverflow = String(
+                root.scrollWidth > root.clientWidth
+              );
+              document.body.dataset.previewBounded = String(
+                preview.clientHeight <= 290 &&
+                preview.scrollHeight > preview.clientHeight &&
+                getComputedStyle(preview).overflowY === "auto"
+              );
+              document.body.dataset.controlBlock = String(
+                getComputedStyle(control).display === "block" &&
+                control.getBoundingClientRect().width >= 800
+              );
+              document.body.dataset.fullPreserved = String(
+                full.value === longContent
+              );
+            </script>
+            """
+        ).strip()
+        html = html.replace(
+            '<script src="/app.js" defer></script>',
+            layout_probe,
+        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_root = Path(temporary)
+            fixture = temporary_root / "companion-layout.html"
+            fixture.write_text(html, encoding="utf-8")
+            chrome_process = subprocess.Popen(
+                [
+                    chrome,
+                    "--headless=new",
+                    "--disable-background-networking",
+                    "--disable-component-update",
+                    "--disable-gpu",
+                    "--disable-sync",
+                    "--force-device-scale-factor=1",
+                    "--no-default-browser-check",
+                    "--no-first-run",
+                    f"--user-data-dir={temporary_root / 'profile'}",
+                    "--window-size=1664,945",
+                    "--dump-dom",
+                    fixture.as_uri(),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            chrome_finished = True
+            try:
+                chrome_stdout, chrome_stderr = chrome_process.communicate(
+                    timeout=20,
+                )
+            except subprocess.TimeoutExpired:
+                # Some macOS Chrome builds keep the headless browser process
+                # alive after --dump-dom has emitted the completed document.
+                chrome_finished = False
+                chrome_process.kill()
+                chrome_stdout, chrome_stderr = chrome_process.communicate()
+
+        if chrome_finished:
+            self.assertEqual(
+                0,
+                chrome_process.returncode,
+                msg=f"Chrome layout probe failed:\n{chrome_stderr}",
+            )
+        self.assertTrue(
+            chrome_stdout.strip(),
+            msg=f"Chrome emitted no layout probe DOM:\n{chrome_stderr}",
+        )
+        body_match = re.search(r"<body ([^>]*)>", chrome_stdout)
+        self.assertIsNotNone(body_match, "Chrome probe body was not emitted.")
+        attributes = dict(
+            re.findall(r'data-([a-z-]+)="([^"]*)"', body_match.group(1))
+        )
+        self.assertEqual("1664", attributes.get("viewport-width"))
+        viewport_height = int(attributes.get("viewport-height", "0"))
+        self.assertGreaterEqual(viewport_height, 850)
+        self.assertLessEqual(viewport_height, 945)
+        self.assertEqual("false", attributes.get("horizontal-overflow"))
+        self.assertEqual("true", attributes.get("preview-bounded"))
+        self.assertEqual("true", attributes.get("control-block"))
+        self.assertEqual("true", attributes.get("full-preserved"))
+
     def test_disconnection_clears_and_disables_stale_ui_until_recovery(
         self,
     ) -> None:
@@ -1704,12 +1908,24 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 this.dataset = {};
                 this.disabled = false;
                 this.checked = false;
-                this.value = "";
+                this.files = [];
+                this._value = "";
                 this.type = "";
                 this.children = [];
                 this.parentNode = null;
                 this.listeners = new Map();
                 this.ownText = "";
+              }
+
+              get value() {
+                return this._value;
+              }
+
+              set value(value) {
+                this._value = value == null ? "" : String(value);
+                if (this._value === "") {
+                  this.files = [];
+                }
               }
 
               get textContent() {
@@ -1829,6 +2045,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             ];
             const buttonIds = new Set([
               "choose-repository",
+              "contract-import",
               "new-run",
               "run",
               ...guidedIntakeButtonIds,
@@ -1842,6 +2059,14 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "approval-reason",
               "approval-reason-label",
               "approval-repository",
+              "contract-file",
+              "contract-file-name",
+              "contract-full-content",
+              "contract-import",
+              "contract-import-error",
+              "contract-import-state",
+              "contract-preview",
+              "contract-preview-status",
               "bridge-as-of-commit",
               "bridge-authority-boundary",
               "bridge-burden-status",
@@ -1987,6 +2212,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "approval-overlay",
               "approval-reason",
               "approval-reason-label",
+              "contract-import-error",
+              "contract-preview",
               "global-error",
               "guided-intake-confirmation",
               "guided-intake-error",
@@ -2522,6 +2749,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               assert.strictEqual(elements.get("task").disabled, false);
               assert.strictEqual(elements.get("run").disabled, false);
               assert.strictEqual(elements.get("new-run").disabled, false);
+              assert.strictEqual(elements.get("contract-file").disabled, false);
+              assert.strictEqual(elements.get("contract-import").disabled, true);
               assert.strictEqual(
                 hidden("intelligence-transplant-card"),
                 false,
@@ -2701,6 +2930,224 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 true,
               );
               assert.strictEqual(elements.get("guided-intake-transfer").disabled, true);
+
+              const contractFetchStart = fetchCalls.length;
+              const boundedTaskBeforeImport = elements.get("task").value;
+              const markdownContent =
+                "# Approved Product Contract\r\n\r\n" +
+                "Unicode: 契約\n" +
+                "<script>globalThis.contractHostile = true</script>";
+              let markdownReads = 0;
+              elements.get("contract-file").files = [
+                {
+                  name: "approved-product-contract.md",
+                  async text() {
+                    markdownReads += 1;
+                    return markdownContent;
+                  },
+                },
+              ];
+              await elements.get("contract-file").dispatch("input");
+              assert.strictEqual(elements.get("contract-import").disabled, false);
+              await elements.get("contract-import").dispatch("click");
+              await settle();
+              assert.strictEqual(markdownReads, 1);
+              assert.strictEqual(
+                elements.get("contract-import-state").textContent,
+                "Imported locally",
+              );
+              assert.strictEqual(
+                elements.get("contract-file-name").textContent,
+                "approved-product-contract.md",
+              );
+              assert.strictEqual(
+                elements.get("contract-preview").textContent,
+                markdownContent,
+              );
+              assert.strictEqual(
+                elements.get("contract-full-content").value,
+                markdownContent,
+              );
+              assert.strictEqual(
+                vm.runInContext("importedContract.content", sandbox),
+                markdownContent,
+              );
+              assert.strictEqual(hidden("contract-preview"), false);
+              assert.strictEqual(hidden("contract-import-error"), true);
+              assert.strictEqual(sandbox.contractHostile, undefined);
+
+              const textContent = "Plain text Contract\r\nkept exactly.\n";
+              let textReads = 0;
+              elements.get("contract-file").files = [
+                {
+                  name: "approved-product-contract.txt",
+                  async text() {
+                    textReads += 1;
+                    return textContent;
+                  },
+                },
+              ];
+              await elements.get("contract-file").dispatch("change");
+              await elements.get("contract-import").dispatch("click");
+              await settle();
+              assert.strictEqual(textReads, 1);
+              assert.strictEqual(
+                elements.get("contract-preview").textContent,
+                textContent,
+              );
+              assert.strictEqual(
+                elements.get("contract-full-content").value,
+                textContent,
+              );
+              assert.strictEqual(
+                vm.runInContext("importedContract.content", sandbox),
+                textContent,
+              );
+
+              let rejectStaleRead;
+              const staleFile = {
+                name: "superseded-contract.md",
+                text() {
+                  return new Promise((_resolve, reject) => {
+                    rejectStaleRead = reject;
+                  });
+                },
+              };
+              elements.get("contract-file").files = [staleFile];
+              await elements.get("contract-file").dispatch("input");
+              const staleImport = elements.get("contract-import").dispatch("click");
+              await settle();
+
+              const currentContent = "Current Contract stays retained.";
+              elements.get("contract-file").files = [
+                {
+                  name: "current-contract.md",
+                  async text() {
+                    return currentContent;
+                  },
+                },
+              ];
+              await elements.get("contract-file").dispatch("input");
+              await elements.get("contract-import").dispatch("click");
+              await settle();
+              rejectStaleRead(new Error("superseded read failed"));
+              await staleImport;
+              await settle();
+              assert.strictEqual(
+                elements.get("contract-file-name").textContent,
+                "current-contract.md",
+              );
+              assert.strictEqual(
+                elements.get("contract-full-content").value,
+                currentContent,
+              );
+              assert.strictEqual(hidden("contract-import-error"), true);
+
+              let sameFileReadCount = 0;
+              let rejectFirstSameFileRead;
+              const sameFileContent = "Newest same-file import wins.";
+              const sameFile = {
+                name: "same-contract.md",
+                text() {
+                  sameFileReadCount += 1;
+                  if (sameFileReadCount === 1) {
+                    return new Promise((_resolve, reject) => {
+                      rejectFirstSameFileRead = reject;
+                    });
+                  }
+                  return Promise.resolve(sameFileContent);
+                },
+              };
+              elements.get("contract-file").files = [sameFile];
+              await elements.get("contract-file").dispatch("input");
+              const firstSameFileImport =
+                elements.get("contract-import").dispatch("click");
+              await settle();
+              await elements.get("contract-import").dispatch("click");
+              await settle();
+              rejectFirstSameFileRead(new Error("first same-file read failed"));
+              await firstSameFileImport;
+              await settle();
+              assert.strictEqual(sameFileReadCount, 2);
+              assert.strictEqual(
+                vm.runInContext("importedContract.content", sandbox),
+                sameFileContent,
+              );
+              assert.strictEqual(
+                elements.get("contract-full-content").value,
+                sameFileContent,
+              );
+              assert.strictEqual(hidden("contract-import-error"), true);
+
+              let unsupportedReads = 0;
+              elements.get("contract-file").files = [
+                {
+                  name: "approved-product-contract.md.exe",
+                  async text() {
+                    unsupportedReads += 1;
+                    return "must not be read";
+                  },
+                },
+              ];
+              await elements.get("contract-file").dispatch("input");
+              await elements.get("contract-import").dispatch("click");
+              await settle();
+              assert.strictEqual(unsupportedReads, 0);
+              assert.strictEqual(
+                elements.get("contract-import-state").textContent,
+                "Rejected",
+              );
+              assert.strictEqual(
+                elements.get("contract-import-error").textContent,
+                "Only .md and .txt Product Contract files are supported.",
+              );
+              assert.strictEqual(elements.get("contract-full-content").value, "");
+              assert.strictEqual(hidden("contract-preview"), true);
+              assert.strictEqual(hidden("contract-import-error"), false);
+
+              const longContent = "A".repeat(7000) + "\r\nFULL_TAIL_契約";
+              const longFilename = `${"very-long-contract-name-".repeat(30)}.MD`;
+              elements.get("contract-file").files = [
+                {
+                  name: longFilename,
+                  async text() {
+                    return longContent;
+                  },
+                },
+              ];
+              await elements.get("contract-file").dispatch("input");
+              await elements.get("contract-import").dispatch("click");
+              await settle();
+              assert.strictEqual(
+                elements.get("contract-file-name").textContent,
+                longFilename,
+              );
+              assert.strictEqual(
+                elements.get("contract-preview").textContent,
+                longContent.slice(0, 4096),
+              );
+              assert.strictEqual(
+                elements.get("contract-preview").textContent.length,
+                4096,
+              );
+              assert.strictEqual(
+                elements.get("contract-full-content").value,
+                longContent,
+              );
+              assert.strictEqual(
+                vm.runInContext("importedContract.content", sandbox),
+                longContent,
+              );
+              assert.strictEqual(
+                elements.get("contract-preview-status").textContent,
+                `Showing first 4096 of ${longContent.length} characters. Full content is retained locally.`,
+              );
+              assert.strictEqual(fetchCalls.length, contractFetchStart);
+              assert.strictEqual(elements.get("task").value, boundedTaskBeforeImport);
+              assert.strictEqual(
+                fetchCalls.some((call) => call.path === "/api/run"),
+                false,
+              );
 
               fetchQueue.push(() =>
                 Promise.resolve(response(selectedStage5State)),
@@ -3068,10 +3515,29 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               elements.get("guided-intake-resulting-delta").value =
                 '{"stale":"delta"}';
 
+              let resolveAfterDisconnect;
+              elements.get("contract-file").files = [
+                {
+                  name: "pending-at-disconnect.md",
+                  text() {
+                    return new Promise((resolve) => {
+                      resolveAfterDisconnect = resolve;
+                    });
+                  },
+                },
+              ];
+              await elements.get("contract-file").dispatch("input");
+              const importPendingAtDisconnect =
+                elements.get("contract-import").dispatch("click");
+              await settle();
+
               fetchQueue.push(() =>
                 Promise.reject(new TypeError("fetch failed")),
               );
               await runNextTimer();
+              resolveAfterDisconnect("late content must stay discarded");
+              await importPendingAtDisconnect;
+              await settle();
 
               assert.strictEqual(
                 elements.get("repository-name").textContent,
@@ -3104,6 +3570,24 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               );
               assert.strictEqual(elements.get("claim-boundary").textContent, "");
               assert.strictEqual(elements.get("defaults").children.length, 0);
+              assert.strictEqual(elements.get("contract-file").value, "");
+              assert.strictEqual(elements.get("contract-file").files.length, 0);
+              assert.strictEqual(elements.get("contract-file").disabled, true);
+              assert.strictEqual(elements.get("contract-import").disabled, true);
+              assert.strictEqual(
+                elements.get("contract-import-state").textContent,
+                "No contract",
+              );
+              assert.strictEqual(
+                elements.get("contract-full-content").value,
+                "",
+              );
+              assert.strictEqual(
+                vm.runInContext("importedContract", sandbox),
+                null,
+              );
+              assert.strictEqual(hidden("contract-preview"), true);
+              assert.strictEqual(hidden("contract-import-error"), true);
               assert.strictEqual(
                 hidden("intelligence-transplant-card"),
                 true,

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -1736,10 +1736,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             ),
             None,
         )
-        self.assertIsNotNone(
-            chrome,
-            "Chrome or Chromium is required for desktop layout verification.",
-        )
+        if chrome is None:
+            self.skipTest(
+                "Chrome or Chromium is unavailable for layout qualification."
+            )
 
         static_root = (
             Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## What

- repair Companion desktop control sizing, clipping, and long-content wrapping
- add an explicit local-only `Import Contract` flow for `.md` and `.txt`
- show the filename and a 4,096-character bounded preview while retaining the canonical full decoded content
- reject unsupported suffixes and invalidate stale concurrent file reads
- add browser-backed and client behavior regressions

## Root cause

The Companion DOM had grown beyond the original stylesheet: ordinary labels, inputs, and selects had no shared block/full-width sizing. Browser intrinsic widths then collapsed or clipped the expanded Manual Bridge controls, while long flex content could expand the document horizontally. No authored zoom or transform caused the failure.

## Safety boundary

- reads only through the browser's local `File.text()`
- adds no server/controller upload route
- sends no Contract content to an external service
- import does not populate the bounded task or start a Run
- Verified Save, Never Again Mode, unlock, Pro, Fable, and release remain out of scope

## Verification

- 1664×945-class real Chrome layout: no horizontal overflow; long preview remains bounded
- focused Companion suite: 183 tests passed in 137.362s
- full suite: 604 tests passed in 323.124s
- `git diff --check` and `node --check decision_os/companion/static/app.js`: passed

Everything beyond this prerequisite repair remains HOLD.
