### PR TITLE
Fix stale repository identity after Companion restart

### DIFF
--- a/decision_os/companion/ordinary_user_path.py
+++ b/decision_os/companion/ordinary_user_path.py
@@ -1404,7 +1404,6 @@ class OrdinaryUserPathCoordinator:
         repository_identity = current_repository_identity
         if isinstance(preparation, dict):
             preparation_id = preparation.get("preparation_id")
-            repository_identity = preparation.get("repository_identity")
             source_identity = deepcopy(preparation.get("source_identity"))
             if isinstance(source_identity, dict):
                 source_identity["title"] = preparation.get("title")
@@ -1415,6 +1414,9 @@ class OrdinaryUserPathCoordinator:
                     "request_id": preparation.get("request_id"),
                     "draft_id": preparation.get("draft_id"),
                     "interpretation_sha256": preparation.get("interpretation_sha256"),
+                    "preparation_repository_identity": preparation.get(
+                        "repository_identity"
+                    ),
                     "gate": preparation.get("gate"),
                     "producer_identity": PRODUCER_IDENTITY,
                     "preparation_receipt_sha256": preparation.get(

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -19,6 +19,8 @@ let contractImportGeneration = 0;
 let ordinaryFocusIntent = null;
 let ordinaryLastErrorId = null;
 let ordinaryLastRevision = -1;
+let ordinarySelectedFilename = null;
+let ordinarySelectedFilenameRevision = null;
 
 const MAX_BRIDGE_ARTIFACT_BYTES = 1024 * 1024;
 const CONTRACT_PREVIEW_CHARACTERS = 4096;
@@ -434,6 +436,50 @@ function friendlyFixedState(value) {
   }[value] || "Unknown";
 }
 
