### PR TITLE
Repair Companion thread start capability

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -357,6 +357,13 @@ _PROTOCOL_METHODS = frozenset(
         "turn/start",
     }
 )
+_PROTOCOL_METHOD_BY_PHASE = {
+    "account_verification": "account/read",
+    "initialize_handshake": "initialize",
+    "model_verification": "model/list",
+    "thread_start": "thread/start",
+    "turn_start": "turn/start",
+}
 _STATE_OR_FILESYSTEM_MARKERS = (
     "codex home",
     "database",
@@ -380,6 +387,34 @@ _INVALID_PARAMS_MARKERS = (
     "schema",
     "unknown field",
 )
+
+
+def _coherent_failure_evidence(
+    protocol_phase: str,
+    category: str,
+    jsonrpc_code: int | None,
+    protocol_method: str | None,
+) -> bool:
+    if category not in _FAILURE_CATEGORIES:
+        return False
+    if protocol_method is not None:
+        if _PROTOCOL_METHOD_BY_PHASE.get(protocol_phase) != protocol_method:
+            return False
+    elif jsonrpc_code is not None or category != "unknown":
+        return False
+
+    if category == "jsonrpc_method_rejected":
+        return jsonrpc_code == -32601
+    if category == "jsonrpc_invalid_params":
+        return jsonrpc_code in {-32600, -32602}
+    if category == "transport_or_process":
+        return jsonrpc_code is None and protocol_method is not None
+    if category == "state_or_filesystem":
+        return bool(
+            protocol_method is not None
+            and jsonrpc_code not in {-32600, -32601, -32602}
+        )
+    return jsonrpc_code not in {-32601, -32602}
 
 
 @dataclass(frozen=True)
@@ -407,26 +442,17 @@ class CodexFailureDiagnostic:
             self.protocol_method is None
             or self.protocol_method in _PROTOCOL_METHODS
         )
-        coherent_category = bool(
-            self.category in _FAILURE_CATEGORIES
-            and (
-                self.category != "jsonrpc_method_rejected"
-                or self.jsonrpc_code == -32601
-            )
-            and (
-                self.category != "jsonrpc_invalid_params"
-                or self.jsonrpc_code in {-32600, -32602}
-            )
-            and (
-                not self.category.startswith("jsonrpc_")
-                or self.protocol_method is not None
-            )
+        coherent_evidence = _coherent_failure_evidence(
+            self.protocol_phase,
+            self.category,
+            self.jsonrpc_code,
+            self.protocol_method,
         )
         if (
             spec != (self.code, self.reason, self.action)
             or not bounded_code
             or not bounded_method
-            or not coherent_category
+            or not coherent_evidence
         ):
             raise ValueError("Codex failure diagnostic must be bounded.")
 

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -339,6 +339,48 @@ _FAILURE_DIAGNOSTIC_SPECS = {
     ),
 }
 
+_FAILURE_CATEGORIES = frozenset(
+    {
+        "jsonrpc_method_rejected",
+        "jsonrpc_invalid_params",
+        "state_or_filesystem",
+        "transport_or_process",
+        "unknown",
+    }
+)
+_PROTOCOL_METHODS = frozenset(
+    {
+        "account/read",
+        "initialize",
+        "model/list",
+        "thread/start",
+        "turn/start",
+    }
+)
+_STATE_OR_FILESYSTEM_MARKERS = (
+    "codex home",
+    "database",
+    "failed to create",
+    "file system",
+    "filesystem",
+    "no such file",
+    "permission denied",
+    "read-only file system",
+    "sqlite",
+    "state directory",
+    "unable to create",
+)
+_INVALID_PARAMS_MARKERS = (
+    "deserialize",
+    "invalid parameter",
+    "invalid params",
+    "invalid request",
+    "missing field",
+    "requires experimentalapi capability",
+    "schema",
+    "unknown field",
+)
+
 
 @dataclass(frozen=True)
 class CodexFailureDiagnostic:
@@ -348,18 +390,55 @@ class CodexFailureDiagnostic:
     protocol_phase: str
     reason: str
     action: str | None = None
+    category: str = "unknown"
+    jsonrpc_code: int | None = None
+    protocol_method: str | None = None
 
     def __post_init__(self) -> None:
         spec = _FAILURE_DIAGNOSTIC_SPECS.get(self.protocol_phase)
-        if spec != (self.code, self.reason, self.action):
+        bounded_code = bool(
+            self.jsonrpc_code is None
+            or (
+                type(self.jsonrpc_code) is int
+                and -(2**63) <= self.jsonrpc_code < 2**63
+            )
+        )
+        bounded_method = bool(
+            self.protocol_method is None
+            or self.protocol_method in _PROTOCOL_METHODS
+        )
+        coherent_category = bool(
+            self.category in _FAILURE_CATEGORIES
+            and (
+                self.category != "jsonrpc_method_rejected"
+                or self.jsonrpc_code == -32601
+            )
+            and (
+                self.category != "jsonrpc_invalid_params"
+                or self.jsonrpc_code in {-32600, -32602}
+            )
+            and (
+                not self.category.startswith("jsonrpc_")
+                or self.protocol_method is not None
+            )
+        )
+        if (
+            spec != (self.code, self.reason, self.action)
+            or not bounded_code
+            or not bounded_method
+            or not coherent_category
+        ):
             raise ValueError("Codex failure diagnostic must be bounded.")
 
