### PR TITLE
Guard failed ordinary review projection bindings

### DIFF
--- a/decision_os/companion/ordinary_user_path.py
+++ b/decision_os/companion/ordinary_user_path.py
@@ -1319,8 +1319,34 @@ class OrdinaryUserPathCoordinator:
             "does_not_authorize": _DOES_NOT_AUTHORIZE,
         }
 
+    @staticmethod
+    def _preparation_binds_current_native_state(
+        preparation: Mapping[str, Any],
+        guided_state: Mapping[str, Any],
+        current_repository_identity: str | None,
+    ) -> bool:
+        interpretation = guided_state.get("current_interpretation")
+        profile = preparation.get("profile")
+        return (
+            profile in (ORDINARY_PROFILE, PRODUCT_PROFILE)
+            and preparation.get("request_id")
+            == guided_state.get("active_request_id")
+            and preparation.get("draft_id")
+            == guided_state.get("active_draft_id")
+            and isinstance(interpretation, dict)
+            and preparation.get("interpretation_sha256")
+            == structured_sha256(interpretation)
+            and preparation.get("repository_identity")
+            == current_repository_identity
+        )
+
     def _projection(self, state: Mapping[str, Any]) -> dict[str, Any]:
-        guided = self.guided_intake.snapshot()
+        with self.guided_intake.store.transaction(
+            write=False,
+            timeout_seconds=0.05,
+        ):
+            guided_state = self.guided_intake.store.load_state()
+            guided = self.guided_intake._snapshot_from_state(guided_state)
         preparation = state.get("preparation")
         local_state = str(state.get("state", "NO_CONTRACT"))
         status = {
@@ -1369,12 +1395,13 @@ class OrdinaryUserPathCoordinator:
         clarification = None
         preparation_id = None
         try:
-            repository_identity = _repository_head(self.repository)
+            current_repository_identity = _repository_head(self.repository)
         except GuidedIntakeIntegrityError:
-            repository_identity = None
+            current_repository_identity = None
             allowed = [action for action in allowed if action != "SELECT_CONTRACT"]
             if local_state == "NO_CONTRACT":
                 progress = "The selected repository needs a committed identity first."
+        repository_identity = current_repository_identity
         if isinstance(preparation, dict):
             preparation_id = preparation.get("preparation_id")
             repository_identity = preparation.get("repository_identity")
@@ -1398,7 +1425,20 @@ class OrdinaryUserPathCoordinator:
                     else None,
                 }
             )
