### PR TITLE
Bind approvals to exact protocol items

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import copy
 from dataclasses import dataclass
+import hashlib
 import json
 from pathlib import Path
 import subprocess
@@ -53,6 +54,8 @@ _UNSUPPORTED_REQUEST_METHOD_REASONS = {
 _UNSUPPORTED_REASON_CODES = frozenset(
     {
         "approval_identity_mismatch",
+        "additional_file_action_item",
+        "duplicate_file_action_item_after_completion",
         "duplicate_approval_request",
         "unapproved_file_completion",
         "unsupported_file_change_shape",
@@ -151,6 +154,18 @@ class _CodexFileActionCandidate:
 
     action: str
     item_id: str
+    outcome: DecisionOutcome
+
+
+@dataclass(frozen=True)
+class _CodexApprovalBinding:
+    """Exact one-Run human decision binding for one protocol item."""
+
+    run_id: str
+    item_id: str
+    decision_type: DecisionType
+    normalized_scope: str
+    change_identity: str
     outcome: DecisionOutcome
 
 
@@ -382,7 +397,7 @@ class CodexAdapter:
         self._resolved_items: set[str] = set()
         self._completed_items: set[str] = set()
         self._pending: dict[str, DecisionOutcome] = {}
-        self._seen: dict[str, DecisionOutcome] = {}
+        self._approval_binding: _CodexApprovalBinding | None = None
         self._permission_denied = False
         self._unsupported_mutation = False
         self._unsupported_reason: str | None = None
@@ -411,7 +426,7 @@ class CodexAdapter:
         self._resolved_items = set()
         self._completed_items = set()
         self._pending = {}
-        self._seen = {}
+        self._approval_binding = None
         self._permission_denied = False
         self._unsupported_mutation = False
         self._unsupported_reason = None
@@ -911,21 +926,24 @@ class CodexAdapter:
             "file approval parameters",
         )
         item_id = params.get("itemId")
-        duplicate_item = (
-            isinstance(item_id, str)
-            and item_id in self._approval_requests.values()
+        valid_request_id = (
+            isinstance(request_id, (str, int))
+            and not isinstance(request_id, bool)
         )
-        if not self._register_approval_request(request_id, item_id):
-            reason = (
-                "duplicate_approval_request"
-                if (
-                    isinstance(request_id, (str, int))
-                    and not isinstance(request_id, bool)
-                    and request_id in self._approval_requests
+        request_replay = bool(
+            valid_request_id and request_id in self._approval_requests
+        )
+        if request_replay:
+            if self._approval_requests[request_id] != item_id:
+                self._mark_unsupported("approval_identity_mismatch")
+                if isinstance(item_id, str):
+                    self._declined_items.add(item_id)
+                self._send(
+                    {"id": request_id, "result": {"decision": "decline"}}
                 )
-                else "approval_identity_mismatch"
-            )
-            self._mark_unsupported(reason)
+                return
+        elif not self._register_approval_request(request_id, item_id):
+            self._mark_unsupported("approval_identity_mismatch")
             if isinstance(item_id, str):
                 self._declined_items.add(item_id)
             self._send(
@@ -945,13 +963,6 @@ class CodexAdapter:
                 {"id": request_id, "result": {"decision": "decline"}}
             )
             return
-        if duplicate_item:
-            self._mark_unsupported("duplicate_approval_request")
-            self._declined_items.add(item_id)
-            self._send(
-                {"id": request_id, "result": {"decision": "decline"}}
-            )
-            return
         try:
             decision_type, raw_path = self._map_file_change(
                 self._items[item_id]
@@ -965,29 +976,74 @@ class CodexAdapter:
             )
             return
 
-        key = (
-            f"{self.engine.store.repository_id}|"
-            f"{decision_type.value}|{normalized}"
-        )
-        if key in self._seen:
-            outcome = self._seen[key]
-        else:
-            self._iteration += 1
-            outcome = self.engine.evaluate(
-                run_id=self._run_id,
-                iteration=self._iteration,
-                decision_type=decision_type,
-                requested_scope=raw_path,
-                source_interrupt_id=item_id,
-                choice_provider=lambda identity: self._approval_choice(
-                    identity,
-                    self._items[item_id],
-                    params,
-                ),
+        changes = self._items[item_id]["changes"]
+        change_identity = hashlib.sha256(
+            json.dumps(
+                changes,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        binding = self._approval_binding
+        if binding is not None:
+            exact_item_replay = bool(
+                binding.run_id == self._run_id
+                and binding.item_id == item_id
+                and binding.decision_type is decision_type
+                and binding.normalized_scope == normalized
+                and binding.change_identity == change_identity
             )
-            self._seen[key] = outcome
-            if outcome.pending_cross_run_checkpoint:
-                self._pending[outcome.identity.decision_key] = outcome
+            if exact_item_replay:
+                self._send(
+                    {
+                        "id": request_id,
+                        "result": {
+                            "decision": (
+                                "accept" if binding.outcome.allowed else "decline"
+                            )
+                        },
+                    }
+                )
+                return
+            reason = (
+                "duplicate_file_action_item_after_completion"
+                if (
+                    binding.decision_type is decision_type
+                    and binding.normalized_scope == normalized
+                )
+                else "additional_file_action_item"
+            )
+            self._mark_unsupported(reason)
+            self._declined_items.add(item_id)
+            self._send(
+                {"id": request_id, "result": {"decision": "decline"}}
+            )
+            return
+
+        self._iteration += 1
+        outcome = self.engine.evaluate(
+            run_id=self._run_id,
+            iteration=self._iteration,
+            decision_type=decision_type,
+            requested_scope=raw_path,
+            source_interrupt_id=item_id,
+            choice_provider=lambda identity: self._approval_choice(
+                identity,
+                self._items[item_id],
+                params,
+            ),
+        )
+        self._approval_binding = _CodexApprovalBinding(
+            run_id=self._run_id,
+            item_id=item_id,
+            decision_type=decision_type,
+            normalized_scope=normalized,
+            change_identity=change_identity,
+            outcome=outcome,
+        )
+        if outcome.pending_cross_run_checkpoint:
+            self._pending[outcome.identity.decision_key] = outcome
 
         if outcome.allowed:
             decision_type, _ = self._map_file_change(self._items[item_id])
@@ -1040,16 +1096,16 @@ class CodexAdapter:
             return
         if (
             request_id not in self._approval_requests
-            or request_id in self._resolved_approval_requests
         ):
             self._identity_failure = True
+            return
+        if request_id in self._resolved_approval_requests:
             return
         self._resolved_approval_requests.add(request_id)
         item_id = self._approval_requests[request_id]
         if item_id is None:
             return
         if item_id in self._resolved_items:
-            self._identity_failure = True
             return
         self._resolved_items.add(item_id)
 
@@ -1097,7 +1153,8 @@ class CodexAdapter:
             self._identity_failure = True
             return
         if item_id in self._items:
-            self._identity_failure = True
+            if self._items[item_id] != item:
+                self._identity_failure = True
             return
         self._items[item_id] = item
 
@@ -1159,11 +1216,19 @@ class CodexAdapter:
             self._identity_failure = True
             return
         approved = self._approved_changes.get(item_id)
+        if item_id in self._completed_items:
+            if (
+                item.get("status") != "completed"
+                or approved is None
+                or item.get("changes") != approved
+                or item_id not in self._resolved_items
+            ):
+                self._identity_failure = True
+            return
         if (
             item.get("status") != "completed"
             or approved is None
             or item.get("changes") != approved
-            or item_id in self._completed_items
             or item_id not in self._resolved_items
         ):
             self._identity_failure = True

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -608,6 +608,357 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 [event.kind for event in lifecycle],
             )
 
+    async def test_exact_file_item_replay_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            changes = [change()]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        request_id="approval-item-1",
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        request_id="approval-item-1",
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        request_id="approval-item-1-retry",
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="approval-item-1",
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="approval-item-1",
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="approval-item-1-retry",
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=changes,
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("idempotent item replay")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual({"item-1"}, adapter._completed_items)
+            self.assertEqual(1, len(adapter._file_action_candidates))
+            checks = [
+                event
+                for event in engine.store.read_events()
+                if event["event_type"] == "DECISION_CHECK"
+            ]
+            self.assertEqual(1, len(checks))
+            decisions = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+                and "decision" in message["result"]
+            ]
+            self.assertEqual(["accept", "accept", "accept"], decisions)
+
+    async def test_live_incident_distinct_same_scope_items_fail_closed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            changes = [change()]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            for index, item_id in enumerate(
+                ("item-1", "item-2", "item-3"),
+                start=1,
+            ):
+                messages.extend(
+                    [
+                        started_item(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            changes=changes,
+                        ),
+                        approval_request(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            request_id=f"approval-{index}",
+                        ),
+                        resolved_request(
+                            thread_id="thread-1",
+                            request_id=f"approval-{index}",
+                        ),
+                        completed_item(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            changes=changes,
+                            status=(
+                                "completed" if index == 1 else "declined"
+                            ),
+                        ),
+                    ]
+                )
+            messages.append(
+                completed_turn(thread_id="thread-1", turn_id="turn-1")
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("live incident shape")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertFalse(result.normal_terminal)
+            self.assertIsNone(result.error_type)
+            self.assertEqual(
+                "duplicate_file_action_item_after_completion",
+                result.unsupported_reason,
+            )
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual("target.txt", result.file_actions[0].normalized_scope)
+            self.assertEqual({"item-1"}, adapter._completed_items)
+            self.assertEqual({"item-2", "item-3"}, adapter._declined_items)
+            checks = [
+                event
+                for event in engine.store.read_events()
+                if event["event_type"] == "DECISION_CHECK"
+            ]
+            self.assertEqual(1, len(checks))
+            self.assertEqual("item-1", checks[0]["source_interrupt_id"])
+            decisions = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+                and "decision" in message["result"]
+            ]
+            self.assertEqual(["accept", "decline", "decline"], decisions)
+
+    async def test_distinct_different_file_item_never_inherits_decision(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            first_changes = [change()]
+            second_changes = [change(path="other.txt", kind="add")]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=first_changes,
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        request_id="approval-1",
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="approval-1",
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        changes=first_changes,
+                    ),
+                    started_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-2",
+                        changes=second_changes,
+                    ),
+                    approval_request(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-2",
+                        request_id="approval-2",
+                    ),
+                    resolved_request(
+                        thread_id="thread-1",
+                        request_id="approval-2",
+                    ),
+                    completed_item(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-2",
+                        changes=second_changes,
+                        status="declined",
+                    ),
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("different second item")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual(
+                "additional_file_action_item",
+                result.unsupported_reason,
+            )
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual({"item-1"}, adapter._completed_items)
+            checks = [
+                event
+                for event in engine.store.read_events()
+                if event["event_type"] == "DECISION_CHECK"
+            ]
+            self.assertEqual(1, len(checks))
+            decisions = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+                and "decision" in message["result"]
+            ]
+            self.assertEqual(["accept", "decline"], decisions)
+
+    async def test_denied_item_cannot_be_reused_or_upgraded(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            changes = [change()]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            for index, item_id in enumerate(("item-1", "item-2"), start=1):
+                messages.extend(
+                    [
+                        started_item(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            changes=changes,
+                        ),
+                        approval_request(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            request_id=f"approval-{index}",
+                        ),
+                        resolved_request(
+                            thread_id="thread-1",
+                            request_id=f"approval-{index}",
+                        ),
+                        completed_item(
+                            thread_id="thread-1",
+                            turn_id="turn-1",
+                            item_id=item_id,
+                            changes=changes,
+                            status="declined",
+                        ),
+                    ]
+                )
+            messages.append(
+                completed_turn(thread_id="thread-1", turn_id="turn-1")
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "3",
+            )
+
+            result = await adapter.run("deny and repeat")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual(
+                "duplicate_file_action_item_after_completion",
+                result.unsupported_reason,
+            )
+            self.assertEqual(1, output.getvalue().count("Selection:"))
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual("denied", result.file_actions[0].status)
+            self.assertEqual(set(), adapter._completed_items)
+            checks = [
+                event
+                for event in engine.store.read_events()
+                if event["event_type"] == "DECISION_CHECK"
+            ]
+            self.assertEqual(1, len(checks))
+            decisions = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+                and "decision" in message["result"]
+            ]
+            self.assertEqual(["decline", "decline"], decisions)
+
     async def test_two_fresh_threads_create_default_then_verified_save(
         self,
     ) -> None:
@@ -986,7 +1337,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                     self.assertFalse(result.normal_terminal)
                     self.assertEqual((), result.file_actions)
 
-    async def test_same_run_repeat_never_becomes_verified(self) -> None:
+    async def test_saved_permission_never_authorizes_distinct_same_run_item(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
             messages = handshake_messages(
@@ -1034,9 +1387,21 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
             result = await adapter.run("same run repeat")
 
-            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual(
+                "duplicate_file_action_item_after_completion",
+                result.unsupported_reason,
+            )
             self.assertEqual((0, 0), engine.store.counters())
             self.assertEqual(1, output.getvalue().count("Selection:"))
+            self.assertLessEqual(len(result.file_actions), 1)
+            decisions = [
+                message["result"]["decision"]
+                for message in factory.transports[0].sent
+                if "result" in message
+                and "decision" in message["result"]
+            ]
+            self.assertEqual(["accept", "decline"], decisions)
             self.assertFalse(
                 any(
                     event["event_type"] == "VERIFIED_SAVE"


### PR DESCRIPTION
## Exact live incident evidence

Self-Hosted Run 002 run `0c2780ce-1209-403b-9ec0-3dbe0bbac482` persisted one human `DECISION_CHECK` but projected three identical public `file_actions`. Each row was `Modify` on `decision_os/companion/static/app.js`, `approved`, `one-time`. Typed adapter state showed distinct protocol item IDs; this was not inferred from model prose or visual rendering.

The root cause was the adapter's action/path cache: it keyed a decision by repository, typed action, and normalized path, then reused that outcome for later item IDs and appended a completion candidate for each accepted request.

## Approval-to-item invariant

This repair enforces:

`one DECISION_CHECK -> one exact approval item identity -> at most one completed public file action`

The frozen per-Run binding contains the Run ID, protocol item ID, typed decision/action, normalized repository-relative scope, a SHA-256 identity of the canonical typed change payload, and the human decision outcome. Approval is never reused on action/path similarity alone.

## Same-item replay semantics

An exact replay must match every bound field. It receives the original accept/decline response without another human prompt, another decision event, another completion candidate, or another public row. Repeated started, resolved, and completed notifications for that exact item are idempotent only when their typed identity and change payload remain identical.

## Distinct-item fail-closed semantics

A different item ID on the same action/path is declined with typed reason `duplicate_file_action_item_after_completion`. A different item ID on another action/path is declined with `additional_file_action_item`. Neither item can inherit an approval or denial, write a file, or create another approved/completed public row.

## One-write / one-public-action proof

The incident-shaped regression sends three distinct item IDs with identical `Modify`/path payloads. It proves one prompt, one `DECISION_CHECK`, decisions `accept / decline / decline`, only `item-1` in the completed set, one write-capable completion candidate, and exactly one public `file_actions` row. Exact same-item delivery and duplicate completion tests also retain one completed item and one public row. Denied and saved-permission regressions prove that later distinct items cannot reuse or upgrade the first decision.

## Rejected Rail delta exclusion

The rejected Self-Hosted Run 002 `app.js` delta is not present in this branch. Its exact evidence patch is preserved outside the repository at `/Users/sn/Documents/v13/Decision_OS_Self_Hosted_Run_002_Rejected_Rail_Delta.patch` (544 bytes, SHA-256 `a2cda50a91680e05a620a32c59f7302788839b2904c626867e4f4f269e3a3007`). `decision_os/companion/static/app.js` is byte-identical to base SHA-256 `ad5dd6274270bcdf5f2cd5073bd8fe871c4b5bdc108e5cc94d10250a1751a530`.

## Excluded probe residue

`validation/companion_manual_live_run_probe_v0_1.md` remains untracked, untouched, and excluded (539 bytes, SHA-256 `f68b3a1f47136782cbb5ade4c4686724c2b877eaaffe52bdb81aa72ae19c6344`).

## Independent validation

- Codex adapter: 35/35 PASS
- Acceleration store/model: 14/14 PASS
- Companion controller: 26/26 PASS
- Companion server/real-browser result coverage: 35/35 PASS
- Full repository suite: 670/670 PASS
- Ordinary golden interpretation: PASS, SHA-256 `7503f4b01c7c05c9ec3aed8855c9fd538c66b9b3b38840f423ec41c2101f4dd7`
- `git diff --check`: PASS
- Node syntax: not required; no client file changed

## Remaining rollout gate

Independent review is accepted. Ready, expected-head merge, and bounded runtime rollout are authorized by Shin. The Self-Hosted Run 002 retry remains HOLD. The Rail `Not used` lifecycle repair remains separately HOLD and is intentionally absent from this PR. Transfer / Builder / Pro / Fable / release / publication remain BLOCK.

## Independent review acceptance

- Result: **PASS**
- Accepted head: `3b994e7eae803f0624c0ad3e57e2c1fd200dae4a`
- Expected base: `e0452fceac1d96491211374bdea58a8a96bbf144`
- Decision owner: Shin