-    def as_dict(self) -> dict[str, str | None]:
+    def as_dict(self) -> dict[str, str | int | None]:
         return {
             "code": self.code,
             "protocol_phase": self.protocol_phase,
             "reason": self.reason,
             "action": self.action,
+            "category": self.category,
+            "jsonrpc_code": self.jsonrpc_code,
+            "protocol_method": self.protocol_method,
         }
 
     @classmethod
@@ -367,7 +446,13 @@ class CodexFailureDiagnostic:
         return _failure_diagnostic(protocol_phase)
 
 
-def _failure_diagnostic(protocol_phase: str) -> CodexFailureDiagnostic:
+def _failure_diagnostic(
+    protocol_phase: str,
+    *,
+    category: str = "unknown",
+    jsonrpc_code: int | None = None,
+    protocol_method: str | None = None,
+) -> CodexFailureDiagnostic:
     phase = (
         protocol_phase
         if protocol_phase in _FAILURE_DIAGNOSTIC_SPECS
@@ -379,6 +464,63 @@ def _failure_diagnostic(protocol_phase: str) -> CodexFailureDiagnostic:
         protocol_phase=phase,
         reason=reason,
         action=action,
+        category=category,
+        jsonrpc_code=jsonrpc_code,
+        protocol_method=protocol_method,
+    )
+
+
+def _bounded_failure_text_category(value: object) -> str:
+    if type(value) is not str:
+        return "unknown"
+    lowered = value.casefold()
+    if "path aliases" in lowered:
+        return "unknown"
+    if any(marker in lowered for marker in _STATE_OR_FILESYSTEM_MARKERS):
+        return "state_or_filesystem"
+    if any(marker in lowered for marker in _INVALID_PARAMS_MARKERS):
+        return "jsonrpc_invalid_params"
+    return "unknown"
+
+
+def _jsonrpc_failure_diagnostic(
+    protocol_phase: str,
+    protocol_method: str,
+    error: object,
+) -> CodexFailureDiagnostic:
+    category = "unknown"
+    jsonrpc_code: int | None = None
+    message: object = None
+    if isinstance(error, dict):
+        raw_code = error.get("code")
+        if type(raw_code) is int and -(2**63) <= raw_code < 2**63:
+            jsonrpc_code = raw_code
+        message = error.get("message")
+    if jsonrpc_code == -32601:
+        category = "jsonrpc_method_rejected"
+    elif jsonrpc_code == -32602:
+        category = "jsonrpc_invalid_params"
+    elif jsonrpc_code == -32600:
+        classified = _bounded_failure_text_category(message)
+        category = (
+            classified
+            if classified == "jsonrpc_invalid_params"
+            else "unknown"
+        )
+    else:
+        category = _bounded_failure_text_category(message)
+    if category == "jsonrpc_invalid_params" and jsonrpc_code not in {
+        -32600,
+        -32602,
+    }:
+        category = "unknown"
+    return _failure_diagnostic(
+        protocol_phase,
+        category=category,
+        jsonrpc_code=jsonrpc_code,
+        protocol_method=(
+            protocol_method if protocol_method in _PROTOCOL_METHODS else None
+        ),
     )
 
 
@@ -393,6 +535,9 @@ def canonical_failure_diagnostic(value: object) -> CodexFailureDiagnostic:
         protocol_phase = object.__getattribute__(value, "protocol_phase")
         reason = object.__getattribute__(value, "reason")
         action = object.__getattribute__(value, "action")
+        category = object.__getattribute__(value, "category")
+        jsonrpc_code = object.__getattribute__(value, "jsonrpc_code")
+        protocol_method = object.__getattribute__(value, "protocol_method")
     except Exception:
         return unknown
     if (
@@ -400,12 +545,23 @@ def canonical_failure_diagnostic(value: object) -> CodexFailureDiagnostic:
         or type(protocol_phase) is not str
         or type(reason) is not str
         or (action is not None and type(action) is not str)
+        or type(category) is not str
+        or (jsonrpc_code is not None and type(jsonrpc_code) is not int)
+        or (protocol_method is not None and type(protocol_method) is not str)
     ):
         return unknown
     spec = _FAILURE_DIAGNOSTIC_SPECS.get(protocol_phase)
     if spec != (code, reason, action):
         return unknown
-    return _failure_diagnostic(protocol_phase)
+    try:
+        return _failure_diagnostic(
+            protocol_phase,
+            category=category,
+            jsonrpc_code=jsonrpc_code,
+            protocol_method=protocol_method,
+        )
+    except ValueError:
+        return unknown
 
 
 class CodexAdapterUnavailable(RuntimeError):
