### PR TITLE
Add Field Notes A5 operational maturity commit bridge

### DIFF
--- a/decision_os/companion/field_notes_maturity_commit.py
+++ b/decision_os/companion/field_notes_maturity_commit.py
@@ -1,0 +1,267 @@
+"""Pure Field Notes Lite A5 bridge from A3 assessment to A4 durability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import hashlib
+from typing import Any, Literal
+
+from decision_os.companion.field_notes_maturity_ledger import (
+    FieldNoteMaturityAppendResult,
+    FieldNoteMaturityLedger,
+    FieldNoteMaturityLedgerSnapshot,
+)
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteReuseClaim,
+    FieldNoteReuseReceipt,
+    assess_field_note_reuse,
+)
+
+
+MaturityCommitStatus = Literal[
+    "NOT_REUSED",
+    "RECORDED",
+    "ALREADY_RECORDED",
+]
+
+
+class FieldNoteMaturityCommitError(RuntimeError):
+    """Base error for an A5 commit that cannot be durably confirmed."""
+
+
+class FieldNoteMaturityCommitValidationError(
+    FieldNoteMaturityCommitError,
+    ValueError,
+):
+    """The typed A5 request or A4 partition identity is invalid."""
+
+
+class FieldNoteMaturityCommitConfirmationError(FieldNoteMaturityCommitError):
+    """A4 read-back did not confirm the exact assessed reuse event."""
+
+
+def _validate_recorded_at(value: Any) -> str:
+    if not isinstance(value, str) or not value or len(value) > 64:
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit recorded_at is invalid."
+        )
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit recorded_at is invalid."
+        ) from exc
+    if parsed.tzinfo is None:
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit recorded_at is invalid."
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityCommitRequest:
+    """Exact Note, bounded A3 claim, and optional non-authoritative A2 context."""
+
+    note: FieldNoteIdentity
+    note_bytes: bytes = field(repr=False)
+    reuse_claim: FieldNoteReuseClaim | None
+    recorded_at: str
+    delivery_context: FieldNoteReconnectReceipt | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.note, FieldNoteIdentity):
+            raise FieldNoteMaturityCommitValidationError(
+                "Maturity commit requires an exact Field Note identity."
+            )
+        if (
+            not isinstance(self.note_bytes, bytes)
+            or hashlib.sha256(self.note_bytes).hexdigest()
+            != self.note.note_sha256
+        ):
+            raise FieldNoteMaturityCommitValidationError(
+                "Maturity commit Note bytes do not match the exact identity."
+            )
+        if self.reuse_claim is not None and not isinstance(
+            self.reuse_claim,
+            FieldNoteReuseClaim,
+        ):
+            raise FieldNoteMaturityCommitValidationError(
+                "Maturity commit reuse claim is not typed A3 evidence."
+            )
+        if self.delivery_context is not None and not isinstance(
+            self.delivery_context,
+            FieldNoteReconnectReceipt,
+        ):
+            raise FieldNoteMaturityCommitValidationError(
+                "Maturity commit delivery context is not a typed A2 receipt."
+            )
+        object.__setattr__(
+            self,
+            "recorded_at",
+            _validate_recorded_at(self.recorded_at),
+        )
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityCommitResult:
+    """Typed A5 result; committed states always contain verified A4 read-back."""
+
+    status: MaturityCommitStatus
+    assessment: FieldNoteReuseReceipt
+    delivery_context: FieldNoteReconnectReceipt | None
+    append_result: FieldNoteMaturityAppendResult | None
+    durable_snapshot: FieldNoteMaturityLedgerSnapshot | None
+
+    def __post_init__(self) -> None:
+        if self.status not in {
+            "NOT_REUSED",
+            "RECORDED",
+            "ALREADY_RECORDED",
+        }:
+            raise ValueError("Maturity commit result status is invalid.")
+        if not isinstance(self.assessment, FieldNoteReuseReceipt):
+            raise ValueError("Maturity commit result lacks its A3 assessment.")
+        if self.delivery_context is not None and not isinstance(
+            self.delivery_context,
+            FieldNoteReconnectReceipt,
+        ):
+            raise ValueError("Maturity commit result has invalid A2 provenance.")
+        if self.status == "NOT_REUSED":
+            if (
+                self.assessment.state != "CANDIDATE"
+                or self.append_result is not None
+                or self.durable_snapshot is not None
+            ):
+                raise ValueError(
+                    "NOT_REUSED cannot contain a durable maturity commit."
+                )
+            return
+        if (
+            self.assessment.state != "REUSED"
+            or self.append_result is None
+            or self.durable_snapshot is None
+            or self.append_result.appended != (self.status == "RECORDED")
+        ):
+            raise ValueError(
+                "Committed maturity result lacks confirmed A4 evidence."
+            )
+        matching = tuple(
+            event
+            for event in self.durable_snapshot.events
+            if event.event_id == self.assessment.reuse_event_id
+        )
+        if (
+            self.durable_snapshot.note != self.assessment.note
+            or self.durable_snapshot.evidence_maturity.state != "REUSED"
+            or self.assessment.reuse_event_id
+            not in self.durable_snapshot.evidence_maturity.reuse_event_ids
+            or matching != (self.append_result.event,)
+            or matching[0].receipt != self.assessment
+        ):
+            raise ValueError(
+                "Committed maturity result is not confirmed by A4 read-back."
+            )
+
+    @property
+    def durable_commit_confirmed(self) -> bool:
+        return self.status in {"RECORDED", "ALREADY_RECORDED"}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "durable_commit_confirmed": self.durable_commit_confirmed,
+            "assessment": self.assessment.as_dict(),
+            "delivery_context": (
+                self.delivery_context.as_dict()
+                if self.delivery_context is not None
+                else None
+            ),
+            "append_result": (
+                {
+                    "appended": self.append_result.appended,
+                    "event": self.append_result.event.as_dict(),
+                }
+                if self.append_result is not None
+                else None
+            ),
+            "durable_snapshot": (
+                self.durable_snapshot.as_dict()
+                if self.durable_snapshot is not None
+                else None
+            ),
+        }
+
+
+def _confirm_read_back(
+    receipt: FieldNoteReuseReceipt,
+    append_result: FieldNoteMaturityAppendResult,
+    snapshot: FieldNoteMaturityLedgerSnapshot,
+) -> None:
+    matching = tuple(
+        event
+        for event in snapshot.events
+        if event.event_id == receipt.reuse_event_id
+    )
+    if (
+        snapshot.note != receipt.note
+        or snapshot.evidence_maturity.state != "REUSED"
+        or receipt.reuse_event_id
+        not in snapshot.evidence_maturity.reuse_event_ids
+        or matching != (append_result.event,)
+        or matching[0].receipt != receipt
+    ):
+        raise FieldNoteMaturityCommitConfirmationError(
+            "A4 read-back did not confirm the exact A3 reuse event."
+        )
+
+
+def commit_field_note_maturity(
+    ledger: FieldNoteMaturityLedger,
+    request: FieldNoteMaturityCommitRequest,
+) -> FieldNoteMaturityCommitResult:
+    """Assess through A3 and report completion only after exact A4 read-back."""
+
+    if not isinstance(ledger, FieldNoteMaturityLedger):
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit requires a typed A4 ledger."
+        )
+    if not isinstance(request, FieldNoteMaturityCommitRequest):
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit request is not typed."
+        )
+    if ledger.note != request.note:
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit request targets a different A4 Note partition."
+        )
+    assessment = assess_field_note_reuse(
+        request.note,
+        request.reuse_claim,
+        note_bytes=request.note_bytes,
+    )
+    if assessment.state != "REUSED":
+        return FieldNoteMaturityCommitResult(
+            status="NOT_REUSED",
+            assessment=assessment,
+            delivery_context=request.delivery_context,
+            append_result=None,
+            durable_snapshot=None,
+        )
+    append_result = ledger.append_receipt(
+        assessment,
+        note_bytes=request.note_bytes,
+        recorded_at=request.recorded_at,
+    )
+    snapshot = ledger.reconstruct(note_bytes=request.note_bytes)
+    _confirm_read_back(assessment, append_result, snapshot)
+    return FieldNoteMaturityCommitResult(
+        status="RECORDED" if append_result.appended else "ALREADY_RECORDED",
+        assessment=assessment,
+        delivery_context=request.delivery_context,
+        append_result=append_result,
+        durable_snapshot=snapshot,
+    )

--- a/decision_os/companion/field_notes_maturity_commit.py
+++ b/decision_os/companion/field_notes_maturity_commit.py
@@ -63,6 +63,41 @@ def _validate_recorded_at(value: Any) -> str:
     return value
 
 
+def _validate_delivery_context(
+    context: FieldNoteReconnectReceipt | None,
+    *,
+    note: FieldNoteIdentity,
+    note_byte_count: int,
+    reusing_run_id: str | None,
+) -> None:
+    if context is None:
+        return
+    if not isinstance(context, FieldNoteReconnectReceipt):
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit delivery context is not a typed A2 receipt."
+        )
+    if (
+        context.state not in {"INJECTED", "ACTIVATION_UNKNOWN"}
+        or context.full_notes_injected != 1
+    ):
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit A2 delivery context is not injected."
+        )
+    if (
+        context.selected_field_note_path != note.note_path
+        or context.selected_field_note_id != note.field_note_id
+        or context.selected_full_note_sha256 != note.note_sha256
+        or context.full_note_bytes_read != note_byte_count
+    ):
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit A2 delivery context does not match the exact Field Note."
+        )
+    if reusing_run_id is not None and context.run_id != reusing_run_id:
+        raise FieldNoteMaturityCommitValidationError(
+            "Maturity commit A2 delivery context belongs to a different reusing Run."
+        )
+
+
 @dataclass(frozen=True)
 class FieldNoteMaturityCommitRequest:
     """Exact Note, bounded A3 claim, and optional non-authoritative A2 context."""
@@ -93,13 +128,16 @@ class FieldNoteMaturityCommitRequest:
             raise FieldNoteMaturityCommitValidationError(
                 "Maturity commit reuse claim is not typed A3 evidence."
             )
-        if self.delivery_context is not None and not isinstance(
+        _validate_delivery_context(
             self.delivery_context,
-            FieldNoteReconnectReceipt,
-        ):
-            raise FieldNoteMaturityCommitValidationError(
-                "Maturity commit delivery context is not a typed A2 receipt."
-            )
+            note=self.note,
+            note_byte_count=len(self.note_bytes),
+            reusing_run_id=(
+                self.reuse_claim.reusing_run_id
+                if self.reuse_claim is not None
+                else None
+            ),
+        )
         object.__setattr__(
             self,
             "recorded_at",
@@ -143,6 +181,7 @@ class FieldNoteMaturityCommitResult:
             return
         if (
             self.assessment.state != "REUSED"
+            or self.assessment.use_evidence is None
             or self.append_result is None
             or self.durable_snapshot is None
             or self.append_result.appended != (self.status == "RECORDED")
@@ -150,6 +189,14 @@ class FieldNoteMaturityCommitResult:
             raise ValueError(
                 "Committed maturity result lacks confirmed A4 evidence."
             )
+        _validate_delivery_context(
+            self.delivery_context,
+            note=self.assessment.note,
+            note_byte_count=(
+                self.assessment.use_evidence.structure_binding.note_size
+            ),
+            reusing_run_id=self.assessment.reusing_run_id,
+        )
         matching = tuple(
             event
             for event in self.durable_snapshot.events

--- a/tests/test_field_notes_maturity_commit.py
+++ b/tests/test_field_notes_maturity_commit.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from decision_os.companion.field_notes_maturity_commit import (
+    FieldNoteMaturityCommitConfirmationError,
+    FieldNoteMaturityCommitRequest,
+    FieldNoteMaturityCommitValidationError,
+    commit_field_note_maturity,
+)
+from decision_os.companion.field_notes_maturity_ledger import (
+    FieldNoteMaturityLedger,
+    FieldNoteMaturityLedgerIntegrityError,
+)
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseClaim,
+    FieldNoteReuseDisposition,
+    FieldNoteStructureBinding,
+    FieldNoteUseEvidence,
+    bind_field_note_structure,
+)
+
+
+AS_OF = "2026-08-04T09:00:00Z"
+RECORDED_AT = "2026-08-04T09:01:00Z"
+STRUCTURE_BYTES = b"Verify canonical state before restart."
+NOTE_BYTES = (
+    b"# A5 Operational Maturity Commit Bridge\n\n"
+    b"## Decision / Pattern\n\n"
+    + STRUCTURE_BYTES
+    + b"\n\n## Limits\n\nCurrent canonical authority always wins.\n"
+)
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def digest(value: str) -> str:
+    return digest_bytes(value.encode("utf-8"))
+
+
+def note_identity(
+    *,
+    field_note_id: str = "fn_a5_candidate",
+    note_bytes: bytes = NOTE_BYTES,
+    note_path: str = (
+        ".decision-os/field-notes/"
+        "2026-08-04-a5-commit-bridge-aaaaaaaaaa.md"
+    ),
+    origin_run_id: str = "run_origin",
+) -> FieldNoteIdentity:
+    return FieldNoteIdentity(
+        note_path=note_path,
+        field_note_id=field_note_id,
+        note_sha256=digest_bytes(note_bytes),
+        origin_run_id=origin_run_id,
+    )
+
+
+def structure_binding(
+    note: FieldNoteIdentity,
+    *,
+    note_bytes: bytes = NOTE_BYTES,
+) -> FieldNoteStructureBinding:
+    start = note_bytes.index(STRUCTURE_BYTES)
+    return bind_field_note_structure(
+        note,
+        note_bytes,
+        structure_id="restart-state-identity-guard",
+        start_byte=start,
+        end_byte=start + len(STRUCTURE_BYTES),
+    )
+
+
+def use_evidence(
+    note: FieldNoteIdentity,
+    *,
+    note_bytes: bytes = NOTE_BYTES,
+    run_suffix: str = "1",
+    evidence_class: str = "RULE_TRACE",
+    binding: FieldNoteStructureBinding | None = None,
+) -> FieldNoteUseEvidence:
+    reusing_run_id = f"run_reuse_{run_suffix}"
+    return FieldNoteUseEvidence(
+        evidence_class=evidence_class,  # type: ignore[arg-type]
+        evidence_origin="IMMEDIATE_COMPLETION_RECORD",
+        reusing_run_id=reusing_run_id,
+        structure_binding=binding or structure_binding(note, note_bytes=note_bytes),
+        evidence_ref=f"run:{reusing_run_id}/evidence:guard",
+        evidence_sha256=digest(f"use-evidence-{run_suffix}"),
+        observer_id="observer_a5",
+        observer_relation="INDEPENDENT",
+        as_of=AS_OF,
+    )
+
+
+def reuse_claim(
+    note: FieldNoteIdentity,
+    *,
+    note_bytes: bytes = NOTE_BYTES,
+    run_suffix: str = "1",
+    evidence_class: str = "RULE_TRACE",
+    outcome: str = "UNKNOWN",
+    action: str | None = None,
+    intervention: str = "NONE",
+    evidence: FieldNoteUseEvidence | None = None,
+    include_evidence: bool = True,
+    claimed_note: FieldNoteIdentity | None = None,
+    narrative: str | None = None,
+) -> FieldNoteReuseClaim:
+    reusing_run_id = f"run_reuse_{run_suffix}"
+    typed_evidence = evidence
+    if typed_evidence is None and include_evidence:
+        typed_evidence = use_evidence(
+            note,
+            note_bytes=note_bytes,
+            run_suffix=run_suffix,
+            evidence_class=evidence_class,
+        )
+    evaluation = None
+    if outcome != "UNKNOWN":
+        causal = outcome in {"HELPFUL", "HARMFUL"}
+        evaluation = FieldNoteOutcomeEvaluation(
+            outcome=outcome,  # type: ignore[arg-type]
+            scope="The bounded A5 test scope.",
+            observer_id="outcome_observer_a5",
+            observer_relation="INDEPENDENT",
+            as_of=AS_OF,
+            causal_evidence_ref=(
+                f"run:{reusing_run_id}/causal" if causal else None
+            ),
+            causal_evidence_sha256=(
+                digest(f"causal-evidence-{run_suffix}") if causal else None
+            ),
+            contribution_separated=True,
+        )
+    if action is None and outcome == "HELPFUL":
+        action = "KEEP"
+    if action is None and outcome in {"NOT_HELPFUL", "HARMFUL"}:
+        action = "STOP"
+    disposition = None
+    if action == "KEEP":
+        disposition = FieldNoteReuseDisposition(action="KEEP")
+    elif action == "STOP":
+        disposition = FieldNoteReuseDisposition(
+            action="STOP",
+            stop_scope=f"Bounded task family {run_suffix}.",
+        )
+    elif action == "REVISE":
+        successor_bytes = note_bytes + run_suffix.encode("ascii")
+        successor = note_identity(
+            field_note_id=f"fn_a5_successor_{run_suffix}",
+            note_bytes=successor_bytes,
+            note_path=(
+                ".decision-os/field-notes/"
+                f"2026-08-04-a5-successor-{run_suffix.zfill(10)}.md"
+            ),
+            origin_run_id=reusing_run_id,
+        )
+        disposition = FieldNoteReuseDisposition(
+            action="REVISE",
+            revision_candidate=successor,
+        )
+    return FieldNoteReuseClaim(
+        claimed_note=claimed_note or note,
+        reusing_run_id=reusing_run_id,
+        use_evidence=typed_evidence,
+        outcome_evaluation=evaluation,
+        human_intervention=intervention,  # type: ignore[arg-type]
+        disposition=disposition,
+        narrative_claim=narrative,
+    )
+
+
+def reconnect_receipt(note: FieldNoteIdentity) -> FieldNoteReconnectReceipt:
+    return FieldNoteReconnectReceipt(
+        run_id="run_reuse_1",
+        state="ACTIVATION_UNKNOWN",
+        failure_reason=None,
+        metadata_entries_seen=1,
+        metadata_candidate_files_seen=1,
+        metadata_files_valid=1,
+        metadata_bytes_read=700,
+        selected_field_note_path=note.note_path,
+        selected_field_note_id=note.field_note_id,
+        selected_metadata_sha256=digest("metadata"),
+        selected_full_note_sha256=note.note_sha256,
+        full_note_bytes_read=len(NOTE_BYTES),
+        full_notes_injected=1,
+        ordinary_distinct_paths_consumed=1,
+    )
+
+
+class MaturityCommitTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name) / "maturity-ledger-v0.1"
+        self.note = note_identity()
+        self.ledger = FieldNoteMaturityLedger(self.root, self.note)
+
+    def request(
+        self,
+        *,
+        claim: FieldNoteReuseClaim | None = None,
+        note: FieldNoteIdentity | None = None,
+        note_bytes: bytes = NOTE_BYTES,
+        recorded_at: str = RECORDED_AT,
+        delivery_context: FieldNoteReconnectReceipt | None = None,
+    ) -> FieldNoteMaturityCommitRequest:
+        return FieldNoteMaturityCommitRequest(
+            note=note or self.note,
+            note_bytes=note_bytes,
+            reuse_claim=(reuse_claim(self.note) if claim is None else claim),
+            recorded_at=recorded_at,
+            delivery_context=delivery_context,
+        )
+
+    def commit(
+        self,
+        *,
+        claim: FieldNoteReuseClaim | None = None,
+        ledger: FieldNoteMaturityLedger | None = None,
+        delivery_context: FieldNoteReconnectReceipt | None = None,
+        recorded_at: str = RECORDED_AT,
+    ):
+        request = self.request(
+            claim=claim,
+            delivery_context=delivery_context,
+            recorded_at=recorded_at,
+        )
+        return commit_field_note_maturity(ledger or self.ledger, request)
+
+
+class FieldNotesMaturityCommitFlowTests(MaturityCommitTestCase):
+    def test_valid_typed_evidence_is_recorded_only_after_a4_read_back(self) -> None:
+        class ReadbackSpyLedger(FieldNoteMaturityLedger):
+            reconstruct_calls = 0
+
+            def reconstruct(self, *, note_bytes: bytes):
+                self.reconstruct_calls += 1
+                return super().reconstruct(note_bytes=note_bytes)
+
+        ledger = ReadbackSpyLedger(self.root, self.note)
+        result = self.commit(ledger=ledger)
+        self.assertEqual("RECORDED", result.status)
+        self.assertTrue(result.durable_commit_confirmed)
+        self.assertEqual(1, ledger.reconstruct_calls)
+        self.assertEqual(result.assessment, result.append_result.event.receipt)
+        self.assertEqual(RECORDED_AT, result.append_result.event.recorded_at)
+        self.assertIn(
+            result.assessment.reuse_event_id,
+            result.durable_snapshot.evidence_maturity.reuse_event_ids,
+        )
+
+    def test_duplicate_retry_returns_already_recorded(self) -> None:
+        first = self.commit()
+        second = self.commit(recorded_at="2026-08-04T09:02:00Z")
+        self.assertEqual("RECORDED", first.status)
+        self.assertEqual("ALREADY_RECORDED", second.status)
+        self.assertTrue(second.durable_commit_confirmed)
+        self.assertEqual(first.durable_snapshot, second.durable_snapshot)
+
+    def test_duplicate_retry_does_not_change_ledger_bytes(self) -> None:
+        self.commit()
+        events_before = self.ledger.events_path.read_bytes()
+        head_before = self.ledger.head_path.read_bytes()
+        self.commit(recorded_at="2026-08-04T09:02:00Z")
+        self.assertEqual(events_before, self.ledger.events_path.read_bytes())
+        self.assertEqual(head_before, self.ledger.head_path.read_bytes())
+
+    def test_duplicate_retry_does_not_increase_event_count(self) -> None:
+        self.commit()
+        second = self.commit()
+        self.assertEqual(1, len(second.durable_snapshot.events))
+        self.assertEqual(
+            1,
+            len(second.durable_snapshot.evidence_maturity.reuse_event_ids),
+        )
+
+    def test_candidate_does_not_enter_a4(self) -> None:
+        claim = reuse_claim(
+            self.note,
+            include_evidence=False,
+            narrative="I used the Note.",
+        )
+        result = self.commit(claim=claim)
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertFalse(result.durable_commit_confirmed)
+        self.assertEqual("CANDIDATE", result.assessment.state)
+        self.assertIsNone(result.append_result)
+        self.assertIsNone(result.durable_snapshot)
+        self.assertFalse(self.root.exists())
+
+    def test_a2_injection_alone_does_not_enter_a4(self) -> None:
+        request = FieldNoteMaturityCommitRequest(
+            note=self.note,
+            note_bytes=NOTE_BYTES,
+            reuse_claim=None,
+            recorded_at=RECORDED_AT,
+            delivery_context=reconnect_receipt(self.note),
+        )
+        result = commit_field_note_maturity(self.ledger, request)
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertEqual("USE_EVIDENCE_MISSING", result.assessment.failure_reason)
+        self.assertEqual(request.delivery_context, result.delivery_context)
+        self.assertFalse(self.root.exists())
+
+    def test_narrative_reuse_claim_does_not_enter_a4(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(
+                self.note,
+                include_evidence=False,
+                narrative="I used the Note and it helped.",
+            )
+        )
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertFalse(self.root.exists())
+
+    def test_task_success_alone_does_not_enter_a4(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(
+                self.note,
+                include_evidence=False,
+                narrative="The task completed successfully.",
+            )
+        )
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertFalse(self.root.exists())
+
+    def test_human_approval_alone_does_not_enter_a4(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(
+                self.note,
+                include_evidence=False,
+                intervention="NON_DECISIVE",
+                narrative="The human approved the result.",
+            )
+        )
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertFalse(self.root.exists())
+
+    def test_exact_claimed_note_mismatch_fails_closed_to_candidate(self) -> None:
+        other = replace(self.note, field_note_id="fn_a5_other")
+        result = self.commit(
+            claim=reuse_claim(self.note, claimed_note=other)
+        )
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertEqual("NOTE_IDENTITY_MISMATCH", result.assessment.failure_reason)
+        self.assertFalse(self.root.exists())
+
+    def test_different_a4_note_partition_is_rejected(self) -> None:
+        other = replace(self.note, field_note_id="fn_a5_other")
+        other_ledger = FieldNoteMaturityLedger(self.root, other)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "different A4 Note partition",
+        ):
+            commit_field_note_maturity(other_ledger, self.request())
+
+    def test_changed_note_bytes_are_rejected_before_assessment(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "do not match",
+        ):
+            self.request(note_bytes=NOTE_BYTES + b"changed")
+        self.assertFalse(self.root.exists())
+
+    def test_invalid_recorded_at_is_rejected_before_assessment(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "recorded_at",
+        ):
+            self.request(recorded_at="not-a-timestamp")
+        self.assertFalse(self.root.exists())
+
+    def test_invalid_structure_binding_fails_closed_to_candidate(self) -> None:
+        binding = replace(
+            structure_binding(self.note),
+            structure_sha256=digest("wrong structure"),
+        )
+        evidence = use_evidence(self.note, binding=binding)
+        result = self.commit(
+            claim=reuse_claim(self.note, evidence=evidence)
+        )
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertEqual(
+            "STRUCTURE_BINDING_INVALID",
+            result.assessment.failure_reason,
+        )
+        self.assertFalse(self.root.exists())
+
+    def test_origin_and_reusing_runs_must_differ(self) -> None:
+        evidence = use_evidence(self.note, run_suffix="origin")
+        evidence = replace(evidence, reusing_run_id=self.note.origin_run_id)
+        claim = FieldNoteReuseClaim(
+            claimed_note=self.note,
+            reusing_run_id=self.note.origin_run_id,
+            use_evidence=evidence,
+            outcome_evaluation=None,
+            human_intervention="NONE",
+            disposition=None,
+        )
+        result = self.commit(claim=claim)
+        self.assertEqual("NOT_REUSED", result.status)
+        self.assertEqual(
+            "ORIGIN_RUN_NOT_DIFFERENT",
+            result.assessment.failure_reason,
+        )
+        self.assertFalse(self.root.exists())
+
+
+class FieldNotesMaturityCommitEvidenceTests(MaturityCommitTestCase):
+    def test_rule_trace_evidence_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, evidence_class="RULE_TRACE")
+        )
+        self.assertEqual("RULE_TRACE", result.assessment.use_evidence.evidence_class)
+        self.assertEqual(result.assessment, result.append_result.event.receipt)
+
+    def test_output_artifact_evidence_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, evidence_class="OUTPUT_ARTIFACT")
+        )
+        self.assertEqual(
+            "OUTPUT_ARTIFACT",
+            result.assessment.use_evidence.evidence_class,
+        )
+        self.assertEqual(result.assessment, result.append_result.event.receipt)
+
+    def test_helpful_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, outcome="HELPFUL")
+        )
+        self.assertEqual("HELPFUL", result.assessment.outcome)
+        self.assertEqual("KEEP", result.assessment.next_action)
+
+    def test_not_helpful_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, outcome="NOT_HELPFUL")
+        )
+        self.assertEqual("NOT_HELPFUL", result.assessment.outcome)
+        self.assertEqual("STOP", result.assessment.next_action)
+
+    def test_harmful_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, outcome="HARMFUL")
+        )
+        self.assertEqual("HARMFUL", result.assessment.outcome)
+        self.assertEqual("STOP", result.assessment.next_action)
+
+    def test_unknown_defaults_to_reused_and_hold(self) -> None:
+        result = self.commit(claim=reuse_claim(self.note))
+        self.assertEqual("REUSED", result.assessment.state)
+        self.assertEqual("UNKNOWN", result.assessment.outcome)
+        self.assertEqual("HOLD", result.assessment.next_action)
+        self.assertTrue(result.assessment.reevaluation_condition)
+
+    def test_causal_evidence_and_outcome_scope_are_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, outcome="HELPFUL")
+        )
+        self.assertEqual("The bounded A5 test scope.", result.assessment.outcome_scope)
+        self.assertTrue(result.assessment.causal_evidence_ref)
+        self.assertTrue(result.assessment.causal_evidence_sha256)
+        self.assertTrue(result.assessment.contribution_separated)
+        self.assertEqual(
+            "outcome_observer_a5",
+            result.assessment.outcome_observer_id,
+        )
+        self.assertEqual(
+            "INDEPENDENT",
+            result.assessment.outcome_observer_relation,
+        )
+        self.assertEqual(
+            "INDEPENDENT_CONFIRMATION",
+            result.assessment.outcome_confirmation,
+        )
+
+    def test_human_intervention_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(
+                self.note,
+                outcome="HELPFUL",
+                intervention="MATERIAL",
+            )
+        )
+        self.assertEqual("MATERIAL", result.assessment.human_intervention)
+        self.assertEqual("HELPFUL", result.assessment.outcome)
+
+    def test_bounded_stop_is_preserved(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(self.note, outcome="HARMFUL")
+        )
+        self.assertEqual("STOP", result.assessment.next_action)
+        self.assertEqual("Bounded task family 1.", result.assessment.stop_scope)
+
+    def test_revise_preserves_forward_predecessor_and_successor(self) -> None:
+        result = self.commit(
+            claim=reuse_claim(
+                self.note,
+                outcome="NOT_HELPFUL",
+                action="REVISE",
+            )
+        )
+        revision = result.assessment.revision
+        self.assertEqual(self.note, revision.predecessor)
+        self.assertNotEqual(self.note, revision.successor)
+        self.assertEqual(
+            result.assessment.reusing_run_id,
+            revision.successor.origin_run_id,
+        )
+
+
+class FieldNotesMaturityCommitIntegrityTests(MaturityCommitTestCase):
+    def test_optional_a2_provenance_does_not_change_maturity(self) -> None:
+        without_root = Path(self.temporary.name) / "without-a2"
+        with_root = Path(self.temporary.name) / "with-a2"
+        without = commit_field_note_maturity(
+            FieldNoteMaturityLedger(without_root, self.note),
+            self.request(),
+        )
+        context = reconnect_receipt(self.note)
+        with_context = commit_field_note_maturity(
+            FieldNoteMaturityLedger(with_root, self.note),
+            self.request(delivery_context=context),
+        )
+        self.assertEqual(without.assessment, with_context.assessment)
+        self.assertEqual(
+            without.durable_snapshot.evidence_maturity,
+            with_context.durable_snapshot.evidence_maturity,
+        )
+        self.assertEqual(
+            0,
+            with_context.durable_snapshot.evidence_maturity.reconnect_receipts_ignored,
+        )
+        self.assertEqual(context, with_context.delivery_context)
+
+    def test_append_failure_cannot_return_committed_success(self) -> None:
+        class AppendFailureLedger(FieldNoteMaturityLedger):
+            def append_receipt(self, *args, **kwargs):
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "simulated A4 append failure"
+                )
+
+        ledger = AppendFailureLedger(self.root, self.note)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "simulated A4 append failure",
+        ):
+            self.commit(ledger=ledger)
+        self.assertFalse(self.root.exists())
+
+    def test_read_back_integrity_failure_cannot_return_committed_success(self) -> None:
+        class ReadbackFailureLedger(FieldNoteMaturityLedger):
+            def reconstruct(self, *, note_bytes: bytes):
+                raise FieldNoteMaturityLedgerIntegrityError(
+                    "simulated A4 read-back failure"
+                )
+
+        ledger = ReadbackFailureLedger(self.root, self.note)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "simulated A4 read-back failure",
+        ):
+            self.commit(ledger=ledger)
+        events = FieldNoteMaturityLedger(self.root, self.note).read_events(
+            note_bytes=NOTE_BYTES
+        )
+        self.assertEqual(1, len(events))
+        recovered = self.commit(
+            ledger=FieldNoteMaturityLedger(self.root, self.note)
+        )
+        self.assertEqual("ALREADY_RECORDED", recovered.status)
+        self.assertEqual(1, len(recovered.durable_snapshot.events))
+
+    def test_unconfirmed_read_back_cannot_return_committed_success(self) -> None:
+        class MissingEventLedger(FieldNoteMaturityLedger):
+            def reconstruct(self, *, note_bytes: bytes):
+                snapshot = super().reconstruct(note_bytes=note_bytes)
+                return replace(snapshot, events=())
+
+        ledger = MissingEventLedger(self.root, self.note)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitConfirmationError,
+            "did not confirm",
+        ):
+            self.commit(ledger=ledger)
+
+    def test_retry_after_simulated_response_loss_reconciles_idempotently(self) -> None:
+        class ResponseLossLedger(FieldNoteMaturityLedger):
+            failed = False
+
+            def append_receipt(self, *args, **kwargs):
+                result = super().append_receipt(*args, **kwargs)
+                if not self.failed:
+                    self.failed = True
+                    raise FieldNoteMaturityLedgerIntegrityError(
+                        "simulated response loss after append"
+                    )
+                return result
+
+        lossy = ResponseLossLedger(self.root, self.note)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "response loss",
+        ):
+            self.commit(ledger=lossy)
+        events_before = lossy.events_path.read_bytes()
+        recovered = self.commit(
+            ledger=FieldNoteMaturityLedger(self.root, self.note)
+        )
+        self.assertEqual("ALREADY_RECORDED", recovered.status)
+        self.assertEqual(1, len(recovered.durable_snapshot.events))
+        self.assertEqual(events_before, lossy.events_path.read_bytes())
+
+    def test_serving_policy_remains_separate_and_delayed(self) -> None:
+        result = self.commit()
+        policy = result.durable_snapshot.current_serving_policy
+        self.assertEqual("REUSED", result.durable_snapshot.evidence_maturity.state)
+        self.assertEqual("DELAY", policy.derivation)
+        self.assertFalse(policy.automatic_derivation_supported)
+        self.assertFalse(policy.complete_state_machine_implemented)
+
+    def test_promotable_remains_unset(self) -> None:
+        result = self.commit()
+        promotion = result.durable_snapshot.evidence_maturity.promotion
+        self.assertEqual("PROMOTABLE", promotion.reserved_state)
+        self.assertEqual("UNSET", promotion.policy_status)
+        self.assertIsNone(promotion.threshold)
+        self.assertFalse(promotion.automatically_derivable)
+
+    def test_reused_does_not_imply_injection(self) -> None:
+        result = self.commit()
+        policy = result.durable_snapshot.current_serving_policy
+        self.assertIsNone(result.delivery_context)
+        self.assertIsNone(policy.automatic_injection)
+
+    def test_canonical_authority_remains_above_field_notes(self) -> None:
+        result = self.commit()
+        self.assertEqual(
+            ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE"),
+            result.durable_snapshot.current_serving_policy.authority_precedence,
+        )
+
+    def test_existing_note_bytes_remain_unchanged(self) -> None:
+        before = bytes(NOTE_BYTES)
+        self.commit()
+        self.assertEqual(before, NOTE_BYTES)
+        self.assertEqual(self.note.note_sha256, digest_bytes(NOTE_BYTES))
+
+    def test_result_serialization_is_deterministic(self) -> None:
+        first = self.commit()
+        second = self.commit()
+        self.assertEqual(first.durable_snapshot, second.durable_snapshot)
+        self.assertEqual(
+            first.as_dict()["durable_snapshot"],
+            second.as_dict()["durable_snapshot"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_field_notes_maturity_commit.py
+++ b/tests/test_field_notes_maturity_commit.py
@@ -9,6 +9,7 @@ import unittest
 from decision_os.companion.field_notes_maturity_commit import (
     FieldNoteMaturityCommitConfirmationError,
     FieldNoteMaturityCommitRequest,
+    FieldNoteMaturityCommitResult,
     FieldNoteMaturityCommitValidationError,
     commit_field_note_maturity,
 )
@@ -182,21 +183,52 @@ def reuse_claim(
     )
 
 
-def reconnect_receipt(note: FieldNoteIdentity) -> FieldNoteReconnectReceipt:
+def reconnect_receipt(
+    note: FieldNoteIdentity,
+    *,
+    state: str = "ACTIVATION_UNKNOWN",
+    run_id: str = "run_reuse_1",
+    note_path: str | None = None,
+    field_note_id: str | None = None,
+    note_sha256: str | None = None,
+    full_note_bytes_read: int | None = None,
+) -> FieldNoteReconnectReceipt:
+    selected = state != "NO_MATCH"
+    injected = state in {"INJECTED", "ACTIVATION_UNKNOWN"}
     return FieldNoteReconnectReceipt(
-        run_id="run_reuse_1",
-        state="ACTIVATION_UNKNOWN",
+        run_id=run_id,
+        state=state,  # type: ignore[arg-type]
         failure_reason=None,
         metadata_entries_seen=1,
         metadata_candidate_files_seen=1,
         metadata_files_valid=1,
         metadata_bytes_read=700,
-        selected_field_note_path=note.note_path,
-        selected_field_note_id=note.field_note_id,
-        selected_metadata_sha256=digest("metadata"),
-        selected_full_note_sha256=note.note_sha256,
-        full_note_bytes_read=len(NOTE_BYTES),
-        full_notes_injected=1,
+        selected_field_note_path=(
+            (note.note_path if note_path is None else note_path)
+            if selected
+            else None
+        ),
+        selected_field_note_id=(
+            (note.field_note_id if field_note_id is None else field_note_id)
+            if selected
+            else None
+        ),
+        selected_metadata_sha256=(digest("metadata") if selected else None),
+        selected_full_note_sha256=(
+            (note.note_sha256 if note_sha256 is None else note_sha256)
+            if selected
+            else None
+        ),
+        full_note_bytes_read=(
+            (
+                len(NOTE_BYTES)
+                if full_note_bytes_read is None
+                else full_note_bytes_read
+            )
+            if selected
+            else 0
+        ),
+        full_notes_injected=1 if injected else 0,
         ordinary_distinct_paths_consumed=1,
     )
 
@@ -418,6 +450,166 @@ class FieldNotesMaturityCommitFlowTests(MaturityCommitTestCase):
             result.assessment.failure_reason,
         )
         self.assertFalse(self.root.exists())
+
+
+class FieldNotesMaturityCommitDeliveryProvenanceTests(MaturityCommitTestCase):
+    def test_matching_injected_a2_context_is_retained(self) -> None:
+        context = reconnect_receipt(self.note, state="INJECTED")
+        result = self.commit(delivery_context=context)
+        self.assertEqual(context, result.delivery_context)
+
+    def test_matching_activation_unknown_a2_context_is_retained(self) -> None:
+        context = reconnect_receipt(self.note, state="ACTIVATION_UNKNOWN")
+        result = self.commit(delivery_context=context)
+        self.assertEqual(context, result.delivery_context)
+
+    def test_absent_a2_context_remains_valid(self) -> None:
+        result = self.commit(delivery_context=None)
+        self.assertEqual("RECORDED", result.status)
+        self.assertIsNone(result.delivery_context)
+
+    def test_no_match_a2_context_is_rejected(self) -> None:
+        context = reconnect_receipt(self.note, state="NO_MATCH")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "not injected",
+        ):
+            self.request(delivery_context=context)
+
+    def test_selected_but_not_injected_a2_context_is_rejected(self) -> None:
+        context = reconnect_receipt(self.note, state="SELECTED")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "not injected",
+        ):
+            self.request(delivery_context=context)
+
+    def test_different_note_path_a2_context_is_rejected(self) -> None:
+        context = reconnect_receipt(
+            self.note,
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-04-different-note-bbbbbbbbbb.md"
+            ),
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "exact Field Note",
+        ):
+            self.request(delivery_context=context)
+
+    def test_different_field_note_id_a2_context_is_rejected(self) -> None:
+        context = reconnect_receipt(
+            self.note,
+            field_note_id="fn_a5_different",
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "exact Field Note",
+        ):
+            self.request(delivery_context=context)
+
+    def test_different_full_note_sha256_a2_context_is_rejected(self) -> None:
+        context = reconnect_receipt(
+            self.note,
+            note_sha256=digest("different full Note"),
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "exact Field Note",
+        ):
+            self.request(delivery_context=context)
+
+    def test_different_full_note_byte_count_a2_context_is_rejected(self) -> None:
+        context = reconnect_receipt(
+            self.note,
+            full_note_bytes_read=len(NOTE_BYTES) + 1,
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "exact Field Note",
+        ):
+            self.request(delivery_context=context)
+
+    def test_different_a2_run_id_is_rejected_when_a3_claim_exists(self) -> None:
+        context = reconnect_receipt(self.note, run_id="run_reuse_different")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityCommitValidationError,
+            "different reusing Run",
+        ):
+            self.request(delivery_context=context)
+
+    def test_rejected_a2_context_creates_no_a4_ledger_mutation(self) -> None:
+        context = reconnect_receipt(
+            self.note,
+            note_sha256=digest("cross-bound Note"),
+        )
+        with self.assertRaises(FieldNoteMaturityCommitValidationError):
+            self.request(delivery_context=context)
+        self.assertFalse(self.root.exists())
+
+    def test_valid_a2_context_does_not_change_a3_or_a4_axes(self) -> None:
+        without_root = Path(self.temporary.name) / "provenance-without-a2"
+        with_root = Path(self.temporary.name) / "provenance-with-a2"
+        without = commit_field_note_maturity(
+            FieldNoteMaturityLedger(without_root, self.note),
+            self.request(),
+        )
+        context = reconnect_receipt(self.note, state="INJECTED")
+        with_context = commit_field_note_maturity(
+            FieldNoteMaturityLedger(with_root, self.note),
+            self.request(delivery_context=context),
+        )
+        self.assertEqual(without.assessment, with_context.assessment)
+        self.assertEqual(
+            without.assessment.reuse_event_id,
+            with_context.assessment.reuse_event_id,
+        )
+        self.assertEqual(
+            without.append_result.event,
+            with_context.append_result.event,
+        )
+        self.assertEqual(
+            without.durable_snapshot.evidence_maturity,
+            with_context.durable_snapshot.evidence_maturity,
+        )
+        self.assertEqual(
+            len(without.durable_snapshot.events),
+            len(with_context.durable_snapshot.events),
+        )
+        self.assertEqual(
+            without.durable_snapshot.current_serving_policy,
+            with_context.durable_snapshot.current_serving_policy,
+        )
+        self.assertIsNone(
+            with_context.durable_snapshot.current_serving_policy
+            .automatic_injection
+        )
+        self.assertEqual(context, with_context.delivery_context)
+
+    def test_direct_committed_result_rejects_cross_bound_a2_context(self) -> None:
+        context = reconnect_receipt(self.note)
+        valid = self.commit(delivery_context=context)
+        cross_bound = (
+            replace(
+                context,
+                selected_field_note_path=(
+                    ".decision-os/field-notes/"
+                    "2026-08-04-direct-cross-bound-cccccccccc.md"
+                ),
+            ),
+            replace(context, run_id="run_reuse_different"),
+        )
+        for invalid_context in cross_bound:
+            with self.subTest(invalid_context=invalid_context):
+                with self.assertRaises(FieldNoteMaturityCommitValidationError):
+                    FieldNoteMaturityCommitResult(
+                        status=valid.status,
+                        assessment=valid.assessment,
+                        delivery_context=invalid_context,
+                        append_result=valid.append_result,
+                        durable_snapshot=valid.durable_snapshot,
+                    )
 
 
 class FieldNotesMaturityCommitEvidenceTests(MaturityCommitTestCase):


### PR DESCRIPTION
## Summary

Implements the bounded Field Notes Lite A5 Operational Maturity Commit Bridge v0.1 as a pure service boundary.

- Accepts an exact typed Note identity, exact Note bytes, bounded A3 reuse claim, recorded As-of, and optional non-authoritative A2 delivery context.
- Invokes A3 assessment and never appends a CANDIDATE result.
- For REUSED, appends through A4, reconstructs the exact Note partition, and confirms the same receipt/event before returning committed success.
- Distinguishes `NOT_REUSED`, `RECORDED`, and `ALREADY_RECORDED`.
- Preserves A4 duplicate idempotence and reconciles retries after append-response or read-back failure without adding an effective event.
- Propagates underlying A4 errors unchanged; no unconfirmed append can become a successful result.
- Preserves complete A3 evidence and keeps Evidence Maturity separate from delayed Current Serving Policy.
- When optional A2 delivery provenance is present, requires one injected exact-Note receipt and the same reusing Run when an A3 claim exists; absence remains valid, and A2 cannot alter assessment, A4 identity/count, Serving Policy, or injection authority.

## Base and head

- Fresh base/main: `b8a6b602e6779c4af7d58f7123806ea6ecb5710b`
- Reviewed head before repair: `7ba5cbbc9912c2e54e3d3f39b095a7b400c54590`
- Current head: `1aa45ca2b53bd32540f160433e068ab7d4e71d66`

## Delta

- `decision_os/companion/field_notes_maturity_commit.py` — typed A5 request/result contracts and the bounded A3 → A4 commit/read-back flow.
- `tests/test_field_notes_maturity_commit.py` — 49 deterministic admission, exact-Note/same-Run A2 provenance, evidence-preservation, retry, failure, and projection tests.

No A1–A4 source changes, runtime wiring, controller/server route, UI, installation, Companion restart, live Run, Serving Policy engine, promotion threshold, or real REUSED evidence is included.

## Validation

- `python3 -m unittest tests.test_field_notes_maturity_commit` — 49/49 PASS
- `python3 -m unittest tests.test_field_notes_maturity_ledger` — 40/40 PASS
- `python3 -m unittest tests.test_field_notes_reuse` — 45/45 PASS
- `python3 -m unittest tests.test_field_notes_lite` — 25/25 PASS
- `python3 -m unittest tests.test_field_notes_reconnect` — 36/36 PASS
- `python3 -m unittest tests.test_companion_controller` — 27/27 PASS
- `python3 -m unittest tests.test_companion_server` — 35/35 PASS
- `python3 -m unittest` — 892/892 PASS
- `python3 -m unittest discover -s tests -p 'test_*.py'` — 892/892 PASS
- Normalized default/explicit IDs — MATCH (892 unique IDs each; SHA-256 `d52b7ebe8e403ee135a0016626bbbf1118c26c78841e30bdd0f9b42cbc85d89b`; no one-sided IDs)
- `python3 -m compileall -q decision_os tests` — PASS
- `git diff --check` and cached diff check — PASS
- Protected Creator Note and four validation artifacts — SHA-256, size, mode, mtime, and inode unchanged from preflight

## Claim boundary

Supported: A5 provides a typed, idempotent operational path that converts bounded A3 reuse evidence into an A4-confirmed durable maturity record and returns a deterministic read-back projection without deriving Serving Policy.

Not claimed: any real Note is REUSED; helpful; PROMOTABLE; automatic promotion; mandatory/default injection; successful intelligence transplant; generalization; performance improvement; measured savings; or external adoption.