+function showOrdinarySelectedFilename(filename) {
+  ordinarySelectedFilename =
+    typeof filename === "string" && filename.length ? filename : null;
+  setText(
+    "ordinary-contract-selected-file",
+    ordinarySelectedFilename
+      ? `Selected file: ${ordinarySelectedFilename}`
+      : "Selected file: None selected.",
+  );
+}
+
+function recordOrdinarySelectedFilename(filename, operationRevision) {
+  ordinarySelectedFilenameRevision = Number.isInteger(operationRevision)
+    ? operationRevision
+    : ordinaryLastRevision;
+  showOrdinarySelectedFilename(filename);
+}
+
+function syncOrdinarySelectedFilename(panel) {
+  const serverFilename = panel?.source_identity?.filename;
+  const serverRevision = Number.isInteger(panel?.operation_revision)
+    ? panel.operation_revision
+    : 0;
+  const preparationSucceeded = [
+    "REVIEW_READY",
+    "NEEDS_CONFIRMATION",
+    "FIXING",
+    "FIXED",
+  ].includes(panel?.state);
+  if (
+    typeof serverFilename === "string" &&
+    serverFilename.length &&
+    (ordinarySelectedFilename === null ||
+      ordinarySelectedFilenameRevision === null ||
+      (preparationSucceeded &&
+        serverRevision > ordinarySelectedFilenameRevision))
+  ) {
+    ordinarySelectedFilenameRevision = null;
+    showOrdinarySelectedFilename(serverFilename);
+    return;
+  }
+  showOrdinarySelectedFilename(ordinarySelectedFilename);
+}
+
 function renderOrdinaryContract(ordinary, repository) {
   const panel = ordinary && typeof ordinary === "object" ? ordinary : null;
   const revision = Number.isInteger(panel?.operation_revision)
@@ -458,6 +504,7 @@ function renderOrdinaryContract(ordinary, repository) {
   const actions = new Set(
     Array.isArray(panel?.allowed_actions) ? panel.allowed_actions : [],
   );
+  syncOrdinarySelectedFilename(panel);
 
   setText(
     "ordinary-contract-status",
@@ -1380,6 +1427,9 @@ function ordinaryFixRequest() {
 byId("ordinary-contract-file").addEventListener("change", async () => {
   const file = byId("ordinary-contract-file").files?.[0] || null;
   const panel = latestState?.ordinary_contract;
+  if (file) {
+    recordOrdinarySelectedFilename(file.name, panel?.operation_revision);
+  }
   if (!file || !panel || !latestState?.repository) {
     return;
   }

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -61,6 +61,9 @@
         Select Contract (.md or .txt)
       </label>
       <input id="ordinary-contract-file" type="file" accept=".md,.txt">
+      <p id="ordinary-contract-selected-file" aria-live="polite">
+        Selected file: None selected.
+      </p>
       <p
         id="ordinary-contract-progress"
         class="ordinary-progress"

--- a/tests/test_companion_ordinary_user_path.py
+++ b/tests/test_companion_ordinary_user_path.py
@@ -392,6 +392,80 @@ class OrdinaryUserPathCoordinatorTest(unittest.TestCase):
                 stale[field] = replacement
                 self.assertFalse(binding(stale, guided_state, self.head))
 
+    def test_restart_after_repository_advance_projects_current_identity(self) -> None:
+        with self.assertRaises(OrdinaryUserPathError) as raised:
+            self.prepare(filename="Contract.pdf")
+        self.assertEqual("PREP_UNSUPPORTED_EXTENSION", raised.exception.code)
+        failed_at_a = self.coordinator.snapshot()
+        preparation_id = failed_at_a["preparation_id"]
+        error = failed_at_a["action_error"]
+        self.assertEqual(self.head, failed_at_a["repository_identity"])
+        self.assertEqual(
+            self.head,
+            failed_at_a["technical_details"]["preparation_repository_identity"],
+        )
+        before_native_state = self.guided.store.load_state()
+        before_events = self.guided.store.read_events()
+
+        (self.repository / "tracked.txt").write_text(
+            "test\nrepository advanced\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ("git", "-C", str(self.repository), "add", "tracked.txt"),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            ("git", "-C", str(self.repository), "commit", "-qm", "advance"),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        head_b = subprocess.run(
+            ("git", "-C", str(self.repository), "rev-parse", "HEAD"),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        self.assertNotEqual(self.head, head_b)
+
+        restarted_guided = GuidedIntakeController(self.repository)
+        restarted = OrdinaryUserPathCoordinator(self.repository, restarted_guided)
+        restarted.recover_incomplete()
+        restarted_panel = restarted.snapshot()
+        self.assertEqual("CANNOT_FIX_SAFELY", restarted_panel["state"])
+        self.assertEqual(head_b, restarted_panel["repository_identity"])
+        self.assertEqual(
+            self.head,
+            restarted_panel["technical_details"][
+                "preparation_repository_identity"
+            ],
+        )
+        self.assertEqual(preparation_id, restarted_panel["preparation_id"])
+        self.assertEqual(error, restarted_panel["action_error"])
+        self.assertIsNone(restarted_panel["review"])
+        self.assertIsNone(restarted_panel["clarification"])
+        self.assertNotIn("FIX_CONTRACT", restarted_panel["allowed_actions"])
+        self.assertIn("SELECT_CONTRACT", restarted_panel["allowed_actions"])
+        self.assertEqual(before_native_state, restarted_guided.store.load_state())
+        self.assertEqual(before_events, restarted_guided.store.read_events())
+
+        prepared_at_b = restarted.prepare(
+            filename=SOURCE_PATH.name,
+            source_bytes=self.source,
+            source_byte_size=len(self.source),
+            source_sha256=sha256_bytes(self.source),
+            expected_repository_identity=head_b,
+            expected_active_request_id=None,
+            idempotency_key=str(uuid.uuid4()),
+        )
+        self.assertEqual("REVIEW_READY", prepared_at_b["state"])
+        self.assertEqual(head_b, prepared_at_b["repository_identity"])
+        fixed = restarted.fix(**self.fix_request(prepared_at_b))
+        self.assertEqual("FIXED", fixed["state"])
+
     def test_corrupt_sidecar_state_fails_closed(self) -> None:
         self.prepare()
         before = self.guided.store.read_events()

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -1389,6 +1389,7 @@ class CompanionServerTest(unittest.TestCase):
         for element_id in (
             "ordinary-contract-status",
             "ordinary-contract-file",
+            "ordinary-contract-selected-file",
             "ordinary-contract-review",
             "ordinary-contract-preserves",
             "ordinary-contract-completion",
@@ -1431,7 +1432,12 @@ class CompanionServerTest(unittest.TestCase):
         )[1].split(b"function contractFileSelectionChanged", 1)[0]
         self.assertIn(b"await file.arrayBuffer()", ordinary_handler)
         self.assertIn(b'crypto.subtle.digest("SHA-256"', javascript)
+        self.assertIn(
+            b"recordOrdinarySelectedFilename(file.name, panel?.operation_revision)",
+            ordinary_handler,
+        )
         self.assertIn(b"bytes?.fill(0)", ordinary_handler)
+        self.assertIn(b'byId("ordinary-contract-file").value = ""', ordinary_handler)
         self.assertNotIn(b"file.text()", ordinary_handler)
         self.assertNotIn(b"guided-intake-original-request", ordinary_handler)
         self.assertNotIn(b'"/api/run"', ordinary_handler)
@@ -2127,6 +2133,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "ordinary-contract-error-state",
               "ordinary-contract-error-what",
               "ordinary-contract-file",
+              "ordinary-contract-selected-file",
               "ordinary-contract-fix",
               "ordinary-contract-preserves",
               "ordinary-contract-progress",
@@ -2146,6 +2153,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               ordinaryLastRevision: 0,
               ordinaryFocusIntent: null,
               ordinaryLastErrorId: null,
+              ordinarySelectedFilename: null,
+              ordinarySelectedFilenameRevision: null,
               byId: (id) => elements.get(id),
               setText: (id, value) => {
                 elements.get(id).textContent = value == null ? "" : String(value);
@@ -2157,7 +2166,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             vm.createContext(sandbox);
             vm.runInContext(
               source.slice(start, end) +
-                "\nthis.renderOrdinaryContract = renderOrdinaryContract;",
+                "\nthis.renderOrdinaryContract = renderOrdinaryContract;" +
+                "\nthis.recordOrdinarySelectedFilename = recordOrdinarySelectedFilename;",
               sandbox,
             );
             const prior = {
@@ -2176,6 +2186,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               allowed_actions: ["SELECT_CONTRACT", "FIX_CONTRACT"],
               action_error: null,
               technical_details: {},
+              source_identity: { filename: "verified-prior.md" },
             };
             const failed = {
               state: "CANNOT_FIX_SAFELY",
@@ -2194,16 +2205,37 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 retryable: false,
               },
               technical_details: {},
+              source_identity: { filename: "unsupported-server.md" },
             };
 
             sandbox.renderOrdinaryContract(prior, { name: "repo" });
+            assert.strictEqual(
+              elements.get("ordinary-contract-selected-file").textContent,
+              "Selected file: verified-prior.md",
+            );
             assert.strictEqual(
               elements.get("ordinary-contract-review").classList.contains("hidden"),
               false,
             );
             assert.strictEqual(elements.get("ordinary-contract-fix").disabled, false);
+            sandbox.recordOrdinarySelectedFilename("attempted-unsupported.md");
+            assert.strictEqual(
+              elements.get("ordinary-contract-selected-file").textContent,
+              "Selected file: attempted-unsupported.md",
+            );
+            sandbox.renderOrdinaryContract(prior, { name: "repo" });
+            assert.strictEqual(
+              elements.get("ordinary-contract-selected-file").textContent,
+              "Selected file: attempted-unsupported.md",
+            );
+            elements.get("ordinary-contract-file").value = "";
             for (let poll = 0; poll < 2; poll += 1) {
               sandbox.renderOrdinaryContract(failed, { name: "repo" });
+              assert.strictEqual(elements.get("ordinary-contract-file").value, "");
+              assert.strictEqual(
+                elements.get("ordinary-contract-selected-file").textContent,
+                "Selected file: attempted-unsupported.md",
+              );
               assert.strictEqual(
                 elements.get("ordinary-contract-review").classList.contains("hidden"),
                 true,
@@ -2226,6 +2258,31 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 "This Contract family is not supported.",
               );
             }
+            sandbox.recordOrdinarySelectedFilename("replacement.md");
+            assert.strictEqual(
+              elements.get("ordinary-contract-selected-file").textContent,
+              "Selected file: replacement.md",
+            );
+            sandbox.renderOrdinaryContract({
+              ...prior,
+              operation_revision: 10,
+              source_identity: { filename: "server-verified-replacement.md" },
+            }, { name: "repo" });
+            assert.strictEqual(
+              elements.get("ordinary-contract-selected-file").textContent,
+              "Selected file: server-verified-replacement.md",
+            );
+
+            sandbox.ordinarySelectedFilename = null;
+            sandbox.ordinarySelectedFilenameRevision = null;
+            sandbox.renderOrdinaryContract({
+              ...failed,
+              operation_revision: 11,
+            }, { name: "repo" });
+            assert.strictEqual(
+              elements.get("ordinary-contract-selected-file").textContent,
+              "Selected file: unsupported-server.md",
+            );
             """
         )
         completed = subprocess.run(
@@ -2743,6 +2800,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "ordinary-contract-error-state",
               "ordinary-contract-error-what",
               "ordinary-contract-file",
+              "ordinary-contract-selected-file",
               "ordinary-contract-fix",
               "ordinary-contract-preserves",
               "ordinary-contract-progress",


### PR DESCRIPTION
## Summary

- Keep `ordinary_contract.repository_identity` bound to the repository's current committed HEAD at projection time.
- Preserve the prior preparation identity only as `technical_details.preparation_repository_identity`.
- Keep the full preparation/native-state binding guard on Fix and confirmation.
- Add a visible `Selected file: <filename>` record that survives preparation, action-local failure, native file-input clearing, and polling; bind it to the server-verified filename after successful preparation.
- Preserve the existing forward-only ordinary state and error evidence without a state-schema change.

## Root cause

After restart, the projection obtained the current repository HEAD and then overwrote the top-level repository identity with the older preparation identity. The browser therefore resubmitted a stale expected identity. Separately, the browser cleared the native file input after byte handling without retaining a visible attempted filename.

## Regression evidence

- Commit-advancement restart: failed preparation at commit A; repository advances to commit B; restarted projection exposes B at top level and A only in Technical details; error/preparation evidence remains; review and clarification are null; Fix is disabled; Select remains available; native state/events are unchanged; a valid selection using B reaches `Ready to fix` and then `FIXED`.
- Browser: selected filename appears immediately, persists through PREPARING, failed response, native FileList clearing, and polling; replacement selection updates it; successful preparation binds the server-returned verified filename; failed review stays null and the persistent error remains visible.
- Ordinary golden interpretation SHA-256: `7503f4b01c7c05c9ec3aed8855c9fd538c66b9b3b38840f423ec41c2101f4dd7`.
- Product historical wrapper SHA-256: `90c5a778b1ed789042151c7aa28d45f3eab790b0df20ad9e4b10da5ce19cbfd5`.
- Focused Companion / Guided Intake suite: `180/180 PASS`.
- Full suite: `659/659 PASS`.
- `node --check decision_os/companion/static/app.js`: PASS.
- `git diff --check`: PASS.

## Safety boundary

- No live Contract preparation retry, Fix, Dismiss, Transfer, Run, model invocation, release, or publication.
- No live Guided Intake mutation.
- Desktop target remains 11,039 bytes with SHA-256 `519bd39305af1a3a7cc35e61e1b9cfc742c5723d0cc64d0d970b070d0e65068e` and is byte-identical to the source and fixed fixture.
- Installed Companion runtime remains byte-identical to main commit `65fbbc5353790056b1fa77a2f2c01099729d57a0`; this branch was not installed.

## Identity and rollback

- Base: `65fbbc5353790056b1fa77a2f2c01099729d57a0`
- Head: `bc00c3bb34d548ef1a2d04b277854b7729e7807b`
- Complete rollback: revert the single head commit.

## Independent review acceptance

- Independent review: `PASS`
- Accepted head: `bc00c3bb34d548ef1a2d04b277854b7729e7807b`
- Expected base: `65fbbc5353790056b1fa77a2f2c01099729d57a0`
- Decision owner: Shin