@@ -605,6 +761,10 @@ class AppServerTransport(Protocol):
     def version(self) -> str:
         """Return the exact CLI version used by this transport."""
 
+    @property
+    def failure_category(self) -> str:
+        """Return one bounded category inferred from private stderr."""
+
     def start(self) -> None:
         """Start one fresh app-server process."""
 
@@ -624,12 +784,19 @@ class _SubprocessTransport:
     def __init__(self, executable: Path) -> None:
         self.executable = executable
         self._version = ""
+        self._failure_category = "unknown"
+        self._failure_category_lock = threading.Lock()
         self._process: subprocess.Popen[str] | None = None
         self._stderr_thread: threading.Thread | None = None
 
     @property
     def version(self) -> str:
         return self._version
+
+    @property
+    def failure_category(self) -> str:
+        with self._failure_category_lock:
+            return self._failure_category
 
     def start(self) -> None:
         if not self.executable.is_file():
@@ -703,8 +870,12 @@ class _SubprocessTransport:
         if process is None or process.stderr is None:
             return
         try:
-            for _line in process.stderr:
-                pass
+            for line in process.stderr:
+                category = _bounded_failure_text_category(line)
+                if category != "state_or_filesystem":
+                    continue
+                with self._failure_category_lock:
+                    self._failure_category = category
         except (OSError, UnicodeError):
             return
 
@@ -909,13 +1080,37 @@ class CodexAdapter:
         self,
         exc: CodexAdapterUnavailable | CodexAdapterFailure,
     ) -> CodexFailureDiagnostic:
+        attached = (
+            None
+            if exc.diagnostic is None
+            else canonical_failure_diagnostic(exc.diagnostic)
+        )
         if self._failure_phase is None:
-            if exc.diagnostic is None:
+            if attached is None:
                 self._latch_failure_phase()
             else:
-                diagnostic = canonical_failure_diagnostic(exc.diagnostic)
-                self._latch_failure_phase(diagnostic.protocol_phase)
-        return self._latched_failure_diagnostic()
+                self._latch_failure_phase(attached.protocol_phase)
+        latched = self._latched_failure_diagnostic()
+        if (
+            attached is not None
+            and attached.protocol_phase == latched.protocol_phase
+        ):
+            return attached
+        return latched
+
+    def _transport_failure_category(self) -> str:
+        transport = self._transport
+        if transport is None:
+            return "transport_or_process"
+        try:
+            category = transport.failure_category
+        except (AttributeError, RuntimeError):
+            category = "unknown"
+        return (
+            category
+            if category == "state_or_filesystem"
+            else "transport_or_process"
+        )
 
     def _send(self, message: dict[str, Any]) -> None:
         if self._transport is None:
@@ -931,20 +1126,55 @@ class CodexAdapter:
         request_phase = self._protocol_phase
         self._request_id += 1
         request_id = self._request_id
-        self._send({"id": request_id, "method": method, "params": params})
+        try:
+            self._send({"id": request_id, "method": method, "params": params})
+        except (CodexAdapterUnavailable, CodexAdapterFailure) as exc:
+            raise CodexAdapterFailure(
+                f"Codex app-server {method} transport failed.",
+                diagnostic=_failure_diagnostic(
+                    request_phase,
+                    category=self._transport_failure_category(),
+                    protocol_method=(
+                        method if method in _PROTOCOL_METHODS else None
+                    ),
+                ),
+            ) from exc
         while True:
-            message = self._receive()
+            try:
+                message = self._receive()
+            except (CodexAdapterUnavailable, CodexAdapterFailure) as exc:
+                raise CodexAdapterFailure(
+                    f"Codex app-server {method} transport failed.",
+                    diagnostic=_failure_diagnostic(
+                        request_phase,
+                        category=self._transport_failure_category(),
+                        protocol_method=(
+                            method if method in _PROTOCOL_METHODS else None
+                        ),
+                    ),
+                ) from exc
             if (
                 message.get("id") == request_id
                 and "method" not in message
             ):
                 if "error" in message:
                     raise CodexAdapterFailure(
-                        f"Codex app-server {method} request failed."
+                        f"Codex app-server {method} request failed.",
+                        diagnostic=_jsonrpc_failure_diagnostic(
+                            request_phase,
+                            method,
+                            message.get("error"),
+                        ),
                     )
                 if "result" not in message:
                     raise CodexAdapterFailure(
-                        f"Codex app-server {method} response is incomplete."
+                        f"Codex app-server {method} response is incomplete.",
+                        diagnostic=_failure_diagnostic(
+                            request_phase,
+                            protocol_method=(
+                                method if method in _PROTOCOL_METHODS else None
+                            ),
+                        ),
                     )
                 return message["result"]
             self._dispatch(message)
