### PR TITLE
Repair typed live-failure diagnostics and Copy response fallback

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -226,13 +226,176 @@ _UNSUPPORTED_REASON_CODES = frozenset(
     | set(_UNSUPPORTED_REQUEST_METHOD_REASONS.values())
 )
 
+_FAILURE_DIAGNOSTIC_SPECS = {
+    "input_validation": (
+        "codex_input_validation_failed",
+        "The bounded Codex task input was rejected safely.",
+        "review_bounded_task",
+    ),
+    "transport_start": (
+        "codex_transport_start_failed",
+        "The private Codex runtime is unavailable.",
+        "recheck_runtime",
+    ),
+    "version_verification": (
+        "codex_version_verification_failed",
+        "The bounded Codex Run failed closed while verifying the runtime version.",
+        "recheck_runtime",
+    ),
+    "initialize_handshake": (
+        "codex_initialize_handshake_failed",
+        "The bounded Codex Run failed closed during runtime initialization.",
+        "recheck_runtime",
+    ),
+    "account_verification": (
+        "codex_account_verification_failed",
+        "The bounded Codex Run failed closed while verifying authentication.",
+        "recheck_runtime",
+    ),
+    "model_verification": (
+        "codex_model_verification_failed",
+        "The bounded Codex Run failed closed while verifying the model configuration.",
+        "recheck_runtime",
+    ),
+    "thread_start": (
+        "codex_thread_start_failed",
+        "The bounded Codex Run failed closed while starting its isolated thread.",
+        "recheck_protocol",
+    ),
+    "thread_identity_verification": (
+        "codex_thread_identity_verification_failed",
+        "The bounded Codex Run failed closed while verifying the isolated thread.",
+        "recheck_protocol",
+    ),
+    "settings_verification": (
+        "codex_settings_verification_failed",
+        "The bounded Codex Run failed closed while verifying runtime settings.",
+        "recheck_runtime",
+    ),
+    "turn_start": (
+        "codex_turn_start_failed",
+        "The bounded Codex Run failed closed while starting the model turn.",
+        "recheck_protocol",
+    ),
+    "turn_started": (
+        "codex_turn_identity_failed",
+        "The bounded Codex Run failed closed while verifying the started turn.",
+        "recheck_protocol",
+    ),
+    "dynamic_tool_call": (
+        "codex_dynamic_tool_call_failed",
+        "The bounded Codex Run failed closed while handling the bounded repository read.",
+        "review_bounded_read",
+    ),
+    "file_change_item": (
+        "codex_file_change_item_failed",
+        "The bounded Codex Run failed closed while verifying a typed file-change item.",
+        "review_file_change",
+    ),
+    "approval_bridge": (
+        "codex_approval_bridge_failed",
+        "The bounded Codex Run failed closed at the exact Approval boundary.",
+        "review_approval_bridge",
+    ),
+    "terminal_wait": (
+        "codex_terminal_wait_failed",
+        "The bounded Codex Run failed closed while waiting for terminal completion.",
+        "review_terminal_state",
+    ),
+    "terminal_completion": (
+        "codex_terminal_completion_failed",
+        "The bounded Codex Run failed closed while verifying terminal completion.",
+        "review_terminal_state",
+    ),
+    "runtime_identity_verification": (
+        "codex_runtime_identity_failed",
+        "The bounded Codex Run failed closed because runtime identity could not be verified.",
+        "recheck_runtime",
+    ),
+    "protocol_message": (
+        "codex_protocol_message_failed",
+        "The bounded Codex Run failed closed while validating an app-server message.",
+        "recheck_protocol",
+    ),
+    "finalization": (
+        "codex_finalization_failed",
+        "The bounded Codex Run failed closed during finalization.",
+        "review_terminal_state",
+    ),
+    "unknown": (
+        "codex_unknown_failure",
+        "The bounded Codex Run failed closed.",
+        None,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class CodexFailureDiagnostic:
+    """Bounded public diagnostic for one failed app-server boundary."""
+
+    code: str
+    protocol_phase: str
+    reason: str
+    action: str | None = None
+
+    def __post_init__(self) -> None:
+        spec = _FAILURE_DIAGNOSTIC_SPECS.get(self.protocol_phase)
+        if spec != (self.code, self.reason, self.action):
+            raise ValueError("Codex failure diagnostic must be bounded.")
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {
+            "code": self.code,
+            "protocol_phase": self.protocol_phase,
+            "reason": self.reason,
+            "action": self.action,
+        }
+
+    @classmethod
+    def for_phase(cls, protocol_phase: str) -> CodexFailureDiagnostic:
+        return _failure_diagnostic(protocol_phase)
+
+
+def _failure_diagnostic(protocol_phase: str) -> CodexFailureDiagnostic:
+    phase = (
+        protocol_phase
+        if protocol_phase in _FAILURE_DIAGNOSTIC_SPECS
+        else "unknown"
+    )
+    code, reason, action = _FAILURE_DIAGNOSTIC_SPECS[phase]
+    return CodexFailureDiagnostic(
+        code=code,
+        protocol_phase=phase,
+        reason=reason,
+        action=action,
+    )
+
 
 class CodexAdapterUnavailable(RuntimeError):
     """The bundled Codex app-server executable is unavailable."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        diagnostic: CodexFailureDiagnostic | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.diagnostic = diagnostic
+
 
 class CodexAdapterFailure(RuntimeError):
     """The app-server contract or bounded run failed before a safe result."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        diagnostic: CodexFailureDiagnostic | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.diagnostic = diagnostic
 
 
 class _ReadValidationError(RuntimeError):
@@ -277,6 +440,7 @@ class CodexRunResult:
     file_actions: tuple[CodexFileAction, ...] = ()
     read_evidence: tuple[CodexReadEvidence, ...] = ()
     unsupported_reason: str | None = None
+    failure_diagnostic: CodexFailureDiagnostic | None = None
 
     def __post_init__(self) -> None:
         if (
@@ -632,6 +796,7 @@ class CodexAdapter:
         self._identity_failure = False
         self._final_message = ""
         self._file_action_candidates: list[_CodexFileActionCandidate] = []
+        self._protocol_phase = "unknown"
 
     def _reset_run(self) -> None:
         self._request_id = 0
@@ -668,6 +833,7 @@ class CodexAdapter:
         self._identity_failure = False
         self._final_message = ""
         self._file_action_candidates = []
+        self._protocol_phase = "unknown"
 
     def _emit(self, kind: str, message: str) -> None:
         if self.lifecycle_sink is None:
@@ -685,6 +851,7 @@ class CodexAdapter:
         return self._transport.receive()
 
     def _request(self, method: str, params: dict[str, Any]) -> Any:
+        request_phase = self._protocol_phase
         self._request_id += 1
         request_id = self._request_id
         self._send({"id": request_id, "method": method, "params": params})
@@ -704,6 +871,7 @@ class CodexAdapter:
                     )
                 return message["result"]
             self._dispatch(message)
+            self._protocol_phase = request_phase
 
     @staticmethod
     def _require_object(value: Any, label: str) -> dict[str, Any]:
@@ -847,6 +1015,7 @@ class CodexAdapter:
             ),
             "thread/start result",
         )
+        self._protocol_phase = "thread_identity_verification"
         thread = self._require_object(result.get("thread"), "thread identity")
         thread_id = thread.get("id")
         cli_version = thread.get("cliVersion")
@@ -2085,17 +2254,32 @@ class CodexAdapter:
     def _dispatch(self, message: dict[str, Any]) -> None:
         method = message.get("method")
         if not isinstance(method, str):
+            self._protocol_phase = "protocol_message"
             raise CodexAdapterFailure(
                 "Codex app-server emitted an uncorrelated response."
             )
         if "id" in message:
             if method == "item/fileChange/requestApproval":
