### PR TITLE
Bound repository reads before writes and add Copy response

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -39,11 +39,19 @@ _DEVELOPER_INSTRUCTIONS = (
     "The read tool is read-only and cannot authorize a mutation. "
     "Do not mutate files through shell commands, other dynamic tools, or MCP "
     "tools. "
-    "Do not touch another path, and stop normally after the requested operation."
+    "Do not touch another path, and stop normally after the requested operation. "
+    "Do not reproduce the complete repository source file in the final response. "
+    "Report only what was changed, the path, and the bounded completion result."
 )
 _READ_TOOL_NAME = "read_repository_text_file"
 _READ_MAX_BYTES = 131_072
 _WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[/\\]")
+_SOURCE_ECHO_MARKER = "[Repository source content withheld.]"
+_FENCE_OPENING = re.compile(
+    r"(?m)^(?P<indent> {0,3})(?P<fence>`{3,}|~{3,})[^\r\n]*(?P<eol>\r?\n)"
+)
+_BLANK_LINE_BEFORE = re.compile(r"(?:\r?\n)[ \t]*(?:\r?\n)\Z")
+_BLANK_LINE_AFTER = re.compile(r"\A(?:\r?\n)[ \t]*(?:\r?\n)")
 _READ_TOOL_SPEC = {
     "type": "function",
     "name": _READ_TOOL_NAME,
@@ -63,6 +71,115 @@ _READ_TOOL_SPEC = {
         },
     },
 }