@@ -962,7 +1192,7 @@ class CodexAdapter:
             self._request(
                 "initialize",
                 {
-                    "capabilities": {"experimentalApi": False},
+                    "capabilities": {"experimentalApi": True},
                     "clientInfo": {
                         "name": _CLIENT_NAME,
                         "title": "Decision OS Verified Save",

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -705,6 +705,104 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
         self.assertIsNot(canonical, rebuilt)
         self.assertEqual(canonical.as_dict(), rebuilt.as_dict())
 
+    def test_allowed_value_cross_combinations_downgrade_to_unknown(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "thread_start",
+                "jsonrpc_method_rejected",
+                -32601,
+                "turn/start",
+            ),
+            (
+                "turn_start",
+                "jsonrpc_invalid_params",
+                -32602,
+                "thread/start",
+            ),
+            (
+                "model_verification",
+                "jsonrpc_method_rejected",
+                -32601,
+                "account/read",
+            ),
+            (
+                "thread_identity_verification",
+                "jsonrpc_invalid_params",
+                -32600,
+                "thread/start",
+            ),
+            (
+                "thread_start",
+                "transport_or_process",
+                -32000,
+                "thread/start",
+            ),
+            (
+                "thread_start",
+                "unknown",
+                -32601,
+                "thread/start",
+            ),
+            (
+                "thread_start",
+                "jsonrpc_invalid_params",
+                -32600,
+                None,
+            ),
+        )
+
+        for phase, category, code, method in cases:
+            with self.subTest(
+                phase=phase,
+                category=category,
+                code=code,
+                method=method,
+            ):
+                forged = CodexFailureDiagnostic.for_phase(phase)
+                object.__setattr__(forged, "category", category)
+                object.__setattr__(forged, "jsonrpc_code", code)
+                object.__setattr__(forged, "protocol_method", method)
+
+                rebuilt = canonical_failure_diagnostic(forged)
+
+                self.assertEqual(
+                    CodexFailureDiagnostic.for_phase("unknown").as_dict(),
+                    rebuilt.as_dict(),
+                )
+
+    def test_valid_thread_start_diagnostics_survive_canonical_rebuild(
+        self,
+    ) -> None:
+        phase = CodexFailureDiagnostic.for_phase("thread_start")
+        cases = (
+            ("jsonrpc_method_rejected", -32601),
+            ("jsonrpc_invalid_params", -32600),
+            ("jsonrpc_invalid_params", -32602),
+            ("state_or_filesystem", -32000),
+            ("transport_or_process", None),
+            ("unknown", -32600),
+            ("unknown", None),
+        )
+
+        for category, code in cases:
+            with self.subTest(category=category, code=code):
+                diagnostic = CodexFailureDiagnostic(
+                    code=phase.code,
+                    protocol_phase=phase.protocol_phase,
+                    reason=phase.reason,
+                    action=phase.action,
+                    category=category,
+                    jsonrpc_code=code,
+                    protocol_method="thread/start",
+                )
+
+                rebuilt = canonical_failure_diagnostic(diagnostic)
+
+                self.assertIsNot(diagnostic, rebuilt)
+                self.assertEqual(diagnostic.as_dict(), rebuilt.as_dict())
+
     async def test_safe_failure_diagnostics_distinguish_protocol_phases(
         self,
     ) -> None:

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -657,6 +657,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             protocol_phase = "thread_start"
             reason = private
             action = "expose_private_data"
+            category = "PRIVATE_CATEGORY"
+            jsonrpc_code = -32600
+            protocol_method = "thread/start"
 
             def as_dict(self) -> dict[str, str]:
                 raise AssertionError("untrusted as_dict must not be called")
@@ -680,6 +683,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             ("protocol_phase", "private_phase"),
             ("reason", private),
             ("action", "expose_private_data"),
+            ("category", "PRIVATE_CATEGORY"),
+            ("jsonrpc_code", True),
+            ("protocol_method", "private/method"),
         ):
             forged = CodexFailureDiagnostic.for_phase("thread_start")
             object.__setattr__(forged, field, value)
@@ -713,7 +719,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 {
                     "id": 4,
                     "error": {
-                        "message": "PRIVATE thread source and secret",
+                        "code": -32600,
+                        "message": (
+                            "thread/start.dynamicTools requires "
+                            "experimentalApi capability; PRIVATE secret"
+                        ),
                     },
                 }
             )
@@ -732,8 +742,21 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             assert thread_diagnostic is not None
             self.assertEqual("codex_thread_start_failed", thread_diagnostic.code)
             self.assertEqual("thread_start", thread_diagnostic.protocol_phase)
+            self.assertEqual(
+                "jsonrpc_invalid_params",
+                thread_diagnostic.category,
+            )
+            self.assertEqual(-32600, thread_diagnostic.jsonrpc_code)
+            self.assertEqual("thread/start", thread_diagnostic.protocol_method)
             self.assertNotIn("PRIVATE", json.dumps(thread_diagnostic.as_dict()))
             self.assertNotIn("secret", json.dumps(thread_diagnostic.as_dict()))