+                self._protocol_phase = "approval_bridge"
                 self._respond_file_approval(message)
             elif method == "item/tool/call":
+                self._protocol_phase = "dynamic_tool_call"
                 self._respond_read_tool_call(message)
             else:
+                self._protocol_phase = "protocol_message"
                 self._respond_unsupported_request(message)
             return
+        self._protocol_phase = {
+            "item/started": "file_change_item",
+            "item/fileChange/patchUpdated": "file_change_item",
+            "item/completed": "file_change_item",
+            "thread/settings/updated": "settings_verification",
+            "serverRequest/resolved": "approval_bridge",
+            "turn/started": "turn_started",
+            "turn/completed": "terminal_completion",
+            "model/rerouted": "runtime_identity_verification",
+            "error": "protocol_message",
+        }.get(method, "protocol_message")
         params = self._require_object(
             message.get("params", {}),
             f"{method} parameters",
@@ -2135,45 +2319,71 @@ class CodexAdapter:
         """Run one fresh thread and promote matches only at a normal checkpoint."""
 
         if not isinstance(prompt, str) or not prompt.strip():
-            raise CodexAdapterFailure("Codex prompt must be a non-empty string.")
+            raise CodexAdapterFailure(
+                "Codex prompt must be a non-empty string.",
+                diagnostic=_failure_diagnostic("input_validation"),
+            )
         self._reset_run()
         self._emit("starting", "Preparing the bounded task.")
         self._transport = self.transport_factory(self.executable)
         turn_started = False
         error_type: str | None = None
+        failure_diagnostic: CodexFailureDiagnostic | None = None
         try:
+            self._protocol_phase = "transport_start"
             self._transport.start()
+            self._protocol_phase = "version_verification"
             if self._transport.version != self.expected_cli_version:
                 raise CodexAdapterFailure(
                     "Bundled Codex CLI version identity mismatch."
                 )
+            self._protocol_phase = "initialize_handshake"
             self._initialize()
+            self._protocol_phase = "account_verification"
             self._verify_account()
+            self._protocol_phase = "model_verification"
             self._verify_model_catalog()
+            self._protocol_phase = "thread_start"
             self._start_thread()
+            self._protocol_phase = "turn_start"
             self._start_turn(prompt)
             turn_started = True
             while self._turn_status is None:
+                self._protocol_phase = "terminal_wait"
                 self._dispatch(self._receive())
         except (CodexAdapterUnavailable, CodexAdapterFailure) as exc:
+            failure_diagnostic = (
+                exc.diagnostic
+                or _failure_diagnostic(self._protocol_phase)
+            )
+            exc.diagnostic = failure_diagnostic
             if not turn_started:
                 raise
             error_type = type(exc).__name__
         except Exception as exc:
+            failure_diagnostic = _failure_diagnostic("unknown")
             if not turn_started:
                 raise CodexAdapterFailure(
-                    "Codex app-server failed before the turn started."
+                    "Codex app-server failed before the turn started.",
+                    diagnostic=failure_diagnostic,
                 ) from exc
             error_type = type(exc).__name__
         finally:
             try:
+                self._protocol_phase = "finalization"
                 self._transport.close()
             except Exception:
                 if error_type is None and turn_started:
                     error_type = "CodexTransportCloseError"
+                    failure_diagnostic = _failure_diagnostic("finalization")
 
         if self._identity_failure and error_type is None:
             error_type = "CodexRuntimeIdentityError"
+            failure_diagnostic = _failure_diagnostic(
+                "settings_verification"
+                if not self._settings_verified
+                else "runtime_identity_verification"
+            )
         all_accepted_completed = self._accepted_items.issubset(
             self._completed_items
         )
@@ -2239,4 +2449,5 @@ class CodexAdapter:
             file_actions=file_actions,
             read_evidence=tuple(self._read_evidence),
             unsupported_reason=self._unsupported_reason,
+            failure_diagnostic=failure_diagnostic,
         )

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -292,6 +292,16 @@ _FAILURE_DIAGNOSTIC_SPECS = {
         "The bounded Codex Run failed closed while verifying a typed file-change item.",
         "review_file_change",
     ),
+    "agent_message": (
+        "codex_agent_message_failed",
+        "The bounded Codex Run failed closed while validating a model response item.",
+        "review_terminal_state",
+    ),
+    "unsupported_item": (
+        "codex_unsupported_item_failed",
+        "The bounded Codex Run failed closed while validating an unsupported item.",
+        "recheck_protocol",
+    ),
     "approval_bridge": (
         "codex_approval_bridge_failed",
         "The bounded Codex Run failed closed at the exact Approval boundary.",
@@ -372,6 +382,32 @@ def _failure_diagnostic(protocol_phase: str) -> CodexFailureDiagnostic:
     )
 
 
+def canonical_failure_diagnostic(value: object) -> CodexFailureDiagnostic:
+    """Rebuild one untrusted diagnostic from canonical identifiers only."""
+
+    unknown = _failure_diagnostic("unknown")
+    if type(value) is not CodexFailureDiagnostic:
+        return unknown
+    try:
+        code = object.__getattribute__(value, "code")
+        protocol_phase = object.__getattribute__(value, "protocol_phase")
+        reason = object.__getattribute__(value, "reason")
+        action = object.__getattribute__(value, "action")
+    except Exception:
+        return unknown
+    if (
+        type(code) is not str
+        or type(protocol_phase) is not str
+        or type(reason) is not str
+        or (action is not None and type(action) is not str)
+    ):
+        return unknown
+    spec = _FAILURE_DIAGNOSTIC_SPECS.get(protocol_phase)
+    if spec != (code, reason, action):
+        return unknown
+    return _failure_diagnostic(protocol_phase)
+
+
 class CodexAdapterUnavailable(RuntimeError):
     """The bundled Codex app-server executable is unavailable."""
 
@@ -382,7 +418,11 @@ class CodexAdapterUnavailable(RuntimeError):
         diagnostic: CodexFailureDiagnostic | None = None,
     ) -> None:
         super().__init__(message)
-        self.diagnostic = diagnostic
+        self.diagnostic = (
+            None
+            if diagnostic is None
+            else canonical_failure_diagnostic(diagnostic)
+        )
 
 
 class CodexAdapterFailure(RuntimeError):
@@ -395,7 +435,11 @@ class CodexAdapterFailure(RuntimeError):
         diagnostic: CodexFailureDiagnostic | None = None,
     ) -> None:
         super().__init__(message)
-        self.diagnostic = diagnostic
+        self.diagnostic = (
+            None
+            if diagnostic is None
+            else canonical_failure_diagnostic(diagnostic)
+        )
 
 
 class _ReadValidationError(RuntimeError):
@@ -590,7 +634,8 @@ class _SubprocessTransport:
     def start(self) -> None:
         if not self.executable.is_file():
             raise CodexAdapterUnavailable(
-                f"Bundled Codex executable is unavailable at {self.executable}."
+                f"Bundled Codex executable is unavailable at {self.executable}.",
+                diagnostic=_failure_diagnostic("transport_start"),
             )
         try:
             completed = subprocess.run(
@@ -601,13 +646,15 @@ class _SubprocessTransport:
             )
         except OSError as exc:
             raise CodexAdapterUnavailable(
-                "Bundled Codex version could not be read."
+                "Bundled Codex version could not be read.",
+                diagnostic=_failure_diagnostic("version_verification"),
             ) from exc
         observed = completed.stdout.strip()
         prefix = "codex-cli "
         if completed.returncode != 0 or not observed.startswith(prefix):
             raise CodexAdapterFailure(
-                "Bundled Codex CLI returned an invalid version identity."
+                "Bundled Codex CLI returned an invalid version identity.",
+                diagnostic=_failure_diagnostic("version_verification"),
             )
         self._version = observed[len(prefix) :].strip()
         try:
@@ -641,7 +688,8 @@ class _SubprocessTransport:
             )
         except OSError as exc:
             raise CodexAdapterUnavailable(
-                "Bundled Codex app-server could not be started."
+                "Bundled Codex app-server could not be started.",
+                diagnostic=_failure_diagnostic("transport_start"),
             ) from exc
         self._stderr_thread = threading.Thread(
             target=self._drain_stderr,
@@ -797,6 +845,7 @@ class CodexAdapter:
         self._final_message = ""
         self._file_action_candidates: list[_CodexFileActionCandidate] = []
         self._protocol_phase = "unknown"
+        self._failure_phase: str | None = None
 
     def _reset_run(self) -> None:
         self._request_id = 0
@@ -834,11 +883,39 @@ class CodexAdapter:
         self._final_message = ""
         self._file_action_candidates = []
         self._protocol_phase = "unknown"
+        self._failure_phase = None
 
     def _emit(self, kind: str, message: str) -> None:
         if self.lifecycle_sink is None:
             return
         self.lifecycle_sink(CodexLifecycleEvent(kind=kind, message=message))
+
+    def _latch_failure_phase(self, protocol_phase: str | None = None) -> None:
+        if self._failure_phase is not None:
+            return
+        phase = self._protocol_phase if protocol_phase is None else protocol_phase
+        self._failure_phase = (
+            phase if phase in _FAILURE_DIAGNOSTIC_SPECS else "unknown"
+        )
+
+    def _mark_identity_failure(self) -> None:
+        self._latch_failure_phase()
+        self._identity_failure = True
+
+    def _latched_failure_diagnostic(self) -> CodexFailureDiagnostic:
+        return _failure_diagnostic(self._failure_phase or "unknown")
+
+    def _diagnostic_for_typed_exception(
+        self,
+        exc: CodexAdapterUnavailable | CodexAdapterFailure,
+    ) -> CodexFailureDiagnostic:
+        if self._failure_phase is None:
+            if exc.diagnostic is None:
+                self._latch_failure_phase()
+            else:
+                diagnostic = canonical_failure_diagnostic(exc.diagnostic)
+                self._latch_failure_phase(diagnostic.protocol_phase)
+        return self._latched_failure_diagnostic()
 
     def _send(self, message: dict[str, Any]) -> None:
         if self._transport is None:
@@ -1066,8 +1143,10 @@ class CodexAdapter:
         )
         deferred = tuple(self._deferred_settings)
         self._deferred_settings = []
+        self._protocol_phase = "settings_verification"
         for params in deferred:
             self._verify_settings(params)
+        self._protocol_phase = "thread_identity_verification"
 
     def _start_turn(self, prompt: str) -> None:
         if self._thread_id is None:
@@ -1181,6 +1260,7 @@ class CodexAdapter:
             raise CodexAdapterFailure(
                 "Codex unsupported reason is not a bounded code."
             )
+        self._latch_failure_phase()
         self._unsupported_mutation = True
         if self._unsupported_reason is None:
             self._unsupported_reason = reason
@@ -1981,19 +2061,19 @@ class CodexAdapter:
 
     def _resolve_request(self, params: dict[str, Any]) -> None:
         if params.get("threadId") != self._thread_id:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         request_id = params.get("requestId")
         if (
             not isinstance(request_id, (str, int))
             or isinstance(request_id, bool)
         ):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         is_approval = request_id in self._approval_requests
         is_read = request_id in self._read_requests
         if is_approval == is_read:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         if is_read:
             if request_id in self._resolved_read_requests:
@@ -2038,7 +2118,7 @@ class CodexAdapter:
 
     def _cache_item(self, params: dict[str, Any]) -> None:
         if not self._ids_match(params):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         item = self._require_object(params.get("item"), "started item")
         item_type = item.get("type")
@@ -2051,7 +2131,7 @@ class CodexAdapter:
             return
         item_id = item.get("id")
         if not isinstance(item_id, str) or not item_id:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         if item_type == "dynamicToolCall":
             arguments = item.get("arguments")
@@ -2067,13 +2147,13 @@ class CodexAdapter:
                 return
         if item_id in self._items:
             if self._items[item_id] != item:
-                self._identity_failure = True
+                self._mark_identity_failure()
             return
         self._items[item_id] = item
 
     def _update_patch(self, params: dict[str, Any]) -> None:
         if not self._ids_match(params):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         item_id = params.get("itemId")
         changes = params.get("changes")
@@ -2082,10 +2162,10 @@ class CodexAdapter:
             or item_id not in self._items
             or not isinstance(changes, list)
         ):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         if item_id in self._approved_changes:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         updated = dict(self._items[item_id])
         updated["changes"] = changes
@@ -2093,7 +2173,7 @@ class CodexAdapter:
 
     def _complete_item(self, params: dict[str, Any]) -> None:
         if not self._ids_match(params):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         item = self._require_object(params.get("item"), "completed item")
         item_type = item.get("type")
@@ -2143,7 +2223,7 @@ class CodexAdapter:
                 )
                 or not resolved
             ):
-                self._identity_failure = True
+                self._mark_identity_failure()
                 return
             self._completed_read_items.add(item_id)
             return
@@ -2154,7 +2234,7 @@ class CodexAdapter:
                 not isinstance(text, str)
                 or phase not in {None, "final_answer", "commentary"}
             ):
-                self._identity_failure = True
+                self._mark_identity_failure()
                 return
             if phase in {None, "final_answer"}:
                 self._final_message = text
@@ -2167,11 +2247,11 @@ class CodexAdapter:
                 item.get("status") != "declined"
                 or item_id not in self._resolved_items
             ):
-                self._identity_failure = True
+                self._mark_identity_failure()
             return
         if item_id not in self._accepted_items:
             self._mark_unsupported("unapproved_file_completion")
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         approved = self._approved_changes.get(item_id)
         if item_id in self._completed_items:
@@ -2181,7 +2261,7 @@ class CodexAdapter:
                 or item.get("changes") != approved
                 or item_id not in self._resolved_items
             ):
-                self._identity_failure = True
+                self._mark_identity_failure()
             return
         if (
             item.get("status") != "completed"
@@ -2189,12 +2269,12 @@ class CodexAdapter:
             or item.get("changes") != approved
             or item_id not in self._resolved_items
         ):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         self._completed_items.add(item_id)
 
     def _invalidate_runtime_identity(self) -> None:
-        self._identity_failure = True
+        self._mark_identity_failure()
         self._settings_verified = False
         self._runtime_identity = None
 
@@ -2232,24 +2312,62 @@ class CodexAdapter:
 
     def _complete_turn(self, params: dict[str, Any]) -> None:
         if params.get("threadId") != self._thread_id:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         turn = self._require_object(params.get("turn"), "completed turn")
         turn_id = turn.get("id")
         if not isinstance(turn_id, str) or not turn_id:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         if self._turn_id is None:
             self._turn_id = turn_id
         elif turn_id != self._turn_id:
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         status = turn.get("status")
         if not isinstance(status, str):
-            self._identity_failure = True
+            self._mark_identity_failure()
             return
         self._turn_status = status
         self._emit("finalizing", "Finalizing the local Receipt.")
