### PR TITLE
Show Contract as not used for manual runs

### DIFF
--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -236,6 +236,7 @@ class CompanionController:
     def _empty_run() -> dict[str, Any]:
         return {
             "run_type": "bounded_task",
+            "task_mode": None,
             "state": "idle",
             "progress": [],
             "result": "",
@@ -1109,11 +1110,21 @@ class CompanionController:
             operation="control",
         )
 
-    def start_run(self, task: str) -> dict[str, Any]:
+    def start_run(
+        self,
+        task: str,
+        *,
+        task_mode: str = "manual",
+    ) -> dict[str, Any]:
         if not isinstance(task, str) or not task.strip():
             raise CompanionError("Enter one bounded task before running.")
         if len(task) > 20_000:
             raise CompanionError("The bounded task exceeds the local size limit.")
+        if not isinstance(task_mode, str) or task_mode not in {
+            "manual",
+            "contract",
+        }:
+            raise CompanionError("Run task mode is invalid.")
         with self._condition:
             repository = self._require_repository()
             if (
@@ -1130,6 +1141,7 @@ class CompanionController:
                 )
             before = self._safe_receipt(repository)
             self._run = self._empty_run()
+            self._run["task_mode"] = task_mode
             self._run["state"] = "running"
             self._run["progress"] = ["Preparing the bounded task."]
             self._run["outcomes"]["execution"] = {

--- a/decision_os/companion/server.py
+++ b/decision_os/companion/server.py
@@ -519,9 +519,15 @@ class CompanionRequestHandler(BaseHTTPRequestHandler):
                     raise CompanionError("Repository picker takes no input.")
                 snapshot = self.server.controller.pick_repository()
             elif path == "/api/run":
-                if set(value) != {"task"}:
+                if set(value) not in ({"task"}, {"task", "task_mode"}):
                     raise CompanionError("Run request fields are invalid.")
-                snapshot = self.server.controller.start_run(value["task"])
+                if "task_mode" in value:
+                    snapshot = self.server.controller.start_run(
+                        value["task"],
+                        task_mode=value["task_mode"],
+                    )
+                else:
+                    snapshot = self.server.controller.start_run(value["task"])
             elif path == "/api/approval":
                 if set(value) != {"choice"}:
                     raise CompanionError("Approval request fields are invalid.")

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -323,14 +323,18 @@ function operationPresentation(
   const historicalFixed = ordinary?.state === "FIXED";
   const fixed = usableCurrentOrdinaryContext(ordinary);
   const staleFixed = historicalFixed && !fixed;
+  const contractStatus =
+    task.mode === "manual"
+      ? "Not used"
+      : fixed
+        ? "Complete"
+        : staleFixed
+          ? "Needs attention"
+          : repository
+            ? "Current"
+            : "Not started";
   const statuses = {
-    contract: fixed
-      ? "Complete"
-      : staleFixed
-        ? "Needs attention"
-        : repository
-          ? "Current"
-          : "Not started",
+    contract: contractStatus,
     task: "Not started",
     run: "Not started",
     approval: approvalSeen ? "Complete" : "Not started",
@@ -338,11 +342,7 @@ function operationPresentation(
   };
 
   if (startPending) {
-    statuses.contract = fixed
-      ? "Complete"
-      : staleFixed
-        ? "Needs attention"
-        : "Not started";
+    statuses.contract = contractStatus;
     statuses.task = "Complete";
     statuses.run = "Waiting for system";
     return {
@@ -356,11 +356,7 @@ function operationPresentation(
   }
 
   if (state === "running") {
-    statuses.contract = fixed
-      ? "Complete"
-      : staleFixed
-        ? "Needs attention"
-        : "Not started";
+    statuses.contract = contractStatus;
     statuses.task = "Complete";
     statuses.run = approval ? "Waiting for you" : "Waiting for system";
     if (approval) {
@@ -388,11 +384,7 @@ function operationPresentation(
 
   if (TERMINAL_RUN_STATES.includes(state)) {
     const needsAttention = ["unsupported", "needs_attention"].includes(state);
-    statuses.contract = fixed
-      ? "Complete"
-      : staleFixed
-        ? "Needs attention"
-        : "Not started";
+    statuses.contract = contractStatus;
     statuses.task = "Complete";
     statuses.run = needsAttention ? "Needs attention" : "Complete";
     statuses.result = needsAttention ? "Needs attention" : "Current";

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -29,6 +29,7 @@ let operationContinuingAfterApproval = false;
 let operationTerminalTransitioned = false;
 let operationLastApprovalKey = null;
 let preparedContractTaskBinding = null;
+let preparedContractTaskStarter = null;
 let ordinaryReviewDisclosureIdentity = null;
 let currentCodexResponse = "";
 let copyResponseResetTimer = null;
@@ -266,8 +267,28 @@ function looksLikePreparedContractTask(value) {
   );
 }
 
+function clearPreparedContractTaskBinding() {
+  preparedContractTaskBinding = null;
+  preparedContractTaskStarter = null;
+}
+
+function invalidateReplacedContractTask(value) {
+  if (value.trim().length === 0) {
+    clearPreparedContractTaskBinding();
+    return;
+  }
+  if (
+    preparedContractTaskBinding !== null &&
+    (!nonEmptyString(preparedContractTaskStarter) ||
+      !value.startsWith(preparedContractTaskStarter))
+  ) {
+    clearPreparedContractTaskBinding();
+  }
+}
+
 function taskReadiness(ordinary, repository) {
   const value = byId("task").value;
+  invalidateReplacedContractTask(value);
   if (value.trim().length === 0) {
     return {
       mode: "empty",
@@ -320,17 +341,23 @@ function operationPresentation(
   const startPending = Boolean(context.startPending);
   const approvalSeen = Boolean(context.approvalSeen);
   const continuing = Boolean(context.continuingAfterApproval);
+  const runLifecycleActive =
+    startPending || state === "running" || TERMINAL_RUN_STATES.includes(state);
+  const runTaskMode = ["manual", "contract"].includes(run?.task_mode)
+    ? run.task_mode
+    : null;
+  const taskMode = runLifecycleActive && runTaskMode ? runTaskMode : task.mode;
   const historicalFixed = ordinary?.state === "FIXED";
   const fixed = usableCurrentOrdinaryContext(ordinary);
   const staleFixed = historicalFixed && !fixed;
   const contractStatus =
-    task.mode === "manual"
+    taskMode === "manual"
       ? "Not used"
       : fixed
         ? "Complete"
         : staleFixed
           ? "Needs attention"
-          : repository
+          : repository && !runLifecycleActive
             ? "Current"
             : "Not started";
   const statuses = {
@@ -579,7 +606,7 @@ function coordinateOperationTransition(run) {
   operationLastApprovalKey = approvalKey;
 }
 
-function beginOperationRun() {
+function beginOperationRun(taskMode) {
   resetOperationTransitionMemory();
   operationStartPending = true;
   byId("run").disabled = true;
@@ -590,7 +617,12 @@ function beginOperationRun() {
   item.textContent = "Starting Run";
   progress.replaceChildren(item);
   renderOperationAwareness(
-    { state: "running", progress: ["Starting Run"], approval: null },
+    {
+      state: "running",
+      task_mode: taskMode,
+      progress: ["Starting Run"],
+      approval: null,
+    },
     latestState?.ordinary_contract,
     latestState?.repository,
   );
@@ -1128,8 +1160,10 @@ function ensureOrdinaryPrepareTaskButton() {
     }
     const task = byId("task");
     if (task.value.trim().length === 0) {
+      const starter = ordinaryFixedTaskStarter(panel);
       preparedContractTaskBinding = binding;
-      task.value = ordinaryFixedTaskStarter(panel);
+      preparedContractTaskStarter = starter;
+      task.value = starter;
       task.dispatchEvent(new Event("input", { bubbles: true }));
     }
     task.scrollIntoView?.({ block: "center" });
@@ -1832,6 +1866,7 @@ function render(state) {
     ? run
     : {
         run_type: "bounded_task",
+        task_mode: null,
         state: "idle",
         progress: [],
         result: "",
@@ -1952,6 +1987,7 @@ function enterDisconnected() {
 
   const emptyRun = {
     run_type: "bounded_task",
+    task_mode: null,
     state: "idle",
     progress: [],
     result: "",
@@ -1971,6 +2007,7 @@ function enterDisconnected() {
   renderApproval(null);
   operationStartPending = false;
   resetOperationTransitionMemory();
+  clearPreparedContractTaskBinding();
   renderOperationAwareness(emptyRun, null, null);
 
   byId("defaults").replaceChildren();
@@ -2389,9 +2426,7 @@ for (const [index, button] of operationStageButtons.entries()) {
 }
 
 byId("task").addEventListener("input", () => {
-  if (byId("task").value.trim().length === 0) {
-    preparedContractTaskBinding = null;
-  }
+  invalidateReplacedContractTask(byId("task").value);
   if (connected && latestState) {
     render(latestState);
   }
@@ -2409,8 +2444,11 @@ byId("run").addEventListener("click", async () => {
   if (byId("run").disabled || requestActive || !currentTask.runnable) {
     return;
   }
-  beginOperationRun();
-  const state = await postJSON("/api/run", { task: byId("task").value });
+  beginOperationRun(currentTask.mode);
+  const state = await postJSON("/api/run", {
+    task: byId("task").value,
+    task_mode: currentTask.mode,
+  });
   operationStartPending = false;
   if (state) {
     render(state);
@@ -2425,7 +2463,7 @@ byId("new-run").addEventListener("click", async () => {
     operationStartPending = false;
     resetOperationTransitionMemory();
     byId("task").value = "";
-    preparedContractTaskBinding = null;
+    clearPreparedContractTaskBinding();
     render(state);
     byId("task").focus();
   }

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -593,12 +593,17 @@ class CompanionControllerTest(unittest.TestCase):
             )
             controller.select_repository(repository)
 
-            controller.start_run("Read the target without changing it.")
+            started = controller.start_run(
+                "Read the target without changing it.",
+                task_mode="contract",
+            )
+            self.assertEqual("contract", started["run"]["task_mode"])
             snapshot = wait_for(
                 controller,
                 lambda state: state["run"]["state"] == "completed",
             )
 
+            self.assertEqual("contract", snapshot["run"]["task_mode"])
             self.assertEqual("Read-only result.", snapshot["run"]["result"])
             self.assertEqual(
                 [

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2035,7 +2035,10 @@ class CompanionServerTest(unittest.TestCase):
         status, _headers, _raw = self.request(
             "POST",
             "/api/run",
-            body={"task": "Modify target.txt once."},
+            body={
+                "task": "Modify target.txt once.",
+                "task_mode": "contract",
+            },
             cookie=cookie,
             csrf=csrf,
             origin=self.server.origin,
@@ -2056,6 +2059,7 @@ class CompanionServerTest(unittest.TestCase):
             time.sleep(0.01)
         self.assertIsNotNone(first)
         self.assertIsNotNone(first["run"]["approval"])
+        self.assertEqual("contract", first["run"]["task_mode"])
 
         status, _headers, raw = self.request(
             "GET",
@@ -2255,6 +2259,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               operationApprovalSeen: false,
               operationContinuingAfterApproval: false,
               preparedContractTaskBinding: null,
+              preparedContractTaskStarter: null,
               operationLastApprovalKey: null,
               operationStartPending: false,
               operationTerminalTransitioned: false,
@@ -2330,15 +2335,21 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             assert.strictEqual(view.statuses.task, "Current");
             assert.strictEqual(view.action, "Select Run to start this bounded task.");
             const manualLifecycle = [
-              [idle, { startPending: true }, "Run starting"],
+              [{ ...idle, task_mode: "manual" }, { startPending: true }, "Run starting"],
               [
-                { state: "running", progress: ["Working"], approval: null },
+                {
+                  state: "running",
+                  task_mode: "manual",
+                  progress: ["Working"],
+                  approval: null,
+                },
                 {},
                 "Run working",
               ],
               [
                 {
                   state: "running",
+                  task_mode: "manual",
                   progress: ["Waiting for approval"],
                   approval: {
                     action: "Modify",
@@ -2349,14 +2360,42 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 "Approval waiting",
               ],
               [
-                { state: "running", progress: ["Continuing"], approval: null },
+                {
+                  state: "running",
+                  task_mode: "manual",
+                  progress: ["Continuing"],
+                  approval: null,
+                },
                 { approvalSeen: true, continuingAfterApproval: true },
                 "post-Approval continuation",
               ],
-              [{ state: "completed", progress: [], approval: null }, {}, "terminal success"],
-              [{ state: "denied", progress: [], approval: null }, {}, "terminal denial"],
               [
-                { state: "needs_attention", progress: [], approval: null },
+                {
+                  state: "completed",
+                  task_mode: "manual",
+                  progress: [],
+                  approval: null,
+                },
+                {},
+                "terminal success",
+              ],
+              [
+                {
+                  state: "denied",
+                  task_mode: "manual",
+                  progress: [],
+                  approval: null,
+                },
+                {},
+                "terminal denial",
+              ],
+              [
+                {
+                  state: "needs_attention",
+                  task_mode: "manual",
+                  progress: [],
+                  approval: null,
+                },
                 {},
                 "terminal needs-attention",
               ],
@@ -2370,6 +2409,20 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 context,
               );
               assert.strictEqual(view.statuses.contract, "Not used", label);
+            }
+            for (const state of ["running", "completed", "needs_attention"]) {
+              view = sandbox.operationPresentation(
+                { state, task_mode: "contract", progress: [], approval: null },
+                null,
+                emptyTask,
+                repository,
+                {},
+              );
+              assert.strictEqual(
+                view.statuses.contract,
+                "Not started",
+                `non-manual repository without Contract: ${state}`,
+              );
             }
             const insertedTask = {
               mode: "contract",
@@ -2476,7 +2529,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
 
             elements.get("task").value = "one bounded task";
             sandbox.latestState = { ordinary_contract: fixed, repository };
-            sandbox.beginOperationRun();
+            sandbox.beginOperationRun("manual");
             assert.strictEqual(elements.get("run").disabled, true);
             assert.strictEqual(elements.get("operation-current").textContent, "Starting Run");
             assert.strictEqual(
@@ -2493,6 +2546,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             sandbox.operationStartPending = false;
             const working = {
               state: "running",
+              task_mode: "manual",
               progress: ["Starting the private Codex runtime."],
               approval: null,
             };
@@ -2511,6 +2565,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             elements.get("approval-overlay").classList.toggle("hidden", false);
             const approval = {
               state: "running",
+              task_mode: "manual",
               progress: ["Waiting for one exact file-change decision."],
               approval: {
                 repository: "repo",
@@ -2543,6 +2598,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             elements.get("result-card").classList.toggle("hidden", false);
             const terminal = {
               state: "unsupported",
+              task_mode: "manual",
               progress: ["Finalizing the local Receipt."],
               result: "The requested file was modified.",
               file_actions: [{ action: "Modify", path: "app.js", status: "approved", access: "one-time" }],
@@ -2571,6 +2627,51 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             assert.strictEqual(elements.get("operation-contract-status").textContent, "Not used");
             sandbox.coordinateOperationTransition(terminal);
             assert.strictEqual(elements.get("result-heading").focusCalls.length, 1);
+
+            elements.get("task").value = "one bounded task";
+            for (const state of ["completed", "denied", "needs_attention"]) {
+              const manualTerminal = {
+                state,
+                task_mode: "manual",
+                progress: [],
+                approval: null,
+              };
+              sandbox.renderOperationAwareness(manualTerminal, fixed, repository);
+              assert.strictEqual(
+                elements.get("operation-contract-status").textContent,
+                "Not used",
+                `manual terminal DOM: ${state}`,
+              );
+            }
+            elements.get("task").value = "";
+            sandbox.renderOperationAwareness(
+              { ...terminal, state: "completed" },
+              fixed,
+              repository,
+            );
+            assert.strictEqual(
+              elements.get("operation-contract-status").textContent,
+              "Not used",
+              "clearing the editor must not relabel a completed manual Run",
+            );
+            elements.get("task").value = [
+              sandbox.CONTRACT_TASK_PREFIX,
+              "Current repository identity: commit-a",
+              "Fixed Contract Request identity: GI-REQ-ONE",
+              `Interpretation SHA-256: ${"a".repeat(64)}`,
+              sandbox.CONTRACT_TASK_MARKER,
+              "Contract-bound replacement.",
+            ].join("\n");
+            sandbox.renderOperationAwareness(
+              { ...terminal, state: "completed" },
+              fixed,
+              repository,
+            );
+            assert.strictEqual(
+              elements.get("operation-contract-status").textContent,
+              "Not used",
+              "editing the editor must not relabel a completed manual Run",
+            );
 
             reducedMotion = true;
             sandbox.moveToOperationStage("task");
@@ -2684,6 +2785,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               UNKNOWN_EXECUTION_AUTHORITY_MESSAGE:
                 "Execution authority is not established for this Contract.",
               preparedContractTaskBinding: null,
+              preparedContractTaskStarter: null,
               latestState: {
                 ordinary_contract: { state: "REVIEW_READY" },
                 repository: { name: "repo-a", path: "/tmp/repo-a" },
@@ -2780,6 +2882,22 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             const manual = sandbox.taskReadiness(interpretationOnly, otherRepository);
             assert.strictEqual(manual.mode, "manual");
             assert.strictEqual(manual.runnable, true);
+
+            elements.get("task").value = "";
+            sandbox.latestState = {
+              ordinary_contract: fixed,
+              repository: { name: "repo-a", path: "/tmp/repo-a" },
+            };
+            button.dispatch("click");
+            assert(elements.get("task").value.includes("GI-REQ-ONE"));
+            elements.get("task").value = "Replacement manual task.";
+            const replaced = sandbox.taskReadiness(
+              fixed,
+              sandbox.latestState.repository,
+            );
+            assert.strictEqual(replaced.mode, "manual");
+            assert.strictEqual(replaced.runnable, true);
+            assert.strictEqual(sandbox.preparedContractTaskBinding, null);
 
             const renderStart = source.indexOf("function renderOrdinaryContract");
             const renderEnd = source.indexOf("\nconst guidedIntakeActionIds", renderStart);
@@ -3618,6 +3736,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               UNKNOWN_EXECUTION_AUTHORITY_MESSAGE:
                 "Execution authority is not established for this Contract.",
               preparedContractTaskBinding: null,
+              preparedContractTaskStarter: null,
               byId: (id) => elements.get(id),
               setText: (id, value) => {
                 elements.get(id).textContent = value == null ? "" : String(value);

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2326,9 +2326,51 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             assert.strictEqual(view.statuses.run, "Not started");
             view = sandbox.operationPresentation(idle, fixed, manualTask, repository, {});
             assert.strictEqual(view.currentStage, "task");
-            assert.strictEqual(view.statuses.contract, "Complete");
+            assert.strictEqual(view.statuses.contract, "Not used");
             assert.strictEqual(view.statuses.task, "Current");
             assert.strictEqual(view.action, "Select Run to start this bounded task.");
+            const manualLifecycle = [
+              [idle, { startPending: true }, "Run starting"],
+              [
+                { state: "running", progress: ["Working"], approval: null },
+                {},
+                "Run working",
+              ],
+              [
+                {
+                  state: "running",
+                  progress: ["Waiting for approval"],
+                  approval: {
+                    action: "Modify",
+                    path: "decision_os/companion/static/app.js",
+                  },
+                },
+                { approvalSeen: true },
+                "Approval waiting",
+              ],
+              [
+                { state: "running", progress: ["Continuing"], approval: null },
+                { approvalSeen: true, continuingAfterApproval: true },
+                "post-Approval continuation",
+              ],
+              [{ state: "completed", progress: [], approval: null }, {}, "terminal success"],
+              [{ state: "denied", progress: [], approval: null }, {}, "terminal denial"],
+              [
+                { state: "needs_attention", progress: [], approval: null },
+                {},
+                "terminal needs-attention",
+              ],
+            ];
+            for (const [run, context, label] of manualLifecycle) {
+              view = sandbox.operationPresentation(
+                run,
+                fixed,
+                manualTask,
+                repository,
+                context,
+              );
+              assert.strictEqual(view.statuses.contract, "Not used", label);
+            }
             const insertedTask = {
               mode: "contract",
               runnable: false,
@@ -2441,6 +2483,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               elements.get("operation-action").textContent,
               "Wait — no action is needed.",
             );
+            assert.strictEqual(
+              elements.get("operation-contract-status").textContent,
+              "Not used",
+            );
             assert.strictEqual(elements.get("progress-card").classList.contains("hidden"), false);
             assert.strictEqual(elements.get("progress-heading").focusCalls.length, 1);
 
@@ -2453,6 +2499,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             sandbox.coordinateOperationTransition(working);
             sandbox.renderOperationAwareness(working, fixed, repository);
             assert.strictEqual(elements.get("operation-current").textContent, "Codex is working");
+            assert.strictEqual(elements.get("operation-contract-status").textContent, "Not used");
             assert.strictEqual(elements.get("operation-run-status").textContent, "Waiting for system");
             const progressFocusAfterWorking = elements.get("progress-heading").focusCalls.length;
             sandbox.coordinateOperationTransition(working);
@@ -2475,6 +2522,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             sandbox.renderOperationAwareness(approval, fixed, repository);
             assert.strictEqual(elements.get("approval-heading").focusCalls.length, 1);
             assert.strictEqual(elements.get("operation-current").textContent, "Approval required");
+            assert.strictEqual(elements.get("operation-contract-status").textContent, "Not used");
             assert.strictEqual(elements.get("operation-approval-status").textContent, "Waiting for you");
             assert.strictEqual(
               elements.get("operation-happening").textContent,
@@ -2487,6 +2535,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             sandbox.coordinateOperationTransition(working);
             sandbox.renderOperationAwareness(working, fixed, repository);
             assert.strictEqual(elements.get("operation-current").textContent, "The Run is continuing");
+            assert.strictEqual(elements.get("operation-contract-status").textContent, "Not used");
             assert.strictEqual(elements.get("progress-heading").focusCalls.length, progressFocusAfterWorking + 1);
             sandbox.coordinateOperationTransition(working);
             assert.strictEqual(elements.get("progress-heading").focusCalls.length, progressFocusAfterWorking + 1);
@@ -2519,6 +2568,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "unsupported_request_method:commandExecution",
             );
             assert.strictEqual(elements.get("operation-current").textContent, "Run needs attention");
+            assert.strictEqual(elements.get("operation-contract-status").textContent, "Not used");
             sandbox.coordinateOperationTransition(terminal);
             assert.strictEqual(elements.get("result-heading").focusCalls.length, 1);
 


### PR DESCRIPTION
### Product change

Manual bounded Runs display Contract status exactly:

`Not used`

throughout the complete run-bound manual lifecycle:

- task ready;
- Run starting;
- Run working;
- Approval waiting;
- post-Approval continuation;
- terminal success;
- terminal denial;
- terminal needs-attention.

Manual-versus-Contract provenance is captured in the bounded Run snapshot at start and is no longer recomputed from the mutable task editor during starting, running, or terminal presentation.

Contract-bound and other non-manual behavior preserve the base Contract status semantics:

- fixed Contract: `Complete`;
- stale Contract: `Needs attention`;
- repository without a fixed/stale Contract: `Current` while idle and `Not started` while running or terminal;
- no repository: `Not started`.

### Bounded repair after independent review

The repair commit closes the reviewed findings by:

- storing `task_mode` on the bounded Run and transporting it through `/api/run`;
- keeping a completed manual Run labeled `Not used` even if the task editor is cleared or replaced;
- invalidating the cached prepared-Contract binding when the exact prepared starter no longer prefixes the editor value;
- restoring the base non-manual repository/no-Contract lifecycle behavior;
- adding state-source, terminal DOM, replacement, HTTP, and controller regression coverage.

Original execution commit:

`be7ccadbcd05874eac8dcb38bcb430d30a9de379`

Bounded repair commit:

`9c437237080649514c82836e9ecd722784955ff6`

### Archived execution-evidence boundary

No new live Companion Run was performed for the repair.

The already archived transcript and verified event chain durably establish:

- one Claude session;
- one user prompt;
- one `Read` of `decision_os/companion/static/app.js`;
- event count `14 → 15`;
- one valid-chain `DECISION_CHECK` for `MODIFY_FILE`;
- three successful `Edit` calls in the archived transcript;
- only the first Edit interrupt ID matches the sole `DECISION_CHECK`;
- no saved repository permission/default was established.

The durable evidence does **not** establish:

- an exact `Allow once` choice;
- a `NORMAL_TERMINAL` label;
- a normal checkpoint;
- why the later two mutations succeeded without another `DECISION_CHECK`.

The reason later mutations succeeded without another `DECISION_CHECK` remains:

`UNKNOWN`

No explanation is inferred from the existing artifacts.

### Identity

- Base commit: `c828297f7837f88f992fb0cffe34928c20b6d1dc`
- Original execution commit: `be7ccadbcd05874eac8dcb38bcb430d30a9de379`
- Repair commit: `9c437237080649514c82836e9ecd722784955ff6`
- Original target before SHA-256: `9800da19c46ff8637bee072b9e134a122c8d00ef89e0d899f25a49e56f781ba1`
- Original target after SHA-256: `212387f32f50f40a7a80f5eef737f21c2fac7973cb80084204492151c3103cfa`
- Protected probe SHA-256: `f68b3a1f47136782cbb5ade4c4686724c2b877eaaffe52bdb81aa72ae19c6344`

### Validation

- focused lifecycle/state-source tests: 4 targeted tests passed;
- Companion server/client: 35 passed;
- Companion controller: 27 passed;
- existing headless-Chrome presentation harness: passed;
- Node syntax: passed;
- `git diff --check`: passed.

The relevant new regression tests were confirmed to fail on `be7ccadbcd05874eac8dcb38bcb430d30a9de379` before the repair.

### Boundaries

- No new branch or execution thread was created.
- No live Companion Run occurred during the repair.
- Companion Claude Execution Bridge has not started.
- The PR remains draft and requires a new independent read-only review.
- Merge, release, publication, Rail reopening, and another live Run remain blocked.