-            if local_state in {
+            preparation_is_current = (
+                self._preparation_binds_current_native_state(
+                    preparation,
+                    guided_state,
+                    current_repository_identity,
+                )
+            )
+            if not preparation_is_current:
+                allowed = [
+                    action
+                    for action in allowed
+                    if action not in {"FIX_CONTRACT", "CONFIRM_ANSWER"}
+                ]
+            if preparation_is_current and local_state in {
                 "REVIEW_READY",
                 "NEEDS_CONFIRMATION",
                 "CANNOT_FIX_SAFELY",
@@ -1407,7 +1447,7 @@ class OrdinaryUserPathCoordinator:
                 "FIX_FAILED",
             }:
                 review = self._review(guided, preparation.get("profile"))
-            if local_state == "NEEDS_CONFIRMATION":
+            if preparation_is_current and local_state == "NEEDS_CONFIRMATION":
                 plan = preparation.get("clarification")
                 if isinstance(plan, dict):
                     clarification = {

--- a/tests/test_companion_ordinary_user_path.py
+++ b/tests/test_companion_ordinary_user_path.py
@@ -328,6 +328,70 @@ class OrdinaryUserPathCoordinatorTest(unittest.TestCase):
         self.assertIsNone(dismissed["action_error"])
         self.assertEqual([], self.guided.store.read_events())
 
+    def test_failed_successor_never_projects_prior_native_review(self) -> None:
+        prepared = self.prepare()
+        fixed = self.coordinator.fix(**self.fix_request(prepared))
+        self.assertEqual("FIXED", fixed["state"])
+        before_native_state = self.guided.store.load_state()
+        before_events = self.guided.store.read_events()
+        unsupported = b"# Ordinary User Path Contract Fixation Closure v0.1\n"
+
+        with self.assertRaises(OrdinaryUserPathError) as raised:
+            self.coordinator.prepare(
+                filename=(
+                    "Decision_OS_Ordinary_User_Path_Contract_"
+                    "Fixation_Closure_v0.1.md"
+                ),
+                source_bytes=unsupported,
+                source_byte_size=len(unsupported),
+                source_sha256=sha256_bytes(unsupported),
+                expected_repository_identity=self.head,
+                expected_active_request_id=prepared["technical_details"][
+                    "request_id"
+                ],
+                idempotency_key=str(uuid.uuid4()),
+            )
+
+        self.assertEqual(
+            "PREP_UNSUPPORTED_CONTRACT_ROLE",
+            raised.exception.code,
+        )
+        failed = self.coordinator.snapshot()
+        polled = self.coordinator.snapshot()
+        for panel in (failed, polled):
+            self.assertEqual("CANNOT_FIX_SAFELY", panel["state"])
+            self.assertIsNone(panel["source_identity"]["profile"])
+            self.assertIsNone(panel["review"])
+            self.assertIsNone(panel["clarification"])
+            self.assertNotIn("FIX_CONTRACT", panel["allowed_actions"])
+            self.assertEqual(
+                "PREP_UNSUPPORTED_CONTRACT_ROLE",
+                panel["action_error"]["code"],
+            )
+            self.assertEqual("NO", panel["action_error"]["anything_fixed"])
+        self.assertEqual(failed["action_error"], polled["action_error"])
+        self.assertEqual(before_native_state, self.guided.store.load_state())
+        self.assertEqual(before_events, self.guided.store.read_events())
+
+    def test_review_projection_requires_every_current_binding(self) -> None:
+        self.prepare()
+        preparation = self.coordinator.store.load_state()["preparation"]
+        guided_state = self.guided.store.load_state()
+        binding = self.coordinator._preparation_binds_current_native_state
+        self.assertTrue(binding(preparation, guided_state, self.head))
+
+        for field, replacement in (
+            ("profile", None),
+            ("request_id", "GI-REQ-stale"),
+            ("draft_id", "GI-DRAFT-stale"),
+            ("interpretation_sha256", "0" * 64),
+            ("repository_identity", "0" * 40),
+        ):
+            with self.subTest(field=field):
+                stale = dict(preparation)
+                stale[field] = replacement
+                self.assertFalse(binding(stale, guided_state, self.head))
+
     def test_corrupt_sidecar_state_fails_closed(self) -> None:
         self.prepare()
         before = self.guided.store.read_events()

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -1582,6 +1582,113 @@ class CompanionServerTest(unittest.TestCase):
         self.assertIsInstance(factory, ScriptedFactory)
         self.assertEqual(1, len(factory.modes))
 
+    def test_failed_ordinary_prepare_hides_prior_review_across_poll(self) -> None:
+        subprocess.run(
+            ("git", "config", "user.email", "ordinary@example.test"),
+            cwd=self.repository,
+            check=True,
+        )
+        subprocess.run(
+            ("git", "config", "user.name", "Ordinary Contract Smoke"),
+            cwd=self.repository,
+            check=True,
+        )
+        subprocess.run(("git", "add", "target.txt"), cwd=self.repository, check=True)
+        subprocess.run(
+            ("git", "commit", "-qm", "ordinary baseline"),
+            cwd=self.repository,
+            check=True,
+        )
+        cookie, csrf = self.bootstrap()
+        status, _headers, raw = self.request("GET", "/api/state", cookie=cookie)
+        self.assertEqual(200, status)
+        initial = json.loads(raw)["ordinary_contract"]
+        source = (
+            Path(__file__).parent
+            / "fixtures"
+            / "ordinary_user_path_v0_1"
+            / "Decision_OS_Ordinary_User_Path_Contract_v0.1_APPROVED_CANDIDATE.md"
+        ).read_bytes()
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/ordinary-contract/prepare",
+            body={
+                "filename": "Decision_OS_Ordinary_User_Path_Contract_v0.1_APPROVED_CANDIDATE.md",
+                "source_base64": base64.b64encode(source).decode("ascii"),
+                "source_byte_size": len(source),
+                "source_sha256": hashlib.sha256(source).hexdigest(),
+                "expected_repository_identity": initial["repository_identity"],
+                "expected_active_request_id": None,
+                "idempotency_key": str(uuid.uuid4()),
+            },
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status, raw.decode("utf-8", errors="replace"))
+        prepared = json.loads(raw)["ordinary_contract"]
+        details = prepared["technical_details"]
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/ordinary-contract/fix",
+            body={
+                "preparation_id": prepared["preparation_id"],
+                "expected_repository_identity": prepared["repository_identity"],
+                "expected_source_sha256": prepared["source_identity"]["sha256"],
+                "expected_request_id": details["request_id"],
+                "expected_draft_id": details["draft_id"],
+                "expected_interpretation_sha256": details[
+                    "interpretation_sha256"
+                ],
+                "idempotency_key": str(uuid.uuid4()),
+            },
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status, raw.decode("utf-8", errors="replace"))
+        guided = self.controller._require_guided_intake()
+        before_native_state = guided.store.load_state()
+        before_events = guided.store.read_events()
+        unsupported = b"# Ordinary User Path Contract Fixation Closure v0.1\n"
+
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/ordinary-contract/prepare",
+            body={
+                "filename": (
+                    "Decision_OS_Ordinary_User_Path_Contract_"
+                    "Fixation_Closure_v0.1.md"
+                ),
+                "source_base64": base64.b64encode(unsupported).decode("ascii"),
+                "source_byte_size": len(unsupported),
+                "source_sha256": hashlib.sha256(unsupported).hexdigest(),
+                "expected_repository_identity": prepared["repository_identity"],
+                "expected_active_request_id": details["request_id"],
+                "idempotency_key": str(uuid.uuid4()),
+            },
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(422, status, raw.decode("utf-8", errors="replace"))
+        failed = json.loads(raw)["ordinary_contract"]
+        status, _headers, raw = self.request("GET", "/api/state", cookie=cookie)
+        self.assertEqual(200, status)
+        polled = json.loads(raw)["ordinary_contract"]
+        for panel in (failed, polled):
+            self.assertEqual("CANNOT_FIX_SAFELY", panel["state"])
+            self.assertIsNone(panel["review"])
+            self.assertIsNone(panel["clarification"])
+            self.assertNotIn("FIX_CONTRACT", panel["allowed_actions"])
+            self.assertEqual(
+                "PREP_UNSUPPORTED_CONTRACT_ROLE",
+                panel["action_error"]["code"],
+            )
+        self.assertEqual(failed["action_error"], polled["action_error"])
+        self.assertEqual(before_native_state, guided.store.load_state())
+        self.assertEqual(before_events, guided.store.read_events())
+
     def test_guided_intake_dom_and_authority_boundary_are_present(self) -> None:
         cookie, _csrf = self.bootstrap()
         status, _headers, html = self.request("GET", "/", cookie=cookie)