+
+    def _notification_protocol_phase(
+        self,
+        method: str,
+        message: dict[str, Any],
+    ) -> str:
+        if method == "item/fileChange/patchUpdated":
+            return "file_change_item"
+        if method in {"item/started", "item/completed"}:
+            params = message.get("params")
+            item = params.get("item") if isinstance(params, dict) else None
+            item_type = item.get("type") if isinstance(item, dict) else None
+            if item_type == "dynamicToolCall":
+                return "dynamic_tool_call"
+            if item_type == "agentMessage":
+                return "agent_message"
+            if item_type == "fileChange":
+                return "file_change_item"
+            if item_type in _UNSUPPORTED_ITEM_TYPES:
+                return "unsupported_item"
+            return "protocol_message"
+        if method == "serverRequest/resolved":
+            params = message.get("params")
+            request_id = (
+                params.get("requestId") if isinstance(params, dict) else None
+            )
+            if request_id in self._read_requests:
+                return "dynamic_tool_call"
+            if request_id in self._approval_requests:
+                return "approval_bridge"
+            return "protocol_message"
+        return {
+            "thread/settings/updated": "settings_verification",
+            "turn/started": "turn_started",
+            "turn/completed": "terminal_completion",
+            "model/rerouted": "runtime_identity_verification",
+            "error": "protocol_message",
+        }.get(method, "protocol_message")
 
     def _dispatch(self, message: dict[str, Any]) -> None:
         method = message.get("method")
@@ -2269,17 +2387,10 @@ class CodexAdapter:
                 self._protocol_phase = "protocol_message"
                 self._respond_unsupported_request(message)
             return
-        self._protocol_phase = {
-            "item/started": "file_change_item",
-            "item/fileChange/patchUpdated": "file_change_item",
-            "item/completed": "file_change_item",
-            "thread/settings/updated": "settings_verification",
-            "serverRequest/resolved": "approval_bridge",
-            "turn/started": "turn_started",
-            "turn/completed": "terminal_completion",
-            "model/rerouted": "runtime_identity_verification",
-            "error": "protocol_message",
-        }.get(method, "protocol_message")
+        self._protocol_phase = self._notification_protocol_phase(
+            method,
+            message,
+        )
         params = self._require_object(
             message.get("params", {}),
             f"{method} parameters",
@@ -2296,7 +2407,7 @@ class CodexAdapter:
             self._resolve_request(params)
         elif method == "turn/started":
             if params.get("threadId") != self._thread_id:
-                self._identity_failure = True
+                self._mark_identity_failure()
             else:
                 turn = self._require_object(
                     params.get("turn"),
@@ -2304,15 +2415,15 @@ class CodexAdapter:
                 )
                 turn_id = turn.get("id")
                 if not isinstance(turn_id, str) or not turn_id:
-                    self._identity_failure = True
+                    self._mark_identity_failure()
                 elif self._turn_id is None:
                     self._turn_id = turn_id
                 elif self._turn_id != turn_id:
-                    self._identity_failure = True
+                    self._mark_identity_failure()
         elif method == "turn/completed":
             self._complete_turn(params)
         elif method in {"model/rerouted", "error"}:
-            self._identity_failure = True
+            self._mark_identity_failure()
             self._runtime_identity = None
 
     async def run(self, prompt: str) -> CodexRunResult:
@@ -2352,16 +2463,14 @@ class CodexAdapter:
                 self._protocol_phase = "terminal_wait"
                 self._dispatch(self._receive())
         except (CodexAdapterUnavailable, CodexAdapterFailure) as exc:
-            failure_diagnostic = (
-                exc.diagnostic
-                or _failure_diagnostic(self._protocol_phase)
-            )
+            failure_diagnostic = self._diagnostic_for_typed_exception(exc)
             exc.diagnostic = failure_diagnostic
             if not turn_started:
                 raise
             error_type = type(exc).__name__
         except Exception as exc:
-            failure_diagnostic = _failure_diagnostic("unknown")
+            self._latch_failure_phase("unknown")
+            failure_diagnostic = self._latched_failure_diagnostic()
             if not turn_started:
                 raise CodexAdapterFailure(
                     "Codex app-server failed before the turn started.",
@@ -2375,15 +2484,18 @@ class CodexAdapter:
             except Exception:
                 if error_type is None and turn_started:
                     error_type = "CodexTransportCloseError"
-                    failure_diagnostic = _failure_diagnostic("finalization")
+                    self._latch_failure_phase("finalization")
+                    failure_diagnostic = self._latched_failure_diagnostic()
 
         if self._identity_failure and error_type is None:
             error_type = "CodexRuntimeIdentityError"
-            failure_diagnostic = _failure_diagnostic(
-                "settings_verification"
-                if not self._settings_verified
-                else "runtime_identity_verification"
-            )
+            if self._failure_phase is None:
+                self._latch_failure_phase(
+                    "settings_verification"
+                    if not self._settings_verified
+                    else "runtime_identity_verification"
+                )
+            failure_diagnostic = self._latched_failure_diagnostic()
         all_accepted_completed = self._accepted_items.issubset(
             self._completed_items
         )

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -25,6 +25,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexFailureDiagnostic,
     CodexLifecycleEvent,
     CodexRunResult,
+    canonical_failure_diagnostic,
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.acceleration.model import RepositoryIdentityError, git_root
@@ -1374,7 +1375,11 @@ class CompanionController:
         result: CodexRunResult,
     ) -> None:
         after = self._safe_receipt(repository)
-        diagnostic = result.failure_diagnostic
+        diagnostic = (
+            None
+            if result.failure_diagnostic is None
+            else canonical_failure_diagnostic(result.failure_diagnostic)
+        )
         with self._condition:
             before = self._run.pop("receipt_before")
             self._run["state"] = (
@@ -1410,14 +1415,18 @@ class CompanionController:
     def _safe_failure(
         exc: Exception,
     ) -> CodexFailureDiagnostic | None:
+        try:
+            attached = exc.diagnostic
+        except Exception:
+            attached = object()
         if isinstance(exc, CodexAdapterUnavailable):
-            return exc.diagnostic or CodexFailureDiagnostic.for_phase(
-                "transport_start"
-            )
+            if attached is None:
+                return CodexFailureDiagnostic.for_phase("transport_start")
+            return canonical_failure_diagnostic(attached)
         if isinstance(exc, CodexAdapterFailure):
-            return exc.diagnostic or CodexFailureDiagnostic.for_phase(
-                "unknown"
-            )
+            if attached is None:
+                return CodexFailureDiagnostic.for_phase("unknown")
+            return canonical_failure_diagnostic(attached)
         return None
 
     @staticmethod

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -22,6 +22,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexAdapterFailure,
     CodexAdapterUnavailable,
     CodexApproval,
+    CodexFailureDiagnostic,
     CodexLifecycleEvent,
     CodexRunResult,
 )
@@ -258,6 +259,7 @@ class CompanionController:
             "receipt_delta": None,
             "approval": None,
             "error": None,
+            "failure": None,
         }
 
     def _load_last_repository(self) -> None:
@@ -1372,27 +1374,59 @@ class CompanionController:
         result: CodexRunResult,
     ) -> None:
         after = self._safe_receipt(repository)
+        diagnostic = result.failure_diagnostic
         with self._condition:
             before = self._run.pop("receipt_before")
-            self._run["state"] = self._display_state(result)
-            self._run["result"] = result.final_message
+            self._run["state"] = (
+                "needs_attention"
+                if diagnostic is not None
+                else self._display_state(result)
+            )
+            self._run["result"] = (
+                "" if diagnostic is not None else result.final_message
+            )
             self._run["file_actions"] = self._public_actions(result)
             self._run["read_evidence"] = self._public_read_evidence(result)
