### PR TITLE
Add Field Notes A3 reuse core

### DIFF
--- a/decision_os/companion/field_notes_reuse.py
+++ b/decision_os/companion/field_notes_reuse.py
@@ -40,8 +40,9 @@ ReuseFailureReason = Literal[
     "USE_EVIDENCE_MISSING",
     "NOTE_IDENTITY_MISMATCH",
     "ORIGIN_RUN_NOT_DIFFERENT",
-    "STRUCTURE_NOT_SPECIFIC",
+    "STRUCTURE_BINDING_INVALID",
 ]
+ServingPolicyDerivation = Literal["DELAY"]
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _GENERIC_STRUCTURE_IDS = frozenset(
@@ -89,6 +90,10 @@ def _sha256(value: Any, label: str) -> str:
     if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
         raise ValueError(f"{label} must be a lowercase SHA-256 digest.")
     return value
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
 
 
 def _relative_path(value: Any, label: str) -> str:
@@ -158,14 +163,122 @@ class FieldNoteIdentity:
 
 
 @dataclass(frozen=True)
+class FieldNoteStructureBinding:
+    """Deterministic byte-range anchor into one exact Field Note."""
+
+    note: FieldNoteIdentity
+    structure_id: str
+    note_size: int
+    start_byte: int
+    end_byte: int
+    structure_sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "structure_id",
+            _bounded_text(self.structure_id, "Structure ID", maximum=256),
+        )
+        object.__setattr__(
+            self,
+            "structure_sha256",
+            _sha256(self.structure_sha256, "Structure digest"),
+        )
+        if (
+            type(self.note_size) is not int
+            or type(self.start_byte) is not int
+            or type(self.end_byte) is not int
+            or self.note_size <= 0
+            or self.start_byte < 0
+            or self.end_byte <= self.start_byte
+            or self.end_byte > self.note_size
+        ):
+            raise ValueError("Structure byte range is outside its bounded schema.")
+
+    @property
+    def binding_sha256(self) -> str:
+        payload = {
+            "note": self.note.as_dict(),
+            "structure_id": self.structure_id,
+            "note_size": self.note_size,
+            "start_byte": self.start_byte,
+            "end_byte": self.end_byte,
+            "structure_sha256": self.structure_sha256,
+        }
+        return _sha256_bytes(canonical_json(payload).encode("utf-8"))
+
+    def verifies(self, note: FieldNoteIdentity, note_bytes: bytes) -> bool:
+        if not isinstance(note_bytes, bytes):
+            return False
+        if (
+            self.note != note
+            or len(note_bytes) != self.note_size
+            or _sha256_bytes(note_bytes) != note.note_sha256
+            or self.structure_id.casefold() in _GENERIC_STRUCTURE_IDS
+            or (self.start_byte == 0 and self.end_byte == len(note_bytes))
+        ):
+            return False
+        structure_bytes = note_bytes[self.start_byte : self.end_byte]
+        if (
+            not structure_bytes.strip()
+            or _sha256_bytes(structure_bytes) != self.structure_sha256
+            or self.structure_sha256 == note.note_sha256
+        ):
+            return False
+        try:
+            note_bytes.decode("utf-8")
+            structure_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return False
+        return True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "note": self.note.as_dict(),
+            "structure_id": self.structure_id,
+            "note_size": self.note_size,
+            "start_byte": self.start_byte,
+            "end_byte": self.end_byte,
+            "structure_sha256": self.structure_sha256,
+            "binding_sha256": self.binding_sha256,
+        }
+
+
+def bind_field_note_structure(
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+    *,
+    structure_id: str,
+    start_byte: int,
+    end_byte: int,
+) -> FieldNoteStructureBinding:
+    """Create an anchor only after verifying the complete exact Note bytes."""
+
+    if not isinstance(note_bytes, bytes) or _sha256_bytes(note_bytes) != (
+        note.note_sha256
+    ):
+        raise ValueError("Structure source bytes do not match the exact Field Note.")
+    binding = FieldNoteStructureBinding(
+        note=note,
+        structure_id=structure_id,
+        note_size=len(note_bytes),
+        start_byte=start_byte,
+        end_byte=end_byte,
+        structure_sha256=_sha256_bytes(note_bytes[start_byte:end_byte]),
+    )
+    if not binding.verifies(note, note_bytes):
+        raise ValueError("Structure binding is not a specific exact-Note range.")
+    return binding
+
+
+@dataclass(frozen=True)
 class FieldNoteUseEvidence:
     """Same-window typed evidence that one Note structure operated."""
 
     evidence_class: UseEvidenceClass
     evidence_origin: UseEvidenceOrigin
     reusing_run_id: str
-    structure_id: str
-    structure_sha256: str
+    structure_binding: FieldNoteStructureBinding
     evidence_ref: str
     evidence_sha256: str
     observer_id: str
@@ -191,16 +304,8 @@ class FieldNoteUseEvidence:
             "reusing_run_id",
             _bounded_text(self.reusing_run_id, "Reusing Run ID", maximum=256),
         )
-        object.__setattr__(
-            self,
-            "structure_id",
-            _bounded_text(self.structure_id, "Structure ID", maximum=256),
-        )
-        object.__setattr__(
-            self,
-            "structure_sha256",
-            _sha256(self.structure_sha256, "Structure digest"),
-        )
+        if not isinstance(self.structure_binding, FieldNoteStructureBinding):
+            raise ValueError("Use evidence lacks a typed structure binding.")
         object.__setattr__(
             self,
             "evidence_ref",
@@ -218,19 +323,20 @@ class FieldNoteUseEvidence:
         )
         object.__setattr__(self, "as_of", _as_of(self.as_of))
 
-    def is_specific_to(self, note: FieldNoteIdentity) -> bool:
-        return bool(
-            self.structure_id.casefold() not in _GENERIC_STRUCTURE_IDS
-            and self.structure_sha256 != note.note_sha256
-        )
+    @property
+    def structure_id(self) -> str:
+        return self.structure_binding.structure_id
 
-    def as_dict(self) -> dict[str, str]:
+    @property
+    def structure_sha256(self) -> str:
+        return self.structure_binding.structure_sha256
+
+    def as_dict(self) -> dict[str, Any]:
         return {
             "evidence_class": self.evidence_class,
             "evidence_origin": self.evidence_origin,
             "reusing_run_id": self.reusing_run_id,
-            "structure_id": self.structure_id,
-            "structure_sha256": self.structure_sha256,
+            "structure_binding": self.structure_binding.as_dict(),
             "evidence_ref": self.evidence_ref,
             "evidence_sha256": self.evidence_sha256,
             "observer_id": self.observer_id,
@@ -553,6 +659,96 @@ class FieldNoteMaturitySummary:
         }
 
 