+
+
+def _trailing_line_ending(value: str) -> str:
+    if value.endswith("\r\n"):
+        return "\r\n"
+    if value.endswith("\n"):
+        return "\n"
+    return ""
+
+
+def _replace_exact_spans(
+    value: str,
+    spans: list[tuple[int, int, str]],
+) -> str:
+    for start, end, replacement in reversed(spans):
+        value = f"{value[:start]}{replacement}{value[end:]}"
+    return value
+
+
+def _redact_fenced_source_echo(message: str, source_content: str) -> str:
+    spans: list[tuple[int, int, str]] = []
+    search_at = 0
+    while opening := _FENCE_OPENING.search(message, search_at):
+        fence = opening.group("fence")
+        closing_pattern = re.compile(
+            rf"(?m)^ {{0,3}}{re.escape(fence[0])}{{{len(fence)},}}"
+            r"[ \t]*(?:\r?\n|\Z)"
+        )
+        closing = closing_pattern.search(message, opening.end())
+        if closing is None:
+            search_at = opening.end()
+            continue
+        body = message[opening.end() : closing.start()]
+        matched = body == source_content
+        if not matched:
+            matched = any(
+                body == f"{source_content}{line_ending}"
+                for line_ending in ("\r\n", "\n")
+            )
+        if matched:
+            boundary = _trailing_line_ending(body)
+            spans.append(
+                (
+                    opening.end(),
+                    closing.start(),
+                    f"{_SOURCE_ECHO_MARKER}{boundary}",
+                )
+            )
+        search_at = closing.end()
+    return _replace_exact_spans(message, spans)
+
+
+def _has_explicit_block_end(source_content: str, suffix: str) -> bool:
+    if not suffix:
+        return True
+    if _BLANK_LINE_AFTER.match(suffix) is not None:
+        return True
+    return bool(_trailing_line_ending(source_content)) and suffix.startswith(
+        ("\r\n", "\n")
+    )
+
+
+def _redact_separate_source_blocks(
+    message: str,
+    source_content: str,
+) -> str:
+    if not source_content.strip():
+        return message
+    spans: list[tuple[int, int, str]] = []
+    search_at = 0
+    while True:
+        start = message.find(source_content, search_at)
+        if start < 0:
+            break
+        end = start + len(source_content)
+        prefix = message[:start]
+        suffix = message[end:]
+        has_start = not prefix or _BLANK_LINE_BEFORE.search(prefix) is not None
+        if has_start and _has_explicit_block_end(source_content, suffix):
+            spans.append(
+                (
+                    start,
+                    end,
+                    f"{_SOURCE_ECHO_MARKER}"
+                    f"{_trailing_line_ending(source_content)}",
+                )
+            )
+        search_at = end
+    return _replace_exact_spans(message, spans)
+
+
+def _redact_complete_source_echo(message: str, source_content: str) -> str:
+    """Suppress only exact complete-source echoes with explicit structure."""
+
+    if not source_content:
+        return message
+    search_at = 0
+    while True:
+        start = message.find(source_content, search_at)
+        if start < 0:
+            break
+        end = start + len(source_content)
+        if not message[:start].strip() and not message[end:].strip():
+            return _SOURCE_ECHO_MARKER
+        search_at = end
+    guarded = _redact_fenced_source_echo(message, source_content)
+    return _redact_separate_source_blocks(guarded, source_content)
+
+
 _UNSUPPORTED_ITEM_TYPES = frozenset(
     {
         "collabAgentToolCall",
@@ -955,14 +1072,10 @@ class CodexAdapter:
     def _final_message_with_diagnostic(self, status: str) -> str:
         message = self._final_message
         read_binding = self._read_binding
-        if (
-            read_binding is not None
-            and read_binding.content
-            and read_binding.content in message
-        ):
-            message = message.replace(
+        if read_binding is not None:
+            message = _redact_complete_source_echo(
+                message,
                 read_binding.content,
-                "[Repository source content withheld.]",
             )
         if (
             status != "UNSUPPORTED_MUTATION"

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -7,13 +7,16 @@ import copy
 from dataclasses import dataclass
 import hashlib
 import json
+import os
 from pathlib import Path
+import re
+import stat
 import subprocess
 import threading
 from typing import Any, Protocol, TextIO
 
 from .engine import AccelerationEngine, CheckpointOutcome, DecisionOutcome
-from .model import DecisionType, ScopeError, normalize_scope
+from .model import DecisionType, ScopeError, git_output, normalize_scope
 
 
 BUNDLED_CODEX_PATH = Path(
@@ -30,15 +33,40 @@ _CLIENT_VERSION = "0.1.0"
 _DEVELOPER_INSTRUCTIONS = (
     "Perform only the requested bounded file operation. "
     "Do not use shell commands. "
+    "Before modifying an existing file, use read_repository_text_file once "
+    "for that exact repository-relative path. "
     "Use the typed file-change tool for exactly one file mutation. "
-    "Do not mutate files through shell commands, dynamic tools, or MCP tools. "
+    "The read tool is read-only and cannot authorize a mutation. "
+    "Do not mutate files through shell commands, other dynamic tools, or MCP "
+    "tools. "
     "Do not touch another path, and stop normally after the requested operation."
 )
+_READ_TOOL_NAME = "read_repository_text_file"
+_READ_MAX_BYTES = 131_072
+_WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[/\\]")
+_READ_TOOL_SPEC = {
+    "type": "function",
+    "name": _READ_TOOL_NAME,
+    "description": (
+        "Read one existing strict UTF-8 text file inside the selected "
+        "repository before proposing a modification to that same file."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["path"],
+        "properties": {
+            "path": {
+                "type": "string",
+                "minLength": 1,
+            }
+        },
+    },
+}
 _UNSUPPORTED_ITEM_TYPES = frozenset(
     {
         "collabAgentToolCall",
         "commandExecution",
-        "dynamicToolCall",
         "hookPrompt",
         "imageGeneration",
         "mcpToolCall",
@@ -57,6 +85,19 @@ _UNSUPPORTED_REASON_CODES = frozenset(
         "additional_file_action_item",
         "duplicate_file_action_item_after_completion",
         "duplicate_approval_request",
+        "modify_requires_repository_read",
+        "read_file_not_utf8",
+        "read_file_too_large",
+        "read_identity_changed",
+        "read_path_not_found",
+        "read_path_not_regular_file",
+        "read_path_outside_repository",
+        "read_preimage_changed_before_approval",
+        "read_request_identity_mismatch",
+        "read_write_path_mismatch",
+        "additional_read_target",
+        "unsupported_dynamic_tool",
+        "unsupported_read_request_shape",
         "unapproved_file_completion",
         "unsupported_file_change_shape",
         "unsupported_request_method:other",
@@ -75,6 +116,22 @@ class CodexAdapterUnavailable(RuntimeError):
 
 class CodexAdapterFailure(RuntimeError):
     """The app-server contract or bounded run failed before a safe result."""
+
+
+class _ReadValidationError(RuntimeError):
+    """One typed repository read was rejected before content disclosure."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        path: str | None,
+        repository_identity: str | None,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.path = path
+        self.repository_identity = repository_identity
 
 
 @dataclass(frozen=True)
@@ -101,6 +158,7 @@ class CodexRunResult:
     checkpoint_outcomes: tuple[CheckpointOutcome, ...]
     final_message: str = ""
     file_actions: tuple[CodexFileAction, ...] = ()
+    read_evidence: tuple[CodexReadEvidence, ...] = ()
     unsupported_reason: str | None = None
 
     def __post_init__(self) -> None:
@@ -146,6 +204,52 @@ class CodexFileAction:
     normalized_scope: str
     access: str
     status: str
+
+
+@dataclass(frozen=True)
+class CodexReadEvidence:
+    """Content-free evidence for one bounded repository read attempt."""
+
+    path: str | None
+    byte_count: int | None
+    sha256: str | None
+    repository_identity: str | None
+    status: str
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in {"succeeded", "failed"}:
+            raise ValueError("Codex read evidence status is unsupported.")
+        if (self.status == "succeeded") != (self.reason is None):
+            raise ValueError(
+                "Codex read evidence status and reason must agree."
+            )
+        if self.reason is not None and self.reason not in _UNSUPPORTED_REASON_CODES:
+            raise ValueError("Codex read evidence reason must be bounded.")
+
+
+@dataclass(frozen=True)
+class _CodexReadBinding:
+    """Exact one-Run binding for one successful dynamic read item."""
+
+    run_id: str
+    call_id: str
+    normalized_scope: str
+    byte_count: int
+    sha256: str
+    repository_identity: str
+    content: str
+    arguments_identity: str
+
+
+@dataclass(frozen=True)
+class _CodexReadResponse:
+    """One exact app-server response retained for replay verification."""
+
+    call_id: str
+    arguments_identity: str
+    success: bool
+    content_items: tuple[dict[str, str], ...]
 
 
 @dataclass(frozen=True)
@@ -392,6 +496,13 @@ class CodexAdapter:
         self._approved_changes: dict[str, list[dict[str, Any]]] = {}
         self._approval_requests: dict[str | int, str | None] = {}
         self._resolved_approval_requests: set[str | int] = set()
+        self._read_requests: dict[str | int, str | None] = {}
+        self._resolved_read_requests: set[str | int] = set()
+        self._read_responses: dict[str, _CodexReadResponse] = {}
+        self._read_replay_failures: dict[str, _CodexReadResponse] = {}
+        self._read_evidence: list[CodexReadEvidence] = []
+        self._read_binding: _CodexReadBinding | None = None
+        self._completed_read_items: set[str] = set()
         self._accepted_items: set[str] = set()
         self._declined_items: set[str] = set()
         self._resolved_items: set[str] = set()
@@ -421,6 +532,13 @@ class CodexAdapter:
         self._approved_changes = {}
         self._approval_requests = {}
         self._resolved_approval_requests = set()
+        self._read_requests = {}
+        self._resolved_read_requests = set()
+        self._read_responses = {}
+        self._read_replay_failures = {}
+        self._read_evidence = []
+        self._read_binding = None
+        self._completed_read_items = set()
         self._accepted_items = set()
         self._declined_items = set()
         self._resolved_items = set()
@@ -602,6 +720,7 @@ class CodexAdapter:
                     },
                     "cwd": str(repository),
                     "developerInstructions": _DEVELOPER_INSTRUCTIONS,
+                    "dynamicTools": [copy.deepcopy(_READ_TOOL_SPEC)],
                     "ephemeral": True,
                     "model": self.expected_model,
                     "modelProvider": "openai",
@@ -834,17 +953,28 @@ class CodexAdapter:
         return tuple(actions)
 
     def _final_message_with_diagnostic(self, status: str) -> str:
+        message = self._final_message
+        read_binding = self._read_binding
+        if (
+            read_binding is not None
+            and read_binding.content
+            and read_binding.content in message
+        ):
+            message = message.replace(
+                read_binding.content,
+                "[Repository source content withheld.]",
+            )
         if (
             status != "UNSUPPORTED_MUTATION"
             or self._unsupported_reason is None
         ):
-            return self._final_message
+            return message
         diagnostic = (
             "Decision OS verification: not verified "
             f"({self._unsupported_reason})."
         )
-        separator = "\n\n" if self._final_message else ""
-        return f"{self._final_message}{separator}{diagnostic}"
+        separator = "\n\n" if message else ""
+        return f"{message}{separator}{diagnostic}"
 
     def _map_file_change(
         self,
@@ -918,6 +1048,439 @@ class CodexAdapter:
             item_id if isinstance(item_id, str) else None
         )
         return True
+
+    @staticmethod
+    def _arguments_identity(arguments: dict[str, Any]) -> str:
+        return hashlib.sha256(
+            json.dumps(
+                arguments,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()
+
+    @staticmethod
+    def _read_content_item(payload: dict[str, Any]) -> tuple[dict[str, str], ...]:
+        return (
+            {
+                "type": "inputText",
+                "text": json.dumps(
+                    payload,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+            },
+        )
+
+    def _record_read_evidence(self, evidence: CodexReadEvidence) -> None:
+        if evidence not in self._read_evidence:
+            self._read_evidence.append(evidence)
+
+    def _read_failure_response(
+        self,
+        *,
+        call_id: str,
+        arguments_identity: str,
+        reason: str,
+        path: str | None,
+        repository_identity: str | None,
+    ) -> _CodexReadResponse:
+        self._mark_unsupported(reason)
+        evidence = CodexReadEvidence(
+            path=path,
+            byte_count=None,
+            sha256=None,
+            repository_identity=repository_identity,
+            status="failed",
+            reason=reason,
+        )
+        self._record_read_evidence(evidence)
+        return _CodexReadResponse(
+            call_id=call_id,
+            arguments_identity=arguments_identity,
+            success=False,
+            content_items=self._read_content_item(
+                {
+                    "bytes": None,
+                    "path": path,
+                    "reason": reason,
+                    "repository_identity": repository_identity,
+                    "sha256": None,
+                    "status": "failed",
+                }
+            ),
+        )
+
+    def _normalized_read_path(self, raw_path: str) -> str:
+        candidate = raw_path.strip()
+        if (
+            not candidate
+            or "\x00" in candidate
+            or "\\" in candidate
+            or Path(candidate).is_absolute()
+            or _WINDOWS_ABSOLUTE_PATH.match(candidate) is not None
+        ):
+            raise _ReadValidationError(
+                "read_path_outside_repository",
+                path=None,
+                repository_identity=None,
+            )
+        parts: list[str] = []
+        for part in candidate.split("/"):
+            if part in {"", "."}:
+                continue
+            if part == ".." or part.casefold() == ".git":
+                raise _ReadValidationError(
+                    "read_path_outside_repository",
+                    path=None,
+                    repository_identity=None,
+                )
+            parts.append(part)
+        if not parts:
+            raise _ReadValidationError(
+                "read_path_outside_repository",
+                path=None,
+                repository_identity=None,
+            )
+        return "/".join(parts)
+
+    def _read_repository_file(
+        self,
+        raw_path: str,
+    ) -> tuple[str, bytes, str, str]:
+        normalized = self._normalized_read_path(raw_path)
+        repository = self.engine.store.repository.resolve(strict=True)
+        try:
+            repository_identity = git_output(
+                repository,
+                "rev-parse",
+                "HEAD^{commit}",
+            )
+        except Exception as exc:
+            raise CodexAdapterFailure(
+                "Selected repository identity is unavailable."
+            ) from exc
+        target = repository.joinpath(*normalized.split("/"))
+        try:
+            resolved = target.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise _ReadValidationError(
+                "read_path_not_found",
+                path=normalized,
+                repository_identity=repository_identity,
+            ) from exc
+        except (OSError, RuntimeError) as exc:
+            raise _ReadValidationError(
+                "read_path_not_regular_file",
+                path=normalized,
+                repository_identity=repository_identity,
+            ) from exc
+        try:
+            relative_resolved = resolved.relative_to(repository)
+        except ValueError as exc:
+            raise _ReadValidationError(
+                "read_path_outside_repository",
+                path=None,
+                repository_identity=repository_identity,
+            ) from exc
+        if any(part.casefold() == ".git" for part in relative_resolved.parts):
+            raise _ReadValidationError(
+                "read_path_outside_repository",
+                path=None,
+                repository_identity=repository_identity,
+            )
+        try:
+            with resolved.open("rb") as handle:
+                before = os.fstat(handle.fileno())
+                if not stat.S_ISREG(before.st_mode):
+                    raise _ReadValidationError(
+                        "read_path_not_regular_file",
+                        path=normalized,
+                        repository_identity=repository_identity,
+                    )
+                if before.st_size > _READ_MAX_BYTES:
+                    raise _ReadValidationError(
+                        "read_file_too_large",
+                        path=normalized,
+                        repository_identity=repository_identity,
+                    )
+                data = handle.read(_READ_MAX_BYTES + 1)
+                after = os.fstat(handle.fileno())
+        except _ReadValidationError:
+            raise
+        except (OSError, ValueError) as exc:
+            raise _ReadValidationError(
+                "read_path_not_regular_file",
+                path=normalized,
+                repository_identity=repository_identity,
+            ) from exc
+        if len(data) > _READ_MAX_BYTES:
+            raise _ReadValidationError(
+                "read_file_too_large",
+                path=normalized,
+                repository_identity=repository_identity,
+            )
+        before_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+        after_identity = (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+        )
+        if before_identity != after_identity:
+            raise _ReadValidationError(
+                "read_identity_changed",
+                path=normalized,
+                repository_identity=repository_identity,
+            )
+        try:
+            content = data.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise _ReadValidationError(
+                "read_file_not_utf8",
+                path=normalized,
+                repository_identity=repository_identity,
+            ) from exc
+        if (
+            git_output(repository, "rev-parse", "HEAD^{commit}")
+            != repository_identity
+        ):
+            raise _ReadValidationError(
+                "read_identity_changed",
+                path=normalized,
+                repository_identity=repository_identity,
+            )
+        return normalized, data, content, repository_identity
+
+    def _send_read_response(
+        self,
+        request_id: str | int,
+        response: _CodexReadResponse,
+    ) -> None:
+        self._send(
+            {
+                "id": request_id,
+                "result": {
+                    "contentItems": [dict(item) for item in response.content_items],
+                    "success": response.success,
+                },
+            }
+        )
+
+    def _respond_read_tool_call(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        params = self._require_object(
+            message.get("params"),
+            "dynamic read parameters",
+        )
+        call_id = params.get("callId")
+        arguments = params.get("arguments")
+        valid_request_id = (
+            isinstance(request_id, (str, int))
+            and not isinstance(request_id, bool)
+        )
+        safe_call_id = call_id if isinstance(call_id, str) else "invalid-read"
+        safe_arguments = arguments if isinstance(arguments, dict) else {}
+        arguments_identity = self._arguments_identity(safe_arguments)
+        if valid_request_id and request_id in self._read_requests:
+            if self._read_requests[request_id] != call_id:
+                response = self._read_failure_response(
+                    call_id=safe_call_id,
+                    arguments_identity=arguments_identity,
+                    reason="read_request_identity_mismatch",
+                    path=None,
+                    repository_identity=None,
+                )
+                self._send_read_response(request_id, response)
+                return
+        elif valid_request_id:
+            self._read_requests[request_id] = (
+                call_id if isinstance(call_id, str) else None
+            )
+        else:
+            response = self._read_failure_response(
+                call_id=safe_call_id,
+                arguments_identity=arguments_identity,
+                reason="read_request_identity_mismatch",
+                path=None,
+                repository_identity=None,
+            )
+            self._send_read_response(request_id, response)
+            return
+
+        item = self._items.get(safe_call_id)
+        valid_shape = bool(
+            set(params).issubset(
+                {"arguments", "callId", "namespace", "threadId", "tool", "turnId"}
+            )
+            and set(params) >= {"arguments", "callId", "threadId", "tool", "turnId"}
+            and isinstance(call_id, str)
+            and bool(call_id)
+            and isinstance(arguments, dict)
+            and set(arguments) == {"path"}
+            and isinstance(arguments.get("path"), str)
+            and params.get("tool") == _READ_TOOL_NAME
+            and params.get("namespace") is None
+            and self._ids_match(params)
+            and self._settings_verified
+            and item is not None
+            and item.get("type") == "dynamicToolCall"
+            and item.get("tool") == _READ_TOOL_NAME
+            and item.get("namespace") is None
+            and item.get("arguments") == arguments
+        )
+        if not valid_shape:
+            reason = (
+                "unsupported_dynamic_tool"
+                if params.get("tool") != _READ_TOOL_NAME
+                else "unsupported_read_request_shape"
+            )
+            response = self._read_failure_response(
+                call_id=safe_call_id,
+                arguments_identity=arguments_identity,
+                reason=reason,
+                path=None,
+                repository_identity=None,
+            )
+            if safe_call_id in self._read_responses:
+                self._read_replay_failures[safe_call_id] = response
+            else:
+                self._read_responses[safe_call_id] = response
+            self._send_read_response(request_id, response)
+            return
+
+        assert isinstance(call_id, str)
+        assert isinstance(arguments, dict)
+        existing = self._read_responses.get(call_id)
+        if existing is not None:
+            if existing.arguments_identity != arguments_identity:
+                response = self._read_failure_response(
+                    call_id=call_id,
+                    arguments_identity=arguments_identity,
+                    reason="read_request_identity_mismatch",
+                    path=None,
+                    repository_identity=None,
+                )
+                self._send_read_response(request_id, response)
+                return
+            replay_failure = self._read_replay_failures.get(call_id)
+            if replay_failure is not None:
+                self._send_read_response(request_id, replay_failure)
+                return
+            if existing.success:
+                binding = self._read_binding
+                try:
+                    current = self._read_repository_file(arguments["path"])
+                except (CodexAdapterFailure, _ReadValidationError):
+                    current = None
+                if (
+                    binding is None
+                    or binding.call_id != call_id
+                    or current is None
+                    or current[0] != binding.normalized_scope
+                    or current[1] != binding.content.encode("utf-8")
+                    or hashlib.sha256(current[1]).hexdigest() != binding.sha256
+                    or current[3] != binding.repository_identity
+                ):
+                    response = self._read_failure_response(
+                        call_id=call_id,
+                        arguments_identity=arguments_identity,
+                        reason="read_identity_changed",
+                        path=(binding.normalized_scope if binding else None),
+                        repository_identity=(
+                            binding.repository_identity if binding else None
+                        ),
+                    )
+                    self._read_replay_failures[call_id] = response
+                    self._send_read_response(request_id, response)
+                    return
+            self._send_read_response(request_id, existing)
+            return
+
+        if self._read_binding is not None:
+            response = self._read_failure_response(
+                call_id=call_id,
+                arguments_identity=arguments_identity,
+                reason="additional_read_target",
+                path=None,
+                repository_identity=self._read_binding.repository_identity,
+            )
+            self._read_responses[call_id] = response
+            self._send_read_response(request_id, response)
+            return
+
+        try:
+            normalized, data, content, repository_identity = (
+                self._read_repository_file(arguments["path"])
+            )
+        except _ReadValidationError as exc:
+            response = self._read_failure_response(
+                call_id=call_id,
+                arguments_identity=arguments_identity,
+                reason=exc.reason,
+                path=exc.path,
+                repository_identity=exc.repository_identity,
+            )
+            self._read_responses[call_id] = response
+            self._send_read_response(request_id, response)
+            return
+        except CodexAdapterFailure:
+            response = self._read_failure_response(
+                call_id=call_id,
+                arguments_identity=arguments_identity,
+                reason="read_request_identity_mismatch",
+                path=None,
+                repository_identity=None,
+            )
+            self._read_responses[call_id] = response
+            self._send_read_response(request_id, response)
+            return
+        digest = hashlib.sha256(data).hexdigest()
+        binding = _CodexReadBinding(
+            run_id=self._run_id,
+            call_id=call_id,
+            normalized_scope=normalized,
+            byte_count=len(data),
+            sha256=digest,
+            repository_identity=repository_identity,
+            content=content,
+            arguments_identity=arguments_identity,
+        )
+        response = _CodexReadResponse(
+            call_id=call_id,
+            arguments_identity=arguments_identity,
+            success=True,
+            content_items=self._read_content_item(
+                {
+                    "bytes": len(data),
+                    "content": content,
+                    "path": normalized,
+                    "repository_identity": repository_identity,
+                    "sha256": digest,
+                }
+            ),
+        )
+        self._read_binding = binding
+        self._read_responses[call_id] = response
+        self._record_read_evidence(
+            CodexReadEvidence(
+                path=normalized,
+                byte_count=len(data),
+                sha256=digest,
+                repository_identity=repository_identity,
+                status="succeeded",
+            )
+        )
+        self._send_read_response(request_id, response)
 
     def _respond_file_approval(self, message: dict[str, Any]) -> None:
         request_id = message.get("id")
@@ -1021,6 +1584,57 @@ class CodexAdapter:
             )
             return
 
+        if decision_type is DecisionType.MODIFY_FILE:
+            read_binding = self._read_binding
+            if (
+                read_binding is None
+                or read_binding.run_id != self._run_id
+                or read_binding.call_id not in self._completed_read_items
+            ):
+                reason = "modify_requires_repository_read"
+            elif read_binding.normalized_scope != normalized:
+                reason = "read_write_path_mismatch"
+            else:
+                try:
+                    current = self._read_repository_file(normalized)
+                except (CodexAdapterFailure, _ReadValidationError):
+                    current = None
+                if (
+                    current is None
+                    or current[0] != read_binding.normalized_scope
+                    or hashlib.sha256(current[1]).hexdigest()
+                    != read_binding.sha256
+                    or current[3] != read_binding.repository_identity
+                ):
+                    reason = "read_preimage_changed_before_approval"
+                else:
+                    reason = None
+            if reason is not None:
+                self._mark_unsupported(reason)
+                self._declined_items.add(item_id)
+                self._record_read_evidence(
+                    CodexReadEvidence(
+                        path=(
+                            read_binding.normalized_scope
+                            if read_binding is not None
+                            else normalized
+                        ),
+                        byte_count=None,
+                        sha256=None,
+                        repository_identity=(
+                            read_binding.repository_identity
+                            if read_binding is not None
+                            else None
+                        ),
+                        status="failed",
+                        reason=reason,
+                    )
+                )
+                self._send(
+                    {"id": request_id, "result": {"decision": "decline"}}
+                )
+                return
+
         self._iteration += 1
         outcome = self.engine.evaluate(
             run_id=self._run_id,
@@ -1094,10 +1708,15 @@ class CodexAdapter:
         ):
             self._identity_failure = True
             return
-        if (
-            request_id not in self._approval_requests
-        ):
+        is_approval = request_id in self._approval_requests
+        is_read = request_id in self._read_requests
+        if is_approval == is_read:
             self._identity_failure = True
+            return
+        if is_read:
+            if request_id in self._resolved_read_requests:
+                return
+            self._resolved_read_requests.add(request_id)
             return
         if request_id in self._resolved_approval_requests:
             return
@@ -1146,12 +1765,24 @@ class CodexAdapter:
                 f"unsupported_item_type:{item_type}"
             )
             return
-        if item_type != "fileChange":
+        if item_type not in {"dynamicToolCall", "fileChange"}:
             return
         item_id = item.get("id")
         if not isinstance(item_id, str) or not item_id:
             self._identity_failure = True
             return
+        if item_type == "dynamicToolCall":
+            arguments = item.get("arguments")
+            if (
+                item.get("tool") != _READ_TOOL_NAME
+                or item.get("namespace") is not None
+                or item.get("status") != "inProgress"
+                or not isinstance(arguments, dict)
+                or set(arguments) != {"path"}
+                or not isinstance(arguments.get("path"), str)
+            ):
+                self._mark_unsupported("unsupported_dynamic_tool")
+                return
         if item_id in self._items:
             if self._items[item_id] != item:
                 self._identity_failure = True
@@ -1188,6 +1819,51 @@ class CodexAdapter:
             self._mark_unsupported(
                 f"unsupported_item_type:{item_type}"
             )
+            return
+        if item_type == "dynamicToolCall":
+            item_id = item.get("id")
+            response = None
+            if isinstance(item_id, str):
+                response = (
+                    self._read_replay_failures.get(item_id)
+                    or self._read_responses.get(item_id)
+                )
+            started = (
+                self._items.get(item_id)
+                if isinstance(item_id, str)
+                else None
+            )
+            resolved = any(
+                request_id in self._resolved_read_requests
+                and request_item_id == item_id
+                for request_id, request_item_id in self._read_requests.items()
+            )
+            expected_status = (
+                "completed" if response is not None and response.success else "failed"
+            )
+            if (
+                response is None
+                or started is None
+                or item.get("tool") != _READ_TOOL_NAME
+                or item.get("namespace") is not None
+                or item.get("arguments") != started.get("arguments")
+                or self._arguments_identity(item.get("arguments", {}))
+                != response.arguments_identity
+                or item.get("status") != expected_status
+                or (
+                    "success" in item
+                    and item.get("success") is not response.success
+                )
+                or (
+                    "contentItems" in item
+                    and item.get("contentItems")
+                    != [dict(value) for value in response.content_items]
+                )
+                or not resolved
+            ):
+                self._identity_failure = True
+                return
+            self._completed_read_items.add(item_id)
             return
         if item_type == "agentMessage":
             text = item.get("text")
@@ -1302,6 +1978,8 @@ class CodexAdapter:
         if "id" in message:
             if method == "item/fileChange/requestApproval":
                 self._respond_file_approval(message)
+            elif method == "item/tool/call":
+                self._respond_read_tool_call(message)
             else:
                 self._respond_unsupported_request(message)
             return
@@ -1386,10 +2064,19 @@ class CodexAdapter:
         all_accepted_completed = self._accepted_items.issubset(
             self._completed_items
         )
+        successful_read_items = {
+            call_id
+            for call_id, response in self._read_responses.items()
+            if response.success
+        }
+        all_reads_completed = successful_read_items.issubset(
+            self._completed_read_items
+        )
         normal_terminal = bool(
             self._turn_status == "completed"
             and self._settings_verified
             and all_accepted_completed
+            and all_reads_completed
             and not self._permission_denied
             and not self._unsupported_mutation
             and not self._identity_failure
@@ -1437,5 +2124,6 @@ class CodexAdapter:
             checkpoint_outcomes=checkpoints,
             final_message=self._final_message_with_diagnostic(status),
             file_actions=file_actions,
+            read_evidence=tuple(self._read_evidence),
             unsupported_reason=self._unsupported_reason,
         )

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -238,6 +238,7 @@ class CompanionController:
             "progress": [],
             "result": "",
             "file_actions": [],
+            "read_evidence": [],
             "outcomes": {
                 "execution": {
                     "state": "not_started",
@@ -609,6 +610,7 @@ class CompanionController:
                 "progress": [],
                 "result": "",
                 "file_actions": [],
+                "read_evidence": [],
                 "runtime": None,
                 "receipt_delta": None,
                 "approval": None,
@@ -1257,6 +1259,22 @@ class CompanionController:
         ]
 
     @staticmethod
+    def _public_read_evidence(
+        result: CodexRunResult,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "path": evidence.path,
+                "bytes": evidence.byte_count,
+                "sha256": evidence.sha256,
+                "repository_identity": evidence.repository_identity,
+                "status": evidence.status,
+                "reason": evidence.reason,
+            }
+            for evidence in result.read_evidence
+        ]
+
+    @staticmethod
     def _public_outcomes(result: CodexRunResult) -> dict[str, Any]:
         execution_completed = result.turn_status == "completed"
         execution = {
@@ -1359,6 +1377,7 @@ class CompanionController:
             self._run["state"] = self._display_state(result)
             self._run["result"] = result.final_message
             self._run["file_actions"] = self._public_actions(result)
+            self._run["read_evidence"] = self._public_read_evidence(result)
             self._run["outcomes"] = self._public_outcomes(result)
             self._run["runtime"] = self._public_runtime(result)
             self._run["receipt_delta"] = self._receipt_delta(before, after)
@@ -1390,6 +1409,7 @@ class CompanionController:
             self._run["state"] = "needs_attention"
             self._run["result"] = ""
             self._run["file_actions"] = []
+            self._run["read_evidence"] = []
             self._run["outcomes"] = {
                 "execution": {
                     "state": "not_completed",

--- a/decision_os/companion/static/app.css
+++ b/decision_os/companion/static/app.css
@@ -558,6 +558,48 @@ summary:focus-visible {
   margin-top: 0.35rem;
 }
 
+.response-heading {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.response-heading h3 {
+  margin-bottom: 0.45rem;
+}
+
+.compact-action {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.75rem;
+}
+
+.read-evidence-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.read-evidence-item {
+  background: #f7f8fb;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  display: grid;
+  gap: 0.3rem 0.8rem;
+  grid-template-columns: max-content minmax(0, 1fr);
+  margin: 0;
+  padding: 0.8rem;
+}
+
+.read-evidence-item dt {
+  font-size: 0.72rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.read-evidence-item dd {
+  overflow-wrap: anywhere;
+}
+
 .technical-details {
   border-top: 1px solid var(--line);
   margin-top: 1rem;
@@ -760,6 +802,7 @@ dd {
   }
 
   .section-heading,
+  .response-heading,
   .file-action,
   .default-row {
     align-items: stretch;

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -30,6 +30,8 @@ let operationTerminalTransitioned = false;
 let operationLastApprovalKey = null;
 let preparedContractTaskBinding = null;
 let ordinaryReviewDisclosureIdentity = null;
+let currentCodexResponse = "";
+let copyResponseResetTimer = null;
 
 const MAX_BRIDGE_ARTIFACT_BYTES = 1024 * 1024;
 const CONTRACT_PREVIEW_CHARACTERS = 4096;
@@ -696,6 +698,81 @@ function renderRuntime(runtime) {
   }
 }
 
+function renderReadEvidence(evidence) {
+  const values = Array.isArray(evidence) ? evidence : [];
+  const target = byId("read-evidence-list");
+  target.replaceChildren();
+  setHidden("read-evidence-card", values.length === 0);
+  for (const value of values) {
+    const item = document.createElement("dl");
+    item.className = "read-evidence-item";
+    const rows = [
+      ["Status", value.status],
+      ["Path", value.path],
+      ["Bytes", value.bytes],
+      ["SHA-256", value.sha256],
+      ["Repository", value.repository_identity],
+      ["Reason", value.reason],
+    ];
+    for (const [label, field] of rows) {
+      if (field == null || field === "") {
+        continue;
+      }
+      const term = document.createElement("dt");
+      const detail = document.createElement("dd");
+      term.textContent = label;
+      detail.textContent = String(field);
+      item.append(term, detail);
+    }
+    target.append(item);
+  }
+}
+
+function resetCopyResponseFeedback() {
+  if (copyResponseResetTimer !== null) {
+    window.clearTimeout?.(copyResponseResetTimer);
+    copyResponseResetTimer = null;
+  }
+  setText("copy-response", "Copy response");
+  setText("copy-response-status", "");
+}
+
+function renderCopyResponse(response, terminal) {
+  const exactResponse = typeof response === "string" ? response : "";
+  if (exactResponse !== currentCodexResponse) {
+    currentCodexResponse = exactResponse;
+    resetCopyResponseFeedback();
+  }
+  const available = terminal && currentCodexResponse.length > 0;
+  setHidden("copy-response", !available);
+  byId("copy-response").disabled = !available;
+}
+
+async function writeClipboardText(value) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+  const activeElement = document.activeElement;
+  const scrollX = window.scrollX;
+  const scrollY = window.scrollY;
+  const localCopy = document.createElement("textarea");
+  localCopy.value = value;
+  localCopy.readOnly = true;
+  localCopy.setAttribute("aria-hidden", "true");
+  localCopy.style.position = "fixed";
+  localCopy.style.inset = "0 auto auto -10000px";
+  document.body.append(localCopy);
+  localCopy.select();
+  const copied = document.execCommand?.("copy") === true;
+  localCopy.remove();
+  activeElement?.focus?.({ preventScroll: true });
+  window.scrollTo?.(scrollX, scrollY);
+  if (!copied) {
+    throw new Error("Clipboard copy failed.");
+  }
+}
+
 function renderResult(run) {
   const terminal = TERMINAL_RUN_STATES.includes(run.state);
   setHidden("result-card", !terminal);
@@ -727,8 +804,10 @@ function renderResult(run) {
         ? "The bounded Run completed without a final text response."
         : run.error || "No final result was available."),
   );
+  renderCopyResponse(run.result, terminal);
   renderActions(run.file_actions);
   renderRuntime(run.runtime);
+  renderReadEvidence(run.read_evidence);
 }
 
 function renderApproval(approval) {
@@ -1753,6 +1832,7 @@ function render(state) {
         progress: [],
         result: "",
         file_actions: [],
+        read_evidence: [],
         outcomes: null,
         runtime: null,
         receipt_delta: null,
@@ -1872,6 +1952,7 @@ function enterDisconnected() {
     progress: [],
     result: "",
     file_actions: [],
+    read_evidence: [],
     outcomes: null,
     runtime: null,
     receipt_delta: null,
@@ -2343,6 +2424,35 @@ byId("new-run").addEventListener("click", async () => {
     preparedContractTaskBinding = null;
     render(state);
     byId("task").focus();
+  }
+});
+
+byId("copy-response").addEventListener("click", async () => {
+  const response = currentCodexResponse;
+  if (byId("copy-response").disabled || response.length === 0) {
+    return;
+  }
+  try {
+    await writeClipboardText(response);
+    setText("copy-response", "Copied");
+    setText("copy-response-status", "Codex response copied.");
+    if (copyResponseResetTimer !== null) {
+      window.clearTimeout?.(copyResponseResetTimer);
+    }
+    copyResponseResetTimer = window.setTimeout(() => {
+      if (currentCodexResponse === response) {
+        setText("copy-response", "Copy response");
+        setText("copy-response-status", "");
+      }
+      copyResponseResetTimer = null;
+    }, 1600);
+  } catch (_error) {
+    if (copyResponseResetTimer !== null) {
+      window.clearTimeout?.(copyResponseResetTimer);
+      copyResponseResetTimer = null;
+    }
+    setText("copy-response", "Copy failed");
+    setText("copy-response-status", "Codex response could not be copied.");
   }
 });
 

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -315,7 +315,21 @@
           <dd id="result-verification-reason" class="path-value hidden"></dd>
         </div>
       </dl>
-      <h3>Codex response</h3>
+      <div class="response-heading">
+        <h3>Codex response</h3>
+        <button
+          id="copy-response"
+          class="secondary compact-action hidden"
+          type="button"
+          disabled
+        >Copy response</button>
+      </div>
+      <p
+        id="copy-response-status"
+        class="visually-hidden"
+        role="status"
+        aria-live="polite"
+      ></p>
       <pre id="result" class="result-text"></pre>
       <div id="file-actions" class="file-actions"></div>
       <dl id="runtime" class="runtime-grid"></dl>
@@ -325,6 +339,22 @@
     <details id="additional-evidence" class="additional-evidence">
       <summary>Additional evidence</summary>
       <div class="additional-evidence-content">
+        <section
+          id="read-evidence-card"
+          class="card hidden"
+          aria-labelledby="read-evidence-heading"
+        >
+          <div class="section-heading">
+            <div>
+              <p class="step">E</p>
+              <h2 id="read-evidence-heading">Repository read evidence</h2>
+            </div>
+          </div>
+          <p class="boundary">
+            Content is withheld. This records only the bounded read identity.
+          </p>
+          <div id="read-evidence-list" class="read-evidence-list"></div>
+        </section>
         <section
           id="intelligence-transplant-card"
           class="card hidden"

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -23,6 +23,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexLifecycleEvent,
     CodexRunResult,
     _SubprocessTransport,
+    _redact_complete_source_echo,
 )
 from decision_os.acceleration.engine import AccelerationEngine
 
@@ -645,6 +646,63 @@ def adapter_for(
 
 
 class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    def test_complete_source_echo_guard_preserves_short_and_partial_text(
+        self,
+    ) -> None:
+        cases = (
+            ("Changed target safely.", "a"),
+            ("Line one\n\nLine two\nLine three", "\n"),
+            ("Concatenate safely; do not recatalog anything.", "cat"),
+            (
+                "Prefix alpha\nbeta only; gamma was not reproduced.",
+                "alpha\nbeta\ngamma\n",
+            ),
+        )
+        for message, source_content in cases:
+            with self.subTest(source_content=source_content):
+                self.assertEqual(
+                    message,
+                    _redact_complete_source_echo(message, source_content),
+                )
+
+        self.assertEqual(
+            "unchanged",
+            _redact_complete_source_echo("unchanged", ""),
+        )
+
+    def test_complete_source_echo_guard_redacts_only_exact_structures(
+        self,
+    ) -> None:
+        marker = "[Repository source content withheld.]"
+        source_content = "alpha\nbeta\ngamma\n"
+        self.assertEqual(
+            marker,
+            _redact_complete_source_echo(
+                f" \t\n{source_content} \n",
+                source_content,
+            ),
+        )
+        self.assertEqual(
+            f"Prefix exact.\n\n```text\n{marker}\n```\n\nSuffix exact.",
+            _redact_complete_source_echo(
+                f"Prefix exact.\n\n```text\n{source_content}```\n\n"
+                "Suffix exact.",
+                source_content,
+            ),
+        )
+        long_source = (
+            "first bounded line\n"
+            "second bounded line\n"
+            "third bounded line\n"
+        )
+        self.assertEqual(
+            f"Prefix exact.\n\n{marker}\n\nSuffix exact.",
+            _redact_complete_source_echo(
+                f"Prefix exact.\n\n{long_source}\nSuffix exact.",
+                long_source,
+            ),
+        )
+
     def test_run_result_rejects_unbounded_unsupported_reason(self) -> None:
         common = {
             "run_id": "run-1",
@@ -713,7 +771,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual("NORMAL_TERMINAL", result.status)
             self.assertTrue(result.normal_terminal)
             self.assertEqual(
-                "Before\n[Repository source content withheld.]After",
+                "Before\none\nAfter",
                 result.final_message,
             )
             self.assertEqual("", output.getvalue())
@@ -736,6 +794,12 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             sent = factory.transports[0].sent
             thread_start = next(
                 value for value in sent if value.get("method") == "thread/start"
+            )
+            self.assertIn(
+                "Do not reproduce the complete repository source file in the "
+                "final response. Report only what was changed, the path, and "
+                "the bounded completion result.",
+                thread_start["params"]["developerInstructions"],
             )
             self.assertEqual(
                 [
@@ -1231,6 +1295,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 approvals[0],
             )
             self.assertEqual(1, len(result.file_actions))
+            self.assertEqual("Modify", result.file_actions[0].action)
+            self.assertEqual(
+                "target.txt",
+                result.file_actions[0].normalized_scope,
+            )
             self.assertEqual("one-time", result.file_actions[0].access)
             self.assertEqual("approved", result.file_actions[0].status)
             self.assertIsNone(result.unsupported_reason)

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections import deque
+import hashlib
 import io
+import json
 from pathlib import Path
 import subprocess
 import tempfile
@@ -34,6 +36,27 @@ def create_repository(parent: Path) -> Path:
         capture_output=True,
     )
     (repository / "target.txt").write_text("one\n", encoding="utf-8")
+    subprocess.run(
+        ("git", "-C", str(repository), "add", "target.txt"),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        (
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-qm",
+            "initial",
+        ),
+        check=True,
+        capture_output=True,
+    )
     return repository
 
 
@@ -268,6 +291,110 @@ def completed_agent_message(
     }
 
 
+def started_read(
+    *,
+    thread_id: str,
+    turn_id: str,
+    call_id: str,
+    path: str,
+) -> dict[str, Any]:
+    return {
+        "method": "item/started",
+        "params": {
+            "item": {
+                "arguments": {"path": path},
+                "id": call_id,
+                "status": "inProgress",
+                "tool": "read_repository_text_file",
+                "type": "dynamicToolCall",
+            },
+            "startedAtMs": 1,
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def read_request(
+    *,
+    thread_id: str,
+    turn_id: str,
+    call_id: str,
+    request_id: str | int,
+    path: str,
+) -> dict[str, Any]:
+    return {
+        "id": request_id,
+        "method": "item/tool/call",
+        "params": {
+            "arguments": {"path": path},
+            "callId": call_id,
+            "threadId": thread_id,
+            "tool": "read_repository_text_file",
+            "turnId": turn_id,
+        },
+    }
+
+
+def completed_read(
+    *,
+    thread_id: str,
+    turn_id: str,
+    call_id: str,
+    path: str,
+    status: str = "completed",
+) -> dict[str, Any]:
+    return {
+        "method": "item/completed",
+        "params": {
+            "completedAtMs": 2,
+            "item": {
+                "arguments": {"path": path},
+                "id": call_id,
+                "status": status,
+                "tool": "read_repository_text_file",
+                "type": "dynamicToolCall",
+            },
+            "threadId": thread_id,
+            "turnId": turn_id,
+        },
+    }
+
+
+def read_messages(
+    *,
+    thread_id: str,
+    turn_id: str,
+    call_id: str,
+    path: str,
+    status: str = "completed",
+) -> list[dict[str, Any]]:
+    request_id = f"request-{call_id}"
+    return [
+        started_read(
+            thread_id=thread_id,
+            turn_id=turn_id,
+            call_id=call_id,
+            path=path,
+        ),
+        read_request(
+            thread_id=thread_id,
+            turn_id=turn_id,
+            call_id=call_id,
+            request_id=request_id,
+            path=path,
+        ),
+        resolved_request(thread_id=thread_id, request_id=request_id),
+        completed_read(
+            thread_id=thread_id,
+            turn_id=turn_id,
+            call_id=call_id,
+            path=path,
+            status=status,
+        ),
+    ]
+
+
 def resolved_request(
     *,
     thread_id: str,
@@ -338,6 +465,22 @@ def file_run_messages(
         turn_id=turn_id,
         **handshake_overrides,
     )
+    if (
+        len(changes) == 1
+        and changes[0].get("kind", {}).get("type") == "update"
+        and changes[0].get("kind", {}).get("move_path") in {None, ""}
+        and isinstance(changes[0].get("path"), str)
+        and not Path(changes[0]["path"]).is_absolute()
+        and ".." not in Path(changes[0]["path"]).parts
+    ):
+        messages.extend(
+            read_messages(
+                thread_id=thread_id,
+                turn_id=turn_id,
+                call_id=f"read-{item_id}",
+                path=changes[0]["path"],
+            )
+        )
     messages.extend(
         [
             started_item(
@@ -529,6 +672,503 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 unsupported_reason="unsupported_request_method:other",
             )
 
+    async def test_dynamic_read_returns_exact_typed_content_without_approval(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            before = (repository / "target.txt").read_bytes()
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-1",
+                    path="target.txt",
+                )
+            )
+            messages.append(
+                completed_agent_message(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    text="Before\none\nAfter",
+                )
+            )
+            messages.append(
+                completed_turn(thread_id="thread-1", turn_id="turn-1")
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, output = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read must not prompt"),
+            )
+
+            result = await adapter.run("Read target.txt.")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertEqual(
+                "Before\n[Repository source content withheld.]After",
+                result.final_message,
+            )
+            self.assertEqual("", output.getvalue())
+            self.assertEqual([], engine.store.read_events())
+            self.assertEqual(before, (repository / "target.txt").read_bytes())
+            self.assertEqual((), result.file_actions)
+            self.assertEqual(1, len(result.read_evidence))
+            evidence = result.read_evidence[0]
+            self.assertEqual("succeeded", evidence.status)
+            self.assertEqual("target.txt", evidence.path)
+            self.assertEqual(len(before), evidence.byte_count)
+            self.assertEqual(hashlib.sha256(before).hexdigest(), evidence.sha256)
+            expected_head = subprocess.run(
+                ("git", "-C", str(repository), "rev-parse", "HEAD"),
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(expected_head, evidence.repository_identity)
+            sent = factory.transports[0].sent
+            thread_start = next(
+                value for value in sent if value.get("method") == "thread/start"
+            )
+            self.assertEqual(
+                [
+                    {
+                        "type": "function",
+                        "name": "read_repository_text_file",
+                        "description": (
+                            "Read one existing strict UTF-8 text file inside "
+                            "the selected repository before proposing a "
+                            "modification to that same file."
+                        ),
+                        "inputSchema": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "required": ["path"],
+                            "properties": {
+                                "path": {"type": "string", "minLength": 1}
+                            },
+                        },
+                    }
+                ],
+                thread_start["params"]["dynamicTools"],
+            )
+            response = next(
+                value
+                for value in sent
+                if value.get("id") == "request-read-1"
+            )
+            self.assertTrue(response["result"]["success"])
+            payload = json.loads(response["result"]["contentItems"][0]["text"])
+            self.assertEqual(
+                {
+                    "bytes": len(before),
+                    "content": "one\n",
+                    "path": "target.txt",
+                    "repository_identity": expected_head,
+                    "sha256": hashlib.sha256(before).hexdigest(),
+                },
+                payload,
+            )
+            self.assertFalse(
+                any(
+                    "decision" in value.get("result", {})
+                    for value in sent
+                )
+            )
+
+    async def test_exact_dynamic_read_replay_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            replay = read_messages(
+                thread_id="thread-1",
+                turn_id="turn-1",
+                call_id="read-1",
+                path="target.txt",
+            )
+            messages.extend(replay[:2])
+            messages.append(replay[1])
+            messages.extend(replay[2:])
+            messages.append(
+                completed_turn(thread_id="thread-1", turn_id="turn-1")
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read replay must not prompt"),
+            )
+
+            result = await adapter.run("Replay one read.")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertEqual(1, len(result.read_evidence))
+            self.assertEqual([], engine.store.read_events())
+            responses = [
+                value
+                for value in factory.transports[0].sent
+                if value.get("id") == "request-read-1"
+            ]
+            self.assertEqual(2, len(responses))
+            self.assertEqual(responses[0], responses[1])
+
+    async def test_second_read_and_changed_replay_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            (repository / "other.txt").write_text("other\n", encoding="utf-8")
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-1",
+                    path="target.txt",
+                )
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-2",
+                    path="other.txt",
+                    status="failed",
+                )
+            )
+            messages.append(
+                completed_turn(thread_id="thread-1", turn_id="turn-1")
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read must not prompt"),
+            )
+
+            result = await adapter.run("Try two reads.")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual("additional_read_target", result.unsupported_reason)
+            self.assertEqual(
+                ["succeeded", "failed"],
+                [value.status for value in result.read_evidence],
+            )
+            self.assertEqual([], engine.store.read_events())
+            response = next(
+                value
+                for value in factory.transports[0].sent
+                if value.get("id") == "request-read-2"
+            )
+            self.assertFalse(response["result"]["success"])
+            self.assertNotIn(
+                "content",
+                json.loads(response["result"]["contentItems"][0]["text"]),
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+            )
+            replay = read_messages(
+                thread_id="thread-2",
+                turn_id="turn-2",
+                call_id="read-1",
+                path="target.txt",
+            )
+            replay[-1] = completed_read(
+                thread_id="thread-2",
+                turn_id="turn-2",
+                call_id="read-1",
+                path="target.txt",
+                status="failed",
+            )
+            messages.extend(replay[:2])
+            messages.append(replay[1])
+            messages.extend(replay[2:])
+            messages.append(
+                completed_turn(thread_id="thread-2", turn_id="turn-2")
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read must not prompt"),
+            )
+            original = adapter._read_repository_file
+            calls = 0
+
+            def mutate_before_replay(path: str) -> tuple[str, bytes, str, str]:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    (repository / "target.txt").write_text(
+                        "changed\n",
+                        encoding="utf-8",
+                    )
+                return original(path)
+
+            with patch.object(
+                adapter,
+                "_read_repository_file",
+                side_effect=mutate_before_replay,
+            ):
+                result = await adapter.run("Replay after byte drift.")
+
+            self.assertEqual("read_identity_changed", result.unsupported_reason)
+            self.assertIsNone(result.error_type)
+            self.assertEqual(
+                ["succeeded", "failed"],
+                [value.status for value in result.read_evidence],
+            )
+
+    async def test_read_path_and_encoding_failures_are_typed(self) -> None:
+        cases = (
+            ("/tmp/outside.txt", "read_path_outside_repository", None),
+            ("../outside.txt", "read_path_outside_repository", None),
+            (".git/config", "read_path_outside_repository", None),
+            ("missing.txt", "read_path_not_found", None),
+            ("directory", "read_path_not_regular_file", "directory"),
+            ("invalid.txt", "read_file_not_utf8", "invalid"),
+            ("large.txt", "read_file_too_large", "large"),
+            ("escape.txt", "read_path_outside_repository", "symlink"),
+            ("git-config.txt", "read_path_outside_repository", "git-symlink"),
+        )
+        for index, (path, reason, fixture) in enumerate(cases, start=1):
+            with self.subTest(path=path):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    repository = create_repository(root)
+                    if fixture == "directory":
+                        (repository / path).mkdir()
+                    elif fixture == "invalid":
+                        (repository / path).write_bytes(b"\xff\xfe")
+                    elif fixture == "large":
+                        (repository / path).write_bytes(b"x" * 131_073)
+                    elif fixture == "symlink":
+                        outside = root / "outside.txt"
+                        outside.write_text("outside\n", encoding="utf-8")
+                        (repository / path).symlink_to(outside)
+                    elif fixture == "git-symlink":
+                        (repository / path).symlink_to(
+                            repository / ".git" / "config"
+                        )
+                    thread_id = f"thread-{index}"
+                    turn_id = f"turn-{index}"
+                    messages = handshake_messages(
+                        repository,
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                    )
+                    messages.extend(
+                        read_messages(
+                            thread_id=thread_id,
+                            turn_id=turn_id,
+                            call_id=f"read-{index}",
+                            path=path,
+                            status="failed",
+                        )
+                    )
+                    messages.append(
+                        completed_turn(thread_id=thread_id, turn_id=turn_id)
+                    )
+                    factory = FakeTransportFactory([messages])
+                    engine, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: self.fail("read must not prompt"),
+                    )
+
+                    result = await adapter.run("Rejected read.")
+
+                    self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+                    self.assertEqual(reason, result.unsupported_reason)
+                    self.assertEqual("failed", result.read_evidence[0].status)
+                    self.assertEqual([], engine.store.read_events())
+
+    async def test_modify_is_bound_to_read_path_and_current_preimage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                    )
+                ]
+            )
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("Read then modify target.txt.")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertEqual(1, len(result.read_evidence))
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual(
+                1,
+                len(
+                    [
+                        event
+                        for event in engine.store.read_events()
+                        if event["event_type"] == "DECISION_CHECK"
+                    ]
+                ),
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = file_run_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+                item_id="item-2",
+                item_status="declined",
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("stale preimage must not prompt"),
+            )
+            original = adapter._read_repository_file
+            calls = 0
+
+            def mutate_before_approval(path: str) -> tuple[str, bytes, str, str]:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    (repository / "target.txt").write_text(
+                        "changed\n",
+                        encoding="utf-8",
+                    )
+                return original(path)
+
+            with patch.object(
+                adapter,
+                "_read_repository_file",
+                side_effect=mutate_before_approval,
+            ):
+                result = await adapter.run("Stale preimage.")
+
+            self.assertEqual(
+                "read_preimage_changed_before_approval",
+                result.unsupported_reason,
+            )
+            self.assertEqual((), result.file_actions)
+            self.assertEqual([], engine.store.read_events())
+            decisions = [
+                value["result"]["decision"]
+                for value in factory.transports[0].sent
+                if "decision" in value.get("result", {})
+            ]
+            self.assertEqual(["decline"], decisions)
+
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            (repository / "other.txt").write_text("other\n", encoding="utf-8")
+            changes = [change(path="other.txt")]
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-3",
+                turn_id="turn-3",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-3",
+                    turn_id="turn-3",
+                    call_id="read-3",
+                    path="target.txt",
+                )
+            )
+            messages.extend(
+                [
+                    started_item(
+                        thread_id="thread-3",
+                        turn_id="turn-3",
+                        item_id="item-3",
+                        changes=changes,
+                    ),
+                    approval_request(
+                        thread_id="thread-3",
+                        turn_id="turn-3",
+                        item_id="item-3",
+                        request_id="approval-item-3",
+                    ),
+                    resolved_request(
+                        thread_id="thread-3",
+                        request_id="approval-item-3",
+                    ),
+                    completed_item(
+                        thread_id="thread-3",
+                        turn_id="turn-3",
+                        item_id="item-3",
+                        changes=changes,
+                        status="declined",
+                    ),
+                    completed_turn(thread_id="thread-3", turn_id="turn-3"),
+                ]
+            )
+            factory = FakeTransportFactory([messages])
+            engine, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("mismatched path must not prompt"),
+            )
+
+            result = await adapter.run("Modify a different file.")
+
+            self.assertEqual("read_write_path_mismatch", result.unsupported_reason)
+            self.assertEqual((), result.file_actions)
+            self.assertEqual([], engine.store.read_events())
+
+    async def test_create_remains_supported_without_repository_read(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            factory = FakeTransportFactory(
+                [
+                    file_run_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        item_id="item-1",
+                        file_changes=[change(path="created.txt", kind="add")],
+                    )
+                ]
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+
+            result = await adapter.run("Create created.txt.")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertEqual((), result.read_evidence)
+            self.assertEqual("Create", result.file_actions[0].action)
+
     async def test_structured_approval_lifecycle_and_final_message_bridge(
         self,
     ) -> None:
@@ -616,6 +1256,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 repository,
                 thread_id="thread-1",
                 turn_id="turn-1",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
             )
             messages.extend(
                 [
@@ -719,6 +1367,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 thread_id="thread-1",
                 turn_id="turn-1",
             )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
+            )
             for index, item_id in enumerate(
                 ("item-1", "item-2", "item-3"),
                 start=1,
@@ -802,6 +1458,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 repository,
                 thread_id="thread-1",
                 turn_id="turn-1",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
             )
             messages.extend(
                 [
@@ -895,6 +1559,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 repository,
                 thread_id="thread-1",
                 turn_id="turn-1",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
             )
             for index, item_id in enumerate(("item-1", "item-2"), start=1):
                 messages.extend(
@@ -1109,14 +1781,26 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             )
             self.assertLess(
                 events.index("approval_completed:accept"),
-                events.index("received:serverRequest/resolved"),
+                events.index(
+                    "received:serverRequest/resolved",
+                    events.index("approval_completed:accept"),
+                ),
             )
             self.assertLess(
-                events.index("received:serverRequest/resolved"),
-                events.index("received:item/completed"),
+                events.index(
+                    "received:serverRequest/resolved",
+                    events.index("approval_completed:accept"),
+                ),
+                events.index(
+                    "received:item/completed",
+                    events.index("approval_completed:accept"),
+                ),
             )
             self.assertLess(
-                events.index("received:item/completed"),
+                events.index(
+                    "received:item/completed",
+                    events.index("approval_completed:accept"),
+                ),
                 events.index("received:turn/completed"),
             )
             self.assertLess(
@@ -1134,6 +1818,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 repository,
                 thread_id="thread-1",
                 turn_id="turn-1",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
             )
             messages.extend(
                 [
@@ -1293,6 +1985,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 message["result"]["decision"]
                 for message in factory.transports[0].sent
                 if "result" in message
+                and "decision" in message["result"]
             ]
             self.assertEqual(["decline"], approvals)
             self.assertEqual(
@@ -1348,6 +2041,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 turn_id="turn-1",
             )
             same_change = [change()]
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
+            )
             for item_id in ("item-1", "item-2"):
                 messages.extend(
                     [
@@ -1594,9 +2295,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 item_status="declined",
                 include_settings_update=True,
             )
-            matching_update = messages[5]
+            matching_update = next(
+                message
+                for message in messages
+                if message.get("method") == "thread/settings/updated"
+            )
             matching_settings = matching_update["params"]["threadSettings"]
-            messages[5] = {
+            update_index = messages.index(matching_update)
+            messages[update_index] = {
                 "method": "thread/settings/updated",
                 "params": {
                     "threadId": "thread-1",
@@ -1606,7 +2312,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                     },
                 },
             }
-            messages.insert(6, matching_update)
+            messages.insert(update_index + 1, matching_update)
             factory = FakeTransportFactory([messages])
             _, adapter, _ = adapter_for(
                 repository,
@@ -1623,7 +2329,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 result.error_type,
             )
             self.assertEqual(
-                "approval_identity_mismatch",
+                "unsupported_read_request_shape",
                 result.unsupported_reason,
             )
             self.assertIsNone(result.runtime_identity)
@@ -1791,6 +2497,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         message["result"]["decision"]
                         for message in factory.transports[0].sent
                         if "result" in message
+                        and "decision" in message["result"]
                     ]
                     self.assertEqual(["decline"], responses)
 
@@ -1929,10 +2636,12 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         result.status,
                     )
                     self.assertFalse(result.normal_terminal)
-                    self.assertEqual(
-                        f"unsupported_item_type:{item_type}",
-                        result.unsupported_reason,
+                    expected_reason = (
+                        "unsupported_dynamic_tool"
+                        if item_type == "dynamicToolCall"
+                        else f"unsupported_item_type:{item_type}"
                     )
+                    self.assertEqual(expected_reason, result.unsupported_reason)
                     self.assertNotIn(
                         "PRIVATE",
                         result.unsupported_reason,
@@ -2064,7 +2773,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 first.unsupported_reason,
             )
             self.assertEqual(
-                "unsupported_item_type:dynamicToolCall",
+                "unsupported_dynamic_tool",
                 second.unsupported_reason,
             )
 
@@ -2234,6 +2943,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 turn_id="turn-2",
             )
             second.extend(
+                read_messages(
+                    thread_id="thread-2",
+                    turn_id="turn-2",
+                    call_id="read-item-2",
+                    path="target.txt",
+                )
+            )
+            second.extend(
                 [
                     started_item(
                         thread_id="thread-2",
@@ -2306,7 +3023,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             second = [
                 message
                 for message in second
-                if message.get("method") != "serverRequest/resolved"
+                if not (
+                    message.get("method") == "serverRequest/resolved"
+                    and message.get("params", {}).get("requestId")
+                    == "approval-item-2"
+                )
             ]
             factory = FakeTransportFactory(
                 [
@@ -2362,6 +3083,18 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                             },
                         },
                     },
+                ]
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-1",
+                    turn_id="turn-1",
+                    call_id="read-item-1",
+                    path="target.txt",
+                )
+            )
+            messages.extend(
+                [
                     started_item(
                         thread_id="thread-1",
                         turn_id="turn-1",

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -26,6 +26,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexApproval,
     CodexFileAction,
     CodexLifecycleEvent,
+    CodexReadEvidence,
     CodexRunResult,
     CodexRuntimeIdentity,
 )
@@ -196,6 +197,15 @@ class ScriptedAdapter:
                 runtime_identity=runtime_identity(),
                 checkpoint_outcomes=(),
                 final_message="Read-only result.",
+                read_evidence=(
+                    CodexReadEvidence(
+                        path="target.txt",
+                        byte_count=7,
+                        sha256="a" * 64,
+                        repository_identity="b" * 40,
+                        status="succeeded",
+                    ),
+                ),
             )
 
         run_id = self.engine.new_run_id()
@@ -533,6 +543,19 @@ class CompanionControllerTest(unittest.TestCase):
             )
 
             self.assertEqual("Read-only result.", snapshot["run"]["result"])
+            self.assertEqual(
+                [
+                    {
+                        "path": "target.txt",
+                        "bytes": 7,
+                        "sha256": "a" * 64,
+                        "repository_identity": "b" * 40,
+                        "status": "succeeded",
+                        "reason": None,
+                    }
+                ],
+                snapshot["run"]["read_evidence"],
+            )
             self.assertEqual(
                 {
                     "estimated_minutes": 0.0,

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2274,6 +2274,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               },
               setHidden: (id, hidden) => elements.get(id).classList.toggle("hidden", hidden),
               renderActions: () => {},
+              renderCopyResponse: () => {},
+              renderReadEvidence: () => {},
               renderRuntime: () => {},
             };
             vm.createContext(sandbox);
@@ -2819,6 +2821,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 progress: [],
                 result: "",
                 file_actions: [],
+                read_evidence: [],
                 outcomes: null,
                 runtime: null,
                 receipt_delta: null,
@@ -2855,12 +2858,20 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 ...baseRun,
                 state: "unsupported",
                 progress: ["Finalizing the local Receipt."],
-                result: "The requested file was modified.",
+                result: "Line one\n日本語 🌐\nLine three",
                 file_actions: [{
                   action: "Modify",
                   path: "decision_os/companion/static/app.js",
                   access: "one-time",
                   status: "approved",
+                }],
+                read_evidence: [{
+                  path: "decision_os/companion/static/app.js",
+                  bytes: 43210,
+                  sha256: "a".repeat(64),
+                  repository_identity: "b".repeat(40),
+                  status: "succeeded",
+                  reason: null,
                 }],
                 outcomes: {
                   execution: {
@@ -2905,6 +2916,19 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               }
               let serverPhase = "idle";
               let reducedMotion = false;
+              window.__clipboardWrites = [];
+              window.__clipboardFail = false;
+              Object.defineProperty(navigator, "clipboard", {
+                configurable: true,
+                value: {
+                  writeText: async (value) => {
+                    if (window.__clipboardFail) {
+                      throw new Error("Synthetic clipboard failure.");
+                    }
+                    window.__clipboardWrites.push(value);
+                  },
+                },
+              });
               window.__focusCounts = {};
               window.__scrollRecords = [];
               const nativeFocus = HTMLElement.prototype.focus;
@@ -2982,6 +3006,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                   bridgeAction.focus();
                   document.body.dataset.advancedClosed = String(!advanced.open);
                   document.body.dataset.evidenceClosed = String(!additionalEvidence.open);
+                  document.body.dataset.copyHiddenEmpty = String(
+                    document.getElementById("copy-response").classList.contains("hidden") &&
+                    document.getElementById("copy-response").disabled
+                  );
                   document.body.dataset.bridgeContained = String(advanced.contains(bridge));
                   document.body.dataset.bridgeHidden = String(
                     typeof bridge.checkVisibility === "function"
@@ -3166,6 +3194,19 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                     focusCounts["approval-heading"] === 1 &&
                     focusCounts["result-heading"] === 1
                   );
+                  const readEvidence = document.getElementById("read-evidence-card");
+                  const readEvidenceText = document.getElementById(
+                    "read-evidence-list",
+                  ).textContent;
+                  document.body.dataset.readEvidence = String(
+                    !readEvidence.classList.contains("hidden") &&
+                    readEvidenceText.includes("decision_os/companion/static/app.js") &&
+                    readEvidenceText.includes("43210") &&
+                    readEvidenceText.includes("a".repeat(64)) &&
+                    readEvidenceText.includes("b".repeat(40)) &&
+                    !readEvidenceText.includes("Line one") &&
+                    !readEvidenceText.includes("日本語")
+                  );
                   reducedMotion = true;
                   const taskStage = document.querySelector(
                     '[data-operation-stage="task"]'
@@ -3189,6 +3230,69 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                     getComputedStyle(
                       document.getElementById("operation-awareness")
                     ).position === "sticky"
+                  );
+                  const copy = document.getElementById("copy-response");
+                  document.body.dataset.copyAvailable = String(
+                    !copy.classList.contains("hidden") &&
+                    !copy.disabled &&
+                    copy.tagName === "BUTTON"
+                  );
+                  copy.focus();
+                  copy.click();
+                  probePhase = "copy-success";
+                  return;
+                }
+                if (
+                  probePhase === "copy-success" &&
+                  document.getElementById("copy-response").textContent === "Copied"
+                ) {
+                  const copy = document.getElementById("copy-response");
+                  document.body.dataset.copySuccess = String(
+                    document.activeElement === copy &&
+                    document.getElementById("copy-response-status").textContent ===
+                      "Codex response copied." &&
+                    window.__clipboardWrites.length === 1 &&
+                    window.__clipboardWrites[0] ===
+                      "Line one\n日本語 🌐\nLine three" &&
+                    latestState.run.state === "unsupported"
+                  );
+                  copy.click();
+                  probePhase = "copy-repeat";
+                  return;
+                }
+                if (
+                  probePhase === "copy-repeat" &&
+                  window.__clipboardWrites.length === 2
+                ) {
+                  document.body.dataset.copyRepeated = String(
+                    window.__clipboardWrites[0] === window.__clipboardWrites[1] &&
+                    latestState.run.state === "unsupported"
+                  );
+                  probePhase = "copy-restore";
+                  return;
+                }
+                if (
+                  probePhase === "copy-restore" &&
+                  document.getElementById("copy-response").textContent === "Copy response"
+                ) {
+                  document.body.dataset.copyRestored = String(
+                    document.getElementById("copy-response-status").textContent === "" &&
+                    document.activeElement.id === "copy-response"
+                  );
+                  window.__clipboardFail = true;
+                  document.getElementById("copy-response").click();
+                  probePhase = "copy-failure";
+                  return;
+                }
+                if (
+                  probePhase === "copy-failure" &&
+                  document.getElementById("copy-response").textContent === "Copy failed"
+                ) {
+                  document.body.dataset.copyFailure = String(
+                    document.activeElement.id === "copy-response" &&
+                    document.getElementById("copy-response-status").textContent ===
+                      "Codex response could not be copied." &&
+                    latestState.run.state === "unsupported"
                   );
                   document.body.dataset.qualified = "true";
                   window.clearInterval(probe);
@@ -3256,6 +3360,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             "contract-density",
             "advanced-closed",
             "evidence-closed",
+            "copy-hidden-empty",
             "bridge-contained",
             "bridge-hidden",
             "bridge-not-focused",
@@ -3275,8 +3380,14 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             "approval-answered-immediate",
             "continuing",
             "terminal",
+            "read-evidence",
             "manual-navigation",
             "sticky",
+            "copy-available",
+            "copy-success",
+            "copy-repeated",
+            "copy-restored",
+            "copy-failure",
             "qualified",
         ):
             self.assertEqual("true", attributes.get(name), name)
@@ -3981,6 +4092,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "ordinary-contract-error-retry",
               "ordinary-contract-error-dismiss",
               "ordinary-contract-prepare-task",
+              "copy-response",
               "new-run",
               "run",
               ...guidedIntakeButtonIds,
@@ -4060,6 +4172,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "bounded-run-receipt-column",
               "choose-repository",
               "claim-boundary",
+              "copy-response",
+              "copy-response-status",
               "defaults",
               "file-actions",
               "global-error",
@@ -4165,6 +4279,9 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "progress-card",
               "progress-heading",
               "receipt-status",
+              "read-evidence-card",
+              "read-evidence-heading",
+              "read-evidence-list",
               "repository-name",
               "repository-path",
               "repository-receipt",

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2858,7 +2858,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 ...baseRun,
                 state: "unsupported",
                 progress: ["Finalizing the local Receipt."],
-                result: "Line one\n日本語 🌐\nLine three",
+                result: "Guarded prefix\n[Repository source content withheld.]\n日本語 🌐\nGuarded suffix",
                 file_actions: [{
                   action: "Modify",
                   path: "decision_os/companion/static/app.js",
@@ -3253,7 +3253,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                       "Codex response copied." &&
                     window.__clipboardWrites.length === 1 &&
                     window.__clipboardWrites[0] ===
-                      "Line one\n日本語 🌐\nLine three" &&
+                      "Guarded prefix\n[Repository source content withheld.]\n日本語 🌐\nGuarded suffix" &&
                     latestState.run.state === "unsupported"
                   );
                   copy.click();


### PR DESCRIPTION
## Protocol preflight evidence

- Companion bundles codex-cli 0.146.0-alpha.3.1, matching CODEX_CLI_VERSION.
- The installed app-server JSON schema exposes server-defined functions through thread/start.dynamicTools, invokes them with the server request item/tool/call, and accepts DynamicToolCallResponse with typed success and contentItems.
- This change uses that supported mechanism only; it introduces no shell, command execution, MCP, network access, or unrecognized JSON-RPC method.

## Read-tool trust boundary

- Adds exactly one server-owned function, read_repository_text_file, with the exact object input {path: string} and no additional properties.
- Requires an active correlated Run, selected repository, relative normalized path, non-.git target, containment after symlink resolution, existing regular file, strict UTF-8, and a 131072-byte maximum.
- Allows one successful distinct file per Run. Exact call replay is idempotent only while path, bytes, SHA-256, and repository HEAD identity remain unchanged.
- Typed failures cover outside/absolute/../.git/symlink escape, missing or non-regular targets, invalid UTF-8, size overflow, second targets, and identity drift.
- Public read evidence contains only path, bytes, SHA-256, repository identity, status, and typed reason. Source content is withheld from Additional evidence; only structurally identifiable complete-source echoes are suppressed from the ordinary Codex response.

## Read-to-write pre-image binding

- Modify requires a successfully completed read in the same Run for the exact normalized path.
- Before any human decision, Companion re-reads the current pre-image and requires the same SHA-256 and repository HEAD.
- Drift fails closed as read_preimage_changed_before_approval; a different path fails as read_write_path_mismatch; neither path creates a decision event, asks for Approval, or authorizes a write.
- Create retains the existing no-pre-read behavior and the single-file boundary.

## Approval invariant preservation

- The PR #58 binding remains intact: one DECISION_CHECK -> one exact protocol item -> at most one completed file action -> at most one public file_actions row.
- Repository reads create no DECISION_CHECK, Approval, saved permission, Guided Intake mutation, or file action.
- Same-item replay, distinct-item fail-closed behavior, denied actions, and saved exact permissions remain covered.

## Copy response UX

- Adds a compact native Copy response button beside the Codex response heading.
- Copies only the exact current response, preserving line breaks and Unicode; metadata, task text, receipts, actions, and Additional evidence are excluded.
- Empty responses hide/disable the action. Success shows Copied then restores the label; failure shows Copy failed with an accessible live status.
- Focus and scroll are preserved, repeated clicks do not mutate Run state, and no dependency was added.

## Independent review repair — non-destructive source-echo guard

- Independent review requested changes on reviewed head `521ab127706f086b5377336c2bd4319043f5bcfe`; one forward-only repair commit was added without rewriting the original commit.
- The developer instruction now explicitly prohibits reproducing the complete repository source file and limits the final response to the change, path, and bounded completion result.
- Unrestricted `message.replace(read_binding.content, marker)` was removed. The guard now recognizes only the whole response with surrounding whitespace, an exact fenced body, or an exact separately delimited block.
- Empty, one-character, newline-only, common short, partial, and ordinary substring occurrences remain byte-for-byte unchanged. The claim remains bounded and is not a semantic DLP or file-outcome inference.
- Typed Result, read evidence, Approval state, file actions, replay, pre-image binding, and Create-without-read behavior are unchanged.
- Copy response continues to copy the exact post-guard response displayed to the user, including multiline text and Unicode.
- Repair commit / current head: `a3f03811169c79bb1496fc4d84b108247c84be41`.

## Independent re-review acceptance

- Independent re-review: PASS.
- Accepted head: `a3f03811169c79bb1496fc4d84b108247c84be41`.
- Expected base: `9a95aa28b674d74a64dae3f72f91ef439373af33`.
- Decision owner: Shin.

## Validation

- Focused Codex adapter/read/source-echo guard: 43/43 PASS.
- Acceleration store/model/CLI/Claude preservation: 31/31 PASS.
- Companion controller: 26/26 PASS.
- Companion server/client, existing read-before-write and Rail harnesses, and real Chrome guarded Copy response qualification: 35/35 PASS.
- Ordinary User Path/compiler: 35/35 PASS; golden interpretation remains 7503f4b01c7c05c9ec3aed8855c9fd538c66b9b3b38840f423ec41c2101f4dd7.
- Full repository suite on commit a3f0381: 678/678 PASS (388.083s).
- Node syntax and git diff --check: PASS.

## Remaining rollout gate

- Accepted for guarded merge and commit-bound isolated qualification.
- Rail Not used repair remains HOLD.
- Transfer / Builder / Pro / Fable / release / publication remain BLOCK.