@@ -1959,6 +2066,182 @@ class CompanionServerTest(unittest.TestCase):
 
 
 class CompanionClientBehaviorTest(unittest.TestCase):
+    def test_failed_ordinary_panel_clears_stale_review_and_disables_fix(
+        self,
+    ) -> None:
+        node = shutil.which("node")
+        self.assertIsNotNone(node, "Node.js is required for client behavior tests.")
+        javascript = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+            / "app.js"
+        )
+        harness = textwrap.dedent(
+            r"""
+            "use strict";
+
+            const assert = require("assert");
+            const fs = require("fs");
+            const vm = require("vm");
+            const source = fs.readFileSync(process.argv[2], "utf8");
+            const start = source.indexOf("function renderOrdinaryList");
+            const end = source.indexOf("\nconst guidedIntakeActionIds", start);
+            assert(start >= 0 && end > start);
+
+            class Element {
+              constructor() {
+                this.checked = false;
+                this.children = [];
+                this.classList = {
+                  values: new Set(),
+                  toggle: (value, force) => {
+                    if (force) this.classList.values.add(value);
+                    else this.classList.values.delete(value);
+                  },
+                  contains: (value) => this.classList.values.has(value),
+                };
+                this.disabled = false;
+                this.textContent = "";
+              }
+              append(child) { this.children.push(child); }
+              replaceChildren(...children) { this.children = children; }
+              focus() {}
+              setAttribute() {}
+            }
+
+            const ids = [
+              "ordinary-contract-answer-confirm",
+              "ordinary-contract-answer-reject",
+              "ordinary-contract-authority",
+              "ordinary-contract-clarification",
+              "ordinary-contract-completion",
+              "ordinary-contract-confirm",
+              "ordinary-contract-dnt",
+              "ordinary-contract-error",
+              "ordinary-contract-error-action",
+              "ordinary-contract-error-dismiss",
+              "ordinary-contract-error-fixed",
+              "ordinary-contract-error-retry",
+              "ordinary-contract-error-state",
+              "ordinary-contract-error-what",
+              "ordinary-contract-file",
+              "ordinary-contract-fix",
+              "ordinary-contract-preserves",
+              "ordinary-contract-progress",
+              "ordinary-contract-question",
+              "ordinary-contract-review",
+              "ordinary-contract-status",
+              "ordinary-contract-success",
+              "ordinary-contract-technical-body",
+              "ordinary-contract-unresolved",
+            ];
+            const elements = new Map(ids.map((id) => [id, new Element()]));
+            const sandbox = {
+              console,
+              document: { createElement: () => new Element() },
+              connected: true,
+              requestActive: false,
+              ordinaryLastRevision: 0,
+              ordinaryFocusIntent: null,
+              ordinaryLastErrorId: null,
+              byId: (id) => elements.get(id),
+              setText: (id, value) => {
+                elements.get(id).textContent = value == null ? "" : String(value);
+              },
+              setHidden: (id, hidden) => {
+                elements.get(id).classList.toggle("hidden", hidden);
+              },
+            };
+            vm.createContext(sandbox);
+            vm.runInContext(
+              source.slice(start, end) +
+                "\nthis.renderOrdinaryContract = renderOrdinaryContract;",
+              sandbox,
+            );
+            const prior = {
+              state: "REVIEW_READY",
+              operation_revision: 8,
+              status_label: "Ready to fix",
+              progress_text: "Review the interpretation before fixing this Contract.",
+              review: {
+                preserves: "Prior native interpretation",
+                completion: "Prior completion",
+                must_not_change: [],
+                unresolved: [],
+                does_not_authorize: "No execution authority.",
+              },
+              clarification: null,
+              allowed_actions: ["SELECT_CONTRACT", "FIX_CONTRACT"],
+              action_error: null,
+              technical_details: {},
+            };
+            const failed = {
+              state: "CANNOT_FIX_SAFELY",
+              operation_revision: 9,
+              status_label: "Cannot be fixed safely",
+              progress_text: "Choose another supported Contract.",
+              review: null,
+              clarification: null,
+              allowed_actions: ["SELECT_CONTRACT", "DISMISS_ERROR"],
+              action_error: {
+                error_id: "OUP-ERR-ONE",
+                code: "PREP_UNSUPPORTED_CONTRACT_ROLE",
+                what_failed: "This Contract family is not supported.",
+                anything_fixed: "NO",
+                user_action_required: "Select another supported Contract.",
+                retryable: false,
+              },
+              technical_details: {},
+            };
+
+            sandbox.renderOrdinaryContract(prior, { name: "repo" });
+            assert.strictEqual(
+              elements.get("ordinary-contract-review").classList.contains("hidden"),
+              false,
+            );
+            assert.strictEqual(elements.get("ordinary-contract-fix").disabled, false);
+            for (let poll = 0; poll < 2; poll += 1) {
+              sandbox.renderOrdinaryContract(failed, { name: "repo" });
+              assert.strictEqual(
+                elements.get("ordinary-contract-review").classList.contains("hidden"),
+                true,
+              );
+              assert.strictEqual(
+                elements.get("ordinary-contract-preserves").textContent,
+                "",
+              );
+              assert.strictEqual(
+                elements.get("ordinary-contract-completion").textContent,
+                "",
+              );
+              assert.strictEqual(elements.get("ordinary-contract-fix").disabled, true);
+              assert.strictEqual(
+                elements.get("ordinary-contract-error").classList.contains("hidden"),
+                false,
+              );
+              assert.strictEqual(
+                elements.get("ordinary-contract-error-what").textContent,
+                "This Contract family is not supported.",
+              );
+            }
+            """
+        )
+        completed = subprocess.run(
+            [node, "-", str(javascript)],
+            input=harness,
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(
+            0,
+            completed.returncode,
+            msg=f"Node ordinary panel harness failed:\n{completed.stdout}{completed.stderr}",
+        )
+
     def test_desktop_layout_contains_long_contract_without_overflow(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Gate the ordinary review and clarification projection on the current supported profile, native Request, native Draft, interpretation SHA-256, and repository commit identity.
- Remove fixation or confirmation actions when those bindings are not current.
- Cover the failed-successor sequence at the coordinator, HTTP polling, and browser-rendering boundaries while proving native Guided Intake state and events remain unchanged.

## Root cause

A failed preparation retained null/unsupported preparation fields, but the ordinary projection unconditionally rebuilt its review from the active native Guided Intake interpretation for all failure-capable states. That exposed the prior successful interpretation beside the current unsupported-family error.

## Validation

- Focused ordinary-path suite: `179/179 PASS`
- Full repository suite: `658/658 PASS`
- Ordinary and Product golden tests: `2/2 PASS`
- `node --check decision_os/companion/static/app.js`: PASS
- `git diff --check`: PASS

## Independent review

- Result: `PASS`
- Accepted head: `e193c973793fe1a54f9e7f4e32fd1259744aa275`
- Decision owner: Shin

## Boundaries

Merge and commit-bound runtime qualification are authorized. Live preparation retry remains HOLD. Transfer, Run, Builder, Pro, Fable, release, and publication remain BLOCKED.

Authorized base: `a53cfad36e55af204fccd4d1842287f0c7fa1e29`.
