### PR TITLE
Recover Companion post-approval repository reads

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -45,7 +45,7 @@ _DEVELOPER_INSTRUCTIONS = (
 )
 _READ_TOOL_NAME = "read_repository_text_file"
 _READ_MAX_BYTES = 131_072
-_READ_MAX_TARGETS = 4
+_READ_MAX_DISTINCT_PATHS = 4
 _WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[/\\]")
 _SOURCE_ECHO_MARKER = "[Repository source content withheld.]"
 _FENCE_OPENING = re.compile(
@@ -58,8 +58,10 @@ _READ_TOOL_SPEC = {
     "name": _READ_TOOL_NAME,
     "description": (
         "Read one existing strict UTF-8 text file inside the selected "
-        "repository. One bounded Run may read up to four exact paths; "
-        "modifying an existing file still requires reading that same path."
+        "repository. One bounded Run may read up to four distinct normalized "
+        "repository paths; additional calls for an admitted path do not use "
+        "another path slot. Modifying an existing file still requires reading "
+        "that same path."
     ),
     "inputSchema": {
         "type": "object",
@@ -1029,7 +1031,9 @@ class CodexAdapter:
         self._read_responses: dict[str, _CodexReadResponse] = {}
         self._read_replay_failures: dict[str, _CodexReadResponse] = {}
         self._read_evidence: list[CodexReadEvidence] = []
+        self._read_evidence_keys: set[tuple[str, str, str | None]] = set()
         self._read_bindings: dict[str, _CodexReadBinding] = {}
+        self._admitted_read_paths: set[str] = set()
         self._completed_read_items: set[str] = set()
         self._accepted_items: set[str] = set()
         self._declined_items: set[str] = set()
@@ -1067,7 +1071,9 @@ class CodexAdapter:
         self._read_responses = {}
         self._read_replay_failures = {}
         self._read_evidence = []
+        self._read_evidence_keys = set()
         self._read_bindings = {}
+        self._admitted_read_paths = set()
         self._completed_read_items = set()
         self._accepted_items = set()
         self._declined_items = set()
@@ -1699,8 +1705,19 @@ class CodexAdapter:
             },
         )
 
-    def _record_read_evidence(self, evidence: CodexReadEvidence) -> None:
-        if evidence not in self._read_evidence:
+    def _record_read_evidence(
+        self,
+        evidence: CodexReadEvidence,
+        *,
+        call_id: str | None = None,
+    ) -> None:
+        if call_id is None:
+            if evidence not in self._read_evidence:
+                self._read_evidence.append(evidence)
+            return
+        key = (call_id, evidence.status, evidence.reason)
+        if key not in self._read_evidence_keys:
+            self._read_evidence_keys.add(key)
             self._read_evidence.append(evidence)
 
     def _read_failure_response(
@@ -1721,7 +1738,7 @@ class CodexAdapter:
             status="failed",
             reason=reason,
         )
-        self._record_read_evidence(evidence)
+        self._record_read_evidence(evidence, call_id=call_id)
         return _CodexReadResponse(
             call_id=call_id,
             arguments_identity=arguments_identity,
@@ -2036,27 +2053,42 @@ class CodexAdapter:
             self._send_read_response(request_id, existing)
             return
 
-        if len(self._read_bindings) >= _READ_MAX_TARGETS:
-            try:
-                failed_path = self._normalized_read_path(arguments["path"])
-            except _ReadValidationError:
-                failed_path = None
+        try:
+            requested_path = self._normalized_read_path(arguments["path"])
+        except _ReadValidationError as exc:
             response = self._read_failure_response(
                 call_id=call_id,
                 arguments_identity=arguments_identity,
-                reason="additional_read_target",
-                path=failed_path,
-                repository_identity=next(
-                    iter(self._read_bindings.values())
-                ).repository_identity,
+                reason=exc.reason,
+                path=exc.path,
+                repository_identity=exc.repository_identity,
             )
             self._read_responses[call_id] = response
             self._send_read_response(request_id, response)
             return
 
+        is_new_path = requested_path not in self._admitted_read_paths
+        if (
+            is_new_path
+            and len(self._admitted_read_paths) >= _READ_MAX_DISTINCT_PATHS
+        ):
+            response = self._read_failure_response(
+                call_id=call_id,
+                arguments_identity=arguments_identity,
+                reason="additional_read_target",
+                path=requested_path,
+                repository_identity=None,
+            )
+            self._read_responses[call_id] = response
+            self._send_read_response(request_id, response)
+            return
+
+        if is_new_path:
+            self._admitted_read_paths.add(requested_path)
+
         try:
             normalized, data, content, repository_identity = (
-                self._read_repository_file(arguments["path"])
+                self._read_repository_file(requested_path)
             )
         except _ReadValidationError as exc:
             response = self._read_failure_response(
@@ -2081,6 +2113,29 @@ class CodexAdapter:
             self._send_read_response(request_id, response)
             return
         digest = hashlib.sha256(data).hexdigest()
+        prior_binding = next(
+            (
+                binding
+                for binding in self._read_bindings.values()
+                if binding.normalized_scope == normalized
+            ),
+            None,
+        )
+        if prior_binding is not None and (
+            data != prior_binding.content.encode("utf-8")
+            or digest != prior_binding.sha256
+            or repository_identity != prior_binding.repository_identity
+        ):
+            response = self._read_failure_response(
+                call_id=call_id,
+                arguments_identity=arguments_identity,
+                reason="read_identity_changed",
+                path=normalized,
+                repository_identity=prior_binding.repository_identity,
+            )
+            self._read_responses[call_id] = response
+            self._send_read_response(request_id, response)
+            return
         binding = _CodexReadBinding(
             run_id=self._run_id,
             call_id=call_id,
@@ -2114,7 +2169,8 @@ class CodexAdapter:
                 sha256=digest,
                 repository_identity=repository_identity,
                 status="succeeded",
-            )
+            ),
+            call_id=call_id,
         )
         self._send_read_response(request_id, response)
 

--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -45,6 +45,7 @@ _DEVELOPER_INSTRUCTIONS = (
 )
 _READ_TOOL_NAME = "read_repository_text_file"
 _READ_MAX_BYTES = 131_072
+_READ_MAX_TARGETS = 4
 _WINDOWS_ABSOLUTE_PATH = re.compile(r"^[A-Za-z]:[/\\]")
 _SOURCE_ECHO_MARKER = "[Repository source content withheld.]"
 _FENCE_OPENING = re.compile(
@@ -57,7 +58,8 @@ _READ_TOOL_SPEC = {
     "name": _READ_TOOL_NAME,
     "description": (
         "Read one existing strict UTF-8 text file inside the selected "
-        "repository before proposing a modification to that same file."
+        "repository. One bounded Run may read up to four exact paths; "
+        "modifying an existing file still requires reading that same path."
     ),
     "inputSchema": {
         "type": "object",
@@ -1027,7 +1029,7 @@ class CodexAdapter:
         self._read_responses: dict[str, _CodexReadResponse] = {}
         self._read_replay_failures: dict[str, _CodexReadResponse] = {}
         self._read_evidence: list[CodexReadEvidence] = []
-        self._read_binding: _CodexReadBinding | None = None
+        self._read_bindings: dict[str, _CodexReadBinding] = {}
         self._completed_read_items: set[str] = set()
         self._accepted_items: set[str] = set()
         self._declined_items: set[str] = set()
@@ -1065,7 +1067,7 @@ class CodexAdapter:
         self._read_responses = {}
         self._read_replay_failures = {}
         self._read_evidence = []
-        self._read_binding = None
+        self._read_bindings = {}
         self._completed_read_items = set()
         self._accepted_items = set()
         self._declined_items = set()
@@ -1576,8 +1578,11 @@ class CodexAdapter:
 
     def _final_message_with_diagnostic(self, status: str) -> str:
         message = self._final_message
-        read_binding = self._read_binding
-        if read_binding is not None:
+        for read_binding in sorted(
+            self._read_bindings.values(),
+            key=lambda value: len(value.content),
+            reverse=True,
+        ):
             message = _redact_complete_source_echo(
                 message,
                 read_binding.content,
@@ -2002,7 +2007,7 @@ class CodexAdapter:
                 self._send_read_response(request_id, replay_failure)
                 return
             if existing.success:
-                binding = self._read_binding
+                binding = self._read_bindings.get(call_id)
                 try:
                     current = self._read_repository_file(arguments["path"])
                 except (CodexAdapterFailure, _ReadValidationError):
@@ -2031,13 +2036,19 @@ class CodexAdapter:
             self._send_read_response(request_id, existing)
             return
 
-        if self._read_binding is not None:
+        if len(self._read_bindings) >= _READ_MAX_TARGETS:
+            try:
+                failed_path = self._normalized_read_path(arguments["path"])
+            except _ReadValidationError:
+                failed_path = None
             response = self._read_failure_response(
                 call_id=call_id,
                 arguments_identity=arguments_identity,
                 reason="additional_read_target",
-                path=None,
-                repository_identity=self._read_binding.repository_identity,
+                path=failed_path,
+                repository_identity=next(
+                    iter(self._read_bindings.values())
+                ).repository_identity,
             )
             self._read_responses[call_id] = response
             self._send_read_response(request_id, response)
@@ -2094,7 +2105,7 @@ class CodexAdapter:
                 }
             ),
         )
-        self._read_binding = binding
+        self._read_bindings[call_id] = binding
         self._read_responses[call_id] = response
         self._record_read_evidence(
             CodexReadEvidence(
@@ -2210,16 +2221,28 @@ class CodexAdapter:
             return
 
         if decision_type is DecisionType.MODIFY_FILE:
-            read_binding = self._read_binding
-            if (
-                read_binding is None
-                or read_binding.run_id != self._run_id
-                or read_binding.call_id not in self._completed_read_items
+            matching_bindings = tuple(
+                binding
+                for binding in self._read_bindings.values()
+                if binding.normalized_scope == normalized
+            )
+            read_binding = next(
+                (
+                    binding
+                    for binding in reversed(matching_bindings)
+                    if binding.run_id == self._run_id
+                    and binding.call_id in self._completed_read_items
+                ),
+                None,
+            )
+            if not self._read_bindings or (
+                matching_bindings and read_binding is None
             ):
                 reason = "modify_requires_repository_read"
-            elif read_binding.normalized_scope != normalized:
+            elif not matching_bindings:
                 reason = "read_write_path_mismatch"
             else:
+                assert read_binding is not None
                 try:
                     current = self._read_repository_file(normalized)
                 except (CodexAdapterFailure, _ReadValidationError):

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -24,6 +24,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexFailureDiagnostic,
     CodexLifecycleEvent,
     CodexRunResult,
+    _READ_MAX_TARGETS,
     _SubprocessTransport,
     _redact_complete_source_echo,
     canonical_failure_diagnostic,
@@ -1509,8 +1510,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         "name": "read_repository_text_file",
                         "description": (
                             "Read one existing strict UTF-8 text file inside "
-                            "the selected repository before proposing a "
-                            "modification to that same file."
+                            "the selected repository. One bounded Run may "
+                            "read up to four exact paths; modifying an existing "
+                            "file still requires reading that same path."
                         ),
                         "inputSchema": {
                             "type": "object",
@@ -1693,7 +1695,9 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(2, len(responses))
             self.assertEqual(responses[0], responses[1])
 
-    async def test_second_read_and_changed_replay_fail_closed(self) -> None:
+    async def test_multiple_reads_succeed_and_changed_replay_fails_closed(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
             (repository / "other.txt").write_text("other\n", encoding="utf-8")
@@ -1716,7 +1720,6 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                     turn_id="turn-1",
                     call_id="read-2",
                     path="other.txt",
-                    status="failed",
                 )
             )
             messages.append(
@@ -1731,10 +1734,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
 
             result = await adapter.run("Try two reads.")
 
-            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
-            self.assertEqual("additional_read_target", result.unsupported_reason)
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertIsNone(result.unsupported_reason)
             self.assertEqual(
-                ["succeeded", "failed"],
+                ["succeeded", "succeeded"],
                 [value.status for value in result.read_evidence],
             )
             self.assertEqual([], engine.store.read_events())
@@ -1743,11 +1747,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 for value in factory.transports[0].sent
                 if value.get("id") == "request-read-2"
             )
-            self.assertFalse(response["result"]["success"])
-            self.assertNotIn(
-                "content",
-                json.loads(response["result"]["contentItems"][0]["text"]),
-            )
+            self.assertTrue(response["result"]["success"])
 
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
@@ -1807,6 +1807,185 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 ["succeeded", "failed"],
                 [value.status for value in result.read_evidence],
             )
+
+    async def test_medium_create_reads_three_sources_and_output_after_write(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            source_paths = (
+                "validation/companion_thread_start_recovery_001.md",
+                "validation/companion_repository_read_recovery_001.md",
+                "validation/companion_live_task_001.md",
+            )
+            for index, path in enumerate(source_paths, start=1):
+                target = repository / path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(f"source {index}\n", encoding="utf-8")
+            output_path = "validation/companion_medium_live_task_001.md"
+            output_content = "# Companion Medium Live Task 001\n"
+            thread_id = "thread-medium"
+            turn_id = "turn-medium"
+            messages = handshake_messages(
+                repository,
+                thread_id=thread_id,
+                turn_id=turn_id,
+            )
+            for index, path in enumerate(source_paths, start=1):
+                messages.extend(
+                    read_messages(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        call_id=f"read-source-{index}",
+                        path=path,
+                    )
+                )
+            changes = [
+                change(
+                    path=output_path,
+                    kind="add",
+                    diff=(
+                        "@@ -0,0 +1 @@\n"
+                        "+# Companion Medium Live Task 001\n"
+                    ),
+                )
+            ]
+            messages.extend(
+                [
+                    started_item(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        item_id="create-output",
+                        changes=changes,
+                    ),
+                    approval_request(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        item_id="create-output",
+                        request_id="approval-output",
+                    ),
+                    resolved_request(
+                        thread_id=thread_id,
+                        request_id="approval-output",
+                    ),
+                    completed_item(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        item_id="create-output",
+                        changes=changes,
+                    ),
+                ]
+            )
+            messages.extend(
+                read_messages(
+                    thread_id=thread_id,
+                    turn_id=turn_id,
+                    call_id="read-output",
+                    path=output_path,
+                )
+            )
+            messages.append(
+                completed_turn(thread_id=thread_id, turn_id=turn_id)
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: "1",
+            )
+            original = adapter._read_repository_file
+
+            def materialize_completed_output(
+                path: str,
+            ) -> tuple[str, bytes, str, str]:
+                if path == output_path:
+                    (repository / output_path).write_text(
+                        output_content,
+                        encoding="utf-8",
+                    )
+                return original(path)
+
+            with patch.object(
+                adapter,
+                "_read_repository_file",
+                side_effect=materialize_completed_output,
+            ):
+                result = await adapter.run("Run the retained medium shape.")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertIsNone(result.unsupported_reason)
+            self.assertEqual(
+                [*source_paths, output_path],
+                [evidence.path for evidence in result.read_evidence],
+            )
+            self.assertTrue(
+                all(
+                    evidence.status == "succeeded"
+                    for evidence in result.read_evidence
+                )
+            )
+            self.assertEqual(1, len(result.file_actions))
+            self.assertEqual("Create", result.file_actions[0].action)
+            self.assertEqual("one-time", result.file_actions[0].access)
+            self.assertEqual("approved", result.file_actions[0].status)
+
+    async def test_fifth_distinct_read_fails_closed_with_requested_path(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            paths = tuple(
+                f"source-{index}.txt"
+                for index in range(1, _READ_MAX_TARGETS + 2)
+            )
+            for path in paths:
+                (repository / path).write_text(path, encoding="utf-8")
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-limit",
+                turn_id="turn-limit",
+            )
+            for index, path in enumerate(paths, start=1):
+                messages.extend(
+                    read_messages(
+                        thread_id="thread-limit",
+                        turn_id="turn-limit",
+                        call_id=f"read-{index}",
+                        path=path,
+                        status=(
+                            "failed"
+                            if index > _READ_MAX_TARGETS
+                            else "completed"
+                        ),
+                    )
+                )
+            messages.append(
+                completed_turn(
+                    thread_id="thread-limit",
+                    turn_id="turn-limit",
+                )
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read must not prompt"),
+            )
+
+            result = await adapter.run("Exceed the exact read cap.")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual("additional_read_target", result.unsupported_reason)
+            self.assertEqual(_READ_MAX_TARGETS + 1, len(result.read_evidence))
+            self.assertEqual("failed", result.read_evidence[-1].status)
+            self.assertEqual(paths[-1], result.read_evidence[-1].path)
+            response = next(
+                value
+                for value in factory.transports[0].sent
+                if value.get("id") == f"request-read-{_READ_MAX_TARGETS + 1}"
+            )
+            self.assertFalse(response["result"]["success"])
 
     async def test_read_path_and_encoding_failures_are_typed(self) -> None:
         cases = (

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -24,7 +24,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexFailureDiagnostic,
     CodexLifecycleEvent,
     CodexRunResult,
-    _READ_MAX_TARGETS,
+    _READ_MAX_DISTINCT_PATHS,
     _SubprocessTransport,
     _redact_complete_source_echo,
     canonical_failure_diagnostic,
@@ -1510,9 +1510,11 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         "name": "read_repository_text_file",
                         "description": (
                             "Read one existing strict UTF-8 text file inside "
-                            "the selected repository. One bounded Run may "
-                            "read up to four exact paths; modifying an existing "
-                            "file still requires reading that same path."
+                            "the selected repository. One bounded Run may read "
+                            "up to four distinct normalized repository paths; "
+                            "additional calls for an admitted path do not use "
+                            "another path slot. Modifying an existing file still "
+                            "requires reading that same path."
                         ),
                         "inputSchema": {
                             "type": "object",
@@ -1695,33 +1697,28 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(2, len(responses))
             self.assertEqual(responses[0], responses[1])
 
-    async def test_multiple_reads_succeed_and_changed_replay_fails_closed(
+    async def test_four_distinct_paths_succeed_and_changed_replay_fails_closed(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
-            (repository / "other.txt").write_text("other\n", encoding="utf-8")
+            paths = ("target.txt", "second.txt", "third.txt", "fourth.txt")
+            for path in paths[1:]:
+                (repository / path).write_text(f"{path}\n", encoding="utf-8")
             messages = handshake_messages(
                 repository,
                 thread_id="thread-1",
                 turn_id="turn-1",
             )
-            messages.extend(
-                read_messages(
-                    thread_id="thread-1",
-                    turn_id="turn-1",
-                    call_id="read-1",
-                    path="target.txt",
+            for index, path in enumerate(paths, start=1):
+                messages.extend(
+                    read_messages(
+                        thread_id="thread-1",
+                        turn_id="turn-1",
+                        call_id=f"read-{index}",
+                        path=path,
+                    )
                 )
-            )
-            messages.extend(
-                read_messages(
-                    thread_id="thread-1",
-                    turn_id="turn-1",
-                    call_id="read-2",
-                    path="other.txt",
-                )
-            )
             messages.append(
                 completed_turn(thread_id="thread-1", turn_id="turn-1")
             )
@@ -1738,16 +1735,21 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(result.normal_terminal)
             self.assertIsNone(result.unsupported_reason)
             self.assertEqual(
-                ["succeeded", "succeeded"],
+                ["succeeded"] * _READ_MAX_DISTINCT_PATHS,
                 [value.status for value in result.read_evidence],
             )
-            self.assertEqual([], engine.store.read_events())
-            response = next(
-                value
-                for value in factory.transports[0].sent
-                if value.get("id") == "request-read-2"
+            self.assertEqual(
+                list(paths),
+                [value.path for value in result.read_evidence],
             )
-            self.assertTrue(response["result"]["success"])
+            self.assertEqual([], engine.store.read_events())
+            for index in range(1, _READ_MAX_DISTINCT_PATHS + 1):
+                response = next(
+                    value
+                    for value in factory.transports[0].sent
+                    if value.get("id") == f"request-read-{index}"
+                )
+                self.assertTrue(response["result"]["success"])
 
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
@@ -1807,6 +1809,155 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 ["succeeded", "failed"],
                 [value.status for value in result.read_evidence],
             )
+
+    async def test_new_call_ids_for_admitted_path_do_not_consume_path_slots(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            for path in ("second.txt", "third.txt", "fourth.txt"):
+                (repository / path).write_text(f"{path}\n", encoding="utf-8")
+            calls = (
+                ("read-target-1", "target.txt"),
+                ("read-second", "second.txt"),
+                ("read-third", "third.txt"),
+                ("read-fourth", "fourth.txt"),
+                ("read-target-2", "./target.txt"),
+                ("read-target-3", "target.txt/"),
+                ("read-target-4", " target.txt "),
+            )
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-repeat",
+                turn_id="turn-repeat",
+            )
+            for call_id, path in calls:
+                messages.extend(
+                    read_messages(
+                        thread_id="thread-repeat",
+                        turn_id="turn-repeat",
+                        call_id=call_id,
+                        path=path,
+                    )
+                )
+            messages.append(
+                completed_turn(
+                    thread_id="thread-repeat",
+                    turn_id="turn-repeat",
+                )
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read must not prompt"),
+            )
+
+            result = await adapter.run("Reuse one admitted normalized path.")
+
+            self.assertEqual("NORMAL_TERMINAL", result.status)
+            self.assertTrue(result.normal_terminal)
+            self.assertEqual(len(calls), len(result.read_evidence))
+            self.assertEqual(
+                [
+                    "target.txt",
+                    "second.txt",
+                    "third.txt",
+                    "fourth.txt",
+                    "target.txt",
+                    "target.txt",
+                    "target.txt",
+                ],
+                [evidence.path for evidence in result.read_evidence],
+            )
+            self.assertTrue(
+                all(
+                    evidence.status == "succeeded"
+                    for evidence in result.read_evidence
+                )
+            )
+            self.assertEqual(
+                {"target.txt", "second.txt", "third.txt", "fourth.txt"},
+                adapter._admitted_read_paths,
+            )
+            self.assertEqual(len(calls), len(adapter._read_bindings))
+
+    async def test_new_call_id_same_path_reread_detects_changed_content(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            messages = handshake_messages(
+                repository,
+                thread_id="thread-reread",
+                turn_id="turn-reread",
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-reread",
+                    turn_id="turn-reread",
+                    call_id="read-before",
+                    path="target.txt",
+                )
+            )
+            messages.extend(
+                read_messages(
+                    thread_id="thread-reread",
+                    turn_id="turn-reread",
+                    call_id="read-after",
+                    path="./target.txt",
+                    status="failed",
+                )
+            )
+            messages.append(
+                completed_turn(
+                    thread_id="thread-reread",
+                    turn_id="turn-reread",
+                )
+            )
+            factory = FakeTransportFactory([messages])
+            _, adapter, _ = adapter_for(
+                repository,
+                factory,
+                choice=lambda: self.fail("read must not prompt"),
+            )
+            original = adapter._read_repository_file
+            read_count = 0
+
+            def mutate_before_new_call(
+                path: str,
+            ) -> tuple[str, bytes, str, str]:
+                nonlocal read_count
+                read_count += 1
+                if read_count == 2:
+                    (repository / "target.txt").write_text(
+                        "changed\n",
+                        encoding="utf-8",
+                    )
+                return original(path)
+
+            with patch.object(
+                adapter,
+                "_read_repository_file",
+                side_effect=mutate_before_new_call,
+            ):
+                result = await adapter.run("Reread one admitted path.")
+
+            self.assertEqual("UNSUPPORTED_MUTATION", result.status)
+            self.assertEqual("read_identity_changed", result.unsupported_reason)
+            self.assertEqual(
+                ["succeeded", "failed"],
+                [evidence.status for evidence in result.read_evidence],
+            )
+            self.assertEqual("target.txt", result.read_evidence[-1].path)
+            self.assertEqual({"target.txt"}, adapter._admitted_read_paths)
+            self.assertEqual({"read-before"}, set(adapter._read_bindings))
+            response = next(
+                value
+                for value in factory.transports[0].sent
+                if value.get("id") == "request-read-after"
+            )
+            self.assertFalse(response["result"]["success"])
 
     async def test_medium_create_reads_three_sources_and_output_after_write(
         self,
@@ -1930,14 +2081,14 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual("one-time", result.file_actions[0].access)
             self.assertEqual("approved", result.file_actions[0].status)
 
-    async def test_fifth_distinct_read_fails_closed_with_requested_path(
+    async def test_fifth_distinct_path_fails_before_filesystem_read(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory))
             paths = tuple(
                 f"source-{index}.txt"
-                for index in range(1, _READ_MAX_TARGETS + 2)
+                for index in range(1, _READ_MAX_DISTINCT_PATHS + 2)
             )
             for path in paths:
                 (repository / path).write_text(path, encoding="utf-8")
@@ -1955,7 +2106,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                         path=path,
                         status=(
                             "failed"
-                            if index > _READ_MAX_TARGETS
+                            if index > _READ_MAX_DISTINCT_PATHS
                             else "completed"
                         ),
                     )
@@ -1973,17 +2124,30 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 choice=lambda: self.fail("read must not prompt"),
             )
 
-            result = await adapter.run("Exceed the exact read cap.")
+            with patch.object(
+                adapter,
+                "_read_repository_file",
+                wraps=adapter._read_repository_file,
+            ) as read_file:
+                result = await adapter.run("Exceed the distinct-path cap.")
 
             self.assertEqual("UNSUPPORTED_MUTATION", result.status)
             self.assertEqual("additional_read_target", result.unsupported_reason)
-            self.assertEqual(_READ_MAX_TARGETS + 1, len(result.read_evidence))
+            self.assertEqual(
+                _READ_MAX_DISTINCT_PATHS + 1,
+                len(result.read_evidence),
+            )
             self.assertEqual("failed", result.read_evidence[-1].status)
             self.assertEqual(paths[-1], result.read_evidence[-1].path)
+            self.assertIsNone(result.read_evidence[-1].byte_count)
+            self.assertIsNone(result.read_evidence[-1].sha256)
+            self.assertIsNone(result.read_evidence[-1].repository_identity)
+            self.assertEqual(_READ_MAX_DISTINCT_PATHS, read_file.call_count)
             response = next(
                 value
                 for value in factory.transports[0].sent
-                if value.get("id") == f"request-read-{_READ_MAX_TARGETS + 1}"
+                if value.get("id")
+                == f"request-read-{_READ_MAX_DISTINCT_PATHS + 1}"
             )
             self.assertFalse(response["result"]["success"])
 


### PR DESCRIPTION
## Problem

The retained Companion medium-task receipt records one successful repository read followed by a dynamic tool-call failure with bounded reason `additional_read_target`. The original adapter admitted only one read binding, while the bounded task required three named source reads and could also perform a bounded output read.

The failed call's requested path, thread/turn/call identity, and ordering relative to the approved write were not retained. Those details remain `UNKNOWN`; this repair does not claim a more specific failed-read classification.

## Exact budget semantics

One fresh bounded Run may admit at most four **distinct normalized repository paths**. The budget is not a call-ID budget:

- a new call ID for an already admitted normalized path consumes no additional path slot;
- every call keeps its own request/arguments identity, response, successful binding, repository identity, current-file validation, and read evidence;
- exact same-call replay remains idempotent and revalidates the current file;
- a new-call reread of an admitted path is freshly read and fails closed if its bytes or repository identity differ from the admitted baseline;
- a fifth distinct normalized path fails before any filesystem read and retains only its safely normalized requested path plus bounded failure status.

Existing same-path modification preimage checks and complete-source redaction remain intact across all admitted calls.

## Focused regressions

- four distinct normalized paths succeed;
- new call IDs for an admitted path continue succeeding after all four path slots are occupied;
- same-call replay and new-call same-path reread detect content drift;
- the fifth distinct path never reaches the filesystem reader;
- the retained medium shape—three source reads, approved one-time Create, and output read after the simulated write—reaches normal terminal completion.

## Verification

- focused distinct-path regressions: 5 passed
- full Codex adapter suite: 61 passed
- Companion controller suite: 27 passed
- Companion server/client/headless-Chrome suite: 35 passed
- full repository suite: 697 passed
- `git diff --check`: passed

## Safety boundary

- no new Companion Run was started;
- the live output file was not modified or staged;
- no install, ready-for-review transition, merge, release, or publication action is included.

## Remaining gate

A live retry remains blocked until this Draft PR is independently reviewed and, under separate authority, merged and installed with runtime identity verified.