+@dataclass(frozen=True)
+class FieldNoteServingPolicyBoundary:
+    """Fail-closed boundary for a future, separate Serving Policy.
+
+    Evidence invalidation, serving reduction, supersession, staleness,
+    contradiction, harm, and successor compression can only become later
+    Forward-only records.  This boundary implements none of those events.
+    """
+
+    note: FieldNoteIdentity
+    derivation: ServingPolicyDerivation = "DELAY"
+    automatic_derivation_supported: Literal[False] = False
+    automatic_injection: None = None
+    complete_state_machine_implemented: Literal[False] = False
+    forward_only_extension: Literal["LATER_RECORDS_ONLY"] = "LATER_RECORDS_ONLY"
+    authority_precedence: tuple[
+        Literal["TOPMOST_CANONICAL"],
+        Literal["ADVISORY_FIELD_NOTE"],
+    ] = ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE")
+    delay_reason: str = "Current Serving Policy is unsupported."
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.note, FieldNoteIdentity)
+            or self.derivation != "DELAY"
+            or self.automatic_derivation_supported is not False
+            or self.automatic_injection is not None
+            or self.complete_state_machine_implemented is not False
+            or self.forward_only_extension != "LATER_RECORDS_ONLY"
+            or self.authority_precedence
+            != ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE")
+        ):
+            raise ValueError("Serving Policy must remain separate and delayed.")
+        object.__setattr__(
+            self,
+            "delay_reason",
+            _bounded_text(self.delay_reason, "Serving Policy delay reason"),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "note": self.note.as_dict(),
+            "derivation": self.derivation,
+            "automatic_derivation_supported": (
+                self.automatic_derivation_supported
+            ),
+            "automatic_injection": self.automatic_injection,
+            "complete_state_machine_implemented": (
+                self.complete_state_machine_implemented
+            ),
+            "forward_only_extension": self.forward_only_extension,
+            "authority_precedence": list(self.authority_precedence),
+            "delay_reason": self.delay_reason,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteA3Projection:
+    """Read-only projection that keeps maturity and serving as separate axes."""
+
+    evidence_maturity: FieldNoteMaturitySummary
+    current_serving_policy: FieldNoteServingPolicyBoundary
+
+    def __post_init__(self) -> None:
+        if self.evidence_maturity.note != self.current_serving_policy.note:
+            raise ValueError("A3 projection axes identify different Field Notes.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "evidence_maturity": self.evidence_maturity.as_dict(),
+            "current_serving_policy": self.current_serving_policy.as_dict(),
+        }
+
+
+def project_field_note_a3_status(
+    maturity: FieldNoteMaturitySummary,
+    *,
+    serving_delay_reason: str = "Current Serving Policy is unsupported.",
+) -> FieldNoteA3Projection:
+    """Project independent axes without deriving serving from maturity."""
+
+    return FieldNoteA3Projection(
+        evidence_maturity=maturity,
+        current_serving_policy=FieldNoteServingPolicyBoundary(
+            note=maturity.note,
+            delay_reason=serving_delay_reason,
+        ),
+    )
+
+
 def _candidate_receipt(
     note: FieldNoteIdentity,
     reusing_run_id: str,
@@ -651,6 +847,8 @@ def _normalized_disposition(
 def assess_field_note_reuse(
     note: FieldNoteIdentity,
     claim: FieldNoteReuseClaim | None,
+    *,
+    note_bytes: bytes | None = None,
 ) -> FieldNoteReuseReceipt:
     """Assess one claim without mutating the Field Note or repository."""
 
@@ -675,11 +873,14 @@ def assess_field_note_reuse(
             claim.reusing_run_id,
             "USE_EVIDENCE_MISSING",
         )
-    if not evidence.is_specific_to(note):
+    if note_bytes is None or not evidence.structure_binding.verifies(
+        note,
+        note_bytes,
+    ):
         return _candidate_receipt(
             note,
             claim.reusing_run_id,
-            "STRUCTURE_NOT_SPECIFIC",
+            "STRUCTURE_BINDING_INVALID",
         )
     evaluation = claim.outcome_evaluation or FieldNoteOutcomeEvaluation(
         outcome="UNKNOWN",

--- a/decision_os/companion/field_notes_reuse.py
+++ b/decision_os/companion/field_notes_reuse.py
@@ -1,0 +1,761 @@
+"""Typed, fail-closed Field Notes Lite A3 reuse evidence.
+
+This module records reuse separately from saved Field Note bytes.  Injection,
+successful completion, narrative claims, and human approval are intentionally
+not inputs that can establish reuse.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+from pathlib import PurePosixPath
+import re
+from typing import Any, Iterable, Literal
+
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+
+
+ReuseState = Literal["CANDIDATE", "REUSED"]
+UseEvidenceClass = Literal["RULE_TRACE", "OUTPUT_ARTIFACT"]
+UseEvidenceOrigin = Literal["REUSING_RUN", "IMMEDIATE_COMPLETION_RECORD"]
+ReuseOutcome = Literal["HELPFUL", "NOT_HELPFUL", "HARMFUL", "UNKNOWN"]
+HumanIntervention = Literal["NONE", "NON_DECISIVE", "MATERIAL", "UNKNOWN"]
+NextAction = Literal["KEEP", "REVISE", "HOLD", "STOP"]
+ObserverRelation = Literal[
+    "REUSING_RUN_SELF",
+    "REUSING_RUN_PARTICIPANT",
+    "INDEPENDENT",
+]
+OutcomeConfirmation = Literal[
+    "SAME_RUN_CLAIM",
+    "RUN_RELATED_CLAIM",
+    "INDEPENDENT_CONFIRMATION",
+]
+ReuseFailureReason = Literal[
+    "USE_EVIDENCE_MISSING",
+    "NOTE_IDENTITY_MISMATCH",
+    "ORIGIN_RUN_NOT_DIFFERENT",
+    "STRUCTURE_NOT_SPECIFIC",
+]
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GENERIC_STRUCTURE_IDS = frozenset(
+    {
+        "entire field note",
+        "entire note",
+        "field note",
+        "note",
+        "the field note",
+        "the note",
+        "whole field note",
+        "whole note",
+    }
+)
+_DEFAULT_OUTCOME_RECHECK = (
+    "Re-evaluate when bounded outcome evidence can determine the specific "
+    "Note structure's contribution."
+)
+_DEFAULT_INTERVENTION_RECHECK = (
+    "Re-evaluate when the specific Note structure's contribution can be "
+    "separated from material or unknown human intervention."
+)
+_DEFAULT_CAUSAL_RECHECK = (
+    "Re-evaluate when bounded causal evidence supports the declared outcome."
+)
+_DEFAULT_ATTRIBUTION_RECHECK = (
+    "Re-evaluate when the specific Note structure's contribution can be "
+    "separated from other Notes and causes."
+)
+_DEFAULT_STOP_SCOPE_RECHECK = (
+    "Re-evaluate after an explicit bounded STOP scope is supplied."
+)
+
+
+def _bounded_text(value: Any, label: str, maximum: int = 2048) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be text.")
+    normalized = value.strip()
+    if not normalized or len(normalized) > maximum or "\x00" in normalized:
+        raise ValueError(f"{label} is outside its bounded schema.")
+    return normalized
+
+
+def _sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest.")
+    return value
+
+
+def _relative_path(value: Any, label: str) -> str:
+    normalized = _bounded_text(value, label, maximum=1024)
+    path = PurePosixPath(normalized)
+    if (
+        path.is_absolute()
+        or normalized.startswith("./")
+        or normalized.endswith("/")
+        or "\\" in normalized
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or path.as_posix() != normalized
+    ):
+        raise ValueError(f"{label} must be a canonical relative path.")
+    return normalized
+
+
+def _as_of(value: Any) -> str:
+    normalized = _bounded_text(value, "As-of", maximum=64)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("As-of must be an RFC 3339 timestamp.") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("As-of must be timezone-aware.")
+    return normalized
+
+
+@dataclass(frozen=True)
+class FieldNoteIdentity:
+    """Exact immutable identity of one saved Field Note."""
+
+    note_path: str
+    field_note_id: str
+    note_sha256: str
+    origin_run_id: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "note_path",
+            _relative_path(self.note_path, "Field Note path"),
+        )
+        object.__setattr__(
+            self,
+            "field_note_id",
+            _bounded_text(self.field_note_id, "Field Note ID", maximum=256),
+        )
+        object.__setattr__(
+            self,
+            "note_sha256",
+            _sha256(self.note_sha256, "Field Note digest"),
+        )
+        object.__setattr__(
+            self,
+            "origin_run_id",
+            _bounded_text(self.origin_run_id, "Origin Run ID", maximum=256),
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "note_path": self.note_path,
+            "field_note_id": self.field_note_id,
+            "note_sha256": self.note_sha256,
+            "origin_run_id": self.origin_run_id,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteUseEvidence:
+    """Same-window typed evidence that one Note structure operated."""
+
+    evidence_class: UseEvidenceClass
+    evidence_origin: UseEvidenceOrigin
+    reusing_run_id: str
+    structure_id: str
+    structure_sha256: str
+    evidence_ref: str
+    evidence_sha256: str
+    observer_id: str
+    observer_relation: ObserverRelation
+    as_of: str
+
+    def __post_init__(self) -> None:
+        if self.evidence_class not in {"RULE_TRACE", "OUTPUT_ARTIFACT"}:
+            raise ValueError("Use-evidence class is unsupported.")
+        if self.evidence_origin not in {
+            "REUSING_RUN",
+            "IMMEDIATE_COMPLETION_RECORD",
+        }:
+            raise ValueError("Use evidence is outside the allowed Run window.")
+        if self.observer_relation not in {
+            "REUSING_RUN_SELF",
+            "REUSING_RUN_PARTICIPANT",
+            "INDEPENDENT",
+        }:
+            raise ValueError("Use-evidence observer relation is unsupported.")
+        object.__setattr__(
+            self,
+            "reusing_run_id",
+            _bounded_text(self.reusing_run_id, "Reusing Run ID", maximum=256),
+        )
+        object.__setattr__(
+            self,
+            "structure_id",
+            _bounded_text(self.structure_id, "Structure ID", maximum=256),
+        )
+        object.__setattr__(
+            self,
+            "structure_sha256",
+            _sha256(self.structure_sha256, "Structure digest"),
+        )
+        object.__setattr__(
+            self,
+            "evidence_ref",
+            _bounded_text(self.evidence_ref, "Use-evidence reference"),
+        )
+        object.__setattr__(
+            self,
+            "evidence_sha256",
+            _sha256(self.evidence_sha256, "Use-evidence digest"),
+        )
+        object.__setattr__(
+            self,
+            "observer_id",
+            _bounded_text(self.observer_id, "Use-evidence observer", maximum=256),
+        )
+        object.__setattr__(self, "as_of", _as_of(self.as_of))
+
+    def is_specific_to(self, note: FieldNoteIdentity) -> bool:
+        return bool(
+            self.structure_id.casefold() not in _GENERIC_STRUCTURE_IDS
+            and self.structure_sha256 != note.note_sha256
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "evidence_class": self.evidence_class,
+            "evidence_origin": self.evidence_origin,
+            "reusing_run_id": self.reusing_run_id,
+            "structure_id": self.structure_id,
+            "structure_sha256": self.structure_sha256,
+            "evidence_ref": self.evidence_ref,
+            "evidence_sha256": self.evidence_sha256,
+            "observer_id": self.observer_id,
+            "observer_relation": self.observer_relation,
+            "as_of": self.as_of,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteOutcomeEvaluation:
+    """Outcome claim kept separate from proof that reuse occurred."""
+
+    outcome: ReuseOutcome
+    scope: str
+    observer_id: str
+    observer_relation: ObserverRelation
+    as_of: str
+    causal_evidence_ref: str | None = None
+    causal_evidence_sha256: str | None = None
+    contribution_separated: bool = False
+
+    def __post_init__(self) -> None:
+        if self.outcome not in {
+            "HELPFUL",
+            "NOT_HELPFUL",
+            "HARMFUL",
+            "UNKNOWN",
+        }:
+            raise ValueError("Reuse outcome is unsupported.")
+        if self.observer_relation not in {
+            "REUSING_RUN_SELF",
+            "REUSING_RUN_PARTICIPANT",
+            "INDEPENDENT",
+        }:
+            raise ValueError("Outcome observer relation is unsupported.")
+        object.__setattr__(
+            self,
+            "scope",
+            _bounded_text(self.scope, "Outcome scope"),
+        )
+        object.__setattr__(
+            self,
+            "observer_id",
+            _bounded_text(self.observer_id, "Outcome observer", maximum=256),
+        )
+        object.__setattr__(self, "as_of", _as_of(self.as_of))
+        if type(self.contribution_separated) is not bool:
+            raise ValueError("Contribution separation must be boolean.")
+        causal = (self.causal_evidence_ref, self.causal_evidence_sha256)
+        if (causal[0] is None) != (causal[1] is None):
+            raise ValueError("Causal evidence identity is incomplete.")
+        if causal[0] is not None:
+            object.__setattr__(
+                self,
+                "causal_evidence_ref",
+                _bounded_text(causal[0], "Causal-evidence reference"),
+            )
+            object.__setattr__(
+                self,
+                "causal_evidence_sha256",
+                _sha256(causal[1], "Causal-evidence digest"),
+            )
+
+    @property
+    def has_causal_evidence(self) -> bool:
+        return self.causal_evidence_ref is not None
+
+    @property
+    def confirmation(self) -> OutcomeConfirmation:
+        if self.observer_relation == "REUSING_RUN_SELF":
+            return "SAME_RUN_CLAIM"
+        if self.observer_relation == "INDEPENDENT":
+            return "INDEPENDENT_CONFIRMATION"
+        return "RUN_RELATED_CLAIM"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome,
+            "scope": self.scope,
+            "observer_id": self.observer_id,
+            "observer_relation": self.observer_relation,
+            "as_of": self.as_of,
+            "causal_evidence_ref": self.causal_evidence_ref,
+            "causal_evidence_sha256": self.causal_evidence_sha256,
+            "contribution_separated": self.contribution_separated,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteReuseDisposition:
+    """Requested next action; invalid mappings are rejected or held."""
+
+    action: NextAction
+    reevaluation_condition: str | None = None
+    stop_scope: str | None = None
+    revision_candidate: FieldNoteIdentity | None = None
+
+    def __post_init__(self) -> None:
+        if self.action not in {"KEEP", "REVISE", "HOLD", "STOP"}:
+            raise ValueError("Reuse next action is unsupported.")
+        if self.reevaluation_condition is not None:
+            object.__setattr__(
+                self,
+                "reevaluation_condition",
+                _bounded_text(
+                    self.reevaluation_condition,
+                    "Re-evaluation condition",
+                ),
+            )
+        if self.stop_scope is not None:
+            object.__setattr__(
+                self,
+                "stop_scope",
+                _bounded_text(self.stop_scope, "STOP scope"),
+            )
+
+
+@dataclass(frozen=True)
+class FieldNoteReuseClaim:
+    """One bounded claim evaluated against a canonical Note identity."""
+
+    claimed_note: FieldNoteIdentity
+    reusing_run_id: str
+    use_evidence: FieldNoteUseEvidence | None
+    outcome_evaluation: FieldNoteOutcomeEvaluation | None
+    human_intervention: HumanIntervention
+    disposition: FieldNoteReuseDisposition | None
+    narrative_claim: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.human_intervention not in {
+            "NONE",
+            "NON_DECISIVE",
+            "MATERIAL",
+            "UNKNOWN",
+        }:
+            raise ValueError("Human-intervention state is unsupported.")
+        object.__setattr__(
+            self,
+            "reusing_run_id",
+            _bounded_text(self.reusing_run_id, "Reusing Run ID", maximum=256),
+        )
+        if self.use_evidence is not None and (
+            self.use_evidence.reusing_run_id != self.reusing_run_id
+        ):
+            raise ValueError("Use evidence is bound to a different reusing Run.")
+        if self.narrative_claim is not None:
+            object.__setattr__(
+                self,
+                "narrative_claim",
+                _bounded_text(self.narrative_claim, "Narrative claim", maximum=4096),
+            )
+
+
+@dataclass(frozen=True)
+class FieldNoteRevisionLink:
+    """Forward-only link to a distinct revision candidate."""
+
+    predecessor: FieldNoteIdentity
+    successor: FieldNoteIdentity
+
+    def __post_init__(self) -> None:
+        if self.predecessor == self.successor:
+            raise ValueError("A revision must be a new Field Note candidate.")
+
+    def as_dict(self) -> dict[str, dict[str, str]]:
+        return {
+            "predecessor": self.predecessor.as_dict(),
+            "successor": self.successor.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class PromotionPolicyBoundary:
+    """Explicitly reserve PROMOTABLE while its policy is unset."""
+
+    reserved_state: Literal["PROMOTABLE"] = "PROMOTABLE"
+    policy_status: Literal["UNSET"] = "UNSET"
+    threshold: None = None
+    automatically_derivable: Literal[False] = False
+
+    def __post_init__(self) -> None:
+        if (
+            self.reserved_state != "PROMOTABLE"
+            or self.policy_status != "UNSET"
+            or self.threshold is not None
+            or self.automatically_derivable is not False
+        ):
+            raise ValueError("PROMOTABLE policy must remain unset.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "reserved_state": self.reserved_state,
+            "policy_status": self.policy_status,
+            "threshold": self.threshold,
+            "automatically_derivable": self.automatically_derivable,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteReuseReceipt:
+    """Immutable A3 receipt for one candidate or verified reuse event."""
+
+    note: FieldNoteIdentity
+    reusing_run_id: str
+    state: ReuseState
+    failure_reason: ReuseFailureReason | None
+    use_evidence: FieldNoteUseEvidence | None
+    claimed_outcome: ReuseOutcome | None
+    outcome: ReuseOutcome | None
+    outcome_confirmation: OutcomeConfirmation | None
+    outcome_observer_id: str | None
+    outcome_observer_relation: ObserverRelation | None
+    outcome_as_of: str | None
+    human_intervention: HumanIntervention | None
+    next_action: NextAction | None
+    reevaluation_condition: str | None
+    stop_scope: str | None
+    revision: FieldNoteRevisionLink | None
+    reuse_event_id: str | None
+    promotion: PromotionPolicyBoundary = PromotionPolicyBoundary()
+
+    def __post_init__(self) -> None:
+        if self.state not in {"CANDIDATE", "REUSED"}:
+            raise ValueError("A3 can derive only CANDIDATE or REUSED.")
+        if self.state == "CANDIDATE":
+            if (
+                self.failure_reason is None
+                or self.use_evidence is not None
+                or self.outcome is not None
+                or self.next_action is not None
+                or self.reuse_event_id is not None
+            ):
+                raise ValueError("Candidate receipt contains reuse-only fields.")
+            return
+        required = (
+            self.use_evidence,
+            self.claimed_outcome,
+            self.outcome,
+            self.outcome_confirmation,
+            self.outcome_observer_id,
+            self.outcome_observer_relation,
+            self.outcome_as_of,
+            self.human_intervention,
+            self.next_action,
+            self.reuse_event_id,
+        )
+        if self.failure_reason is not None or any(value is None for value in required):
+            raise ValueError("Reused receipt lacks its typed evidence axes.")
+        _sha256(self.reuse_event_id, "Reuse event ID")
+        if self.outcome == "UNKNOWN" and self.next_action != "HOLD":
+            raise ValueError("UNKNOWN outcome must HOLD.")
+        if self.next_action == "HOLD" and self.reevaluation_condition is None:
+            raise ValueError("HOLD requires a re-evaluation condition.")
+        if self.next_action == "STOP" and self.stop_scope is None:
+            raise ValueError("STOP requires an explicit bounded scope.")
+        if self.next_action == "REVISE" and self.revision is None:
+            raise ValueError("REVISE requires a forward revision link.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "note": self.note.as_dict(),
+            "reusing_run_id": self.reusing_run_id,
+            "state": self.state,
+            "failure_reason": self.failure_reason,
+            "use_evidence": (
+                self.use_evidence.as_dict() if self.use_evidence else None
+            ),
+            "claimed_outcome": self.claimed_outcome,
+            "outcome": self.outcome,
+            "outcome_confirmation": self.outcome_confirmation,
+            "outcome_observer_id": self.outcome_observer_id,
+            "outcome_observer_relation": self.outcome_observer_relation,
+            "outcome_as_of": self.outcome_as_of,
+            "human_intervention": self.human_intervention,
+            "next_action": self.next_action,
+            "reevaluation_condition": self.reevaluation_condition,
+            "stop_scope": self.stop_scope,
+            "revision": self.revision.as_dict() if self.revision else None,
+            "reuse_event_id": self.reuse_event_id,
+            "promotion": self.promotion.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturitySummary:
+    """Deduplicated maturity capped at REUSED while policy is unset."""
+
+    note: FieldNoteIdentity
+    state: ReuseState
+    reuse_event_ids: tuple[str, ...]
+    duplicate_reuse_records_ignored: int
+    reconnect_receipts_ignored: int
+    promotion: PromotionPolicyBoundary = PromotionPolicyBoundary()
+
+    def __post_init__(self) -> None:
+        if self.state not in {"CANDIDATE", "REUSED"}:
+            raise ValueError("A3 summary cannot derive PROMOTABLE.")
+        if self.state == "CANDIDATE" and self.reuse_event_ids:
+            raise ValueError("Candidate summary cannot contain reuse events.")
+        if self.state == "REUSED" and not self.reuse_event_ids:
+            raise ValueError("Reused summary requires a reuse event.")
+        counters = (
+            self.duplicate_reuse_records_ignored,
+            self.reconnect_receipts_ignored,
+        )
+        if any(type(value) is not int or value < 0 for value in counters):
+            raise ValueError("Maturity summary counters are invalid.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "note": self.note.as_dict(),
+            "state": self.state,
+            "reuse_event_ids": list(self.reuse_event_ids),
+            "duplicate_reuse_records_ignored": (
+                self.duplicate_reuse_records_ignored
+            ),
+            "reconnect_receipts_ignored": self.reconnect_receipts_ignored,
+            "promotion": self.promotion.as_dict(),
+        }
+
+
+def _candidate_receipt(
+    note: FieldNoteIdentity,
+    reusing_run_id: str,
+    reason: ReuseFailureReason,
+) -> FieldNoteReuseReceipt:
+    return FieldNoteReuseReceipt(
+        note=note,
+        reusing_run_id=_bounded_text(
+            reusing_run_id,
+            "Reusing Run ID",
+            maximum=256,
+        ),
+        state="CANDIDATE",
+        failure_reason=reason,
+        use_evidence=None,
+        claimed_outcome=None,
+        outcome=None,
+        outcome_confirmation=None,
+        outcome_observer_id=None,
+        outcome_observer_relation=None,
+        outcome_as_of=None,
+        human_intervention=None,
+        next_action=None,
+        reevaluation_condition=None,
+        stop_scope=None,
+        revision=None,
+        reuse_event_id=None,
+    )
+
+
+def _effective_outcome(
+    evaluation: FieldNoteOutcomeEvaluation,
+    intervention: HumanIntervention,
+) -> tuple[ReuseOutcome, str | None]:
+    if intervention in {"MATERIAL", "UNKNOWN"} and not (
+        evaluation.contribution_separated
+    ):
+        return "UNKNOWN", _DEFAULT_INTERVENTION_RECHECK
+    if evaluation.outcome != "UNKNOWN" and not (
+        evaluation.contribution_separated
+    ):
+        return "UNKNOWN", _DEFAULT_ATTRIBUTION_RECHECK
+    if evaluation.outcome in {"HELPFUL", "HARMFUL"} and not (
+        evaluation.has_causal_evidence
+    ):
+        return "UNKNOWN", _DEFAULT_CAUSAL_RECHECK
+    return evaluation.outcome, None
+
+
+def _normalized_disposition(
+    *,
+    note: FieldNoteIdentity,
+    reusing_run_id: str,
+    outcome: ReuseOutcome,
+    disposition: FieldNoteReuseDisposition | None,
+    forced_reevaluation: str | None,
+) -> tuple[
+    NextAction,
+    str | None,
+    str | None,
+    FieldNoteRevisionLink | None,
+]:
+    if outcome == "UNKNOWN":
+        condition = forced_reevaluation
+        if condition is None and disposition is not None:
+            condition = disposition.reevaluation_condition
+        return "HOLD", condition or _DEFAULT_OUTCOME_RECHECK, None, None
+    if disposition is None:
+        raise ValueError("A known reuse outcome requires a next action.")
+    allowed = {
+        "HELPFUL": {"KEEP", "REVISE"},
+        "NOT_HELPFUL": {"REVISE", "STOP"},
+        "HARMFUL": {"REVISE", "STOP"},
+    }
+    if disposition.action not in allowed[outcome]:
+        raise ValueError("Next action is invalid for the reuse outcome.")
+    if disposition.action == "STOP":
+        if disposition.stop_scope is None:
+            return (
+                "HOLD",
+                disposition.reevaluation_condition or _DEFAULT_STOP_SCOPE_RECHECK,
+                None,
+                None,
+            )
+        return "STOP", None, disposition.stop_scope, None
+    if disposition.action == "REVISE":
+        successor = disposition.revision_candidate
+        if successor is None:
+            raise ValueError("REVISE requires a new candidate identity.")
+        if successor.origin_run_id != reusing_run_id:
+            raise ValueError("Revision candidate must originate in the reusing Run.")
+        return "REVISE", None, None, FieldNoteRevisionLink(note, successor)
+    return "KEEP", None, None, None
+
+
+def assess_field_note_reuse(
+    note: FieldNoteIdentity,
+    claim: FieldNoteReuseClaim | None,
+) -> FieldNoteReuseReceipt:
+    """Assess one claim without mutating the Field Note or repository."""
+
+    if claim is None:
+        return _candidate_receipt(note, "UNBOUND_REUSE_RUN", "USE_EVIDENCE_MISSING")
+    if claim.claimed_note != note:
+        return _candidate_receipt(
+            note,
+            claim.reusing_run_id,
+            "NOTE_IDENTITY_MISMATCH",
+        )
+    if claim.reusing_run_id == note.origin_run_id:
+        return _candidate_receipt(
+            note,
+            claim.reusing_run_id,
+            "ORIGIN_RUN_NOT_DIFFERENT",
+        )
+    evidence = claim.use_evidence
+    if evidence is None:
+        return _candidate_receipt(
+            note,
+            claim.reusing_run_id,
+            "USE_EVIDENCE_MISSING",
+        )
+    if not evidence.is_specific_to(note):
+        return _candidate_receipt(
+            note,
+            claim.reusing_run_id,
+            "STRUCTURE_NOT_SPECIFIC",
+        )
+    evaluation = claim.outcome_evaluation or FieldNoteOutcomeEvaluation(
+        outcome="UNKNOWN",
+        scope="The bounded reusing Run.",
+        observer_id=evidence.observer_id,
+        observer_relation=evidence.observer_relation,
+        as_of=evidence.as_of,
+    )
+    outcome, forced_reevaluation = _effective_outcome(
+        evaluation,
+        claim.human_intervention,
+    )
+    action, condition, stop_scope, revision = _normalized_disposition(
+        note=note,
+        reusing_run_id=claim.reusing_run_id,
+        outcome=outcome,
+        disposition=claim.disposition,
+        forced_reevaluation=forced_reevaluation,
+    )
+    event_payload = {
+        "note": note.as_dict(),
+        "reusing_run_id": claim.reusing_run_id,
+        "use_evidence": evidence.as_dict(),
+    }
+    reuse_event_id = hashlib.sha256(
+        canonical_json(event_payload).encode("utf-8")
+    ).hexdigest()
+    return FieldNoteReuseReceipt(
+        note=note,
+        reusing_run_id=claim.reusing_run_id,
+        state="REUSED",
+        failure_reason=None,
+        use_evidence=evidence,
+        claimed_outcome=evaluation.outcome,
+        outcome=outcome,
+        outcome_confirmation=evaluation.confirmation,
+        outcome_observer_id=evaluation.observer_id,
+        outcome_observer_relation=evaluation.observer_relation,
+        outcome_as_of=evaluation.as_of,
+        human_intervention=claim.human_intervention,
+        next_action=action,
+        reevaluation_condition=condition,
+        stop_scope=stop_scope,
+        revision=revision,
+        reuse_event_id=reuse_event_id,
+    )
+
+
+def summarize_field_note_maturity(
+    note: FieldNoteIdentity,
+    reuse_receipts: Iterable[FieldNoteReuseReceipt],
+    reconnect_receipts: Iterable[FieldNoteReconnectReceipt] = (),
+) -> FieldNoteMaturitySummary:
+    """Deduplicate reuse and explicitly ignore A2 injection as maturity."""
+
+    event_ids: set[str] = set()
+    duplicates = 0
+    for receipt in reuse_receipts:
+        if receipt.note != note:
+            raise ValueError("Reuse receipt belongs to a different Field Note.")
+        if receipt.state != "REUSED" or receipt.reuse_event_id is None:
+            continue
+        if receipt.reuse_event_id in event_ids:
+            duplicates += 1
+        else:
+            event_ids.add(receipt.reuse_event_id)
+    ignored_reconnects = 0
+    for receipt in reconnect_receipts:
+        if not isinstance(receipt, FieldNoteReconnectReceipt):
+            raise ValueError("Reconnect receipt type is invalid.")
+        ignored_reconnects += 1
+    ordered = tuple(sorted(event_ids))
+    return FieldNoteMaturitySummary(
+        note=note,
+        state="REUSED" if ordered else "CANDIDATE",
+        reuse_event_ids=ordered,
+        duplicate_reuse_records_ignored=duplicates,
+        reconnect_receipts_ignored=ignored_reconnects,
+    )

--- a/tests/test_field_notes_reuse.py
+++ b/tests/test_field_notes_reuse.py
@@ -9,23 +9,39 @@ from decision_os.companion.field_notes_reconnect import (
     FieldNoteReconnectReceipt,
 )
 from decision_os.companion.field_notes_reuse import (
+    FieldNoteA3Projection,
     FieldNoteIdentity,
     FieldNoteMaturitySummary,
     FieldNoteOutcomeEvaluation,
     FieldNoteReuseClaim,
     FieldNoteReuseDisposition,
     FieldNoteReuseReceipt,
+    FieldNoteServingPolicyBoundary,
+    FieldNoteStructureBinding,
     FieldNoteUseEvidence,
-    assess_field_note_reuse,
+    assess_field_note_reuse as assess_reuse_core,
+    bind_field_note_structure,
+    project_field_note_a3_status,
     summarize_field_note_maturity,
 )
 
 
 AS_OF = "2026-08-03T12:00:00Z"
+STRUCTURE_BYTES = b"Verify canonical state before restart."
+NOTE_BYTES = (
+    b"# A3 Reuse Core\n\n"
+    b"## Decision / Pattern\n\n"
+    + STRUCTURE_BYTES
+    + b"\n\n## Limits\n\nConfirm repository identity first.\n"
+)
 
 
 def digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
 
 
 def note_identity(
@@ -41,8 +57,25 @@ def note_identity(
     return FieldNoteIdentity(
         note_path=note_path,
         field_note_id=field_note_id,
-        note_sha256=note_sha256 or digest("exact note bytes"),
+        note_sha256=note_sha256 or digest_bytes(NOTE_BYTES),
         origin_run_id=origin_run_id,
+    )
+
+
+def structure_binding(
+    *,
+    note: FieldNoteIdentity | None = None,
+    note_bytes: bytes = NOTE_BYTES,
+    structure_id: str = "restart-state-identity-guard",
+) -> FieldNoteStructureBinding:
+    canonical_note = note or note_identity()
+    start = note_bytes.index(STRUCTURE_BYTES)
+    return bind_field_note_structure(
+        canonical_note,
+        note_bytes,
+        structure_id=structure_id,
+        start_byte=start,
+        end_byte=start + len(STRUCTURE_BYTES),
     )
 
 
@@ -50,8 +83,7 @@ def use_evidence(
     *,
     evidence_class: str = "RULE_TRACE",
     reusing_run_id: str = "run_reuse",
-    structure_id: str = "restart-state-identity-guard",
-    structure_sha256: str | None = None,
+    binding: FieldNoteStructureBinding | None = None,
     evidence_ref: str = "run:run_reuse/rule-trace:guard-1",
     evidence_sha256: str | None = None,
 ) -> FieldNoteUseEvidence:
@@ -59,14 +91,22 @@ def use_evidence(
         evidence_class=evidence_class,  # type: ignore[arg-type]
         evidence_origin="IMMEDIATE_COMPLETION_RECORD",
         reusing_run_id=reusing_run_id,
-        structure_id=structure_id,
-        structure_sha256=structure_sha256 or digest("specific structure"),
+        structure_binding=binding or structure_binding(),
         evidence_ref=evidence_ref,
         evidence_sha256=evidence_sha256 or digest("typed use evidence"),
         observer_id="observer_a3",
         observer_relation="INDEPENDENT",
         as_of=AS_OF,
     )
+
+
+def assess_field_note_reuse(
+    note: FieldNoteIdentity,
+    claim: FieldNoteReuseClaim | None,
+    *,
+    note_bytes: bytes = NOTE_BYTES,
+) -> FieldNoteReuseReceipt:
+    return assess_reuse_core(note, claim, note_bytes=note_bytes)
 
 
 def outcome_evaluation(
@@ -207,18 +247,105 @@ class FieldNotesReuseAdmissionTests(unittest.TestCase):
 
     def test_whole_note_without_specific_structure_is_insufficient(self) -> None:
         note = note_identity()
+        whole_note = FieldNoteStructureBinding(
+            note=note,
+            structure_id="whole Note",
+            note_size=len(NOTE_BYTES),
+            start_byte=0,
+            end_byte=len(NOTE_BYTES),
+            structure_sha256=note.note_sha256,
+        )
         receipt = assess_field_note_reuse(
             note,
             reuse_claim(
                 note,
-                evidence=use_evidence(
-                    structure_id="whole Note",
-                    structure_sha256=note.note_sha256,
-                ),
+                evidence=use_evidence(binding=whole_note),
             ),
         )
         self.assertEqual("CANDIDATE", receipt.state)
-        self.assertEqual("STRUCTURE_NOT_SPECIFIC", receipt.failure_reason)
+        self.assertEqual("STRUCTURE_BINDING_INVALID", receipt.failure_reason)
+
+    def test_exact_note_byte_range_binding_can_establish_reuse(self) -> None:
+        note = note_identity()
+        binding = structure_binding(note=note)
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence(binding=binding)),
+        )
+        self.assertEqual("REUSED", receipt.state)
+        self.assertEqual(digest_bytes(STRUCTURE_BYTES), binding.structure_sha256)
+        self.assertEqual(note, binding.note)
+
+    def test_arbitrary_structure_id_and_digest_fail_closed(self) -> None:
+        note = note_identity()
+        start = NOTE_BYTES.index(STRUCTURE_BYTES)
+        arbitrary = FieldNoteStructureBinding(
+            note=note,
+            structure_id="arbitrary-external-claim",
+            note_size=len(NOTE_BYTES),
+            start_byte=start,
+            end_byte=start + len(STRUCTURE_BYTES),
+            structure_sha256=digest("arbitrary external bytes"),
+        )
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence(binding=arbitrary)),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("STRUCTURE_BINDING_INVALID", receipt.failure_reason)
+
+    def test_structure_bound_to_different_note_fails_closed(self) -> None:
+        note = note_identity()
+        other_bytes = NOTE_BYTES.replace(b"repository", b"canonical")
+        other_note = note_identity(
+            field_note_id="fn_other_note",
+            note_sha256=digest_bytes(other_bytes),
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-03-other-note-bbbbbbbbbb.md"
+            ),
+        )
+        other_binding = structure_binding(
+            note=other_note,
+            note_bytes=other_bytes,
+        )
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence(binding=other_binding)),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("STRUCTURE_BINDING_INVALID", receipt.failure_reason)
+
+    def test_changed_note_identity_invalidates_structure_binding(self) -> None:
+        note = note_identity()
+        binding = structure_binding(note=note)
+        changed = replace(note, field_note_id="fn_changed_identity")
+        receipt = assess_field_note_reuse(
+            changed,
+            reuse_claim(changed, evidence=use_evidence(binding=binding)),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("STRUCTURE_BINDING_INVALID", receipt.failure_reason)
+
+    def test_structure_verification_does_not_change_note_bytes(self) -> None:
+        note = note_identity()
+        before = bytes(NOTE_BYTES)
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        self.assertEqual("REUSED", receipt.state)
+        self.assertEqual(before, NOTE_BYTES)
+        self.assertEqual(note.note_sha256, digest_bytes(NOTE_BYTES))
+
+    def test_missing_exact_note_bytes_cannot_establish_reuse(self) -> None:
+        note = note_identity()
+        receipt = assess_reuse_core(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("STRUCTURE_BINDING_INVALID", receipt.failure_reason)
 
     def test_rule_trace_can_establish_reuse(self) -> None:
         note = note_identity()
@@ -264,8 +391,7 @@ class FieldNotesReuseAdmissionTests(unittest.TestCase):
                 evidence_class="RULE_TRACE",
                 evidence_origin="LATER_NARRATIVE",  # type: ignore[arg-type]
                 reusing_run_id="run_reuse",
-                structure_id="restart-state-identity-guard",
-                structure_sha256=digest("specific structure"),
+                structure_binding=structure_binding(),
                 evidence_ref="later:narrative",
                 evidence_sha256=digest("later narrative"),
                 observer_id="observer",
@@ -649,6 +775,100 @@ class FieldNotesReusePromotionBoundaryTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "different Field Note"):
             summarize_field_note_maturity(note, (receipt,))
+
+
+class FieldNotesServingPolicyBoundaryTests(unittest.TestCase):
+    def reused_summary(self) -> FieldNoteMaturitySummary:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        return summarize_field_note_maturity(note, (receipt,))
+
+    def test_reused_does_not_imply_default_or_mandatory_injection(self) -> None:
+        projection = project_field_note_a3_status(self.reused_summary())
+        self.assertIsInstance(projection, FieldNoteA3Projection)
+        self.assertEqual("REUSED", projection.evidence_maturity.state)
+        self.assertEqual("DELAY", projection.current_serving_policy.derivation)
+        self.assertIsNone(projection.current_serving_policy.automatic_injection)
+        self.assertFalse(
+            projection.current_serving_policy.automatic_derivation_supported
+        )
+
+    def test_conceptual_serving_reduction_cannot_change_maturity(self) -> None:
+        maturity = self.reused_summary()
+        before = maturity.as_dict()
+        projection = project_field_note_a3_status(
+            maturity,
+            serving_delay_reason=(
+                "A conceptual serving reduction awaits a future "
+                "Forward-only record."
+            ),
+        )
+        self.assertEqual("REUSED", projection.evidence_maturity.state)
+        self.assertEqual(before, maturity.as_dict())
+        self.assertIn(
+            "serving reduction",
+            projection.current_serving_policy.delay_reason,
+        )
+
+    def test_reuse_disposition_is_not_a_serving_policy_state(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HELPFUL", causal=True),
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        maturity = summarize_field_note_maturity(note, (receipt,))
+        serialized = project_field_note_a3_status(maturity).as_dict()
+        serving = serialized["current_serving_policy"]
+        self.assertEqual("KEEP", receipt.next_action)
+        self.assertNotIn("next_action", serving)
+        self.assertNotIn("KEEP", serving.values())
+
+    def test_serving_policy_automatic_derivation_is_fail_closed(self) -> None:
+        policy = FieldNoteServingPolicyBoundary(note=note_identity())
+        with self.assertRaisesRegex(ValueError, "separate and delayed"):
+            replace(policy, derivation="DEFAULT")  # type: ignore[arg-type]
+        with self.assertRaisesRegex(ValueError, "separate and delayed"):
+            replace(
+                policy,
+                automatic_derivation_supported=True,  # type: ignore[arg-type]
+            )
+
+    def test_promotable_remains_unset_when_serving_is_delayed(self) -> None:
+        projection = project_field_note_a3_status(self.reused_summary())
+        self.assertEqual(
+            "UNSET",
+            projection.evidence_maturity.promotion.policy_status,
+        )
+        self.assertEqual("DELAY", projection.current_serving_policy.derivation)
+
+    def test_a2_receipt_cannot_establish_maturity_or_serving(self) -> None:
+        note = note_identity()
+        maturity = summarize_field_note_maturity(
+            note,
+            (),
+            (reconnect_receipt(note),),
+        )
+        projection = project_field_note_a3_status(maturity)
+        self.assertEqual("CANDIDATE", projection.evidence_maturity.state)
+        self.assertEqual(1, maturity.reconnect_receipts_ignored)
+        self.assertEqual("DELAY", projection.current_serving_policy.derivation)
+
+    def test_topmost_canonical_authority_outranks_advisory_note(self) -> None:
+        policy = FieldNoteServingPolicyBoundary(note=note_identity())
+        self.assertEqual(
+            ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE"),
+            policy.authority_precedence,
+        )
+        self.assertFalse(policy.complete_state_machine_implemented)
+        self.assertEqual("LATER_RECORDS_ONLY", policy.forward_only_extension)
 
 
 class FieldNotesReuseProtectedArtifactTests(unittest.TestCase):

--- a/tests/test_field_notes_reuse.py
+++ b/tests/test_field_notes_reuse.py
@@ -1,0 +1,694 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+from pathlib import Path
+import unittest
+
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteMaturitySummary,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseClaim,
+    FieldNoteReuseDisposition,
+    FieldNoteReuseReceipt,
+    FieldNoteUseEvidence,
+    assess_field_note_reuse,
+    summarize_field_note_maturity,
+)
+
+
+AS_OF = "2026-08-03T12:00:00Z"
+
+
+def digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def note_identity(
+    *,
+    field_note_id: str = "fn_a3_candidate",
+    note_sha256: str | None = None,
+    origin_run_id: str = "run_origin",
+    note_path: str = (
+        ".decision-os/field-notes/"
+        "2026-08-03-a3-reuse-core-aaaaaaaaaa.md"
+    ),
+) -> FieldNoteIdentity:
+    return FieldNoteIdentity(
+        note_path=note_path,
+        field_note_id=field_note_id,
+        note_sha256=note_sha256 or digest("exact note bytes"),
+        origin_run_id=origin_run_id,
+    )
+
+
+def use_evidence(
+    *,
+    evidence_class: str = "RULE_TRACE",
+    reusing_run_id: str = "run_reuse",
+    structure_id: str = "restart-state-identity-guard",
+    structure_sha256: str | None = None,
+    evidence_ref: str = "run:run_reuse/rule-trace:guard-1",
+    evidence_sha256: str | None = None,
+) -> FieldNoteUseEvidence:
+    return FieldNoteUseEvidence(
+        evidence_class=evidence_class,  # type: ignore[arg-type]
+        evidence_origin="IMMEDIATE_COMPLETION_RECORD",
+        reusing_run_id=reusing_run_id,
+        structure_id=structure_id,
+        structure_sha256=structure_sha256 or digest("specific structure"),
+        evidence_ref=evidence_ref,
+        evidence_sha256=evidence_sha256 or digest("typed use evidence"),
+        observer_id="observer_a3",
+        observer_relation="INDEPENDENT",
+        as_of=AS_OF,
+    )
+
+
+def outcome_evaluation(
+    outcome: str = "UNKNOWN",
+    *,
+    causal: bool = False,
+    contribution_separated: bool | None = None,
+    observer_relation: str = "INDEPENDENT",
+) -> FieldNoteOutcomeEvaluation:
+    return FieldNoteOutcomeEvaluation(
+        outcome=outcome,  # type: ignore[arg-type]
+        scope="The declared bounded test scope.",
+        observer_id="outcome_observer",
+        observer_relation=observer_relation,  # type: ignore[arg-type]
+        as_of=AS_OF,
+        causal_evidence_ref=(
+            "run:run_reuse/outcome:causal-1" if causal else None
+        ),
+        causal_evidence_sha256=(digest("causal evidence") if causal else None),
+        contribution_separated=(
+            outcome != "UNKNOWN"
+            if contribution_separated is None
+            else contribution_separated
+        ),
+    )
+
+
+def disposition(
+    action: str,
+    *,
+    condition: str | None = None,
+    stop_scope: str | None = None,
+    revision_candidate: FieldNoteIdentity | None = None,
+) -> FieldNoteReuseDisposition:
+    return FieldNoteReuseDisposition(
+        action=action,  # type: ignore[arg-type]
+        reevaluation_condition=condition,
+        stop_scope=stop_scope,
+        revision_candidate=revision_candidate,
+    )
+
+
+def reuse_claim(
+    canonical_note: FieldNoteIdentity,
+    *,
+    claimed_note: FieldNoteIdentity | None = None,
+    reusing_run_id: str = "run_reuse",
+    evidence: FieldNoteUseEvidence | None = None,
+    outcome: FieldNoteOutcomeEvaluation | None = None,
+    intervention: str = "NONE",
+    next_disposition: FieldNoteReuseDisposition | None = None,
+    narrative: str | None = None,
+) -> FieldNoteReuseClaim:
+    return FieldNoteReuseClaim(
+        claimed_note=claimed_note or canonical_note,
+        reusing_run_id=reusing_run_id,
+        use_evidence=evidence,
+        outcome_evaluation=outcome,
+        human_intervention=intervention,  # type: ignore[arg-type]
+        disposition=next_disposition,
+        narrative_claim=narrative,
+    )
+
+
+def reconnect_receipt(
+    canonical_note: FieldNoteIdentity,
+    *,
+    run_id: str = "run_reuse",
+) -> FieldNoteReconnectReceipt:
+    return FieldNoteReconnectReceipt(
+        run_id=run_id,
+        state="ACTIVATION_UNKNOWN",
+        failure_reason=None,
+        metadata_entries_seen=1,
+        metadata_candidate_files_seen=1,
+        metadata_files_valid=1,
+        metadata_bytes_read=700,
+        selected_field_note_path=canonical_note.note_path,
+        selected_field_note_id=canonical_note.field_note_id,
+        selected_metadata_sha256=digest("metadata"),
+        selected_full_note_sha256=canonical_note.note_sha256,
+        full_note_bytes_read=2743,
+        full_notes_injected=1,
+        ordinary_distinct_paths_consumed=1,
+    )
+
+
+class FieldNotesReuseAdmissionTests(unittest.TestCase):
+    def test_injection_alone_cannot_produce_reused(self) -> None:
+        note = note_identity()
+        summary = summarize_field_note_maturity(
+            note,
+            (),
+            (reconnect_receipt(note),),
+        )
+        self.assertEqual("CANDIDATE", summary.state)
+        self.assertEqual(1, summary.reconnect_receipts_ignored)
+
+    def test_free_form_i_used_the_note_cannot_produce_reused(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                narrative="I used the Note and it helped.",
+                evidence=None,
+            ),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("USE_EVIDENCE_MISSING", receipt.failure_reason)
+
+    def test_same_run_as_note_origin_cannot_satisfy_reuse(self) -> None:
+        note = note_identity(origin_run_id="run_same")
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                reusing_run_id="run_same",
+                evidence=use_evidence(reusing_run_id="run_same"),
+            ),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("ORIGIN_RUN_NOT_DIFFERENT", receipt.failure_reason)
+
+    def test_exact_note_identity_is_required(self) -> None:
+        note = note_identity()
+        wrong = note_identity(note_sha256=digest("different exact bytes"))
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                claimed_note=wrong,
+                evidence=use_evidence(),
+            ),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("NOTE_IDENTITY_MISMATCH", receipt.failure_reason)
+
+    def test_whole_note_without_specific_structure_is_insufficient(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(
+                    structure_id="whole Note",
+                    structure_sha256=note.note_sha256,
+                ),
+            ),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertEqual("STRUCTURE_NOT_SPECIFIC", receipt.failure_reason)
+
+    def test_rule_trace_can_establish_reuse(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        self.assertEqual("REUSED", receipt.state)
+        self.assertEqual("RULE_TRACE", receipt.use_evidence.evidence_class)
+
+    def test_output_artifact_can_establish_reuse(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(
+                    evidence_class="OUTPUT_ARTIFACT",
+                    evidence_ref="artifact:decision-1/path:result.md",
+                    evidence_sha256=digest("verified output artifact"),
+                ),
+            ),
+        )
+        self.assertEqual("REUSED", receipt.state)
+        self.assertEqual("OUTPUT_ARTIFACT", receipt.use_evidence.evidence_class)
+
+    def test_later_hindsight_resemblance_cannot_establish_reuse(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=None,
+                narrative="A later report resembles the Note in hindsight.",
+            ),
+        )
+        self.assertEqual("CANDIDATE", receipt.state)
+        self.assertIsNone(receipt.use_evidence)
+
+    def test_use_evidence_rejects_later_narrative_origin(self) -> None:
+        with self.assertRaisesRegex(ValueError, "allowed Run window"):
+            FieldNoteUseEvidence(
+                evidence_class="RULE_TRACE",
+                evidence_origin="LATER_NARRATIVE",  # type: ignore[arg-type]
+                reusing_run_id="run_reuse",
+                structure_id="restart-state-identity-guard",
+                structure_sha256=digest("specific structure"),
+                evidence_ref="later:narrative",
+                evidence_sha256=digest("later narrative"),
+                observer_id="observer",
+                observer_relation="INDEPENDENT",
+                as_of=AS_OF,
+            )
+
+
+class FieldNotesReuseOutcomeTests(unittest.TestCase):
+    def test_reused_can_coexist_with_helpful(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HELPFUL", causal=True),
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        self.assertEqual(("REUSED", "HELPFUL", "KEEP"), (
+            receipt.state,
+            receipt.outcome,
+            receipt.next_action,
+        ))
+
+    def test_reused_can_coexist_with_not_helpful(self) -> None:
+        note = note_identity()
+        revision = note_identity(
+            field_note_id="fn_a3_revision",
+            note_sha256=digest("new candidate bytes"),
+            origin_run_id="run_reuse",
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-03-a3-revision-bbbbbbbbbb.md"
+            ),
+        )
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("NOT_HELPFUL"),
+                next_disposition=disposition(
+                    "REVISE",
+                    revision_candidate=revision,
+                ),
+            ),
+        )
+        self.assertEqual("NOT_HELPFUL", receipt.outcome)
+        self.assertEqual("REVISE", receipt.next_action)
+
+    def test_reused_can_coexist_with_harmful(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HARMFUL", causal=True),
+                next_disposition=disposition(
+                    "STOP",
+                    stop_scope="This exact task family in this repository.",
+                ),
+            ),
+        )
+        self.assertEqual("HARMFUL", receipt.outcome)
+        self.assertEqual("STOP", receipt.next_action)
+
+    def test_reused_can_coexist_with_unknown(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        self.assertEqual("UNKNOWN", receipt.outcome)
+        self.assertEqual("HOLD", receipt.next_action)
+
+    def test_helpful_without_causal_evidence_fails_closed(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HELPFUL", causal=False),
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        self.assertEqual("HELPFUL", receipt.claimed_outcome)
+        self.assertEqual("UNKNOWN", receipt.outcome)
+        self.assertEqual("HOLD", receipt.next_action)
+
+    def test_harmful_without_causal_evidence_becomes_unknown(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HARMFUL", causal=False),
+                next_disposition=disposition(
+                    "STOP",
+                    stop_scope="This exact task family.",
+                ),
+            ),
+        )
+        self.assertEqual("HARMFUL", receipt.claimed_outcome)
+        self.assertEqual("UNKNOWN", receipt.outcome)
+        self.assertEqual("HOLD", receipt.next_action)
+
+    def test_material_and_unknown_human_intervention_are_retained(self) -> None:
+        note = note_identity()
+        for intervention in ("MATERIAL", "UNKNOWN"):
+            with self.subTest(intervention=intervention):
+                receipt = assess_field_note_reuse(
+                    note,
+                    reuse_claim(
+                        note,
+                        evidence=use_evidence(),
+                        outcome=outcome_evaluation("UNKNOWN"),
+                        intervention=intervention,
+                    ),
+                )
+                self.assertEqual(intervention, receipt.human_intervention)
+
+    def test_unseparated_material_intervention_forces_unknown(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation(
+                    "HELPFUL",
+                    causal=True,
+                    contribution_separated=False,
+                ),
+                intervention="MATERIAL",
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        self.assertEqual("UNKNOWN", receipt.outcome)
+        self.assertEqual("HOLD", receipt.next_action)
+        self.assertIn("human intervention", receipt.reevaluation_condition)
+
+    def test_separated_material_intervention_can_preserve_causal_outcome(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation(
+                    "HELPFUL",
+                    causal=True,
+                    contribution_separated=True,
+                ),
+                intervention="MATERIAL",
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        self.assertEqual("HELPFUL", receipt.outcome)
+        self.assertEqual("MATERIAL", receipt.human_intervention)
+
+    def test_unseparated_other_causes_force_unknown(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation(
+                    "NOT_HELPFUL",
+                    contribution_separated=False,
+                ),
+                next_disposition=disposition("STOP", stop_scope="Task alpha."),
+            ),
+        )
+        self.assertEqual("UNKNOWN", receipt.outcome)
+        self.assertEqual("HOLD", receipt.next_action)
+        self.assertIn("other Notes and causes", receipt.reevaluation_condition)
+
+    def test_same_run_outcome_observer_is_not_independent_confirmation(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation(
+                    "HELPFUL",
+                    causal=True,
+                    observer_relation="REUSING_RUN_SELF",
+                ),
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        self.assertEqual("SAME_RUN_CLAIM", receipt.outcome_confirmation)
+
+
+class FieldNotesReuseDispositionTests(unittest.TestCase):
+    def test_unknown_requires_hold(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("UNKNOWN"),
+                next_disposition=disposition("KEEP"),
+            ),
+        )
+        self.assertEqual("HOLD", receipt.next_action)
+
+    def test_hold_requires_a_reevaluation_condition(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        self.assertTrue(receipt.reevaluation_condition)
+        with self.assertRaisesRegex(ValueError, "re-evaluation condition"):
+            replace(receipt, reevaluation_condition=None)
+
+    def test_stop_requires_explicit_bounded_scope(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HARMFUL", causal=True),
+                next_disposition=disposition(
+                    "STOP",
+                    stop_scope="Only task family alpha in repository current.",
+                ),
+            ),
+        )
+        self.assertEqual("STOP", receipt.next_action)
+        self.assertEqual(
+            "Only task family alpha in repository current.",
+            receipt.stop_scope,
+        )
+
+    def test_stop_without_scope_fails_closed_to_hold(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("HARMFUL", causal=True),
+                next_disposition=disposition("STOP"),
+            ),
+        )
+        self.assertEqual("HOLD", receipt.next_action)
+        self.assertIsNone(receipt.stop_scope)
+        self.assertIn("STOP scope", receipt.reevaluation_condition)
+
+    def test_revise_links_forward_without_mutating_predecessor(self) -> None:
+        note = note_identity()
+        before = note.as_dict()
+        successor = note_identity(
+            field_note_id="fn_a3_successor",
+            note_sha256=digest("successor bytes"),
+            origin_run_id="run_reuse",
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-03-a3-successor-cccccccccc.md"
+            ),
+        )
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(
+                note,
+                evidence=use_evidence(),
+                outcome=outcome_evaluation("NOT_HELPFUL"),
+                next_disposition=disposition(
+                    "REVISE",
+                    revision_candidate=successor,
+                ),
+            ),
+        )
+        self.assertEqual(before, note.as_dict())
+        self.assertEqual(note, receipt.revision.predecessor)
+        self.assertEqual(successor, receipt.revision.successor)
+
+    def test_global_stop_is_not_an_ordinary_action(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported"):
+            FieldNoteReuseDisposition(
+                action="GLOBAL_STOP",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_outcome_action_mapping_is_rejected(self) -> None:
+        note = note_identity()
+        with self.assertRaisesRegex(ValueError, "invalid for the reuse outcome"):
+            assess_field_note_reuse(
+                note,
+                reuse_claim(
+                    note,
+                    evidence=use_evidence(),
+                    outcome=outcome_evaluation("HELPFUL", causal=True),
+                    next_disposition=disposition(
+                        "STOP",
+                        stop_scope="A bounded scope.",
+                    ),
+                ),
+            )
+
+
+class FieldNotesReusePromotionBoundaryTests(unittest.TestCase):
+    def test_no_automatic_promotable_transition_exists(self) -> None:
+        note = note_identity()
+        receipts = []
+        for index in range(5):
+            run_id = f"run_reuse_{index}"
+            receipt = assess_field_note_reuse(
+                note,
+                reuse_claim(
+                    note,
+                    reusing_run_id=run_id,
+                    evidence=use_evidence(
+                        reusing_run_id=run_id,
+                        evidence_ref=f"run:{run_id}/rule-trace:guard",
+                        evidence_sha256=digest(f"evidence {index}"),
+                    ),
+                ),
+            )
+            receipts.append(receipt)
+        summary = summarize_field_note_maturity(note, receipts)
+        self.assertEqual("REUSED", summary.state)
+        self.assertEqual("UNSET", summary.promotion.policy_status)
+        self.assertIsNone(summary.promotion.threshold)
+        self.assertFalse(summary.promotion.automatically_derivable)
+
+    def test_duplicate_evidence_and_repeated_injection_do_not_raise_maturity(
+        self,
+    ) -> None:
+        note = note_identity()
+        claim = reuse_claim(note, evidence=use_evidence())
+        first = assess_field_note_reuse(note, claim)
+        duplicate = assess_field_note_reuse(note, claim)
+        summary = summarize_field_note_maturity(
+            note,
+            (first, duplicate),
+            (reconnect_receipt(note), reconnect_receipt(note, run_id="run_2")),
+        )
+        self.assertEqual("REUSED", summary.state)
+        self.assertEqual(1, len(summary.reuse_event_ids))
+        self.assertEqual(1, summary.duplicate_reuse_records_ignored)
+        self.assertEqual(2, summary.reconnect_receipts_ignored)
+        self.assertEqual("UNSET", summary.promotion.policy_status)
+
+    def test_receipt_serialization_preserves_promotion_boundary(self) -> None:
+        note = note_identity()
+        receipt = assess_field_note_reuse(
+            note,
+            reuse_claim(note, evidence=use_evidence()),
+        )
+        projection = receipt.as_dict()
+        self.assertEqual(
+            {
+                "reserved_state": "PROMOTABLE",
+                "policy_status": "UNSET",
+                "threshold": None,
+                "automatically_derivable": False,
+            },
+            projection["promotion"],
+        )
+
+    def test_summary_rejects_cross_note_receipts(self) -> None:
+        note = note_identity()
+        other = note_identity(
+            field_note_id="fn_other",
+            note_sha256=digest("other note"),
+        )
+        receipt = assess_field_note_reuse(
+            other,
+            reuse_claim(other, evidence=use_evidence()),
+        )
+        with self.assertRaisesRegex(ValueError, "different Field Note"):
+            summarize_field_note_maturity(note, (receipt,))
+
+
+class FieldNotesReuseProtectedArtifactTests(unittest.TestCase):
+    def test_local_protected_artifacts_match_fixed_identities(self) -> None:
+        repository = Path(__file__).resolve().parents[1]
+        expected = {
+            Path(
+                ".decision-os/field-notes/"
+                "2026-08-03-topmost-canonical-state-restart-guard-"
+                "lcmwhjvkpf.md"
+            ): (
+                2743,
+                "3c2e45460f21a2346a8d100ebfefc6ed079994e687a70911e5f4a8954cf2d05d",
+            ),
+            Path("validation/companion_live_task_001.md"): (
+                779,
+                "e28815932e0a3baf34bc0c6b0e2f9a03130e10260765367458a53116502845cf",
+            ),
+            Path("validation/companion_manual_live_run_probe_v0_1.md"): (
+                539,
+                "f68b3a1f47136782cbb5ade4c4686724c2b877eaaffe52bdb81aa72ae19c6344",
+            ),
+            Path("validation/companion_medium_live_task_001.md"): (
+                4632,
+                "a096b2455d7d57d24f3dd0a2b1e5b7c26a782e6870f2e076cdebdf7348a5a411",
+            ),
+            Path("validation/companion_medium_live_task_002.md"): (
+                4139,
+                "0f2203beddb5469dfe00deeae392277cd0634aa5b0713296efb2a754a59b8bba",
+            ),
+        }
+        missing = [path for path in expected if not (repository / path).exists()]
+        if missing:
+            self.skipTest("Protected creator artifacts are local-only.")
+        for relative, (size, sha256) in expected.items():
+            with self.subTest(path=relative.as_posix()):
+                data = (repository / relative).read_bytes()
+                self.assertEqual(size, len(data))
+                self.assertEqual(sha256, hashlib.sha256(data).hexdigest())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- add a pure, typed A3 Reuse Core for exact Field Note identity, later-Run use evidence, outcome, human intervention, bounded next action, revision links, and maturity summaries
- enforce exact Note-to-structure binding with a deterministic UTF-8 byte-range anchor containing the exact Note identity, full Note size, byte offsets, structure digest, and canonical binding digest
- reverify the complete Note SHA-256 and bound structure bytes at reuse assessment time; missing bytes, arbitrary hashes, another Note, changed identity, generic whole-Note labels, and full-Note ranges fail closed
- separate historical Evidence Maturity from Current Serving Policy through a read-only A3 projection
- keep Serving Policy fixed at `DELAY`, with automatic derivation/injection unavailable, its complete state machine unimplemented, and topmost canonical authority ahead of advisory Field Notes
- reserve `PROMOTABLE` with an explicit `UNSET` policy and no automatic transition
- cover the bounded contract with 45 focused tests

## Why

A3 needs a fail-closed distinction between a saved `CANDIDATE` and demonstrable later-Run `REUSED` evidence. A specific structure must be provably part of the exact Note, and historical reuse evidence must not imply that the Note should always be served now.

## Repair closure

### Exact Note-to-structure binding

The binding is a bounded contiguous UTF-8 byte range verified against the complete exact Note bytes. It is sidecar/ledger compatible and requires no semantic matching engine or mutation of Note bytes.

### Evidence Maturity / Serving Policy separation

The serialized A3 projection has independent `evidence_maturity` and `current_serving_policy` axes. Reuse-result dispositions (`KEEP / REVISE / HOLD / STOP`) remain receipt outcomes and are not serving states. Serving Policy remains `DELAY`; possible future evidence invalidation, serving reduction, supersession, staleness, contradiction, harm, or successor compression require later Forward-only records and are not implemented here.

## Claim boundary

This implementation establishes only a typed and tested mechanism that can classify a bounded record as `CANDIDATE` or `REUSED` when exact-Note structure binding and typed later-Run evidence are supplied.

It generates no real maturity evidence and does not retrospectively classify the creator A2 proof as `REUSED`. It does not claim default or mandatory injection, helpfulness, activation, promotion, canonicity, generalization, improved performance, successful intelligence transplant, lower-model equivalence, or any `PROMOTABLE` or serving threshold.

## Scope

Changed files only:

- `decision_os/companion/field_notes_reuse.py`
- `tests/test_field_notes_reuse.py`

No A1, A2, controller, server, UI, runtime, existing Note, or validation artifact was modified. No runtime install, Companion restart, live Run, release, automatic serving downgrade, GLOBAL_STOP action, or merge occurred.

## Verification

- `python3 -m unittest tests.test_field_notes_reuse` — 45/45 PASS
- `python3 -m unittest tests.test_field_notes_lite` — 25/25 PASS
- `python3 -m unittest tests.test_field_notes_reconnect` — 36/36 PASS
- `python3 -m unittest tests.test_companion_controller` — 27/27 PASS
- `python3 -m unittest tests.test_companion_server` — 35/35 PASS
- `python3 -m unittest` — 803/803 PASS
- `python3 -m unittest discover -s tests -p 'test_*.py'` — 803/803 PASS
- normalized default/explicit suite identities — MATCH (803 IDs; no differences)
- `git diff --check` — PASS

Base identity: `00b08949ab046388e97ba14e81fa243b76b680df`

Prior reviewed head: `234fe2ae424d702691d10a6a4256f1d45374d993`

Repair head: `cf27bd6802b9160904192db9b4dc2465527832a0`

The protected creator Note remains SHA-256 `3c2e45460f21a2346a8d100ebfefc6ed079994e687a70911e5f4a8954cf2d05d`; its size, mode, mtime, and inode and those of all four protected validation artifacts match preflight.