+            self.assertNotIn(
+                "turn/start",
+                [
+                    message.get("method")
+                    for message in factory.transports[0].sent
+                ],
+            )
 
             cases = (
                 (
@@ -790,6 +813,159 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                     self.assertNotIn("secret", json.dumps(diagnostic.as_dict()))
                     self.assertEqual((), result.file_actions)
                     self.assertEqual((), result.checkpoint_outcomes)
+
+    def test_repaired_capability_qualifies_thread_without_starting_turn(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            before = subprocess.run(
+                ("git", "-C", str(repository), "status", "--porcelain"),
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-qualified",
+                turn_id="unused-turn",
+            )[:4]
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("qualification must not prompt"),
+            )
+            transport = factory(adapter.executable)
+            adapter._transport = transport
+
+            try:
+                transport.start()
+                adapter._protocol_phase = "initialize_handshake"
+                adapter._initialize()
+                adapter._protocol_phase = "account_verification"
+                adapter._verify_account()
+                adapter._protocol_phase = "model_verification"
+                adapter._verify_model_catalog()
+                adapter._protocol_phase = "thread_start"
+                adapter._start_thread()
+            finally:
+                transport.close()
+
+            methods = [
+                message.get("method")
+                for message in transport.sent
+                if "method" in message
+            ]
+            initialize = next(
+                message
+                for message in transport.sent
+                if message.get("method") == "initialize"
+            )
+            self.assertEqual(
+                {"experimentalApi": True},
+                initialize["params"]["capabilities"],
+            )
+            self.assertIn("thread/start", methods)
+            self.assertNotIn("turn/start", methods)
+            self.assertEqual("thread-qualified", adapter._thread_id)
+            after = subprocess.run(
+                ("git", "-C", str(repository), "status", "--porcelain"),
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertEqual(before, after)
+
+    async def test_thread_start_jsonrpc_categories_are_bounded(self) -> None:
+        cases = (
+            (-32601, "PRIVATE method secret", "jsonrpc_method_rejected"),
+            (-32602, "PRIVATE schema secret", "jsonrpc_invalid_params"),
+            (
+                -32000,
+                "Failed to create state database at /PRIVATE/path secret",
+                "state_or_filesystem",
+            ),
+            (-32099, "PRIVATE arbitrary provider secret", "unknown"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            for code, message, category in cases:
+                with self.subTest(code=code):
+                    messages = handshake_messages(
+                        repository,
+                        thread_id="unused-thread",
+                        turn_id="unused-turn",
+                    )[:3]
+                    messages.append(
+                        {
+                            "id": 4,
+                            "error": {"code": code, "message": message},
+                        }
+                    )
+                    factory = FakeTransportFactory([messages])
+                    _, adapter, _ = adapter_for(
+                        repository,
+                        factory,
+                        choice=lambda: self.fail("must not prompt"),
+                    )
+
+                    with self.assertRaises(CodexAdapterFailure) as captured:
+                        await adapter.run("bounded thread failure")
+
+                    diagnostic = captured.exception.diagnostic
+                    self.assertIsNotNone(diagnostic)
+                    assert diagnostic is not None
+                    self.assertEqual(category, diagnostic.category)
+                    self.assertEqual(code, diagnostic.jsonrpc_code)
+                    self.assertEqual(
+                        "thread/start",
+                        diagnostic.protocol_method,
+                    )
+                    serialized = json.dumps(diagnostic.as_dict())
+                    self.assertNotIn("PRIVATE", serialized)
+                    self.assertNotIn("secret", serialized)
+
+    async def test_thread_start_transport_failure_is_bounded(self) -> None:
+        class FailingReceiveTransport(FakeTransport):
+            def receive(self) -> dict[str, Any]:
+                if self.messages:
+                    return super().receive()
+                raise CodexAdapterFailure(
+                    "PRIVATE control stream path and secret"
+                )
+
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            transport = FailingReceiveTransport(
+                handshake_messages(
+                    repository,
+                    thread_id="unused-thread",
+                    turn_id="unused-turn",
+                )[:3]
+            )
+            engine = AccelerationEngine(
+                repository,
+                adapter=ADAPTER_NAME,
+                adapter_version=CODEX_CLI_VERSION,
+            )
+            adapter = CodexAdapter(
+                engine,
+                input_func=lambda: self.fail("must not prompt"),
+                stdout=io.StringIO(),
+                transport_factory=lambda _executable: transport,
+            )
+
+            with self.assertRaises(CodexAdapterFailure) as captured:
+                await adapter.run("transport failure")
+
+            diagnostic = captured.exception.diagnostic
+            self.assertIsNotNone(diagnostic)
+            assert diagnostic is not None
+            self.assertEqual("transport_or_process", diagnostic.category)
+            self.assertIsNone(diagnostic.jsonrpc_code)
+            self.assertEqual("thread/start", diagnostic.protocol_method)
+            self.assertNotIn("PRIVATE", json.dumps(diagnostic.as_dict()))
 
     async def test_first_failure_phase_latch_preserves_actual_boundary(
         self,

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -179,6 +179,18 @@ class MaliciousDiagnostic:
         raise AssertionError("untrusted as_dict must not be called")
 
 
+def allowed_value_cross_forged_diagnostic() -> CodexFailureDiagnostic:
+    diagnostic = CodexFailureDiagnostic.for_phase("thread_start")
+    object.__setattr__(
+        diagnostic,
+        "category",
+        "jsonrpc_method_rejected",
+    )
+    object.__setattr__(diagnostic, "jsonrpc_code", -32601)
+    object.__setattr__(diagnostic, "protocol_method", "turn/start")
+    return diagnostic
+
+
 class ScriptedAdapter:
     def __init__(
         self,
@@ -222,6 +234,13 @@ class ScriptedAdapter:
             )
             failure.diagnostic = MaliciousDiagnostic()  # type: ignore[assignment]
             raise failure
+        if self.mode == "cross_forged_failure":
+            failure = CodexAdapterFailure(
+                "PRIVATE raw exception message",
+                diagnostic=CodexFailureDiagnostic.for_phase("thread_start"),
+            )
+            failure.diagnostic = allowed_value_cross_forged_diagnostic()
+            raise failure
         if self.mode == "typed_result_failure":
             return CodexRunResult(
                 run_id=self.engine.new_run_id(),
@@ -254,6 +273,26 @@ class ScriptedAdapter:
                 result,
                 "failure_diagnostic",
                 MaliciousDiagnostic(),
+            )
+            return result
+        if self.mode == "cross_forged_result_failure":
+            result = CodexRunResult(
+                run_id=self.engine.new_run_id(),
+                normal_terminal=False,
+                status="ABNORMAL_TERMINAL",
+                error_type="CodexAdapterFailure",
+                turn_status=None,
+                runtime_identity=None,
+                checkpoint_outcomes=(),
+                final_message="PRIVATE incomplete model text",
+                failure_diagnostic=CodexFailureDiagnostic.for_phase(
+                    "dynamic_tool_call"
+                ),
+            )
+            object.__setattr__(
+                result,
+                "failure_diagnostic",
+                allowed_value_cross_forged_diagnostic(),
             )
             return result
         if self.mode == "read_only":
@@ -1913,11 +1952,18 @@ class CompanionControllerTest(unittest.TestCase):
                 ScriptedFactory(
                     "forged_failure",
                     "forged_result_failure",
+                    "cross_forged_failure",
+                    "cross_forged_result_failure",
                 ),
             )
             controller.select_repository(repository)
 
-            for task in ("Forged exception.", "Forged result."):
+            for task in (
+                "Forged exception.",
+                "Forged result.",
+                "Cross-forged exception.",
+                "Cross-forged result.",
+            ):
                 with self.subTest(task=task):
                     controller.start_run(task)
                     state = wait_for(

--- a/tests/test_companion_controller.py
+++ b/tests/test_companion_controller.py
@@ -171,6 +171,9 @@ class MaliciousDiagnostic:
     protocol_phase = "private_phase"
     reason = "PRIVATE raw exception, source, prompt, path, and secret"
     action = "expose_private_data"
+    category = "PRIVATE_CATEGORY"
+    jsonrpc_code = -32600
+    protocol_method = "private/method"
 
     def as_dict(self) -> dict[str, str]:
         raise AssertionError("untrusted as_dict must not be called")
@@ -199,9 +202,18 @@ class ScriptedAdapter:
         if self.mode == "failure":
             raise CodexAdapterFailure("sensitive raw adapter failure")
         if self.mode == "typed_failure":
+            base = CodexFailureDiagnostic.for_phase("thread_start")
             raise CodexAdapterFailure(
                 "sensitive raw thread/start response",
-                diagnostic=CodexFailureDiagnostic.for_phase("thread_start"),
+                diagnostic=CodexFailureDiagnostic(
+                    code=base.code,
+                    protocol_phase=base.protocol_phase,
+                    reason=base.reason,
+                    action=base.action,
+                    category="jsonrpc_invalid_params",
+                    jsonrpc_code=-32600,
+                    protocol_method="thread/start",
+                ),
             )
         if self.mode == "forged_failure":
             failure = CodexAdapterFailure(
@@ -1860,6 +1872,9 @@ class CompanionControllerTest(unittest.TestCase):
                     "protocol_phase": "thread_start",
                     "reason": typed["run"]["error"],
                     "action": "recheck_protocol",
+                    "category": "jsonrpc_invalid_params",
+                    "jsonrpc_code": -32600,
+                    "protocol_method": "thread/start",
                 },
                 typed["run"]["failure"],
             )
@@ -1926,6 +1941,9 @@ class CompanionControllerTest(unittest.TestCase):
                             "protocol_phase": "unknown",
                             "reason": run["error"],
                             "action": None,
+                            "category": "unknown",
+                            "jsonrpc_code": None,
+                            "protocol_method": None,
                         },
                         run["failure"],
                     )

--- a/validation/companion_thread_start_recovery_001.md
+++ b/validation/companion_thread_start_recovery_001.md
@@ -1,0 +1,165 @@
+# Companion `thread/start` Recovery 001
+
+Date: 2026-08-02 JST
+
+Branch: `codex/13-64-companion-thread-start-recovery`
+
+Canonical base: `3b8a0f99c418707d0da53a3c03c0a48b4a1232b7`
+
+## Integrity Before Diagnosis
+
+- `HEAD` exactly matched the canonical base.
+- The tracked worktree and index were clean.
+- The only untracked repository file was the protected manual probe.
+- Protected probe SHA-256:
+  `f68b3a1f47136782cbb5ade4c4686724c2b877eaaffe52bdb81aa72ae19c6344`.
+- Bundled executable version: `0.146.0-alpha.3.1`.
+
+## Exact Original Boundary
+
+The adapter initialized app-server with:
+
+```json
+{"capabilities":{"experimentalApi":false}}
+```
+
+It then sent `thread/start` with these top-level fields:
+
+```text
+approvalPolicy
+approvalsReviewer
+config
+cwd
+developerInstructions
+dynamicTools
+ephemeral
+model
+modelProvider
+sandbox
+serviceTier
+```
+
+The bounded settings were:
+
+- approval policy: `on-request`;
+- approval reviewer: `user`;
+- sandbox: `read-only`;
+- dynamic tool: exactly one typed `read_repository_text_file` function;
+- model: `gpt-5.6-sol`;
+- service tier: `priority`;
+- reasoning effort: `ultra`, inside the thread config;
+- ephemeral thread: `true`;
+- model provider: `openai`;
+- current working directory: the selected repository;
+- inherited process environment, with Codex state resolved by app-server.
+
+The nested config fields were `features`, `mcp_servers`,
+`model_reasoning_effort`, and `plugins`. The feature block disabled `apps`,
+`hooks`, `multi_agent`, `remote_plugin`, `shell_tool`, and
+`skill_mcp_dependency_install`. MCP servers and plugins were empty. These
+boundaries remained unchanged by the repair.
+
+## Installed Protocol Evidence
+
+The exact bundled executable generated both its stable and experimental JSON
+Schema bundles. In the stable `ThreadStartParams` schema, `dynamicTools` was
+absent. In the experimental schema, `dynamicTools` was present and its declared
+function shape matched the adapter request. The same executable accepts the
+client capability `experimentalApi` during `initialize`.
+
+This establishes that the typed dynamic tool is an experimental app-server
+surface in this installed runtime. Declaring it while explicitly declining the
+experimental capability is internally incompatible.
+
+## No-Turn Reproduction
+
+Three of the maximum six permitted `thread/start` probes were used. Every
+probe used:
+
+- the exact bundled executable;
+- a fresh isolated Git repository;
+- a writable isolated Codex state directory;
+- the same copied ChatGPT authentication identity;
+- the exact adapter startup config and exact `thread/start` request;
+- no `turn/start`, model task, Approval, or repository mutation.
+
+| Probe | Single variable | Result | JSON-RPC | Bounded category | Process / transport | Repository |
+|---|---|---|---|---|---|---|
+| 1 | Original `experimentalApi=false` | Failed | `-32600` | invalid params / capability | clean exit / response received | unchanged |
+| 2 | `experimentalApi=true` | Succeeded with a fresh thread identity | none | success | clean exit / response received | unchanged |
+| 3 | Restored `experimentalApi=false` | Failed | `-32600` | invalid params / capability | clean exit / response received | unchanged |
+
+The sanitized local app-server reason for probes 1 and 3 was:
+
+```text
+thread/start.dynamicTools requires experimentalApi capability
+```
+
+Account type remained `chatgpt`, the required model remained present in the
+local model catalog, stderr did not contain a protocol, state, permission,
+schema, or transport failure, and no transport closure caused the failure.
+
+## Established Root Cause
+
+`ROOT_CAUSE = INITIALIZE_CAPABILITY_MISMATCH`
+
+The adapter declared the experimental `dynamicTools` field at `thread/start`
+while its preceding `initialize` request explicitly advertised
+`experimentalApi=false`. App-server therefore rejected the request with
+JSON-RPC `-32600` before stateful model execution. Changing only that capability
+to `true` made the same `thread/start` request succeed; restoring `false`
+restored the failure.
+
+The failure was not caused by the typed phase label, repository permissions,
+Codex-state writability, process transport, authentication, model identity,
+sandbox representation, Approval policy, service tier, or the nested feature
+block.
+
+## Forward-Only Repair
+
+The compatibility repair changes only the initialization capability from
+`false` to `true`. It does not remove the dynamic read tool or weaken the
+read-only sandbox, network restriction, human Approval boundary, one-file
+boundary, read-before-write requirement, exact item identity, unsupported-tool
+fail-closed handling, or runtime identity checks.
+
+The diagnostic repair retains only canonical bounded values:
+
+- the existing canonical failure code, phase, reason, and action;
+- one category from `jsonrpc_method_rejected`, `jsonrpc_invalid_params`,
+  `state_or_filesystem`, `transport_or_process`, or `unknown`;
+- an exact signed 64-bit JSON-RPC integer code when present;
+- one known adapter protocol method when present.
+
+Raw JSON-RPC messages, stderr, credentials, prompts, repository contents,
+provider text, and private paths are not stored or projected. App-server error
+and stderr text are reduced immediately to bounded categories. Malformed,
+lookalike, subclassed, incomplete, or forged diagnostics still rebuild to the
+canonical `unknown` diagnostic.
+
+## Regression and Qualification Status
+
+Focused adapter tests: PASS — 54 tests.
+
+Companion controller tests: PASS — 27 tests.
+
+Companion server/client and headless presentation tests: PASS — 35 tests.
+
+Full repository suite: PASS — 690 tests.
+
+Staged `git diff --check`: PASS after the validation record was added.
+
+Post-repair isolated live `thread/start`: PASS.
+
+The post-repair qualification copied the branch `decision_os` runtime into a
+temporary runtime root and used a fresh committed Git repository plus a fresh
+writable Codex state directory carrying only the same authentication identity.
+The staged branch adapter advertised `experimentalApi=true`, received a fresh
+thread identity from bundled app-server `0.146.0-alpha.3.1`, retained the exact
+read-only request field set, model `gpt-5.6-sol`, service tier `priority`, and
+ChatGPT account type, and sent no `turn/start`. The repository `HEAD`, status,
+tracked-file hash, and absence of Decision OS acceleration state were unchanged.
+App-server was terminated only by the qualifier's bounded close after the
+successful response; no transport failure occurred.
+
+The installed Companion app was not replaced.

--- a/validation/companion_thread_start_recovery_001.md
+++ b/validation/companion_thread_start_recovery_001.md
@@ -131,21 +131,28 @@ The diagnostic repair retains only canonical bounded values:
 - an exact signed 64-bit JSON-RPC integer code when present;
 - one known adapter protocol method when present.
 
+Canonical rebuilding also requires those bounded values to form one coherent
+protocol tuple. A method must belong to its declared request phase; JSON-RPC
+codes must agree with their bounded category; transport failures cannot carry a
+JSON-RPC code; and code-bearing failures must identify the matching request
+method. Valid `thread/start` diagnostics retain their bounded evidence.
+
 Raw JSON-RPC messages, stderr, credentials, prompts, repository contents,
 provider text, and private paths are not stored or projected. App-server error
 and stderr text are reduced immediately to bounded categories. Malformed,
-lookalike, subclassed, incomplete, or forged diagnostics still rebuild to the
-canonical `unknown` diagnostic.
+lookalike, subclassed, incomplete, or forged diagnostics with incoherent
+phase, method, category, or code combinations rebuild to the canonical
+`unknown` diagnostic.
 
 ## Regression and Qualification Status
 
-Focused adapter tests: PASS — 54 tests.
+Focused adapter tests: PASS — 56 tests.
 
 Companion controller tests: PASS — 27 tests.
 
 Companion server/client and headless presentation tests: PASS — 35 tests.
 
-Full repository suite: PASS — 690 tests.
+Full repository suite: PASS — 692 tests.
 
 Staged `git diff --check`: PASS after the validation record was added.
 


### PR DESCRIPTION
## Summary

- advertise the app-server experimental capability required by the existing typed dynamic read tool
- preserve bounded failure evidence as canonical category, JSON-RPC code, and known protocol method
- add regression coverage for the observed capability rejection, no-turn qualification, transport/state/schema categories, redaction, and forged diagnostics
- record the sanitized root-cause and qualification evidence

## Root cause

The adapter declared `dynamicTools` at `thread/start` while `initialize` explicitly advertised `experimentalApi=false`. Bundled Codex app-server `0.146.0-alpha.3.1` reproducibly rejected the request with JSON-RPC `-32600`. Changing only that capability to `true` made the unchanged `thread/start` request succeed; restoring `false` restored the failure.

## Impact and boundaries

The central Companion `thread/start` route is restored without weakening the read-only sandbox, network restriction, human Approval, one-file boundary, read-before-write, exact item identity, unsupported-tool fail-closed behavior, or runtime identity verification.

Raw stderr, provider messages, credentials, prompts, source content, and private paths are not projected. The protected manual probe remains untracked and byte-identical. The installed Companion app was not replaced.

## Validation

- focused Codex adapter tests: 54 passed
- Companion controller tests: 27 passed
- Companion server/client and headless presentation tests: 35 passed
- full repository suite: 690 passed
- staged `git diff --check`: passed
- isolated staged-runtime `thread/start`: passed with a fresh thread identity, no `turn/start`, no model task, no Approval, and no repository mutation

Validation record: `validation/companion_thread_start_recovery_001.md`

## Remaining gates

This PR is intentionally Draft. App installation, another Companion task, ready-for-review transition, merge, release, and publication remain out of scope.