### PR TITLE
Add Field Notes A4 durable maturity ledger

### DIFF
--- a/decision_os/companion/field_notes_maturity_ledger.py
+++ b/decision_os/companion/field_notes_maturity_ledger.py
@@ -1,0 +1,989 @@
+"""Durable, append-only Field Notes Lite A4 maturity evidence ledger."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import threading
+from typing import Any, Iterator, Mapping
+
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteMaturitySummary,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseReceipt,
+    FieldNoteRevisionLink,
+    FieldNoteServingPolicyBoundary,
+    FieldNoteStructureBinding,
+    FieldNoteUseEvidence,
+    PromotionPolicyBoundary,
+    project_field_note_a3_status,
+    summarize_field_note_maturity,
+)
+
+
+LEDGER_EVENT_SCHEMA = "decision-os.field-note-maturity-ledger-event.v0.1"
+LEDGER_HEAD_SCHEMA = "decision-os.field-note-maturity-ledger-head.v0.1"
+LEDGER_EVENT_KIND = "A3_REUSE"
+GENESIS_EVENT_SHA256 = "0" * 64
+MAX_LEDGER_BYTES = 8 * 1024 * 1024
+MAX_EVENT_BYTES = 128 * 1024
+MAX_HEAD_BYTES = 4 * 1024
+MAX_EVENTS = 4096
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_EVENT_KEYS = frozenset(
+    {
+        "event_id",
+        "event_kind",
+        "event_sha256",
+        "note_partition_sha256",
+        "previous_event_sha256",
+        "receipt",
+        "receipt_sha256",
+        "recorded_at",
+        "schema",
+        "sequence",
+    }
+)
+_HEAD_KEYS = frozenset(
+    {
+        "event_chain_head",
+        "event_count",
+        "head_sha256",
+        "note_partition_sha256",
+        "schema",
+    }
+)
+_IDENTITY_KEYS = frozenset(
+    {"note_path", "field_note_id", "note_sha256", "origin_run_id"}
+)
+_BINDING_KEYS = frozenset(
+    {
+        "binding_sha256",
+        "end_byte",
+        "note",
+        "note_size",
+        "start_byte",
+        "structure_id",
+        "structure_sha256",
+    }
+)
+_USE_EVIDENCE_KEYS = frozenset(
+    {
+        "as_of",
+        "evidence_class",
+        "evidence_origin",
+        "evidence_ref",
+        "evidence_sha256",
+        "observer_id",
+        "observer_relation",
+        "reusing_run_id",
+        "structure_binding",
+    }
+)
+_RECEIPT_KEYS = frozenset(
+    {
+        "causal_evidence_ref",
+        "causal_evidence_sha256",
+        "claimed_outcome",
+        "contribution_separated",
+        "failure_reason",
+        "human_intervention",
+        "next_action",
+        "note",
+        "outcome",
+        "outcome_as_of",
+        "outcome_confirmation",
+        "outcome_observer_id",
+        "outcome_observer_relation",
+        "outcome_scope",
+        "promotion",
+        "reevaluation_condition",
+        "reusing_run_id",
+        "reuse_event_id",
+        "revision",
+        "state",
+        "stop_scope",
+        "use_evidence",
+    }
+)
+
+
+class FieldNoteMaturityLedgerError(RuntimeError):
+    """Base A4 ledger error."""
+
+
+class FieldNoteMaturityLedgerValidationError(FieldNoteMaturityLedgerError):
+    """Input is not a validated A3 reuse event for this Note partition."""
+
+
+class FieldNoteMaturityLedgerIntegrityError(FieldNoteMaturityLedgerError):
+    """Durable ledger bytes fail the bounded integrity contract."""
+
+
+def _canonical_bytes(value: Mapping[str, Any]) -> bytes:
+    return canonical_json(value).encode("utf-8")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _require_sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise FieldNoteMaturityLedgerIntegrityError(f"Invalid {label}.")
+    return value
+
+
+def _require_mapping(
+    value: Any,
+    keys: frozenset[str],
+    label: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise FieldNoteMaturityLedgerIntegrityError(f"Malformed {label}.")
+    return value
+
+
+def _integrity_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Duplicate JSON member in maturity ledger."
+            )
+        result[key] = value
+    return result
+
+
+def _validate_timestamp(value: Any) -> str:
+    if not isinstance(value, str) or not value or len(value) > 64:
+        raise FieldNoteMaturityLedgerValidationError(
+            "Ledger recorded_at is invalid."
+        )
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise FieldNoteMaturityLedgerValidationError(
+            "Ledger recorded_at is invalid."
+        ) from exc
+    if parsed.tzinfo is None:
+        raise FieldNoteMaturityLedgerValidationError(
+            "Ledger recorded_at is invalid."
+        )
+    return value
+
+
+def _identity_from_dict(value: Any) -> FieldNoteIdentity:
+    data = _require_mapping(value, _IDENTITY_KEYS, "Field Note identity")
+    try:
+        return FieldNoteIdentity(
+            note_path=data["note_path"],
+            field_note_id=data["field_note_id"],
+            note_sha256=data["note_sha256"],
+            origin_run_id=data["origin_run_id"],
+        )
+    except (TypeError, ValueError) as exc:
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "Malformed Field Note identity."
+        ) from exc
+
+
+def _binding_from_dict(value: Any) -> FieldNoteStructureBinding:
+    data = _require_mapping(value, _BINDING_KEYS, "structure binding")
+    stored_binding_sha256 = _require_sha256(
+        data["binding_sha256"],
+        "structure binding digest",
+    )
+    try:
+        binding = FieldNoteStructureBinding(
+            note=_identity_from_dict(data["note"]),
+            structure_id=data["structure_id"],
+            note_size=data["note_size"],
+            start_byte=data["start_byte"],
+            end_byte=data["end_byte"],
+            structure_sha256=data["structure_sha256"],
+        )
+    except (TypeError, ValueError) as exc:
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "Malformed structure binding."
+        ) from exc
+    if binding.binding_sha256 != stored_binding_sha256:
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "Structure binding identity mismatch."
+        )
+    return binding
+
+
+def _use_evidence_from_dict(value: Any) -> FieldNoteUseEvidence:
+    data = _require_mapping(value, _USE_EVIDENCE_KEYS, "use evidence")
+    try:
+        return FieldNoteUseEvidence(
+            evidence_class=data["evidence_class"],
+            evidence_origin=data["evidence_origin"],
+            reusing_run_id=data["reusing_run_id"],
+            structure_binding=_binding_from_dict(data["structure_binding"]),
+            evidence_ref=data["evidence_ref"],
+            evidence_sha256=data["evidence_sha256"],
+            observer_id=data["observer_id"],
+            observer_relation=data["observer_relation"],
+            as_of=data["as_of"],
+        )
+    except (TypeError, ValueError) as exc:
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "Malformed use evidence."
+        ) from exc
+
+
+def _revision_from_dict(value: Any) -> FieldNoteRevisionLink:
+    data = _require_mapping(
+        value,
+        frozenset({"predecessor", "successor"}),
+        "revision link",
+    )
+    try:
+        return FieldNoteRevisionLink(
+            predecessor=_identity_from_dict(data["predecessor"]),
+            successor=_identity_from_dict(data["successor"]),
+        )
+    except (TypeError, ValueError) as exc:
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "Malformed revision link."
+        ) from exc
+
+
+def _receipt_from_dict(value: Any) -> FieldNoteReuseReceipt:
+    data = _require_mapping(value, _RECEIPT_KEYS, "A3 reuse receipt")
+    if data["promotion"] != PromotionPolicyBoundary().as_dict():
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "PROMOTABLE policy boundary is invalid."
+        )
+    use_evidence = (
+        _use_evidence_from_dict(data["use_evidence"])
+        if data["use_evidence"] is not None
+        else None
+    )
+    revision = (
+        _revision_from_dict(data["revision"])
+        if data["revision"] is not None
+        else None
+    )
+    try:
+        return FieldNoteReuseReceipt(
+            note=_identity_from_dict(data["note"]),
+            reusing_run_id=data["reusing_run_id"],
+            state=data["state"],
+            failure_reason=data["failure_reason"],
+            use_evidence=use_evidence,
+            claimed_outcome=data["claimed_outcome"],
+            outcome=data["outcome"],
+            outcome_confirmation=data["outcome_confirmation"],
+            outcome_observer_id=data["outcome_observer_id"],
+            outcome_observer_relation=data["outcome_observer_relation"],
+            outcome_as_of=data["outcome_as_of"],
+            outcome_scope=data["outcome_scope"],
+            causal_evidence_ref=data["causal_evidence_ref"],
+            causal_evidence_sha256=data["causal_evidence_sha256"],
+            contribution_separated=data["contribution_separated"],
+            human_intervention=data["human_intervention"],
+            next_action=data["next_action"],
+            reevaluation_condition=data["reevaluation_condition"],
+            stop_scope=data["stop_scope"],
+            revision=revision,
+            reuse_event_id=data["reuse_event_id"],
+        )
+    except (TypeError, ValueError) as exc:
+        raise FieldNoteMaturityLedgerIntegrityError(
+            "Malformed A3 reuse receipt."
+        ) from exc
+
+
+def _expected_reuse_event_id(receipt: FieldNoteReuseReceipt) -> str:
+    if receipt.use_evidence is None:
+        return ""
+    payload = {
+        "note": receipt.note.as_dict(),
+        "reusing_run_id": receipt.reusing_run_id,
+        "use_evidence": receipt.use_evidence.as_dict(),
+    }
+    return _sha256_bytes(_canonical_bytes(payload))
+
+
+def _validate_reused_receipt(
+    receipt: Any,
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+) -> None:
+    if not isinstance(receipt, FieldNoteReuseReceipt):
+        raise FieldNoteMaturityLedgerValidationError(
+            "Only typed A3 reuse receipts may enter the maturity ledger."
+        )
+    if (
+        receipt.state != "REUSED"
+        or receipt.failure_reason is not None
+        or receipt.note != note
+        or receipt.reusing_run_id == note.origin_run_id
+        or receipt.use_evidence is None
+        or receipt.use_evidence.reusing_run_id != receipt.reusing_run_id
+        or receipt.reuse_event_id != _expected_reuse_event_id(receipt)
+        or receipt.promotion != PromotionPolicyBoundary()
+        or not receipt.use_evidence.structure_binding.verifies(note, note_bytes)
+    ):
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 reuse receipt is not valid for this exact Note partition."
+        )
+    try:
+        evaluation = FieldNoteOutcomeEvaluation(
+            outcome=receipt.claimed_outcome,
+            scope=receipt.outcome_scope,
+            observer_id=receipt.outcome_observer_id,
+            observer_relation=receipt.outcome_observer_relation,
+            as_of=receipt.outcome_as_of,
+            causal_evidence_ref=receipt.causal_evidence_ref,
+            causal_evidence_sha256=receipt.causal_evidence_sha256,
+            contribution_separated=receipt.contribution_separated,
+        )
+    except (TypeError, ValueError) as exc:
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 outcome evidence is malformed."
+        ) from exc
+    if receipt.outcome_confirmation != evaluation.confirmation:
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 outcome confirmation is inconsistent."
+        )
+    intervention = receipt.human_intervention
+    if intervention not in {"NONE", "NON_DECISIVE", "MATERIAL", "UNKNOWN"}:
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 human-intervention evidence is malformed."
+        )
+    expected_outcome = evaluation.outcome
+    if (
+        intervention in {"MATERIAL", "UNKNOWN"}
+        and not evaluation.contribution_separated
+    ) or (
+        evaluation.outcome != "UNKNOWN"
+        and not evaluation.contribution_separated
+    ) or (
+        evaluation.outcome in {"HELPFUL", "HARMFUL"}
+        and not evaluation.has_causal_evidence
+    ):
+        expected_outcome = "UNKNOWN"
+    if receipt.outcome != expected_outcome:
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 claimed and effective outcomes are inconsistent."
+        )
+    action = receipt.next_action
+    if receipt.outcome == "UNKNOWN":
+        allowed_actions = {"HOLD"}
+    elif receipt.outcome == "HELPFUL":
+        allowed_actions = {"KEEP", "REVISE"}
+    else:
+        allowed_actions = {"REVISE", "STOP", "HOLD"}
+    if action not in allowed_actions:
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 reuse disposition is inconsistent with its outcome."
+        )
+    if action == "HOLD":
+        if (
+            not isinstance(receipt.reevaluation_condition, str)
+            or not receipt.reevaluation_condition.strip()
+            or receipt.stop_scope is not None
+            or receipt.revision is not None
+        ):
+            raise FieldNoteMaturityLedgerValidationError(
+                "A3 HOLD disposition is malformed."
+            )
+    elif action == "STOP":
+        if (
+            not isinstance(receipt.stop_scope, str)
+            or not receipt.stop_scope.strip()
+            or receipt.reevaluation_condition is not None
+            or receipt.revision is not None
+        ):
+            raise FieldNoteMaturityLedgerValidationError(
+                "A3 STOP disposition is malformed."
+            )
+    elif action == "REVISE":
+        revision = receipt.revision
+        if (
+            revision is None
+            or revision.predecessor != note
+            or revision.successor.origin_run_id != receipt.reusing_run_id
+            or receipt.reevaluation_condition is not None
+            or receipt.stop_scope is not None
+        ):
+            raise FieldNoteMaturityLedgerValidationError(
+                "A3 REVISE disposition is malformed."
+            )
+    elif (
+        receipt.reevaluation_condition is not None
+        or receipt.stop_scope is not None
+        or receipt.revision is not None
+    ):
+        raise FieldNoteMaturityLedgerValidationError(
+            "A3 KEEP disposition is malformed."
+        )
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityLedgerEvent:
+    sequence: int
+    recorded_at: str
+    note_partition_sha256: str
+    previous_event_sha256: str
+    event_id: str
+    receipt: FieldNoteReuseReceipt
+    receipt_sha256: str
+    event_sha256: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": LEDGER_EVENT_SCHEMA,
+            "event_kind": LEDGER_EVENT_KIND,
+            "sequence": self.sequence,
+            "recorded_at": self.recorded_at,
+            "note_partition_sha256": self.note_partition_sha256,
+            "previous_event_sha256": self.previous_event_sha256,
+            "event_id": self.event_id,
+            "receipt": self.receipt.as_dict(),
+            "receipt_sha256": self.receipt_sha256,
+            "event_sha256": self.event_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityAppendResult:
+    appended: bool
+    event: FieldNoteMaturityLedgerEvent
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityLedgerSnapshot:
+    note: FieldNoteIdentity
+    events: tuple[FieldNoteMaturityLedgerEvent, ...]
+    evidence_maturity: FieldNoteMaturitySummary
+    current_serving_policy: FieldNoteServingPolicyBoundary
+    chain_head_sha256: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "note": self.note.as_dict(),
+            "events": [event.as_dict() for event in self.events],
+            "evidence_maturity": self.evidence_maturity.as_dict(),
+            "current_serving_policy": self.current_serving_policy.as_dict(),
+            "chain_head_sha256": self.chain_head_sha256,
+        }
+
+
+class FieldNoteMaturityLedger:
+    """One exact-Note append-only JSONL partition below a caller-owned root."""
+
+    def __init__(self, root: Path, note: FieldNoteIdentity) -> None:
+        if not isinstance(note, FieldNoteIdentity):
+            raise FieldNoteMaturityLedgerValidationError(
+                "Maturity ledger requires an exact Field Note identity."
+            )
+        self.root = Path(root)
+        self.note = note
+        self.note_partition_sha256 = _sha256_bytes(
+            _canonical_bytes(note.as_dict())
+        )
+        self.events_path = self.root / f"{self.note_partition_sha256}.jsonl"
+        self.head_path = self.root / f"{self.note_partition_sha256}.head.json"
+        self.lock_path = self.root / ".maturity-ledger.lock"
+        self._thread_lock = threading.RLock()
+
+    def _assert_root(self) -> None:
+        if self.root.is_symlink() or not self.root.is_dir():
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger root is unsafe."
+            )
+
+    def _ensure_root(self) -> None:
+        if self.root.is_symlink():
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger root is unsafe."
+            )
+        try:
+            self.root.mkdir(mode=0o700, parents=True, exist_ok=True)
+            os.chmod(self.root, 0o700)
+        except OSError as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger root cannot be created safely."
+            ) from exc
+        self._assert_root()
+
+    @staticmethod
+    def _assert_private_file(path: Path) -> None:
+        if path.is_symlink():
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger file is unsafe."
+            )
+        try:
+            mode = path.stat().st_mode
+        except OSError as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger file cannot be inspected."
+            ) from exc
+        if not stat.S_ISREG(mode) or stat.S_IMODE(mode) & 0o077:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger file is unsafe."
+            )
+
+    @contextmanager
+    def _locked(self, *, write: bool) -> Iterator[bool]:
+        with self._thread_lock:
+            if write:
+                self._ensure_root()
+            elif not os.path.lexists(self.root):
+                yield False
+                return
+            else:
+                self._assert_root()
+            if not write and not self.lock_path.exists():
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger lock boundary is missing."
+                )
+            if self.lock_path.is_symlink():
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger lock boundary is unsafe."
+                )
+            flags = os.O_RDWR | os.O_CREAT if write else os.O_RDONLY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            try:
+                descriptor = os.open(self.lock_path, flags, 0o600)
+                if write:
+                    os.fchmod(descriptor, 0o600)
+                lock_mode = fcntl.LOCK_EX if write else fcntl.LOCK_SH
+                fcntl.flock(descriptor, lock_mode)
+                self._assert_private_file(self.lock_path)
+            except (OSError, FieldNoteMaturityLedgerIntegrityError) as exc:
+                if "descriptor" in locals():
+                    os.close(descriptor)
+                if isinstance(exc, FieldNoteMaturityLedgerIntegrityError):
+                    raise
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger lock boundary failed."
+                ) from exc
+            try:
+                yield True
+            finally:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+                finally:
+                    os.close(descriptor)
+
+    def _event_from_dict(
+        self,
+        value: Any,
+        *,
+        expected_sequence: int,
+        expected_previous: str,
+        note_bytes: bytes,
+    ) -> FieldNoteMaturityLedgerEvent:
+        data = _require_mapping(value, _EVENT_KEYS, "maturity event")
+        if data["schema"] != LEDGER_EVENT_SCHEMA:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Unsupported maturity ledger event version."
+            )
+        if data["event_kind"] != LEDGER_EVENT_KIND:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Unsupported maturity ledger event kind."
+            )
+        if (
+            type(data["sequence"]) is not int
+            or data["sequence"] != expected_sequence
+        ):
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger sequence is invalid."
+            )
+        try:
+            recorded_at = _validate_timestamp(data["recorded_at"])
+        except FieldNoteMaturityLedgerValidationError as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger recorded_at is invalid."
+            ) from exc
+        partition = _require_sha256(
+            data["note_partition_sha256"],
+            "Note partition digest",
+        )
+        previous = _require_sha256(
+            data["previous_event_sha256"],
+            "previous-event digest",
+        )
+        event_id = _require_sha256(data["event_id"], "reuse event identity")
+        receipt_sha256 = _require_sha256(
+            data["receipt_sha256"],
+            "receipt digest",
+        )
+        event_sha256 = _require_sha256(
+            data["event_sha256"],
+            "event digest",
+        )
+        if partition != self.note_partition_sha256 or previous != expected_previous:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger identity chain is invalid."
+            )
+        receipt = _receipt_from_dict(data["receipt"])
+        if receipt_sha256 != _sha256_bytes(_canonical_bytes(receipt.as_dict())):
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "A3 receipt payload was mutated."
+            )
+        try:
+            _validate_reused_receipt(receipt, self.note, note_bytes)
+        except FieldNoteMaturityLedgerValidationError as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Stored A3 receipt is invalid."
+            ) from exc
+        if event_id != receipt.reuse_event_id:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Reuse event identity mismatch."
+            )
+        body = {key: item for key, item in data.items() if key != "event_sha256"}
+        if event_sha256 != _sha256_bytes(_canonical_bytes(body)):
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity event payload was mutated."
+            )
+        return FieldNoteMaturityLedgerEvent(
+            sequence=expected_sequence,
+            recorded_at=recorded_at,
+            note_partition_sha256=partition,
+            previous_event_sha256=previous,
+            event_id=event_id,
+            receipt=receipt,
+            receipt_sha256=receipt_sha256,
+            event_sha256=event_sha256,
+        )
+
+    def _read_head_unlocked(self) -> tuple[int, str]:
+        if not os.path.lexists(self.head_path):
+            if os.path.lexists(self.events_path):
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger head anchor is missing."
+                )
+            return 0, GENESIS_EVENT_SHA256
+        self._assert_private_file(self.head_path)
+        try:
+            if self.head_path.stat().st_size > MAX_HEAD_BYTES:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger head anchor is oversized."
+                )
+            raw = self.head_path.read_bytes()
+            parsed = json.loads(raw, object_pairs_hook=_integrity_object)
+        except FieldNoteMaturityLedgerIntegrityError:
+            raise
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger head anchor is malformed."
+            ) from exc
+        data = _require_mapping(parsed, _HEAD_KEYS, "maturity ledger head")
+        if _canonical_bytes(data) != raw or data["schema"] != LEDGER_HEAD_SCHEMA:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger head anchor is malformed."
+            )
+        event_count = data["event_count"]
+        if (
+            type(event_count) is not int
+            or event_count < 0
+            or event_count > MAX_EVENTS
+        ):
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger head count is invalid."
+            )
+        partition = _require_sha256(
+            data["note_partition_sha256"],
+            "head Note partition digest",
+        )
+        event_chain_head = _require_sha256(
+            data["event_chain_head"],
+            "head event-chain digest",
+        )
+        head_sha256 = _require_sha256(data["head_sha256"], "head digest")
+        body = {key: item for key, item in data.items() if key != "head_sha256"}
+        if (
+            partition != self.note_partition_sha256
+            or head_sha256 != _sha256_bytes(_canonical_bytes(body))
+            or (event_count == 0) != (event_chain_head == GENESIS_EVENT_SHA256)
+        ):
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger head anchor is invalid."
+            )
+        return event_count, event_chain_head
+
+    def _write_head_unlocked(self, event_count: int, event_chain_head: str) -> None:
+        body = {
+            "schema": LEDGER_HEAD_SCHEMA,
+            "note_partition_sha256": self.note_partition_sha256,
+            "event_count": event_count,
+            "event_chain_head": event_chain_head,
+        }
+        payload = _canonical_bytes(
+            {
+                **body,
+                "head_sha256": _sha256_bytes(_canonical_bytes(body)),
+            }
+        )
+        if os.path.lexists(self.head_path):
+            self._assert_private_file(self.head_path)
+        temporary = self.root / (
+            f".{self.note_partition_sha256}.{os.getpid()}."
+            f"{threading.get_ident()}.tmp"
+        )
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(temporary, flags, 0o600)
+            view = memoryview(payload)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short maturity ledger head write")
+                view = view[written:]
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = None
+            os.replace(temporary, self.head_path)
+            parent = os.open(self.root, os.O_RDONLY)
+            try:
+                os.fsync(parent)
+            finally:
+                os.close(parent)
+        except OSError as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger head anchor cannot be published."
+            ) from exc
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+    def _read_events_unlocked(
+        self,
+        note_bytes: bytes,
+    ) -> tuple[FieldNoteMaturityLedgerEvent, ...]:
+        anchored_count, anchored_head = self._read_head_unlocked()
+        if not os.path.lexists(self.events_path):
+            if anchored_count != 0:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger event history is missing."
+                )
+            return ()
+        self._assert_private_file(self.events_path)
+        try:
+            raw = self.events_path.read_bytes()
+        except OSError as exc:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger cannot be read."
+            ) from exc
+        if (
+            not raw
+            or len(raw) > MAX_LEDGER_BYTES
+            or not raw.endswith(b"\n")
+        ):
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger is oversized or truncated."
+            )
+        lines = raw.splitlines()
+        if len(lines) > MAX_EVENTS:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger event bound was exceeded."
+            )
+        events: list[FieldNoteMaturityLedgerEvent] = []
+        previous = GENESIS_EVENT_SHA256
+        seen_event_ids: set[str] = set()
+        for sequence, line in enumerate(lines):
+            if not line or len(line) > MAX_EVENT_BYTES:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger event is malformed or oversized."
+                )
+            try:
+                parsed = json.loads(
+                    line,
+                    object_pairs_hook=_integrity_object,
+                )
+            except FieldNoteMaturityLedgerIntegrityError:
+                raise
+            except (UnicodeError, json.JSONDecodeError) as exc:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger event is malformed."
+                ) from exc
+            if not isinstance(parsed, dict) or _canonical_bytes(parsed) != line:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger event is not canonical."
+                )
+            event = self._event_from_dict(
+                parsed,
+                expected_sequence=sequence,
+                expected_previous=previous,
+                note_bytes=note_bytes,
+            )
+            if event.event_id in seen_event_ids:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Duplicate reuse event replay detected."
+                )
+            seen_event_ids.add(event.event_id)
+            events.append(event)
+            previous = event.event_sha256
+        if anchored_count != len(events) or anchored_head != previous:
+            raise FieldNoteMaturityLedgerIntegrityError(
+                "Maturity ledger head does not match its event history."
+            )
+        return tuple(events)
+
+    def read_events(
+        self,
+        *,
+        note_bytes: bytes,
+    ) -> tuple[FieldNoteMaturityLedgerEvent, ...]:
+        if not isinstance(note_bytes, bytes) or _sha256_bytes(note_bytes) != (
+            self.note.note_sha256
+        ):
+            raise FieldNoteMaturityLedgerValidationError(
+                "Current Note bytes do not match the ledger partition identity."
+            )
+        with self._locked(write=False) as available:
+            if not available:
+                return ()
+            return self._read_events_unlocked(note_bytes)
+
+    def append_receipt(
+        self,
+        receipt: FieldNoteReuseReceipt,
+        *,
+        note_bytes: bytes,
+        recorded_at: str,
+    ) -> FieldNoteMaturityAppendResult:
+        _validate_reused_receipt(receipt, self.note, note_bytes)
+        recorded_at = _validate_timestamp(recorded_at)
+        with self._locked(write=True):
+            events = self._read_events_unlocked(note_bytes)
+            if not os.path.lexists(self.head_path):
+                self._write_head_unlocked(0, GENESIS_EVENT_SHA256)
+            receipt_bytes = _canonical_bytes(receipt.as_dict())
+            for event in events:
+                if event.event_id != receipt.reuse_event_id:
+                    continue
+                if _canonical_bytes(event.receipt.as_dict()) != receipt_bytes:
+                    raise FieldNoteMaturityLedgerValidationError(
+                        "Reuse event identity collides with different evidence."
+                    )
+                return FieldNoteMaturityAppendResult(False, event)
+            if len(events) >= MAX_EVENTS:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger event bound was exceeded."
+                )
+            body = {
+                "schema": LEDGER_EVENT_SCHEMA,
+                "event_kind": LEDGER_EVENT_KIND,
+                "sequence": len(events),
+                "recorded_at": recorded_at,
+                "note_partition_sha256": self.note_partition_sha256,
+                "previous_event_sha256": (
+                    events[-1].event_sha256
+                    if events
+                    else GENESIS_EVENT_SHA256
+                ),
+                "event_id": receipt.reuse_event_id,
+                "receipt": receipt.as_dict(),
+                "receipt_sha256": _sha256_bytes(receipt_bytes),
+            }
+            event_data = {
+                **body,
+                "event_sha256": _sha256_bytes(_canonical_bytes(body)),
+            }
+            payload = _canonical_bytes(event_data) + b"\n"
+            if self.events_path.exists():
+                self._assert_private_file(self.events_path)
+                current_size = self.events_path.stat().st_size
+            else:
+                current_size = 0
+            if len(payload) > MAX_EVENT_BYTES or (
+                current_size + len(payload) > MAX_LEDGER_BYTES
+            ):
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger size bound was exceeded."
+                )
+            created = not self.events_path.exists()
+            flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            try:
+                descriptor = os.open(self.events_path, flags, 0o600)
+                os.fchmod(descriptor, 0o600)
+                view = memoryview(payload)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        raise OSError("short maturity ledger append")
+                    view = view[written:]
+                os.fsync(descriptor)
+            except OSError as exc:
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "Maturity ledger append failed."
+                ) from exc
+            finally:
+                if "descriptor" in locals():
+                    os.close(descriptor)
+            if created:
+                try:
+                    parent = os.open(self.root, os.O_RDONLY)
+                    try:
+                        os.fsync(parent)
+                    finally:
+                        os.close(parent)
+                except OSError as exc:
+                    raise FieldNoteMaturityLedgerIntegrityError(
+                        "Maturity ledger directory sync failed."
+                    ) from exc
+            event = self._event_from_dict(
+                event_data,
+                expected_sequence=len(events),
+                expected_previous=body["previous_event_sha256"],
+                note_bytes=note_bytes,
+            )
+            self._write_head_unlocked(len(events) + 1, event.event_sha256)
+            return FieldNoteMaturityAppendResult(True, event)
+
+    def reconstruct(
+        self,
+        *,
+        note_bytes: bytes,
+    ) -> FieldNoteMaturityLedgerSnapshot:
+        events = self.read_events(note_bytes=note_bytes)
+        maturity = summarize_field_note_maturity(
+            self.note,
+            tuple(event.receipt for event in events),
+        )
+        projection = project_field_note_a3_status(
+            maturity,
+            serving_delay_reason=(
+                "A4 does not derive Current Serving Policy from maturity history."
+            ),
+        )
+        return FieldNoteMaturityLedgerSnapshot(
+            note=self.note,
+            events=events,
+            evidence_maturity=projection.evidence_maturity,
+            current_serving_policy=projection.current_serving_policy,
+            chain_head_sha256=(
+                events[-1].event_sha256 if events else GENESIS_EVENT_SHA256
+            ),
+        )

--- a/decision_os/companion/field_notes_reuse.py
+++ b/decision_os/companion/field_notes_reuse.py
@@ -551,6 +551,10 @@ class FieldNoteReuseReceipt:
     outcome_observer_id: str | None
     outcome_observer_relation: ObserverRelation | None
     outcome_as_of: str | None
+    outcome_scope: str | None
+    causal_evidence_ref: str | None
+    causal_evidence_sha256: str | None
+    contribution_separated: bool | None
     human_intervention: HumanIntervention | None
     next_action: NextAction | None
     reevaluation_condition: str | None
@@ -567,6 +571,10 @@ class FieldNoteReuseReceipt:
                 self.failure_reason is None
                 or self.use_evidence is not None
                 or self.outcome is not None
+                or self.outcome_scope is not None
+                or self.causal_evidence_ref is not None
+                or self.causal_evidence_sha256 is not None
+                or self.contribution_separated is not None
                 or self.next_action is not None
                 or self.reuse_event_id is not None
             ):
@@ -580,12 +588,23 @@ class FieldNoteReuseReceipt:
             self.outcome_observer_id,
             self.outcome_observer_relation,
             self.outcome_as_of,
+            self.outcome_scope,
+            self.contribution_separated,
             self.human_intervention,
             self.next_action,
             self.reuse_event_id,
         )
         if self.failure_reason is not None or any(value is None for value in required):
             raise ValueError("Reused receipt lacks its typed evidence axes.")
+        if type(self.contribution_separated) is not bool:
+            raise ValueError("Reused receipt has an invalid attribution axis.")
+        causal = (self.causal_evidence_ref, self.causal_evidence_sha256)
+        if (causal[0] is None) != (causal[1] is None):
+            raise ValueError("Reused receipt has incomplete causal evidence.")
+        if causal[1] is not None:
+            _sha256(causal[1], "Causal-evidence digest")
+        if self.outcome in {"HELPFUL", "HARMFUL"} and causal[0] is None:
+            raise ValueError("Causal outcome lacks causal evidence.")
         _sha256(self.reuse_event_id, "Reuse event ID")
         if self.outcome == "UNKNOWN" and self.next_action != "HOLD":
             raise ValueError("UNKNOWN outcome must HOLD.")
@@ -611,6 +630,10 @@ class FieldNoteReuseReceipt:
             "outcome_observer_id": self.outcome_observer_id,
             "outcome_observer_relation": self.outcome_observer_relation,
             "outcome_as_of": self.outcome_as_of,
+            "outcome_scope": self.outcome_scope,
+            "causal_evidence_ref": self.causal_evidence_ref,
+            "causal_evidence_sha256": self.causal_evidence_sha256,
+            "contribution_separated": self.contribution_separated,
             "human_intervention": self.human_intervention,
             "next_action": self.next_action,
             "reevaluation_condition": self.reevaluation_condition,
@@ -770,6 +793,10 @@ def _candidate_receipt(
         outcome_observer_id=None,
         outcome_observer_relation=None,
         outcome_as_of=None,
+        outcome_scope=None,
+        causal_evidence_ref=None,
+        causal_evidence_sha256=None,
+        contribution_separated=None,
         human_intervention=None,
         next_action=None,
         reevaluation_condition=None,
@@ -920,6 +947,10 @@ def assess_field_note_reuse(
         outcome_observer_id=evaluation.observer_id,
         outcome_observer_relation=evaluation.observer_relation,
         outcome_as_of=evaluation.as_of,
+        outcome_scope=evaluation.scope,
+        causal_evidence_ref=evaluation.causal_evidence_ref,
+        causal_evidence_sha256=evaluation.causal_evidence_sha256,
+        contribution_separated=evaluation.contribution_separated,
         human_intervention=claim.human_intervention,
         next_action=action,
         reevaluation_condition=condition,

--- a/tests/test_field_notes_maturity_ledger.py
+++ b/tests/test_field_notes_maturity_ledger.py
@@ -1,0 +1,696 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from decision_os.companion.field_notes_maturity_ledger import (
+    GENESIS_EVENT_SHA256,
+    LEDGER_EVENT_SCHEMA,
+    FieldNoteMaturityLedger,
+    FieldNoteMaturityLedgerIntegrityError,
+    FieldNoteMaturityLedgerValidationError,
+)
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseClaim,
+    FieldNoteReuseDisposition,
+    FieldNoteReuseReceipt,
+    FieldNoteUseEvidence,
+    assess_field_note_reuse,
+    bind_field_note_structure,
+)
+
+
+AS_OF = "2026-08-03T12:00:00Z"
+RECORDED_AT = "2026-08-03T12:01:00Z"
+STRUCTURE_BYTES = b"Verify canonical state before restart."
+NOTE_BYTES = (
+    b"# A4 Durable Maturity Ledger\n\n"
+    b"## Decision / Pattern\n\n"
+    + STRUCTURE_BYTES
+    + b"\n\n## Limits\n\nCurrent authority always wins.\n"
+)
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def digest(value: str) -> str:
+    return digest_bytes(value.encode("utf-8"))
+
+
+def note_identity(
+    *,
+    field_note_id: str = "fn_a4_candidate",
+    note_bytes: bytes = NOTE_BYTES,
+    note_path: str = (
+        ".decision-os/field-notes/"
+        "2026-08-03-a4-ledger-aaaaaaaaaa.md"
+    ),
+    origin_run_id: str = "run_origin",
+) -> FieldNoteIdentity:
+    return FieldNoteIdentity(
+        note_path=note_path,
+        field_note_id=field_note_id,
+        note_sha256=digest_bytes(note_bytes),
+        origin_run_id=origin_run_id,
+    )
+
+
+def reuse_receipt(
+    note: FieldNoteIdentity,
+    *,
+    note_bytes: bytes = NOTE_BYTES,
+    run_suffix: str = "1",
+    outcome: str = "UNKNOWN",
+    action: str | None = None,
+    intervention: str = "NONE",
+    evidence_class: str = "RULE_TRACE",
+) -> FieldNoteReuseReceipt:
+    reusing_run_id = f"run_reuse_{run_suffix}"
+    start = note_bytes.index(STRUCTURE_BYTES)
+    binding = bind_field_note_structure(
+        note,
+        note_bytes,
+        structure_id="restart-state-identity-guard",
+        start_byte=start,
+        end_byte=start + len(STRUCTURE_BYTES),
+    )
+    evidence = FieldNoteUseEvidence(
+        evidence_class=evidence_class,  # type: ignore[arg-type]
+        evidence_origin="IMMEDIATE_COMPLETION_RECORD",
+        reusing_run_id=reusing_run_id,
+        structure_binding=binding,
+        evidence_ref=f"run:{reusing_run_id}/evidence:guard",
+        evidence_sha256=digest(f"evidence-{run_suffix}"),
+        observer_id="observer_a4",
+        observer_relation="INDEPENDENT",
+        as_of=AS_OF,
+    )
+    evaluation = None
+    if outcome != "UNKNOWN":
+        causal = outcome in {"HELPFUL", "HARMFUL"}
+        evaluation = FieldNoteOutcomeEvaluation(
+            outcome=outcome,  # type: ignore[arg-type]
+            scope="The bounded A4 test scope.",
+            observer_id="outcome_observer_a4",
+            observer_relation="INDEPENDENT",
+            as_of=AS_OF,
+            causal_evidence_ref=(
+                f"run:{reusing_run_id}/causal" if causal else None
+            ),
+            causal_evidence_sha256=(
+                digest(f"causal-{run_suffix}") if causal else None
+            ),
+            contribution_separated=True,
+        )
+    disposition = None
+    if action == "KEEP":
+        disposition = FieldNoteReuseDisposition(action="KEEP")
+    elif action == "STOP":
+        disposition = FieldNoteReuseDisposition(
+            action="STOP",
+            stop_scope=f"Bounded task family {run_suffix}.",
+        )
+    elif action == "REVISE":
+        successor = note_identity(
+            field_note_id=f"fn_a4_successor_{run_suffix}",
+            note_bytes=(note_bytes + run_suffix.encode("ascii")),
+            note_path=(
+                ".decision-os/field-notes/"
+                f"2026-08-03-a4-successor-{run_suffix.zfill(10)}.md"
+            ),
+            origin_run_id=reusing_run_id,
+        )
+        disposition = FieldNoteReuseDisposition(
+            action="REVISE",
+            revision_candidate=successor,
+        )
+    claim = FieldNoteReuseClaim(
+        claimed_note=note,
+        reusing_run_id=reusing_run_id,
+        use_evidence=evidence,
+        outcome_evaluation=evaluation,
+        human_intervention=intervention,  # type: ignore[arg-type]
+        disposition=disposition,
+    )
+    receipt = assess_field_note_reuse(note, claim, note_bytes=note_bytes)
+    if receipt.state != "REUSED":
+        raise AssertionError("test fixture failed to produce REUSED")
+    return receipt
+
+
+def candidate_receipt(note: FieldNoteIdentity) -> FieldNoteReuseReceipt:
+    claim = FieldNoteReuseClaim(
+        claimed_note=note,
+        reusing_run_id="run_candidate",
+        use_evidence=None,
+        outcome_evaluation=None,
+        human_intervention="NONE",
+        disposition=None,
+        narrative_claim="I used the Note.",
+    )
+    return assess_field_note_reuse(note, claim, note_bytes=NOTE_BYTES)
+
+
+def reconnect_receipt(note: FieldNoteIdentity) -> FieldNoteReconnectReceipt:
+    return FieldNoteReconnectReceipt(
+        run_id="run_reuse_1",
+        state="ACTIVATION_UNKNOWN",
+        failure_reason=None,
+        metadata_entries_seen=1,
+        metadata_candidate_files_seen=1,
+        metadata_files_valid=1,
+        metadata_bytes_read=700,
+        selected_field_note_path=note.note_path,
+        selected_field_note_id=note.field_note_id,
+        selected_metadata_sha256=digest("metadata"),
+        selected_full_note_sha256=note.note_sha256,
+        full_note_bytes_read=len(NOTE_BYTES),
+        full_notes_injected=1,
+        ordinary_distinct_paths_consumed=1,
+    )
+
+
+class LedgerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name) / "maturity-ledger-v0.1"
+        self.note = note_identity()
+        self.ledger = FieldNoteMaturityLedger(self.root, self.note)
+
+    def append(
+        self,
+        receipt: FieldNoteReuseReceipt,
+        *,
+        ledger: FieldNoteMaturityLedger | None = None,
+        note_bytes: bytes = NOTE_BYTES,
+    ):
+        return (ledger or self.ledger).append_receipt(
+            receipt,
+            note_bytes=note_bytes,
+            recorded_at=RECORDED_AT,
+        )
+
+    def parsed_lines(
+        self,
+        ledger: FieldNoteMaturityLedger | None = None,
+    ) -> list[dict]:
+        path = (ledger or self.ledger).events_path
+        return [json.loads(line) for line in path.read_text().splitlines()]
+
+    def rewrite_lines(
+        self,
+        events: list[dict],
+        ledger: FieldNoteMaturityLedger | None = None,
+    ) -> None:
+        path = (ledger or self.ledger).events_path
+        payload = "".join(f"{canonical_json(event)}\n" for event in events)
+        path.write_text(payload)
+
+    @staticmethod
+    def rehash_event(event: dict) -> None:
+        body = {key: value for key, value in event.items() if key != "event_sha256"}
+        event["event_sha256"] = digest(canonical_json(body))
+
+
+class FieldNotesMaturityLedgerAdmissionTests(LedgerTestCase):
+    def test_valid_a3_reused_receipt_is_durably_recorded(self) -> None:
+        receipt = reuse_receipt(self.note)
+        result = self.append(receipt)
+        self.assertTrue(result.appended)
+        self.assertTrue(self.ledger.events_path.is_file())
+        self.assertTrue(self.ledger.head_path.is_file())
+        self.assertEqual(0, result.event.sequence)
+        self.assertEqual(receipt, result.event.receipt)
+        self.assertEqual(
+            (result.event,),
+            self.ledger.read_events(note_bytes=NOTE_BYTES),
+        )
+
+    def test_candidate_receipt_cannot_enter_ledger(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerValidationError,
+            "not valid|Only typed",
+        ):
+            self.append(candidate_receipt(self.note))
+        self.assertFalse(self.root.exists())
+
+    def test_a2_injection_alone_cannot_enter_ledger(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerValidationError,
+            "Only typed A3",
+        ):
+            self.append(reconnect_receipt(self.note))  # type: ignore[arg-type]
+        self.assertFalse(self.root.exists())
+
+    def test_free_form_narrative_cannot_enter_ledger(self) -> None:
+        receipt = candidate_receipt(self.note)
+        self.assertEqual("USE_EVIDENCE_MISSING", receipt.failure_reason)
+        with self.assertRaises(FieldNoteMaturityLedgerValidationError):
+            self.append(receipt)
+
+    def test_exact_note_and_structure_identity_are_preserved(self) -> None:
+        receipt = reuse_receipt(self.note)
+        event = self.append(receipt).event
+        stored = event.receipt.use_evidence.structure_binding
+        self.assertEqual(self.note, event.receipt.note)
+        self.assertEqual(self.note, stored.note)
+        self.assertEqual(digest_bytes(STRUCTURE_BYTES), stored.structure_sha256)
+
+    def test_receipt_for_another_note_is_rejected(self) -> None:
+        other_bytes = NOTE_BYTES.replace(b"Current", b"Topmost")
+        other = note_identity(
+            field_note_id="fn_a4_other",
+            note_bytes=other_bytes,
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-03-a4-other-bbbbbbbbbb.md"
+            ),
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerValidationError,
+            "exact Note partition",
+        ):
+            self.append(
+                reuse_receipt(other, note_bytes=other_bytes),
+                note_bytes=other_bytes,
+            )
+
+    def test_changed_note_identity_is_rejected(self) -> None:
+        changed = replace(self.note, field_note_id="fn_a4_changed")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerValidationError,
+            "exact Note partition",
+        ):
+            self.append(reuse_receipt(changed))
+
+    def test_duplicate_append_is_byte_idempotent(self) -> None:
+        receipt = reuse_receipt(self.note)
+        first = self.append(receipt)
+        before = self.ledger.events_path.read_bytes()
+        head_before = self.ledger.head_path.read_bytes()
+        second = self.append(receipt)
+        self.assertTrue(first.appended)
+        self.assertFalse(second.appended)
+        self.assertEqual(first.event, second.event)
+        self.assertEqual(before, self.ledger.events_path.read_bytes())
+        self.assertEqual(head_before, self.ledger.head_path.read_bytes())
+
+    def test_duplicate_append_does_not_inflate_reconstruction(self) -> None:
+        receipt = reuse_receipt(self.note)
+        self.append(receipt)
+        self.append(receipt)
+        snapshot = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(1, len(snapshot.events))
+        self.assertEqual(1, len(snapshot.evidence_maturity.reuse_event_ids))
+
+    def test_same_event_identity_with_different_payload_is_rejected(self) -> None:
+        helpful = reuse_receipt(
+            self.note,
+            outcome="HELPFUL",
+            action="KEEP",
+        )
+        harmful = reuse_receipt(
+            self.note,
+            outcome="HARMFUL",
+            action="STOP",
+        )
+        self.assertEqual(helpful.reuse_event_id, harmful.reuse_event_id)
+        self.append(helpful)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerValidationError,
+            "collides",
+        ):
+            self.append(harmful)
+
+
+class FieldNotesMaturityLedgerRetentionTests(LedgerTestCase):
+    def test_all_outcomes_are_retained_not_only_positive_results(self) -> None:
+        cases = (
+            ("HELPFUL", "KEEP"),
+            ("NOT_HELPFUL", "STOP"),
+            ("HARMFUL", "STOP"),
+            ("UNKNOWN", None),
+        )
+        for index, (outcome, action) in enumerate(cases, start=1):
+            self.append(
+                reuse_receipt(
+                    self.note,
+                    run_suffix=str(index),
+                    outcome=outcome,
+                    action=action,
+                )
+            )
+        snapshot = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(
+            ["HELPFUL", "NOT_HELPFUL", "HARMFUL", "UNKNOWN"],
+            [event.receipt.outcome for event in snapshot.events],
+        )
+
+    def test_causal_evidence_is_retained_for_causal_outcomes(self) -> None:
+        for index, outcome in enumerate(("HELPFUL", "HARMFUL"), start=1):
+            action = "KEEP" if outcome == "HELPFUL" else "STOP"
+            self.append(
+                reuse_receipt(
+                    self.note,
+                    run_suffix=str(index),
+                    outcome=outcome,
+                    action=action,
+                )
+            )
+        receipts = [
+            event.receipt
+            for event in self.ledger.read_events(note_bytes=NOTE_BYTES)
+        ]
+        self.assertTrue(all(item.causal_evidence_ref for item in receipts))
+        self.assertTrue(all(item.causal_evidence_sha256 for item in receipts))
+        self.assertTrue(all(item.outcome_scope for item in receipts))
+
+    def test_material_and_unknown_human_intervention_are_retained(self) -> None:
+        for index, intervention in enumerate(("MATERIAL", "UNKNOWN"), start=1):
+            self.append(
+                reuse_receipt(
+                    self.note,
+                    run_suffix=str(index),
+                    outcome="UNKNOWN",
+                    intervention=intervention,
+                )
+            )
+        snapshot = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(
+            ["MATERIAL", "UNKNOWN"],
+            [event.receipt.human_intervention for event in snapshot.events],
+        )
+
+    def test_hold_and_bounded_stop_are_retained(self) -> None:
+        self.append(reuse_receipt(self.note, run_suffix="1"))
+        self.append(
+            reuse_receipt(
+                self.note,
+                run_suffix="2",
+                outcome="HARMFUL",
+                action="STOP",
+            )
+        )
+        events = self.ledger.read_events(note_bytes=NOTE_BYTES)
+        self.assertEqual("HOLD", events[0].receipt.next_action)
+        self.assertTrue(events[0].receipt.reevaluation_condition)
+        self.assertEqual("STOP", events[1].receipt.next_action)
+        self.assertEqual("Bounded task family 2.", events[1].receipt.stop_scope)
+
+    def test_revise_preserves_forward_predecessor_and_successor(self) -> None:
+        receipt = reuse_receipt(
+            self.note,
+            outcome="NOT_HELPFUL",
+            action="REVISE",
+        )
+        self.append(receipt)
+        stored = self.ledger.read_events(note_bytes=NOTE_BYTES)[0].receipt
+        self.assertEqual(self.note, stored.revision.predecessor)
+        self.assertNotEqual(self.note, stored.revision.successor)
+        self.assertEqual(stored.reusing_run_id, stored.revision.successor.origin_run_id)
+
+    def test_rule_trace_and_output_artifact_evidence_are_retained(self) -> None:
+        for index, evidence_class in enumerate(
+            ("RULE_TRACE", "OUTPUT_ARTIFACT"),
+            start=1,
+        ):
+            self.append(
+                reuse_receipt(
+                    self.note,
+                    run_suffix=str(index),
+                    evidence_class=evidence_class,
+                )
+            )
+        events = self.ledger.read_events(note_bytes=NOTE_BYTES)
+        self.assertEqual(
+            ["RULE_TRACE", "OUTPUT_ARTIFACT"],
+            [event.receipt.use_evidence.evidence_class for event in events],
+        )
+
+    def test_existing_note_bytes_are_not_modified(self) -> None:
+        before = bytes(NOTE_BYTES)
+        self.append(reuse_receipt(self.note))
+        self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(before, NOTE_BYTES)
+        self.assertEqual(self.note.note_sha256, digest_bytes(NOTE_BYTES))
+
+
+class FieldNotesMaturityLedgerIntegrityTests(LedgerTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.append(reuse_receipt(self.note))
+
+    def test_event_payload_tampering_is_detected(self) -> None:
+        events = self.parsed_lines()
+        events[0]["receipt"]["outcome"] = "HARMFUL"
+        self.rewrite_lines(events)
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+
+    def test_exact_note_identity_tampering_is_detected(self) -> None:
+        events = self.parsed_lines()
+        events[0]["receipt"]["note"]["field_note_id"] = "fn_tampered"
+        self.rewrite_lines(events)
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_event_identity_tampering_is_detected_even_if_rehashed(self) -> None:
+        events = self.parsed_lines()
+        events[0]["event_id"] = digest("forged-event-id")
+        self.rehash_event(events[0])
+        self.rewrite_lines(events)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "identity mismatch",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_truncated_record_fails_closed(self) -> None:
+        raw = self.ledger.events_path.read_bytes()
+        self.ledger.events_path.write_bytes(raw[:-1])
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "truncated",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_whole_trailing_record_removal_fails_closed(self) -> None:
+        self.append(reuse_receipt(self.note, run_suffix="2"))
+        events = self.parsed_lines()
+        self.rewrite_lines(events[:1])
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "head",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_missing_head_anchor_fails_closed(self) -> None:
+        self.ledger.head_path.unlink()
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "anchor is missing",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_head_anchor_tampering_fails_closed(self) -> None:
+        head = json.loads(self.ledger.head_path.read_text())
+        head["event_count"] = 2
+        self.ledger.head_path.write_text(canonical_json(head))
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "anchor is invalid",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_empty_existing_partition_fails_closed(self) -> None:
+        self.ledger.events_path.write_bytes(b"")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "truncated",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_boolean_sequence_fails_closed_even_if_rehashed(self) -> None:
+        events = self.parsed_lines()
+        events[0]["sequence"] = False
+        self.rehash_event(events[0])
+        self.rewrite_lines(events)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "sequence",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_invalid_recorded_at_fails_closed_even_if_rehashed(self) -> None:
+        events = self.parsed_lines()
+        events[0]["recorded_at"] = "not-a-timestamp"
+        self.rehash_event(events[0])
+        self.rewrite_lines(events)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "recorded_at",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_malformed_record_fails_closed(self) -> None:
+        self.ledger.events_path.write_bytes(b"{not-json}\n")
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_unsupported_event_version_fails_closed(self) -> None:
+        events = self.parsed_lines()
+        events[0]["schema"] = "decision-os.unsupported.v9"
+        self.rehash_event(events[0])
+        self.rewrite_lines(events)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "Unsupported",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_cross_note_contamination_fails_closed(self) -> None:
+        other_bytes = NOTE_BYTES.replace(b"Current", b"Topmost")
+        other_note = note_identity(
+            field_note_id="fn_a4_other",
+            note_bytes=other_bytes,
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-03-a4-other-bbbbbbbbbb.md"
+            ),
+        )
+        other_ledger = FieldNoteMaturityLedger(self.root, other_note)
+        self.append(
+            reuse_receipt(other_note, note_bytes=other_bytes),
+            ledger=other_ledger,
+            note_bytes=other_bytes,
+        )
+        self.ledger.events_path.write_bytes(other_ledger.events_path.read_bytes())
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "identity chain",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_reordered_records_fail_closed(self) -> None:
+        self.append(reuse_receipt(self.note, run_suffix="2"))
+        events = self.parsed_lines()
+        self.rewrite_lines(list(reversed(events)))
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_duplicate_event_replay_fails_closed(self) -> None:
+        events = self.parsed_lines()
+        self.rewrite_lines([events[0], events[0]])
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.ledger.read_events(note_bytes=NOTE_BYTES)
+
+    def test_changed_current_note_bytes_fail_closed(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerValidationError,
+            "Current Note bytes",
+        ):
+            self.ledger.read_events(note_bytes=NOTE_BYTES + b"changed")
+
+
+class FieldNotesMaturityLedgerReconstructionTests(LedgerTestCase):
+    def test_empty_ledger_reconstructs_candidate_deterministically(self) -> None:
+        first = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        second = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(first, second)
+        self.assertEqual("CANDIDATE", first.evidence_maturity.state)
+        self.assertEqual(GENESIS_EVENT_SHA256, first.chain_head_sha256)
+
+    def test_same_ledger_reconstructs_identically(self) -> None:
+        self.append(reuse_receipt(self.note, run_suffix="1"))
+        self.append(reuse_receipt(self.note, run_suffix="2"))
+        first = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        second = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(first.as_dict(), second.as_dict())
+
+    def test_automatic_maturity_is_capped_at_reused(self) -> None:
+        for index in range(1, 6):
+            self.append(reuse_receipt(self.note, run_suffix=str(index)))
+        snapshot = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual("REUSED", snapshot.evidence_maturity.state)
+        self.assertEqual(5, len(snapshot.evidence_maturity.reuse_event_ids))
+        self.assertEqual("UNSET", snapshot.evidence_maturity.promotion.policy_status)
+        self.assertIsNone(snapshot.evidence_maturity.promotion.threshold)
+
+    def test_reused_does_not_derive_serving_or_injection(self) -> None:
+        self.append(reuse_receipt(self.note))
+        snapshot = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        policy = snapshot.current_serving_policy
+        self.assertEqual("REUSED", snapshot.evidence_maturity.state)
+        self.assertEqual("DELAY", policy.derivation)
+        self.assertFalse(policy.automatic_derivation_supported)
+        self.assertIsNone(policy.automatic_injection)
+        self.assertFalse(policy.complete_state_machine_implemented)
+
+    def test_canonical_authority_remains_above_advisory_note(self) -> None:
+        snapshot = self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(
+            ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE"),
+            snapshot.current_serving_policy.authority_precedence,
+        )
+
+    def test_reconstruction_is_read_only(self) -> None:
+        self.append(reuse_receipt(self.note))
+        before = self.ledger.events_path.read_bytes()
+        self.ledger.reconstruct(note_bytes=NOTE_BYTES)
+        self.assertEqual(before, self.ledger.events_path.read_bytes())
+
+
+class FieldNotesMaturityLedgerProtectedArtifactTests(unittest.TestCase):
+    def test_local_protected_artifacts_match_fixed_identities(self) -> None:
+        repository = Path(__file__).resolve().parents[1]
+        expected = {
+            Path(
+                ".decision-os/field-notes/"
+                "2026-08-03-topmost-canonical-state-restart-guard-"
+                "lcmwhjvkpf.md"
+            ): (
+                2743,
+                "3c2e45460f21a2346a8d100ebfefc6ed079994e687a70911e5f4a8954cf2d05d",
+            ),
+            Path("validation/companion_live_task_001.md"): (
+                779,
+                "e28815932e0a3baf34bc0c6b0e2f9a03130e10260765367458a53116502845cf",
+            ),
+            Path("validation/companion_manual_live_run_probe_v0_1.md"): (
+                539,
+                "f68b3a1f47136782cbb5ade4c4686724c2b877eaaffe52bdb81aa72ae19c6344",
+            ),
+            Path("validation/companion_medium_live_task_001.md"): (
+                4632,
+                "a096b2455d7d57d24f3dd0a2b1e5b7c26a782e6870f2e076cdebdf7348a5a411",
+            ),
+            Path("validation/companion_medium_live_task_002.md"): (
+                4139,
+                "0f2203beddb5469dfe00deeae392277cd0634aa5b0713296efb2a754a59b8bba",
+            ),
+        }
+        missing = [path for path in expected if not (repository / path).exists()]
+        if missing:
+            self.skipTest("Protected creator artifacts are local-only.")
+        for relative, (size, sha256) in expected.items():
+            with self.subTest(path=relative.as_posix()):
+                data = (repository / relative).read_bytes()
+                self.assertEqual(size, len(data))
+                self.assertEqual(sha256, digest_bytes(data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the bounded Field Notes Lite A4 Durable Maturity Ledger v0.1 as a pure library-level recording and reconstruction layer.

- Stores validated A3 `REUSED` receipts in one exact-Note JSONL partition outside Field Note bytes.
- Uses canonical JSON, SHA-256 event chaining, a per-Note count/head anchor, private files, process/thread locking, append + fsync, bounded parsing, and fail-closed validation.
- Makes duplicate append idempotent by canonical A3 reuse-event identity.
- Preserves positive and negative outcomes, causal attribution, human intervention, bounded HOLD/STOP, and forward-only REVISE links.
- Reconstructs Evidence Maturity deterministically, capped at `CANDIDATE` or `REUSED`.
- Keeps `PROMOTABLE` policy `UNSET` and Current Serving Policy separate and `DELAY`.

## Base and head

- Fresh base/main: `4cda3419d51291d73208be24adf9a1e44af8e434`
- Head: `535ee138102f2550cf2cd5f88e5741b127704fcb`

## Delta

- `decision_os/companion/field_notes_reuse.py` — preserve the typed outcome scope, causal evidence, and contribution-separation axes in immutable A3 receipts.
- `decision_os/companion/field_notes_maturity_ledger.py` — bounded append-only A4 ledger and deterministic read-only reconstruction.
- `tests/test_field_notes_maturity_ledger.py` — 40 admission, retention, integrity, reconstruction, and protected-artifact tests.

No runtime wiring, installation, Companion restart, live Run, creator evidence, Serving Policy state machine, or promotion threshold is included.

## Validation

- `python3 -m unittest tests.test_field_notes_maturity_ledger` — 40/40 PASS
- `python3 -m unittest tests.test_field_notes_reuse` — 45/45 PASS
- `python3 -m unittest tests.test_field_notes_lite` — 25/25 PASS
- `python3 -m unittest tests.test_field_notes_reconnect` — 36/36 PASS
- `python3 -m unittest tests.test_companion_controller` — 27/27 PASS
- `python3 -m unittest tests.test_companion_server` — 35/35 PASS
- `python3 -m unittest` — 843/843 PASS
- `python3 -m unittest discover -s tests -p 'test_*.py'` — 843/843 PASS
- Normalized default/explicit test IDs — MATCH (843 each; no one-sided IDs)
- `python3 -m py_compile decision_os/companion/field_notes_reuse.py decision_os/companion/field_notes_maturity_ledger.py tests/test_field_notes_maturity_ledger.py` — PASS
- `git diff --check` and cached diff check — PASS
- Protected Creator Note and four protected validation artifacts — SHA-256, size, mode, mtime, and inode unchanged from preflight

## Claim boundary

Supported: A4 provides a typed, append-only, duplicate-safe mechanism for durably preserving validated A3 maturity evidence and deterministically reconstructing bounded Evidence Maturity without modifying Field Note bytes or deriving current Serving Policy.

Not claimed: any real Note is REUSED; PROMOTABLE; automatic promotion; mandatory/default injection; successful intelligence transplant; generalized or performance improvement; measured savings; Serving Policy implementation; external adoption.