-            self._run["outcomes"] = self._public_outcomes(result)
+            outcomes = self._public_outcomes(result)
+            if diagnostic is not None:
+                outcomes["verification"] = {
+                    "state": "needs_attention",
+                    "label": "Needs attention",
+                    "reason": diagnostic.reason,
+                }
+            self._run["outcomes"] = outcomes
             self._run["runtime"] = self._public_runtime(result)
             self._run["receipt_delta"] = self._receipt_delta(before, after)
             self._run["approval"] = None
-            self._run["error"] = None
+            self._run["error"] = (
+                diagnostic.reason if diagnostic is not None else None
+            )
+            self._run["failure"] = (
+                diagnostic.as_dict() if diagnostic is not None else None
+            )
             self._condition.notify_all()
 
     @staticmethod
+    def _safe_failure(
+        exc: Exception,
+    ) -> CodexFailureDiagnostic | None:
+        if isinstance(exc, CodexAdapterUnavailable):
+            return exc.diagnostic or CodexFailureDiagnostic.for_phase(
+                "transport_start"
+            )
+        if isinstance(exc, CodexAdapterFailure):
+            return exc.diagnostic or CodexFailureDiagnostic.for_phase(
+                "unknown"
+            )
+        return None
+
+    @staticmethod
     def _safe_error(exc: Exception) -> str:
+        diagnostic = CompanionController._safe_failure(exc)
+        if diagnostic is not None:
+            return diagnostic.reason
         if isinstance(exc, StateIntegrityError):
             return "Repository verification state is corrupted."
-        if isinstance(exc, CodexAdapterUnavailable):
-            return "The private Codex runtime is unavailable."
-        if isinstance(exc, CodexAdapterFailure):
-            return "The bounded Codex Run failed closed."
         if isinstance(exc, LifecycleEventError):
             return "The companion received an invalid progress event."
         if isinstance(exc, ApprovalStateError):
@@ -1404,6 +1438,7 @@ class CompanionController:
             after = self._safe_receipt(repository)
         except StateIntegrityError:
             after = None
+        diagnostic = self._safe_failure(exc)
         with self._condition:
             before = self._run.pop("receipt_before", None)
             self._run["state"] = "needs_attention"
@@ -1424,7 +1459,11 @@ class CompanionController:
                 "verification": {
                     "state": "needs_attention",
                     "label": "Needs attention",
-                    "reason": None,
+                    "reason": (
+                        diagnostic.reason
+                        if diagnostic is not None
+                        else None
+                    ),
                 },
             }
             self._run["runtime"] = None
@@ -1435,6 +1474,9 @@ class CompanionController:
             )
             self._run["approval"] = None
             self._run["error"] = self._safe_error(exc)
+            self._run["failure"] = (
+                diagnostic.as_dict() if diagnostic is not None else None
+            )
             self._approval_choice = "3"
             self._condition.notify_all()
 

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -773,8 +773,26 @@ async function writeClipboardText(value) {
   }
 }
 
+function visibleResponse(run) {
+  const error = typeof run.error === "string" ? run.error : "";
+  if (error) {
+    return error;
+  }
+  const result = typeof run.result === "string" ? run.result : "";
+  if (result) {
+    return result;
+  }
+  if (!TERMINAL_RUN_STATES.includes(run.state)) {
+    return "";
+  }
+  return run.state === "completed"
+    ? "The bounded Run completed without a final text response."
+    : "No final result was available.";
+}
+
 function renderResult(run) {
   const terminal = TERMINAL_RUN_STATES.includes(run.state);
+  const response = visibleResponse(run);
   setHidden("result-card", !terminal);
   byId("new-run").disabled = !terminal;
   setText(
@@ -797,14 +815,8 @@ function renderResult(run) {
   const verificationReason = outcomes.verification?.reason || "";
   setText("result-verification-reason", verificationReason);
   setHidden("result-verification-reason", !verificationReason);
-  setText(
-    "result",
-    run.result ||
-      (run.state === "completed"
-        ? "The bounded Run completed without a final text response."
-        : run.error || "No final result was available."),
-  );
-  renderCopyResponse(run.result, terminal);
+  setText("result", response);
+  renderCopyResponse(response, terminal);
   renderActions(run.file_actions);
   renderRuntime(run.runtime);
   renderReadEvidence(run.read_evidence);

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -19,12 +19,14 @@ from decision_os.acceleration.codex_adapter import (
     CODEX_SERVICE_TIER,
     CodexAdapter,
     CodexAdapterFailure,
+    CodexAdapterUnavailable,
     CodexApproval,
     CodexFailureDiagnostic,
     CodexLifecycleEvent,
     CodexRunResult,
     _SubprocessTransport,
     _redact_complete_source_echo,
+    canonical_failure_diagnostic,
 )
 from decision_os.acceleration.engine import AccelerationEngine
 
@@ -647,6 +649,56 @@ def adapter_for(
 
 
 class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    def test_untrusted_failure_diagnostics_are_canonically_rebuilt(self) -> None:
+        private = "PRIVATE raw exception, source, prompt, and secret"
+
+        class Lookalike:
+            code = "codex_thread_start_failed"
+            protocol_phase = "thread_start"
+            reason = private
+            action = "expose_private_data"
+
+            def as_dict(self) -> dict[str, str]:
+                raise AssertionError("untrusted as_dict must not be called")
+
+        class DiagnosticSubclass(CodexFailureDiagnostic):
+            def as_dict(self) -> dict[str, str]:
+                return {"reason": private}
+
+        canonical = CodexFailureDiagnostic.for_phase("thread_start")
+        invalid_values: list[object] = [
+            Lookalike(),
+            DiagnosticSubclass(
+                code=canonical.code,
+                protocol_phase=canonical.protocol_phase,
+                reason=canonical.reason,
+                action=canonical.action,
+            ),
+        ]
+        for field, value in (
+            ("code", "PRIVATE_FAILURE"),
+            ("protocol_phase", "private_phase"),
+            ("reason", private),
+            ("action", "expose_private_data"),
+        ):
+            forged = CodexFailureDiagnostic.for_phase("thread_start")
+            object.__setattr__(forged, field, value)
+            invalid_values.append(forged)
+        incomplete = object.__new__(CodexFailureDiagnostic)
+        object.__setattr__(incomplete, "protocol_phase", "thread_start")
+        invalid_values.append(incomplete)
+
+        for value in invalid_values:
+            with self.subTest(value_type=type(value).__name__):
+                rebuilt = canonical_failure_diagnostic(value)
+                self.assertEqual("unknown", rebuilt.protocol_phase)
+                self.assertEqual("codex_unknown_failure", rebuilt.code)
+                self.assertNotIn(private, json.dumps(rebuilt.as_dict()))
+
+        rebuilt = canonical_failure_diagnostic(canonical)
+        self.assertIsNot(canonical, rebuilt)
+        self.assertEqual(canonical.as_dict(), rebuilt.as_dict())
+
     async def test_safe_failure_diagnostics_distinguish_protocol_phases(
         self,
     ) -> None:
@@ -738,6 +790,279 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                     self.assertNotIn("secret", json.dumps(diagnostic.as_dict()))
                     self.assertEqual((), result.file_actions)
                     self.assertEqual((), result.checkpoint_outcomes)
+
+    async def test_first_failure_phase_latch_preserves_actual_boundary(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    {
+                        "method": "turn/started",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turn": {"id": "wrong-turn"},
+                        },
+                    },
+                    completed_turn(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    ),
+                ]
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                FakeTransportFactory([messages]),
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("turn identity failure")
+
+            self.assertEqual(
+                "turn_started",
+                result.failure_diagnostic.protocol_phase,
+            )
+
+            deferred = handshake_messages(
+                repository,
+                thread_id="thread-2",
+                turn_id="turn-2",
+            )
+            deferred.insert(
+                3,
+                {
+                    "method": "thread/settings/updated",
+                    "params": {
+                        "threadId": "thread-2",
+                        "threadSettings": "PRIVATE malformed settings",
+                    },
+                },
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                FakeTransportFactory([deferred]),
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            with self.assertRaises(CodexAdapterFailure) as captured:
+                await adapter.run("deferred settings failure")
+
+            diagnostic = captured.exception.diagnostic
+            self.assertIsNotNone(diagnostic)
+            assert diagnostic is not None
+            self.assertEqual(
+                "settings_verification",
+                diagnostic.protocol_phase,
+            )
+            self.assertNotIn("PRIVATE", json.dumps(diagnostic.as_dict()))
+
+    async def test_item_failure_phases_follow_the_actual_item_type(self) -> None:
+        cases = (
+            (
+                "agent_message",
+                {
+                    "id": "message-1",
+                    "phase": "final_answer",
+                    "text": 42,
+                    "type": "agentMessage",
+                },
+            ),
+            (
+                "dynamic_tool_call",
+                {
+                    "id": "read-1",
+                    "status": "completed",
+                    "tool": "read_repository_text_file",
+                    "type": "dynamicToolCall",
+                },
+            ),
+            (
+                "file_change_item",
+                {
+                    "changes": [],
+                    "id": "file-1",
+                    "status": "completed",
+                    "type": "fileChange",
+                },
+            ),
+        )
+        for index, (expected_phase, item) in enumerate(cases, start=1):
+            with self.subTest(expected_phase=expected_phase):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    thread_id = f"thread-{index}"
+                    turn_id = f"turn-{index}"
+                    messages = handshake_messages(
+                        repository,
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                    )
+                    messages.extend(
+                        [
+                            {
+                                "method": "item/completed",
+                                "params": {
+                                    "item": item,
+                                    "threadId": thread_id,
+                                    "turnId": turn_id,
+                                },
+                            },
+                            completed_turn(
+                                thread_id=thread_id,
+                                turn_id=turn_id,
+                            ),
+                        ]
+                    )
+                    _, adapter, _ = adapter_for(
+                        repository,
+                        FakeTransportFactory([messages]),
+                        choice=lambda: self.fail("must not prompt"),
+                    )
+
+                    result = await adapter.run("typed item failure")
+
+                    diagnostic = result.failure_diagnostic
+                    self.assertIsNotNone(diagnostic)
+                    assert diagnostic is not None
+                    self.assertEqual(
+                        expected_phase,
+                        diagnostic.protocol_phase,
+                    )
+
+    async def test_unsupported_item_phase_precedes_secondary_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    {
+                        "method": "item/completed",
+                        "params": {
+                            "item": {
+                                "id": "command-1",
+                                "type": "commandExecution",
+                            },
+                            "threadId": "thread-1",
+                            "turnId": "turn-1",
+                        },
+                    },
+                    {
+                        "method": "item/completed",
+                        "params": "PRIVATE malformed secondary error",
+                    },
+                ]
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                FakeTransportFactory([messages]),
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("unsupported item failure")
+
+            diagnostic = result.failure_diagnostic
+            self.assertIsNotNone(diagnostic)
+            assert diagnostic is not None
+            self.assertEqual("unsupported_item", diagnostic.protocol_phase)
+            self.assertEqual((), result.file_actions)
+            self.assertNotIn("PRIVATE", json.dumps(diagnostic.as_dict()))
+
+    async def test_later_failure_does_not_replace_first_latched_phase(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )
+            messages.extend(
+                [
+                    {
+                        "method": "turn/started",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turn": {"id": "wrong-turn"},
+                        },
+                    },
+                    {
+                        "method": "item/completed",
+                        "params": "PRIVATE malformed secondary error",
+                    },
+                ]
+            )
+            _, adapter, _ = adapter_for(
+                repository,
+                FakeTransportFactory([messages]),
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            result = await adapter.run("multiple failure signals")
+
+            self.assertEqual(
+                "turn_started",
+                result.failure_diagnostic.protocol_phase,
+            )
+
+    def test_transport_start_distinguishes_version_and_process_failures(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            executable = Path(directory) / "codex"
+            executable.write_text("placeholder", encoding="utf-8")
+            transport = _SubprocessTransport(executable)
+            invalid_version = subprocess.CompletedProcess(
+                args=(str(executable), "--version"),
+                returncode=1,
+                stdout="PRIVATE invalid version response",
+                stderr="PRIVATE stderr",
+            )
+            with patch.object(subprocess, "run", return_value=invalid_version):
+                with self.assertRaises(CodexAdapterFailure) as captured:
+                    transport.start()
+            diagnostic = captured.exception.diagnostic
+            self.assertIsNotNone(diagnostic)
+            assert diagnostic is not None
+            self.assertEqual(
+                "version_verification",
+                diagnostic.protocol_phase,
+            )
+            self.assertNotIn("PRIVATE", json.dumps(diagnostic.as_dict()))
+
+            valid_version = subprocess.CompletedProcess(
+                args=(str(executable), "--version"),
+                returncode=0,
+                stdout=f"codex-cli {CODEX_CLI_VERSION}\n",
+                stderr="",
+            )
+            transport = _SubprocessTransport(executable)
+            with (
+                patch.object(subprocess, "run", return_value=valid_version),
+                patch.object(
+                    subprocess,
+                    "Popen",
+                    side_effect=OSError("PRIVATE process path and secret"),
+                ),
+            ):
+                with self.assertRaises(CodexAdapterUnavailable) as captured:
+                    transport.start()
+            diagnostic = captured.exception.diagnostic
+            self.assertIsNotNone(diagnostic)
+            assert diagnostic is not None
+            self.assertEqual("transport_start", diagnostic.protocol_phase)
+            self.assertNotIn("PRIVATE", json.dumps(diagnostic.as_dict()))
 
     def test_failure_diagnostic_rejects_unbounded_public_values(self) -> None:
         with self.assertRaisesRegex(ValueError, "bounded"):

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -20,6 +20,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexAdapter,
     CodexAdapterFailure,
     CodexApproval,
+    CodexFailureDiagnostic,
     CodexLifecycleEvent,
     CodexRunResult,
     _SubprocessTransport,
@@ -646,6 +647,107 @@ def adapter_for(
 
 
 class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    async def test_safe_failure_diagnostics_distinguish_protocol_phases(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            thread_failure_messages = handshake_messages(
+                repository,
+                thread_id="thread-1",
+                turn_id="turn-1",
+            )[:3]
+            thread_failure_messages.append(
+                {
+                    "id": 4,
+                    "error": {
+                        "message": "PRIVATE thread source and secret",
+                    },
+                }
+            )
+            factory = FakeTransportFactory([thread_failure_messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("must not prompt"),
+            )
+
+            with self.assertRaises(CodexAdapterFailure) as captured:
+                await adapter.run("thread failure")
+
+            thread_diagnostic = captured.exception.diagnostic
+            self.assertIsNotNone(thread_diagnostic)
+            assert thread_diagnostic is not None
+            self.assertEqual("codex_thread_start_failed", thread_diagnostic.code)
+            self.assertEqual("thread_start", thread_diagnostic.protocol_phase)
+            self.assertNotIn("PRIVATE", json.dumps(thread_diagnostic.as_dict()))
+            self.assertNotIn("secret", json.dumps(thread_diagnostic.as_dict()))
+
+            cases = (
+                (
+                    "settings_verification",
+                    {
+                        "method": "thread/settings/updated",
+                        "params": {
+                            "threadId": "thread-1",
+                            "threadSettings": "PRIVATE settings secret",
+                        },
+                    },
+                ),
+                (
+                    "dynamic_tool_call",
+                    {
+                        "id": "read-private",
+                        "method": "item/tool/call",
+                        "params": "PRIVATE repository source",
+                    },
+                ),
+                (
+                    "terminal_completion",
+                    {
+                        "method": "turn/completed",
+                        "params": {
+                            "threadId": "thread-1",
+                            "turn": "PRIVATE terminal secret",
+                        },
+                    },
+                ),
+            )
+            for phase, failure_message in cases:
+                with self.subTest(phase=phase):
+                    messages = handshake_messages(
+                        repository,
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                    )
+                    messages.append(failure_message)
+                    case_factory = FakeTransportFactory([messages])
+                    _, case_adapter, _ = adapter_for(
+                        repository,
+                        case_factory,
+                        choice=lambda: self.fail("must not prompt"),
+                    )
+
+                    result = await case_adapter.run(f"{phase} failure")
+
+                    diagnostic = result.failure_diagnostic
+                    self.assertIsNotNone(diagnostic)
+                    assert diagnostic is not None
+                    self.assertEqual(phase, diagnostic.protocol_phase)
+                    self.assertNotIn("PRIVATE", json.dumps(diagnostic.as_dict()))
+                    self.assertNotIn("secret", json.dumps(diagnostic.as_dict()))
+                    self.assertEqual((), result.file_actions)
+                    self.assertEqual((), result.checkpoint_outcomes)
+
+    def test_failure_diagnostic_rejects_unbounded_public_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "bounded"):
+            CodexFailureDiagnostic(
+                code="PRIVATE_FAILURE",
+                protocol_phase="thread_start",
+                reason="PRIVATE source body and secret",
+                action="expose_private_data",
+            )
+
     def test_complete_source_echo_guard_preserves_short_and_partial_text(
         self,
     ) -> None:

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -166,6 +166,16 @@ def runtime_identity() -> CodexRuntimeIdentity:
     )
 
 
+class MaliciousDiagnostic:
+    code = "PRIVATE_FAILURE"
+    protocol_phase = "private_phase"
+    reason = "PRIVATE raw exception, source, prompt, path, and secret"
+    action = "expose_private_data"
+
+    def as_dict(self) -> dict[str, str]:
+        raise AssertionError("untrusted as_dict must not be called")
+
+
 class ScriptedAdapter:
     def __init__(
         self,
@@ -193,6 +203,13 @@ class ScriptedAdapter:
                 "sensitive raw thread/start response",
                 diagnostic=CodexFailureDiagnostic.for_phase("thread_start"),
             )
+        if self.mode == "forged_failure":
+            failure = CodexAdapterFailure(
+                "PRIVATE raw exception message",
+                diagnostic=CodexFailureDiagnostic.for_phase("thread_start"),
+            )
+            failure.diagnostic = MaliciousDiagnostic()  # type: ignore[assignment]
+            raise failure
         if self.mode == "typed_result_failure":
             return CodexRunResult(
                 run_id=self.engine.new_run_id(),
@@ -207,6 +224,26 @@ class ScriptedAdapter:
                     "dynamic_tool_call"
                 ),
             )
+        if self.mode == "forged_result_failure":
+            result = CodexRunResult(
+                run_id=self.engine.new_run_id(),
+                normal_terminal=False,
+                status="ABNORMAL_TERMINAL",
+                error_type="CodexAdapterFailure",
+                turn_status=None,
+                runtime_identity=None,
+                checkpoint_outcomes=(),
+                final_message="PRIVATE incomplete model text",
+                failure_diagnostic=CodexFailureDiagnostic.for_phase(
+                    "dynamic_tool_call"
+                ),
+            )
+            object.__setattr__(
+                result,
+                "failure_diagnostic",
+                MaliciousDiagnostic(),
+            )
+            return result
         if self.mode == "read_only":
             return CodexRunResult(
                 run_id=self.engine.new_run_id(),
@@ -1846,6 +1883,55 @@ class CompanionControllerTest(unittest.TestCase):
             self.assertEqual([], typed_result["run"]["file_actions"])
             self.assertIsNone(typed_result["run"]["approval"])
             self.assertNotIn("sensitive", json.dumps(typed_result))
+
+    def test_forged_diagnostics_downgrade_before_public_projection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root / "forged",
+                ScriptedFactory(
+                    "forged_failure",
+                    "forged_result_failure",
+                ),
+            )
+            controller.select_repository(repository)
+
+            for task in ("Forged exception.", "Forged result."):
+                with self.subTest(task=task):
+                    controller.start_run(task)
+                    state = wait_for(
+                        controller,
+                        lambda value: (
+                            value["run"]["state"] == "needs_attention"
+                        ),
+                    )
+                    run = state["run"]
+                    self.assertEqual(
+                        "The bounded Codex Run failed closed.",
+                        run["error"],
+                    )
+                    self.assertEqual(
+                        run["error"],
+                        run["outcomes"]["verification"]["reason"],
+                    )
+                    self.assertEqual(
+                        {
+                            "code": "codex_unknown_failure",
+                            "protocol_phase": "unknown",
+                            "reason": run["error"],
+                            "action": None,
+                        },
+                        run["failure"],
+                    )
+                    self.assertEqual("", run["result"])
+                    self.assertEqual([], run["file_actions"])
+                    self.assertEqual([], run["read_evidence"])
+                    self.assertIsNone(run["approval"])
+                    serialized = json.dumps(state)
+                    self.assertNotIn("PRIVATE", serialized)
+                    self.assertNotIn("secret", serialized)
+                    controller.new_run()
 
     def test_corrupted_event_chain_blocks_repository_selection(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -24,6 +24,7 @@ from decision_os.acceleration.codex_adapter import (
     CODEX_SERVICE_TIER,
     CodexAdapterFailure,
     CodexApproval,
+    CodexFailureDiagnostic,
     CodexFileAction,
     CodexLifecycleEvent,
     CodexReadEvidence,
@@ -187,6 +188,25 @@ class ScriptedAdapter:
             self.lifecycle_sink({"kind": "raw", "message": "<script>"})
         if self.mode == "failure":
             raise CodexAdapterFailure("sensitive raw adapter failure")
+        if self.mode == "typed_failure":
+            raise CodexAdapterFailure(
+                "sensitive raw thread/start response",
+                diagnostic=CodexFailureDiagnostic.for_phase("thread_start"),
+            )
+        if self.mode == "typed_result_failure":
+            return CodexRunResult(
+                run_id=self.engine.new_run_id(),
+                normal_terminal=False,
+                status="ABNORMAL_TERMINAL",
+                error_type="CodexAdapterFailure",
+                turn_status=None,
+                runtime_identity=None,
+                checkpoint_outcomes=(),
+                final_message="sensitive incomplete model text",
+                failure_diagnostic=CodexFailureDiagnostic.for_phase(
+                    "dynamic_tool_call"
+                ),
+            )
         if self.mode == "read_only":
             return CodexRunResult(
                 run_id=self.engine.new_run_id(),
@@ -1756,6 +1776,14 @@ class CompanionControllerTest(unittest.TestCase):
                 failed["run"]["error"],
             )
             self.assertEqual(
+                "The bounded Codex Run failed closed.",
+                failed["run"]["outcomes"]["verification"]["reason"],
+            )
+            self.assertEqual(
+                "codex_unknown_failure",
+                failed["run"]["failure"]["code"],
+            )
+            self.assertEqual(
                 {
                     "state": "unknown",
                     "label": (
@@ -1765,6 +1793,59 @@ class CompanionControllerTest(unittest.TestCase):
                 failed["run"]["outcomes"]["file_change"],
             )
             self.assertNotIn("sensitive", json.dumps(failed))
+
+            controller = self.make_controller(
+                root / "typed-failure",
+                ScriptedFactory("typed_failure", "typed_result_failure"),
+            )
+            controller.select_repository(repository)
+            controller.start_run("Typed adapter failure.")
+            typed = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "needs_attention",
+            )
+            self.assertEqual(
+                "The bounded Codex Run failed closed while starting its isolated thread.",
+                typed["run"]["error"],
+            )
+            self.assertEqual(
+                typed["run"]["error"],
+                typed["run"]["outcomes"]["verification"]["reason"],
+            )
+            self.assertEqual(
+                {
+                    "code": "codex_thread_start_failed",
+                    "protocol_phase": "thread_start",
+                    "reason": typed["run"]["error"],
+                    "action": "recheck_protocol",
+                },
+                typed["run"]["failure"],
+            )
+            self.assertEqual([], typed["run"]["file_actions"])
+            self.assertIsNone(typed["run"]["approval"])
+            self.assertNotIn("sensitive", json.dumps(typed))
+
+            controller.new_run()
+            controller.start_run("Typed result failure.")
+            typed_result = wait_for(
+                controller,
+                lambda state: state["run"]["state"] == "needs_attention",
+            )
+            self.assertEqual(
+                "The bounded Codex Run failed closed while handling the bounded repository read.",
+                typed_result["run"]["error"],
+            )
+            self.assertEqual(
+                "dynamic_tool_call",
+                typed_result["run"]["failure"]["protocol_phase"],
+            )
+            self.assertEqual(
+                typed_result["run"]["error"],
+                typed_result["run"]["outcomes"]["verification"]["reason"],
+            )
+            self.assertEqual([], typed_result["run"]["file_actions"])
+            self.assertIsNone(typed_result["run"]["approval"])
+            self.assertNotIn("sensitive", json.dumps(typed_result))
 
     def test_corrupted_event_chain_blocks_repository_selection(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2180,7 +2180,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             const source = fs.readFileSync(process.argv[2], "utf8");
             const operationStart = source.indexOf("function statusLabel");
             const operationEnd = source.indexOf("\nfunction formatNumber", operationStart);
-            const resultStart = source.indexOf("function renderResult");
+            const resultStart = source.indexOf("function visibleResponse");
             const resultEnd = source.indexOf("\nfunction renderApproval", resultStart);
             assert(operationStart >= 0 && operationEnd > operationStart);
             assert(resultStart >= 0 && resultEnd > resultStart);
@@ -2889,6 +2889,36 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                   },
                 },
               };
+              const failureResponse =
+                "The bounded Codex Run failed closed while verifying runtime settings.";
+              const failureRun = {
+                ...baseRun,
+                state: "needs_attention",
+                progress: ["Starting the private Codex runtime."],
+                result: "PRIVATE incomplete model text",
+                error: failureResponse,
+                failure: {
+                  code: "codex_settings_verification_failed",
+                  protocol_phase: "settings_verification",
+                  reason: failureResponse,
+                  action: "recheck_runtime",
+                },
+                outcomes: {
+                  execution: {
+                    state: "not_completed",
+                    label: "Codex turn did not complete",
+                  },
+                  file_change: {
+                    state: "unknown",
+                    label: "Not established — file-change outcome requires review",
+                  },
+                  verification: {
+                    state: "needs_attention",
+                    label: "Needs attention",
+                    reason: failureResponse,
+                  },
+                },
+              };
               function state(run) {
                 return {
                   csrf: "browser-csrf",
@@ -2983,6 +3013,9 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                   }
                   if (serverPhase === "terminal") {
                     return browserResponse(state(terminalRun));
+                  }
+                  if (serverPhase === "failure") {
+                    return browserResponse(state(failureRun));
                   }
                   return browserResponse(state(baseRun));
                 }
@@ -3288,11 +3321,46 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                   probePhase === "copy-failure" &&
                   document.getElementById("copy-response").textContent === "Copy failed"
                 ) {
-                  document.body.dataset.copyFailure = String(
+                  const failedCopyPreserved = (
                     document.activeElement.id === "copy-response" &&
                     document.getElementById("copy-response-status").textContent ===
                       "Codex response could not be copied." &&
                     latestState.run.state === "unsupported"
+                  );
+                  serverPhase = "failure";
+                  window.__clipboardFail = false;
+                  render(state(failureRun));
+                  const failureCopy = document.getElementById("copy-response");
+                  document.body.dataset.copyFailure = String(
+                    failedCopyPreserved &&
+                    document.getElementById("result").textContent === failureResponse &&
+                    document.getElementById("result-verification-reason").textContent ===
+                      failureResponse &&
+                    !failureCopy.classList.contains("hidden") &&
+                    !failureCopy.disabled &&
+                    visibleResponse({ state: "running", result: "", error: null }) === "" &&
+                    visibleResponse({ state: "completed", result: "", error: null }) ===
+                      "The bounded Run completed without a final text response." &&
+                    visibleResponse({
+                      state: "needs_attention",
+                      result: "",
+                      error: null,
+                    }) === "No final result was available."
+                  );
+                  failureCopy.click();
+                  probePhase = "failure-copy";
+                  return;
+                }
+                if (
+                  probePhase === "failure-copy" &&
+                  document.getElementById("copy-response").textContent === "Copied"
+                ) {
+                  document.body.dataset.failureCopy = String(
+                    document.getElementById("result").textContent === failureResponse &&
+                    window.__clipboardWrites.at(-1) === failureResponse &&
+                    latestState.run.state === "needs_attention" &&
+                    latestState.run.file_actions.length === 0 &&
+                    latestState.run.approval == null
                   );
                   document.body.dataset.qualified = "true";
                   window.clearInterval(probe);
@@ -3388,6 +3456,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             "copy-repeated",
             "copy-restored",
             "copy-failure",
+            "failure-copy",
             "qualified",
         ):
             self.assertEqual("true", attributes.get(name), name)


### PR DESCRIPTION
## Summary

- Historical Self-Hosted Run 002 cause remains canonically UNKNOWN because the original implementation discarded exception, stderr, traceback, and phase evidence.
- Incident-time no-mutation proof passed.
- The controller previously collapsed every `CodexAdapterFailure` into one generic response and left verification reason empty.
- The client displayed `run.error` as fallback but allowed Copy response only from `run.result`.
- The repair introduces bounded typed diagnostics with canonical reconstruction.
- Malformed, forged, mutated, subclassed, or lookalike diagnostics downgrade to `codex_unknown_failure`.
- Raw exception text, stderr, prompts, source, secrets, and private paths are not projected.
- A first-failure phase latch preserves the originating protocol boundary.
- Item phases distinguish agent message, dynamic tool call, file change, and unsupported item.
- CLI version verification is separated from app-server process startup.
- One exact visible response is used for both display and Copy response.
- No Approval, file action, read evidence, or mutation outcome is fabricated.

## Review history

- Initial repair commit: `632a096e39080e85fa7ab4eb1322e1a8c8dda4ff`
- Forward-only repair commit: `0b303ab36ce5a968cd4e6eff5e9cb88c41c0133b`
- Independent initial review: CHANGES_REQUIRED
- Independent re-review of `0b303ab`: PASS

## Validation

- Codex adapter: 51 passed
- Companion controller: 27 passed
- Companion server/client: 35 passed
- Acceleration CLI: 9 passed
- Seven focused regressions: passed
- Non-live Chrome Copy harness: passed
- Node syntax: passed
- `git diff --check`: passed
- No live Companion Run or model turn was used for validation.

## Remaining gates

- Isolated live diagnostic qualification: separately unauthorized
- Merge: BLOCK
- Rail “Contract — Not used”: HOLD
- Transfer / Builder / Pro / Fable / release / publication: BLOCK
