### PR TITLE
Add Field Notes A6 maturity evidence review surface

### DIFF
--- a/decision_os/companion/field_notes_maturity_review.py
+++ b/decision_os/companion/field_notes_maturity_review.py
@@ -1,0 +1,619 @@
+"""Read-only Field Notes Lite A6 maturity evidence review projection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import re
+from typing import Any, Literal
+
+from decision_os.companion.field_notes_maturity_ledger import (
+    GENESIS_EVENT_SHA256,
+    FieldNoteMaturityLedger,
+    FieldNoteMaturityLedgerEvent,
+)
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteMaturitySummary,
+    FieldNoteRevisionLink,
+    FieldNoteServingPolicyBoundary,
+    HumanIntervention,
+    NextAction,
+    ObserverRelation,
+    OutcomeConfirmation,
+    ReuseOutcome,
+    UseEvidenceClass,
+    UseEvidenceOrigin,
+)
+
+
+MATURITY_REVIEW_SCHEMA = "decision-os.field-note-maturity-review.v0.1"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class FieldNoteMaturityReviewError(RuntimeError):
+    """Base error for an A6 review packet that cannot be produced safely."""
+
+
+class FieldNoteMaturityReviewValidationError(
+    FieldNoteMaturityReviewError,
+    ValueError,
+):
+    """The requested exact Note, A4 partition, or review As-of is invalid."""
+
+
+def _validate_review_as_of(value: Any) -> str:
+    if not isinstance(value, str):
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review As-of must be text."
+        )
+    normalized = value.strip()
+    if not normalized or len(normalized) > 64 or "\x00" in normalized:
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review As-of is outside its bounded schema."
+        )
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review As-of must be an RFC 3339 timestamp."
+        ) from exc
+    if parsed.tzinfo is None:
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review As-of must be timezone-aware."
+        )
+    return normalized
+
+
+def _require_sha256(value: Any, label: str) -> None:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest.")
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityReviewLedgerIdentity:
+    """Exact A4 partition and verified event-chain identity."""
+
+    note_partition_sha256: str
+    chain_head_sha256: str
+    durable_event_count: int
+
+    def __post_init__(self) -> None:
+        _require_sha256(self.note_partition_sha256, "Note partition identity")
+        _require_sha256(self.chain_head_sha256, "A4 chain head")
+        if type(self.durable_event_count) is not int or self.durable_event_count < 0:
+            raise ValueError("Durable event count is invalid.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "note_partition_sha256": self.note_partition_sha256,
+            "chain_head_sha256": self.chain_head_sha256,
+            "durable_event_count": self.durable_event_count,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityReviewSignals:
+    """Deterministic evidence descriptions, never scores or policy decisions."""
+
+    helpful_outcomes: int
+    not_helpful_outcomes: int
+    harmful_outcomes: int
+    unknown_outcomes: int
+    material_or_unknown_interventions: int
+    same_run_outcome_claims: int
+    run_related_outcome_claims: int
+    independent_outcome_confirmations: int
+    keep_dispositions: int
+    hold_dispositions: int
+    stop_dispositions: int
+    revise_links: int
+    unique_reusing_runs: int
+    unique_specific_structures: int
+    rule_trace_events: int
+    output_artifact_events: int
+    evidence_classes: tuple[UseEvidenceClass, ...]
+
+    def __post_init__(self) -> None:
+        counts = (
+            self.helpful_outcomes,
+            self.not_helpful_outcomes,
+            self.harmful_outcomes,
+            self.unknown_outcomes,
+            self.material_or_unknown_interventions,
+            self.same_run_outcome_claims,
+            self.run_related_outcome_claims,
+            self.independent_outcome_confirmations,
+            self.keep_dispositions,
+            self.hold_dispositions,
+            self.stop_dispositions,
+            self.revise_links,
+            self.unique_reusing_runs,
+            self.unique_specific_structures,
+            self.rule_trace_events,
+            self.output_artifact_events,
+        )
+        if any(type(value) is not int or value < 0 for value in counts):
+            raise ValueError("Maturity review signal counts are invalid.")
+        if (
+            tuple(sorted(set(self.evidence_classes))) != self.evidence_classes
+            or any(
+                value not in {"RULE_TRACE", "OUTPUT_ARTIFACT"}
+                for value in self.evidence_classes
+            )
+        ):
+            raise ValueError("Maturity review evidence classes are invalid.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "helpful_outcomes": self.helpful_outcomes,
+            "not_helpful_outcomes": self.not_helpful_outcomes,
+            "harmful_outcomes": self.harmful_outcomes,
+            "unknown_outcomes": self.unknown_outcomes,
+            "material_or_unknown_interventions": (
+                self.material_or_unknown_interventions
+            ),
+            "same_run_outcome_claims": self.same_run_outcome_claims,
+            "run_related_outcome_claims": self.run_related_outcome_claims,
+            "independent_outcome_confirmations": (
+                self.independent_outcome_confirmations
+            ),
+            "keep_dispositions": self.keep_dispositions,
+            "hold_dispositions": self.hold_dispositions,
+            "stop_dispositions": self.stop_dispositions,
+            "revise_links": self.revise_links,
+            "unique_reusing_runs": self.unique_reusing_runs,
+            "unique_specific_structures": self.unique_specific_structures,
+            "rule_trace_events": self.rule_trace_events,
+            "output_artifact_events": self.output_artifact_events,
+            "evidence_classes": list(self.evidence_classes),
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityEventReview:
+    """Bounded projection of one sequence-ordered, A4-verified reuse event."""
+
+    sequence: int
+    recorded_at: str
+    event_id: str
+    previous_event_sha256: str
+    event_sha256: str
+    reusing_run_id: str
+    structure_id: str
+    structure_sha256: str
+    structure_binding_sha256: str
+    evidence_class: UseEvidenceClass
+    evidence_origin: UseEvidenceOrigin
+    evidence_ref: str
+    evidence_sha256: str
+    use_evidence_observer_id: str
+    use_evidence_observer_relation: ObserverRelation
+    use_evidence_as_of: str
+    claimed_outcome: ReuseOutcome
+    effective_outcome: ReuseOutcome
+    outcome_scope: str
+    causal_evidence_ref: str | None
+    causal_evidence_sha256: str | None
+    outcome_observer_id: str
+    outcome_observer_relation: ObserverRelation
+    outcome_confirmation: OutcomeConfirmation
+    outcome_as_of: str
+    contribution_separated: bool
+    human_intervention: HumanIntervention
+    next_action: NextAction
+    reevaluation_condition: str | None
+    stop_scope: str | None
+    revision: FieldNoteRevisionLink | None
+
+    def __post_init__(self) -> None:
+        if type(self.sequence) is not int or self.sequence < 0:
+            raise ValueError("Maturity event review sequence is invalid.")
+        for value, label in (
+            (self.event_id, "Reuse event identity"),
+            (self.previous_event_sha256, "Previous event identity"),
+            (self.event_sha256, "Event identity"),
+            (self.structure_sha256, "Structure identity"),
+            (self.structure_binding_sha256, "Structure binding identity"),
+            (self.evidence_sha256, "Use-evidence identity"),
+        ):
+            _require_sha256(value, label)
+        if self.causal_evidence_sha256 is not None:
+            _require_sha256(
+                self.causal_evidence_sha256,
+                "Causal-evidence identity",
+            )
+        if (self.causal_evidence_ref is None) != (
+            self.causal_evidence_sha256 is None
+        ):
+            raise ValueError("Causal-evidence identity is incomplete.")
+        if type(self.contribution_separated) is not bool:
+            raise ValueError("Contribution separation is invalid.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sequence": self.sequence,
+            "recorded_at": self.recorded_at,
+            "event_id": self.event_id,
+            "previous_event_sha256": self.previous_event_sha256,
+            "event_sha256": self.event_sha256,
+            "reusing_run_id": self.reusing_run_id,
+            "structure": {
+                "structure_id": self.structure_id,
+                "structure_sha256": self.structure_sha256,
+                "structure_binding_sha256": self.structure_binding_sha256,
+            },
+            "use_evidence": {
+                "evidence_class": self.evidence_class,
+                "evidence_origin": self.evidence_origin,
+                "evidence_ref": self.evidence_ref,
+                "evidence_sha256": self.evidence_sha256,
+                "observer_id": self.use_evidence_observer_id,
+                "observer_relation": self.use_evidence_observer_relation,
+                "as_of": self.use_evidence_as_of,
+            },
+            "outcome_evidence": {
+                "claimed_outcome": self.claimed_outcome,
+                "effective_outcome": self.effective_outcome,
+                "scope": self.outcome_scope,
+                "causal_evidence_ref": self.causal_evidence_ref,
+                "causal_evidence_sha256": self.causal_evidence_sha256,
+                "observer_id": self.outcome_observer_id,
+                "observer_relation": self.outcome_observer_relation,
+                "confirmation": self.outcome_confirmation,
+                "as_of": self.outcome_as_of,
+                "contribution_separated": self.contribution_separated,
+                "human_intervention": self.human_intervention,
+            },
+            "disposition": {
+                "next_action": self.next_action,
+                "reevaluation_condition": self.reevaluation_condition,
+                "stop_scope": self.stop_scope,
+                "revision": (
+                    self.revision.as_dict() if self.revision is not None else None
+                ),
+            },
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityReviewClaimBoundary:
+    """Fixed limit: durable history is neither current truth nor policy."""
+
+    evidence_scope: Literal["HISTORICAL_AS_OF_RECORDS"] = (
+        "HISTORICAL_AS_OF_RECORDS"
+    )
+    current_usefulness: Literal["NOT_ESTABLISHED"] = "NOT_ESTABLISHED"
+    promotion_decision: Literal["NOT_PERFORMED"] = "NOT_PERFORMED"
+    serving_policy_derived: Literal[False] = False
+    full_note_contents_included: Literal[False] = False
+
+    def __post_init__(self) -> None:
+        if (
+            self.evidence_scope != "HISTORICAL_AS_OF_RECORDS"
+            or self.current_usefulness != "NOT_ESTABLISHED"
+            or self.promotion_decision != "NOT_PERFORMED"
+            or self.serving_policy_derived is not False
+            or self.full_note_contents_included is not False
+        ):
+            raise ValueError("Maturity review claim boundary is invalid.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "evidence_scope": self.evidence_scope,
+            "current_usefulness": self.current_usefulness,
+            "promotion_decision": self.promotion_decision,
+            "serving_policy_derived": self.serving_policy_derived,
+            "full_note_contents_included": self.full_note_contents_included,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteMaturityReviewPacket:
+    """Canonical A6 packet projected only from verified A4 reconstruction."""
+
+    schema: Literal["decision-os.field-note-maturity-review.v0.1"]
+    review_as_of: str
+    note_identity: FieldNoteIdentity
+    ledger_identity: FieldNoteMaturityReviewLedgerIdentity
+    evidence_maturity: FieldNoteMaturitySummary
+    current_serving_policy: FieldNoteServingPolicyBoundary
+    aggregate_evidence_signals: FieldNoteMaturityReviewSignals
+    ordered_event_reviews: tuple[FieldNoteMaturityEventReview, ...]
+    claim_boundary: FieldNoteMaturityReviewClaimBoundary
+
+    def __post_init__(self) -> None:
+        if self.schema != MATURITY_REVIEW_SCHEMA:
+            raise ValueError("Maturity review schema is unsupported.")
+        object.__setattr__(
+            self,
+            "review_as_of",
+            _validate_review_as_of(self.review_as_of),
+        )
+        if not isinstance(self.note_identity, FieldNoteIdentity):
+            raise ValueError("Maturity review lacks an exact Note identity.")
+        expected_partition = hashlib.sha256(
+            canonical_json(self.note_identity.as_dict()).encode("utf-8")
+        ).hexdigest()
+        reviews = self.ordered_event_reviews
+        event_ids = tuple(sorted(item.event_id for item in reviews))
+        sequence = tuple(item.sequence for item in reviews)
+        chain_is_valid = all(
+            item.previous_event_sha256
+            == (
+                GENESIS_EVENT_SHA256
+                if index == 0
+                else reviews[index - 1].event_sha256
+            )
+            for index, item in enumerate(reviews)
+        )
+        expected_head = (
+            reviews[-1].event_sha256 if reviews else GENESIS_EVENT_SHA256
+        )
+        if (
+            not isinstance(
+                self.ledger_identity,
+                FieldNoteMaturityReviewLedgerIdentity,
+            )
+            or self.ledger_identity.note_partition_sha256 != expected_partition
+            or self.ledger_identity.durable_event_count != len(reviews)
+            or self.ledger_identity.chain_head_sha256 != expected_head
+            or sequence != tuple(range(len(reviews)))
+            or not chain_is_valid
+        ):
+            raise ValueError("Maturity review ledger identity is inconsistent.")
+        if (
+            not isinstance(self.evidence_maturity, FieldNoteMaturitySummary)
+            or self.evidence_maturity.note != self.note_identity
+            or self.evidence_maturity.reuse_event_ids != event_ids
+            or (self.evidence_maturity.state == "CANDIDATE") != (not reviews)
+        ):
+            raise ValueError("Maturity review evidence summary is inconsistent.")
+        if (
+            not isinstance(
+                self.current_serving_policy,
+                FieldNoteServingPolicyBoundary,
+            )
+            or self.current_serving_policy.note != self.note_identity
+        ):
+            raise ValueError("Maturity review Serving Policy boundary is invalid.")
+        if self.aggregate_evidence_signals != _review_signals(reviews):
+            raise ValueError("Maturity review aggregate signals are inconsistent.")
+        if not isinstance(
+            self.claim_boundary,
+            FieldNoteMaturityReviewClaimBoundary,
+        ):
+            raise ValueError("Maturity review claim boundary is invalid.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "review_as_of": self.review_as_of,
+            "note_identity": self.note_identity.as_dict(),
+            "ledger_identity": self.ledger_identity.as_dict(),
+            "evidence_maturity": self.evidence_maturity.as_dict(),
+            "current_serving_policy": self.current_serving_policy.as_dict(),
+            "aggregate_evidence_signals": (
+                self.aggregate_evidence_signals.as_dict()
+            ),
+            "ordered_event_reviews": [
+                event.as_dict() for event in self.ordered_event_reviews
+            ],
+            "claim_boundary": self.claim_boundary.as_dict(),
+        }
+
+    def serialize(self) -> str:
+        """Return one deterministic canonical JSON representation."""
+
+        return canonical_json(self.as_dict())
+
+    def render_text(self) -> str:
+        """Render a concise review without Note or artifact contents."""
+
+        promotion = self.evidence_maturity.promotion
+        policy = self.current_serving_policy
+        signals = self.aggregate_evidence_signals
+        classes = ",".join(signals.evidence_classes) or "NONE"
+        lines = [
+            "Field Note Maturity Evidence Review v0.1",
+            f"Review As-of: {self.review_as_of}",
+            f"Note: {self.note_identity.note_path}",
+            f"Field Note ID: {self.note_identity.field_note_id}",
+            f"Note SHA-256: {self.note_identity.note_sha256}",
+            f"Origin Run: {self.note_identity.origin_run_id}",
+            f"A4 partition: {self.ledger_identity.note_partition_sha256}",
+            f"A4 chain head: {self.ledger_identity.chain_head_sha256}",
+            f"Durable events: {self.ledger_identity.durable_event_count}",
+            (
+                "Evidence Maturity: "
+                f"{self.evidence_maturity.state} (historical evidence)"
+            ),
+            (
+                "PROMOTABLE policy: "
+                f"{promotion.policy_status}; automatic promotion unavailable"
+            ),
+            (
+                "Current Serving Policy: "
+                f"{policy.derivation}; separate and not derived from maturity"
+            ),
+            "Authority: TOPMOST_CANONICAL > ADVISORY_FIELD_NOTE",
+            (
+                "Signals: "
+                f"helpful={signals.helpful_outcomes}, "
+                f"not_helpful={signals.not_helpful_outcomes}, "
+                f"harmful={signals.harmful_outcomes}, "
+                f"unknown={signals.unknown_outcomes}, "
+                f"intervention_affected="
+                f"{signals.material_or_unknown_interventions}, "
+                f"hold={signals.hold_dispositions}, "
+                f"stop={signals.stop_dispositions}, "
+                f"revise={signals.revise_links}, "
+                f"runs={signals.unique_reusing_runs}, "
+                f"structures={signals.unique_specific_structures}, "
+                f"evidence_classes={classes}"
+            ),
+        ]
+        for event in self.ordered_event_reviews:
+            lines.append(
+                f"Event {event.sequence}: recorded={event.recorded_at}; "
+                f"run={event.reusing_run_id}; "
+                f"structure={event.structure_id}; "
+                f"evidence={event.evidence_class}; "
+                f"claimed_outcome={event.claimed_outcome}; "
+                f"effective_outcome={event.effective_outcome}; "
+                f"confirmation={event.outcome_confirmation}; "
+                f"intervention={event.human_intervention}; "
+                f"disposition={event.next_action}"
+            )
+        lines.append(
+            "Claim boundary: historical evidence only; current usefulness is "
+            "not established; promotion is not decided; serving is not derived."
+        )
+        return "\n".join(lines) + "\n"
+
+
+def _event_review(event: FieldNoteMaturityLedgerEvent) -> FieldNoteMaturityEventReview:
+    receipt = event.receipt
+    evidence = receipt.use_evidence
+    if evidence is None:
+        raise ValueError("Verified A4 reuse event lacks use evidence.")
+    binding = evidence.structure_binding
+    if (
+        receipt.claimed_outcome is None
+        or receipt.outcome is None
+        or receipt.outcome_scope is None
+        or receipt.outcome_observer_id is None
+        or receipt.outcome_observer_relation is None
+        or receipt.outcome_confirmation is None
+        or receipt.outcome_as_of is None
+        or receipt.contribution_separated is None
+        or receipt.human_intervention is None
+        or receipt.next_action is None
+    ):
+        raise ValueError("Verified A4 reuse event lacks review evidence axes.")
+    return FieldNoteMaturityEventReview(
+        sequence=event.sequence,
+        recorded_at=event.recorded_at,
+        event_id=event.event_id,
+        previous_event_sha256=event.previous_event_sha256,
+        event_sha256=event.event_sha256,
+        reusing_run_id=receipt.reusing_run_id,
+        structure_id=binding.structure_id,
+        structure_sha256=binding.structure_sha256,
+        structure_binding_sha256=binding.binding_sha256,
+        evidence_class=evidence.evidence_class,
+        evidence_origin=evidence.evidence_origin,
+        evidence_ref=evidence.evidence_ref,
+        evidence_sha256=evidence.evidence_sha256,
+        use_evidence_observer_id=evidence.observer_id,
+        use_evidence_observer_relation=evidence.observer_relation,
+        use_evidence_as_of=evidence.as_of,
+        claimed_outcome=receipt.claimed_outcome,
+        effective_outcome=receipt.outcome,
+        outcome_scope=receipt.outcome_scope,
+        causal_evidence_ref=receipt.causal_evidence_ref,
+        causal_evidence_sha256=receipt.causal_evidence_sha256,
+        outcome_observer_id=receipt.outcome_observer_id,
+        outcome_observer_relation=receipt.outcome_observer_relation,
+        outcome_confirmation=receipt.outcome_confirmation,
+        outcome_as_of=receipt.outcome_as_of,
+        contribution_separated=receipt.contribution_separated,
+        human_intervention=receipt.human_intervention,
+        next_action=receipt.next_action,
+        reevaluation_condition=receipt.reevaluation_condition,
+        stop_scope=receipt.stop_scope,
+        revision=receipt.revision,
+    )
+
+
+def _review_signals(
+    events: tuple[FieldNoteMaturityEventReview, ...],
+) -> FieldNoteMaturityReviewSignals:
+    outcomes = tuple(event.effective_outcome for event in events)
+    confirmations = tuple(event.outcome_confirmation for event in events)
+    actions = tuple(event.next_action for event in events)
+    classes = tuple(sorted({event.evidence_class for event in events}))
+    return FieldNoteMaturityReviewSignals(
+        helpful_outcomes=outcomes.count("HELPFUL"),
+        not_helpful_outcomes=outcomes.count("NOT_HELPFUL"),
+        harmful_outcomes=outcomes.count("HARMFUL"),
+        unknown_outcomes=outcomes.count("UNKNOWN"),
+        material_or_unknown_interventions=sum(
+            event.human_intervention in {"MATERIAL", "UNKNOWN"}
+            for event in events
+        ),
+        same_run_outcome_claims=confirmations.count("SAME_RUN_CLAIM"),
+        run_related_outcome_claims=confirmations.count("RUN_RELATED_CLAIM"),
+        independent_outcome_confirmations=confirmations.count(
+            "INDEPENDENT_CONFIRMATION"
+        ),
+        keep_dispositions=actions.count("KEEP"),
+        hold_dispositions=actions.count("HOLD"),
+        stop_dispositions=actions.count("STOP"),
+        revise_links=sum(event.revision is not None for event in events),
+        unique_reusing_runs=len({event.reusing_run_id for event in events}),
+        unique_specific_structures=len(
+            {event.structure_binding_sha256 for event in events}
+        ),
+        rule_trace_events=sum(
+            event.evidence_class == "RULE_TRACE" for event in events
+        ),
+        output_artifact_events=sum(
+            event.evidence_class == "OUTPUT_ARTIFACT" for event in events
+        ),
+        evidence_classes=classes,
+    )
+
+
+def review_field_note_maturity(
+    ledger: FieldNoteMaturityLedger,
+    note: FieldNoteIdentity,
+    *,
+    note_bytes: bytes,
+    review_as_of: str,
+) -> FieldNoteMaturityReviewPacket:
+    """Project verified A4 history without modifying evidence or deriving policy."""
+
+    if not isinstance(ledger, FieldNoteMaturityLedger):
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review requires a typed A4 ledger."
+        )
+    if not isinstance(note, FieldNoteIdentity):
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review requires an exact Field Note identity."
+        )
+    if ledger.note != note:
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review targets a different A4 Note partition."
+        )
+    if (
+        not isinstance(note_bytes, bytes)
+        or hashlib.sha256(note_bytes).hexdigest() != note.note_sha256
+    ):
+        raise FieldNoteMaturityReviewValidationError(
+            "Maturity review Note bytes do not match the exact identity."
+        )
+    review_as_of = _validate_review_as_of(review_as_of)
+    snapshot = ledger.reconstruct(note_bytes=note_bytes)
+    if snapshot.note != note:
+        raise FieldNoteMaturityReviewValidationError(
+            "A4 reconstruction returned a cross-bound Note identity."
+        )
+    event_reviews = tuple(_event_review(event) for event in snapshot.events)
+    return FieldNoteMaturityReviewPacket(
+        schema=MATURITY_REVIEW_SCHEMA,
+        review_as_of=review_as_of,
+        note_identity=note,
+        ledger_identity=FieldNoteMaturityReviewLedgerIdentity(
+            note_partition_sha256=ledger.note_partition_sha256,
+            chain_head_sha256=snapshot.chain_head_sha256,
+            durable_event_count=len(snapshot.events),
+        ),
+        evidence_maturity=snapshot.evidence_maturity,
+        current_serving_policy=snapshot.current_serving_policy,
+        aggregate_evidence_signals=_review_signals(event_reviews),
+        ordered_event_reviews=event_reviews,
+        claim_boundary=FieldNoteMaturityReviewClaimBoundary(),
+    )

--- a/decision_os/companion/field_notes_maturity_review.py
+++ b/decision_os/companion/field_notes_maturity_review.py
@@ -44,26 +44,31 @@ class FieldNoteMaturityReviewValidationError(
     """The requested exact Note, A4 partition, or review As-of is invalid."""
 
 
-def _validate_review_as_of(value: Any) -> str:
+def _parse_as_of(value: Any, *, label: str) -> tuple[str, datetime]:
     if not isinstance(value, str):
         raise FieldNoteMaturityReviewValidationError(
-            "Maturity review As-of must be text."
+            f"{label} must be text."
         )
     normalized = value.strip()
     if not normalized or len(normalized) > 64 or "\x00" in normalized:
         raise FieldNoteMaturityReviewValidationError(
-            "Maturity review As-of is outside its bounded schema."
+            f"{label} is outside its bounded schema."
         )
     try:
         parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
     except ValueError as exc:
         raise FieldNoteMaturityReviewValidationError(
-            "Maturity review As-of must be an RFC 3339 timestamp."
+            f"{label} must be an RFC 3339 timestamp."
         ) from exc
     if parsed.tzinfo is None:
         raise FieldNoteMaturityReviewValidationError(
-            "Maturity review As-of must be timezone-aware."
+            f"{label} must be timezone-aware."
         )
+    return normalized, parsed
+
+
+def _validate_review_as_of(value: Any) -> str:
+    normalized, _ = _parse_as_of(value, label="Maturity review As-of")
     return normalized
 
 
@@ -211,6 +216,13 @@ class FieldNoteMaturityEventReview:
     def __post_init__(self) -> None:
         if type(self.sequence) is not int or self.sequence < 0:
             raise ValueError("Maturity event review sequence is invalid.")
+        for field, label in (
+            ("recorded_at", "Event recorded-at"),
+            ("use_evidence_as_of", "Use-evidence As-of"),
+            ("outcome_as_of", "Outcome-evidence As-of"),
+        ):
+            normalized, _ = _parse_as_of(getattr(self, field), label=label)
+            object.__setattr__(self, field, normalized)
         for value, label in (
             (self.event_id, "Reuse event identity"),
             (self.previous_event_sha256, "Previous event identity"),
@@ -327,10 +339,14 @@ class FieldNoteMaturityReviewPacket:
     def __post_init__(self) -> None:
         if self.schema != MATURITY_REVIEW_SCHEMA:
             raise ValueError("Maturity review schema is unsupported.")
+        review_as_of, review_instant = _parse_as_of(
+            self.review_as_of,
+            label="Maturity review As-of",
+        )
         object.__setattr__(
             self,
             "review_as_of",
-            _validate_review_as_of(self.review_as_of),
+            review_as_of,
         )
         if not isinstance(self.note_identity, FieldNoteIdentity):
             raise ValueError("Maturity review lacks an exact Note identity.")
@@ -338,6 +354,20 @@ class FieldNoteMaturityReviewPacket:
             canonical_json(self.note_identity.as_dict()).encode("utf-8")
         ).hexdigest()
         reviews = self.ordered_event_reviews
+        for item in reviews:
+            for evidence_as_of, label in (
+                (item.recorded_at, "Event recorded-at"),
+                (item.use_evidence_as_of, "Use-evidence As-of"),
+                (item.outcome_as_of, "Outcome-evidence As-of"),
+            ):
+                _, evidence_instant = _parse_as_of(
+                    evidence_as_of,
+                    label=label,
+                )
+                if evidence_instant > review_instant:
+                    raise FieldNoteMaturityReviewValidationError(
+                        "Maturity review As-of precedes included evidence."
+                    )
         event_ids = tuple(sorted(item.event_id for item in reviews))
         sequence = tuple(item.sequence for item in reviews)
         chain_is_valid = all(

--- a/tests/test_field_notes_maturity_review.py
+++ b/tests/test_field_notes_maturity_review.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import hashlib
 import json
 from pathlib import Path
@@ -90,6 +91,8 @@ def reuse_receipt(
     contribution_separated: bool = True,
     intervention: str = "NONE",
     action: str | None = None,
+    use_as_of: str = USE_AS_OF,
+    outcome_as_of: str | None = None,
 ) -> object:
     run_id = reusing_run_id or f"run_reuse_{evidence_tag}"
     structure_bytes = STRUCTURE_A if structure == "A" else STRUCTURE_B
@@ -115,7 +118,7 @@ def reuse_receipt(
         evidence_sha256=digest(f"use evidence {evidence_tag}"),
         observer_id=use_observer_id,
         observer_relation=use_observer_relation,  # type: ignore[arg-type]
-        as_of=USE_AS_OF,
+        as_of=use_as_of,
     )
     causal = outcome in {"HELPFUL", "HARMFUL"}
     evaluation = FieldNoteOutcomeEvaluation(
@@ -123,7 +126,7 @@ def reuse_receipt(
         scope=outcome_scope,
         observer_id=outcome_observer_id,
         observer_relation=outcome_observer_relation,  # type: ignore[arg-type]
-        as_of=USE_AS_OF,
+        as_of=outcome_as_of if outcome_as_of is not None else use_as_of,
         causal_evidence_ref=(
             f"run:{run_id}/causal:{evidence_tag}" if causal else None
         ),
@@ -201,9 +204,10 @@ class MaturityReviewTestCase(unittest.TestCase):
         self.ledger = FieldNoteMaturityLedger(self.root, self.note)
         self.append_count = 0
 
-    def append(self, **kwargs):
+    def append(self, *, recorded_at: str | None = None, **kwargs):
         receipt = reuse_receipt(self.note, **kwargs)
-        recorded_at = f"2026-08-04T11:{self.append_count:02d}:00Z"
+        if recorded_at is None:
+            recorded_at = f"2026-08-04T11:{self.append_count:02d}:00Z"
         self.append_count += 1
         return self.ledger.append_receipt(
             receipt,
@@ -616,6 +620,123 @@ class FieldNotesMaturityReviewBoundaryTests(MaturityReviewTestCase):
         self.assertEqual("NOT_ESTABLISHED", boundary.current_usefulness)
         self.assertEqual("NOT_PERFORMED", boundary.promotion_decision)
         self.assertFalse(boundary.serving_policy_derived)
+
+
+class FieldNotesMaturityReviewTemporalTests(MaturityReviewTestCase):
+    def test_review_as_of_later_than_all_included_evidence_succeeds(self) -> None:
+        self.append(
+            recorded_at="2026-08-04T11:00:00Z",
+            use_as_of="2026-08-04T10:00:00Z",
+            outcome_as_of="2026-08-04T11:30:00Z",
+        )
+        packet = self.review(review_as_of="2026-08-04T12:00:00Z")
+        self.assertEqual(1, len(packet.ordered_event_reviews))
+
+    def test_review_as_of_equal_to_latest_evidence_succeeds(self) -> None:
+        self.append(
+            recorded_at="2026-08-04T11:00:00Z",
+            use_as_of="2026-08-04T10:00:00Z",
+            outcome_as_of="2026-08-04T12:00:00Z",
+        )
+        packet = self.review(review_as_of="2026-08-04T12:00:00Z")
+        self.assertEqual(
+            packet.review_as_of,
+            packet.ordered_event_reviews[0].outcome_as_of,
+        )
+
+    def test_review_as_of_earlier_than_recorded_at_fails_closed(self) -> None:
+        self.append(recorded_at="2026-08-04T12:00:01Z")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "precedes included evidence",
+        ):
+            self.review(review_as_of="2026-08-04T12:00:00Z")
+
+    def test_review_as_of_earlier_than_use_evidence_fails_closed(self) -> None:
+        self.append(
+            use_as_of="2026-08-04T12:00:01Z",
+            outcome_as_of="2026-08-04T11:00:00Z",
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "precedes included evidence",
+        ):
+            self.review(review_as_of="2026-08-04T12:00:00Z")
+
+    def test_review_as_of_earlier_than_outcome_evidence_fails_closed(self) -> None:
+        self.append(outcome_as_of="2026-08-04T12:00:01Z")
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "precedes included evidence",
+        ):
+            self.review(review_as_of="2026-08-04T12:00:00Z")
+
+    def test_equivalent_timezone_offsets_compare_by_instant(self) -> None:
+        equivalent = "2026-08-04T12:00:00+09:00"
+        self.append(
+            recorded_at=equivalent,
+            use_as_of=equivalent,
+            outcome_as_of=equivalent,
+        )
+        packet = self.review(review_as_of="2026-08-04T03:00:00Z")
+        self.assertEqual(1, len(packet.ordered_event_reviews))
+
+    def test_malformed_event_review_timestamps_are_rejected(self) -> None:
+        self.append()
+        event = self.review().ordered_event_reviews[0]
+        for field in (
+            "recorded_at",
+            "use_evidence_as_of",
+            "outcome_as_of",
+        ):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                FieldNoteMaturityReviewValidationError,
+                "RFC 3339",
+            ):
+                replace(event, **{field: "not-a-timestamp"})
+
+    def test_direct_packet_construction_rejects_future_evidence(self) -> None:
+        self.append()
+        packet = self.review(review_as_of="2026-08-04T12:00:00Z")
+        future_event = replace(
+            packet.ordered_event_reviews[0],
+            outcome_as_of="2026-08-04T12:00:01Z",
+        )
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "precedes included evidence",
+        ):
+            replace(packet, ordered_event_reviews=(future_event,))
+
+    def test_failed_temporal_review_leaves_all_input_bytes_unchanged(self) -> None:
+        self.append(recorded_at="2026-08-04T12:00:01Z")
+        paths = (
+            self.ledger.events_path,
+            self.ledger.head_path,
+            self.ledger.lock_path,
+        )
+        note_before = bytes(NOTE_BYTES)
+        ledger_before = {path: path.read_bytes() for path in paths}
+        with self.assertRaises(FieldNoteMaturityReviewValidationError):
+            self.review(review_as_of="2026-08-04T12:00:00Z")
+        self.assertEqual(note_before, NOTE_BYTES)
+        self.assertEqual(
+            ledger_before,
+            {path: path.read_bytes() for path in paths},
+        )
+
+    def test_repeated_valid_temporal_generation_remains_deterministic(self) -> None:
+        equivalent = "2026-08-04T12:00:00+09:00"
+        self.append(
+            recorded_at=equivalent,
+            use_as_of=equivalent,
+            outcome_as_of=equivalent,
+        )
+        first = self.review(review_as_of="2026-08-04T03:00:00Z")
+        second = self.review(review_as_of="2026-08-04T03:00:00Z")
+        self.assertEqual(first, second)
+        self.assertEqual(first.serialize(), second.serialize())
+        self.assertEqual(first.render_text(), second.render_text())
 
 
 class FieldNotesMaturityReviewIntegrityTests(MaturityReviewTestCase):

--- a/tests/test_field_notes_maturity_review.py
+++ b/tests/test_field_notes_maturity_review.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from decision_os.companion.field_notes_maturity_ledger import (
+    GENESIS_EVENT_SHA256,
+    FieldNoteMaturityLedger,
+    FieldNoteMaturityLedgerIntegrityError,
+)
+from decision_os.companion.field_notes_maturity_review import (
+    MATURITY_REVIEW_SCHEMA,
+    FieldNoteMaturityReviewValidationError,
+    review_field_note_maturity,
+)
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseClaim,
+    FieldNoteReuseDisposition,
+    FieldNoteUseEvidence,
+    assess_field_note_reuse,
+    bind_field_note_structure,
+)
+
+
+REVIEW_AS_OF = "2026-08-04T12:00:00Z"
+USE_AS_OF = "2026-08-04T10:00:00Z"
+STRUCTURE_A = b"Verify canonical state before restart."
+STRUCTURE_B = b"Preserve every bounded negative outcome."
+PRIVATE_BODY = b"Private full Note paragraph that A6 must never expose."
+NOTE_BYTES = (
+    b"# A6 Maturity Evidence Review\n\n"
+    b"## Decision / Pattern\n\n"
+    + STRUCTURE_A
+    + b"\n"
+    + STRUCTURE_B
+    + b"\n\n## Private Context\n\n"
+    + PRIVATE_BODY
+    + b"\n\n## Limits\n\nCurrent canonical authority always wins.\n"
+)
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def digest(value: str) -> str:
+    return digest_bytes(value.encode("utf-8"))
+
+
+def note_identity(
+    *,
+    field_note_id: str = "fn_a6_review",
+    note_bytes: bytes = NOTE_BYTES,
+    note_path: str = (
+        ".decision-os/field-notes/"
+        "2026-08-04-a6-maturity-review-aaaaaaaaaa.md"
+    ),
+    origin_run_id: str = "run_origin",
+) -> FieldNoteIdentity:
+    return FieldNoteIdentity(
+        note_path=note_path,
+        field_note_id=field_note_id,
+        note_sha256=digest_bytes(note_bytes),
+        origin_run_id=origin_run_id,
+    )
+
+
+def reuse_receipt(
+    note: FieldNoteIdentity,
+    *,
+    evidence_tag: str = "1",
+    reusing_run_id: str | None = None,
+    structure: str = "A",
+    evidence_class: str = "RULE_TRACE",
+    outcome: str = "UNKNOWN",
+    outcome_scope: str = "The bounded A6 review test scope.",
+    outcome_observer_id: str = "outcome_observer_a6",
+    outcome_observer_relation: str = "INDEPENDENT",
+    use_observer_id: str = "use_observer_a6",
+    use_observer_relation: str = "INDEPENDENT",
+    contribution_separated: bool = True,
+    intervention: str = "NONE",
+    action: str | None = None,
+) -> object:
+    run_id = reusing_run_id or f"run_reuse_{evidence_tag}"
+    structure_bytes = STRUCTURE_A if structure == "A" else STRUCTURE_B
+    structure_id = (
+        "canonical-restart-state-guard"
+        if structure == "A"
+        else "negative-outcome-retention"
+    )
+    start = NOTE_BYTES.index(structure_bytes)
+    binding = bind_field_note_structure(
+        note,
+        NOTE_BYTES,
+        structure_id=structure_id,
+        start_byte=start,
+        end_byte=start + len(structure_bytes),
+    )
+    evidence = FieldNoteUseEvidence(
+        evidence_class=evidence_class,  # type: ignore[arg-type]
+        evidence_origin="IMMEDIATE_COMPLETION_RECORD",
+        reusing_run_id=run_id,
+        structure_binding=binding,
+        evidence_ref=f"run:{run_id}/evidence:{evidence_tag}",
+        evidence_sha256=digest(f"use evidence {evidence_tag}"),
+        observer_id=use_observer_id,
+        observer_relation=use_observer_relation,  # type: ignore[arg-type]
+        as_of=USE_AS_OF,
+    )
+    causal = outcome in {"HELPFUL", "HARMFUL"}
+    evaluation = FieldNoteOutcomeEvaluation(
+        outcome=outcome,  # type: ignore[arg-type]
+        scope=outcome_scope,
+        observer_id=outcome_observer_id,
+        observer_relation=outcome_observer_relation,  # type: ignore[arg-type]
+        as_of=USE_AS_OF,
+        causal_evidence_ref=(
+            f"run:{run_id}/causal:{evidence_tag}" if causal else None
+        ),
+        causal_evidence_sha256=(
+            digest(f"causal evidence {evidence_tag}") if causal else None
+        ),
+        contribution_separated=contribution_separated,
+    )
+    if action is None and outcome == "HELPFUL":
+        action = "KEEP"
+    if action is None and outcome in {"NOT_HELPFUL", "HARMFUL"}:
+        action = "STOP"
+    disposition = None
+    if action == "KEEP":
+        disposition = FieldNoteReuseDisposition(action="KEEP")
+    elif action == "STOP":
+        disposition = FieldNoteReuseDisposition(
+            action="STOP",
+            stop_scope=f"Bounded A6 task family {evidence_tag}.",
+        )
+    elif action == "REVISE":
+        successor_bytes = NOTE_BYTES + evidence_tag.encode("ascii")
+        successor = note_identity(
+            field_note_id=f"fn_a6_successor_{evidence_tag}",
+            note_bytes=successor_bytes,
+            note_path=(
+                ".decision-os/field-notes/"
+                f"2026-08-04-a6-successor-{evidence_tag.zfill(10)}.md"
+            ),
+            origin_run_id=run_id,
+        )
+        disposition = FieldNoteReuseDisposition(
+            action="REVISE",
+            revision_candidate=successor,
+        )
+    claim = FieldNoteReuseClaim(
+        claimed_note=note,
+        reusing_run_id=run_id,
+        use_evidence=evidence,
+        outcome_evaluation=evaluation,
+        human_intervention=intervention,  # type: ignore[arg-type]
+        disposition=disposition,
+    )
+    receipt = assess_field_note_reuse(note, claim, note_bytes=NOTE_BYTES)
+    if receipt.state != "REUSED":
+        raise AssertionError("A6 test fixture failed to produce REUSED")
+    return receipt
+
+
+def reconnect_receipt(note: FieldNoteIdentity) -> FieldNoteReconnectReceipt:
+    return FieldNoteReconnectReceipt(
+        run_id="run_reuse_1",
+        state="ACTIVATION_UNKNOWN",
+        failure_reason=None,
+        metadata_entries_seen=1,
+        metadata_candidate_files_seen=1,
+        metadata_files_valid=1,
+        metadata_bytes_read=700,
+        selected_field_note_path=note.note_path,
+        selected_field_note_id=note.field_note_id,
+        selected_metadata_sha256=digest("metadata"),
+        selected_full_note_sha256=note.note_sha256,
+        full_note_bytes_read=len(NOTE_BYTES),
+        full_notes_injected=1,
+        ordinary_distinct_paths_consumed=1,
+    )
+
+
+class MaturityReviewTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name) / "maturity-ledger-v0.1"
+        self.note = note_identity()
+        self.ledger = FieldNoteMaturityLedger(self.root, self.note)
+        self.append_count = 0
+
+    def append(self, **kwargs):
+        receipt = reuse_receipt(self.note, **kwargs)
+        recorded_at = f"2026-08-04T11:{self.append_count:02d}:00Z"
+        self.append_count += 1
+        return self.ledger.append_receipt(
+            receipt,
+            note_bytes=NOTE_BYTES,
+            recorded_at=recorded_at,
+        )
+
+    def review(self, *, review_as_of: str = REVIEW_AS_OF):
+        return review_field_note_maturity(
+            self.ledger,
+            self.note,
+            note_bytes=NOTE_BYTES,
+            review_as_of=review_as_of,
+        )
+
+    def parsed_events(self) -> list[dict]:
+        return [
+            json.loads(line)
+            for line in self.ledger.events_path.read_text().splitlines()
+        ]
+
+    def rewrite_events(self, events: list[dict]) -> None:
+        self.ledger.events_path.write_text(
+            "".join(f"{canonical_json(event)}\n" for event in events)
+        )
+
+
+class FieldNotesMaturityReviewProjectionTests(MaturityReviewTestCase):
+    def test_empty_valid_ledger_produces_candidate_review(self) -> None:
+        packet = self.review()
+        self.assertEqual(MATURITY_REVIEW_SCHEMA, packet.schema)
+        self.assertEqual("CANDIDATE", packet.evidence_maturity.state)
+        self.assertEqual(0, packet.ledger_identity.durable_event_count)
+        self.assertEqual((), packet.ordered_event_reviews)
+        self.assertFalse(self.root.exists())
+
+    def test_one_durable_event_produces_reused_review(self) -> None:
+        self.append()
+        packet = self.review()
+        self.assertEqual("REUSED", packet.evidence_maturity.state)
+        self.assertEqual(1, len(packet.ordered_event_reviews))
+
+    def test_multiple_events_remain_in_durable_sequence_order(self) -> None:
+        for tag in ("1", "2", "3"):
+            self.append(evidence_tag=tag)
+        packet = self.review()
+        self.assertEqual(
+            [0, 1, 2],
+            [event.sequence for event in packet.ordered_event_reviews],
+        )
+        self.assertEqual(
+            ["run_reuse_1", "run_reuse_2", "run_reuse_3"],
+            [event.reusing_run_id for event in packet.ordered_event_reviews],
+        )
+
+    def test_repeated_generation_is_deterministic(self) -> None:
+        self.append(outcome="HARMFUL")
+        first = self.review()
+        second = self.review()
+        self.assertEqual(first, second)
+        self.assertEqual(first.serialize(), second.serialize())
+        self.assertEqual(first.render_text(), second.render_text())
+
+    def test_review_as_of_is_the_only_caller_supplied_projection_variation(self) -> None:
+        self.append()
+        first = self.review(review_as_of="2026-08-04T12:00:00Z")
+        second = self.review(review_as_of="2026-08-04T13:00:00Z")
+        first_data = first.as_dict()
+        second_data = second.as_dict()
+        self.assertNotEqual(first_data.pop("review_as_of"), second_data.pop("review_as_of"))
+        self.assertEqual(first_data, second_data)
+
+    def test_exact_note_identity_is_preserved(self) -> None:
+        packet = self.review()
+        self.assertEqual(self.note, packet.note_identity)
+        self.assertEqual(self.note.as_dict(), packet.as_dict()["note_identity"])
+
+    def test_a4_chain_head_and_event_count_are_preserved(self) -> None:
+        first = self.append(evidence_tag="1")
+        second = self.append(evidence_tag="2")
+        packet = self.review()
+        self.assertEqual(2, packet.ledger_identity.durable_event_count)
+        self.assertEqual(
+            second.event.event_sha256,
+            packet.ledger_identity.chain_head_sha256,
+        )
+        self.assertEqual(
+            first.event.event_sha256,
+            packet.ordered_event_reviews[1].previous_event_sha256,
+        )
+
+    def test_review_generation_is_read_only(self) -> None:
+        self.append()
+        paths = (
+            self.ledger.events_path,
+            self.ledger.head_path,
+            self.ledger.lock_path,
+        )
+        before = {
+            path: (
+                path.read_bytes(),
+                path.stat().st_size,
+                path.stat().st_mode,
+                path.stat().st_mtime_ns,
+                path.stat().st_ino,
+            )
+            for path in paths
+        }
+        note_before = bytes(NOTE_BYTES)
+        self.review()
+        self.review()
+        after = {
+            path: (
+                path.read_bytes(),
+                path.stat().st_size,
+                path.stat().st_mode,
+                path.stat().st_mtime_ns,
+                path.stat().st_ino,
+            )
+            for path in paths
+        }
+        self.assertEqual(before, after)
+        self.assertEqual(note_before, NOTE_BYTES)
+
+    def test_serialization_and_text_projection_are_canonical(self) -> None:
+        self.append(outcome="NOT_HELPFUL")
+        packet = self.review()
+        self.assertEqual(canonical_json(packet.as_dict()), packet.serialize())
+        self.assertTrue(packet.render_text().endswith("\n"))
+        self.assertIn("historical evidence", packet.render_text())
+
+
+class FieldNotesMaturityReviewEvidenceTests(MaturityReviewTestCase):
+    def test_unique_reusing_run_count_is_correct(self) -> None:
+        self.append(evidence_tag="1", reusing_run_id="run_shared", structure="A")
+        self.append(evidence_tag="2", reusing_run_id="run_shared", structure="B")
+        self.append(evidence_tag="3", reusing_run_id="run_other", structure="A")
+        self.assertEqual(2, self.review().aggregate_evidence_signals.unique_reusing_runs)
+
+    def test_unique_specific_structure_count_is_correct(self) -> None:
+        self.append(evidence_tag="1", structure="A")
+        self.append(evidence_tag="2", structure="A")
+        self.append(evidence_tag="3", structure="B")
+        packet = self.review()
+        self.assertEqual(
+            2,
+            packet.aggregate_evidence_signals.unique_specific_structures,
+        )
+
+    def test_rule_trace_is_represented(self) -> None:
+        self.append(evidence_class="RULE_TRACE")
+        packet = self.review()
+        self.assertEqual("RULE_TRACE", packet.ordered_event_reviews[0].evidence_class)
+        self.assertEqual(1, packet.aggregate_evidence_signals.rule_trace_events)
+
+    def test_output_artifact_is_represented_by_identity_only(self) -> None:
+        self.append(evidence_class="OUTPUT_ARTIFACT")
+        packet = self.review()
+        event = packet.ordered_event_reviews[0]
+        self.assertEqual("OUTPUT_ARTIFACT", event.evidence_class)
+        self.assertEqual(1, packet.aggregate_evidence_signals.output_artifact_events)
+        self.assertTrue(event.evidence_ref)
+        self.assertRegex(event.evidence_sha256, r"^[0-9a-f]{64}$")
+
+    def test_helpful_is_represented(self) -> None:
+        self.append(outcome="HELPFUL")
+        packet = self.review()
+        self.assertEqual("HELPFUL", packet.ordered_event_reviews[0].effective_outcome)
+        self.assertEqual(1, packet.aggregate_evidence_signals.helpful_outcomes)
+
+    def test_not_helpful_is_represented(self) -> None:
+        self.append(outcome="NOT_HELPFUL")
+        packet = self.review()
+        self.assertEqual(
+            "NOT_HELPFUL",
+            packet.ordered_event_reviews[0].effective_outcome,
+        )
+        self.assertEqual(1, packet.aggregate_evidence_signals.not_helpful_outcomes)
+
+    def test_harmful_is_represented(self) -> None:
+        self.append(outcome="HARMFUL")
+        packet = self.review()
+        self.assertEqual("HARMFUL", packet.ordered_event_reviews[0].effective_outcome)
+        self.assertEqual(1, packet.aggregate_evidence_signals.harmful_outcomes)
+
+    def test_unknown_is_represented(self) -> None:
+        self.append(outcome="UNKNOWN")
+        packet = self.review()
+        self.assertEqual("UNKNOWN", packet.ordered_event_reviews[0].effective_outcome)
+        self.assertEqual(1, packet.aggregate_evidence_signals.unknown_outcomes)
+
+    def test_mixed_positive_and_negative_evidence_remains_mixed(self) -> None:
+        cases = (
+            ("1", "HELPFUL"),
+            ("2", "NOT_HELPFUL"),
+            ("3", "HARMFUL"),
+            ("4", "UNKNOWN"),
+        )
+        for tag, outcome in cases:
+            self.append(evidence_tag=tag, outcome=outcome)
+        packet = self.review()
+        self.assertEqual(
+            ["HELPFUL", "NOT_HELPFUL", "HARMFUL", "UNKNOWN"],
+            [event.effective_outcome for event in packet.ordered_event_reviews],
+        )
+        rendered = packet.render_text()
+        for _, outcome in cases:
+            self.assertIn(f"effective_outcome={outcome}", rendered)
+
+    def test_outcome_scope_is_preserved(self) -> None:
+        scope = "One exact bounded A6 task family."
+        self.append(outcome_scope=scope)
+        self.assertEqual(scope, self.review().ordered_event_reviews[0].outcome_scope)
+
+    def test_causal_evidence_identity_is_preserved(self) -> None:
+        result = self.append(outcome="HARMFUL")
+        receipt = result.event.receipt
+        event = self.review().ordered_event_reviews[0]
+        self.assertEqual(receipt.causal_evidence_ref, event.causal_evidence_ref)
+        self.assertEqual(
+            receipt.causal_evidence_sha256,
+            event.causal_evidence_sha256,
+        )
+
+    def test_use_and_outcome_observer_identity_and_relation_are_preserved(self) -> None:
+        self.append(
+            use_observer_id="use_observer_exact",
+            use_observer_relation="REUSING_RUN_PARTICIPANT",
+            outcome_observer_id="outcome_observer_exact",
+            outcome_observer_relation="INDEPENDENT",
+        )
+        event = self.review().ordered_event_reviews[0]
+        self.assertEqual("use_observer_exact", event.use_evidence_observer_id)
+        self.assertEqual(
+            "REUSING_RUN_PARTICIPANT",
+            event.use_evidence_observer_relation,
+        )
+        self.assertEqual("outcome_observer_exact", event.outcome_observer_id)
+        self.assertEqual("INDEPENDENT", event.outcome_observer_relation)
+
+    def test_confirmation_class_is_preserved(self) -> None:
+        self.append(outcome_observer_relation="INDEPENDENT")
+        event = self.review().ordered_event_reviews[0]
+        self.assertEqual("INDEPENDENT_CONFIRMATION", event.outcome_confirmation)
+
+    def test_contribution_separation_is_preserved(self) -> None:
+        self.append(contribution_separated=False, outcome="UNKNOWN")
+        event = self.review().ordered_event_reviews[0]
+        self.assertFalse(event.contribution_separated)
+
+    def test_material_and_unknown_human_intervention_are_preserved(self) -> None:
+        self.append(evidence_tag="1", intervention="MATERIAL")
+        self.append(evidence_tag="2", intervention="UNKNOWN")
+        packet = self.review()
+        self.assertEqual(
+            ["MATERIAL", "UNKNOWN"],
+            [event.human_intervention for event in packet.ordered_event_reviews],
+        )
+        self.assertEqual(
+            2,
+            packet.aggregate_evidence_signals.material_or_unknown_interventions,
+        )
+
+    def test_hold_and_reevaluation_condition_are_preserved(self) -> None:
+        self.append(outcome="UNKNOWN")
+        event = self.review().ordered_event_reviews[0]
+        self.assertEqual("HOLD", event.next_action)
+        self.assertTrue(event.reevaluation_condition)
+        self.assertEqual(1, self.review().aggregate_evidence_signals.hold_dispositions)
+
+    def test_bounded_stop_and_scope_are_preserved(self) -> None:
+        self.append(outcome="HARMFUL", action="STOP")
+        event = self.review().ordered_event_reviews[0]
+        self.assertEqual("STOP", event.next_action)
+        self.assertEqual("Bounded A6 task family 1.", event.stop_scope)
+        self.assertEqual(1, self.review().aggregate_evidence_signals.stop_dispositions)
+
+    def test_revise_predecessor_and_successor_lineage_are_preserved(self) -> None:
+        self.append(outcome="NOT_HELPFUL", action="REVISE")
+        event = self.review().ordered_event_reviews[0]
+        self.assertEqual(self.note, event.revision.predecessor)
+        self.assertNotEqual(self.note, event.revision.successor)
+        self.assertEqual(event.reusing_run_id, event.revision.successor.origin_run_id)
+        self.assertEqual(1, self.review().aggregate_evidence_signals.revise_links)
+
+    def test_same_run_and_run_related_claims_remain_distinguishable(self) -> None:
+        self.append(
+            evidence_tag="1",
+            outcome_observer_relation="REUSING_RUN_SELF",
+        )
+        self.append(
+            evidence_tag="2",
+            outcome_observer_relation="REUSING_RUN_PARTICIPANT",
+        )
+        self.append(
+            evidence_tag="3",
+            outcome_observer_relation="INDEPENDENT",
+        )
+        packet = self.review()
+        self.assertEqual(
+            [
+                "SAME_RUN_CLAIM",
+                "RUN_RELATED_CLAIM",
+                "INDEPENDENT_CONFIRMATION",
+            ],
+            [event.outcome_confirmation for event in packet.ordered_event_reviews],
+        )
+        signals = packet.aggregate_evidence_signals
+        self.assertEqual(1, signals.same_run_outcome_claims)
+        self.assertEqual(1, signals.run_related_outcome_claims)
+        self.assertEqual(1, signals.independent_outcome_confirmations)
+
+    def test_recorded_run_structure_and_use_evidence_identities_are_preserved(self) -> None:
+        appended = self.append(evidence_tag="7", structure="B")
+        event = self.review().ordered_event_reviews[0]
+        binding = appended.event.receipt.use_evidence.structure_binding
+        self.assertEqual(appended.event.recorded_at, event.recorded_at)
+        self.assertEqual("run_reuse_7", event.reusing_run_id)
+        self.assertEqual(binding.structure_id, event.structure_id)
+        self.assertEqual(binding.structure_sha256, event.structure_sha256)
+        self.assertEqual(binding.binding_sha256, event.structure_binding_sha256)
+
+
+class FieldNotesMaturityReviewBoundaryTests(MaturityReviewTestCase):
+    def test_a2_injection_is_not_an_a6_input_or_reuse_evidence(self) -> None:
+        delivery = reconnect_receipt(self.note)
+        packet = self.review()
+        self.assertEqual(0, packet.ledger_identity.durable_event_count)
+        self.assertEqual("CANDIDATE", packet.evidence_maturity.state)
+        self.assertEqual(0, packet.evidence_maturity.reconnect_receipts_ignored)
+        self.assertIsNone(packet.current_serving_policy.automatic_injection)
+        with self.assertRaises(TypeError):
+            review_field_note_maturity(
+                self.ledger,
+                self.note,
+                note_bytes=NOTE_BYTES,
+                review_as_of=REVIEW_AS_OF,
+                delivery_context=delivery,  # type: ignore[call-arg]
+            )
+
+    def test_promotable_remains_reserved_and_unset(self) -> None:
+        for tag in ("1", "2", "3"):
+            self.append(evidence_tag=tag, outcome="HELPFUL")
+        promotion = self.review().evidence_maturity.promotion
+        self.assertEqual("PROMOTABLE", promotion.reserved_state)
+        self.assertEqual("UNSET", promotion.policy_status)
+        self.assertIsNone(promotion.threshold)
+        self.assertFalse(promotion.automatically_derivable)
+
+    def test_no_promotion_recommendation_or_score_exists(self) -> None:
+        self.append(outcome="HELPFUL")
+        packet = self.review()
+
+        def keys(value):
+            if isinstance(value, dict):
+                result = set(value)
+                for nested in value.values():
+                    result.update(keys(nested))
+                return result
+            if isinstance(value, list):
+                result = set()
+                for nested in value:
+                    result.update(keys(nested))
+                return result
+            return set()
+
+        serialized_keys = keys(packet.as_dict())
+        self.assertFalse(any("score" in key for key in serialized_keys))
+        self.assertFalse(any("recommend" in key for key in serialized_keys))
+        self.assertNotIn("promotion-ready", packet.serialize().casefold())
+
+    def test_serving_policy_remains_separate_and_delayed(self) -> None:
+        self.append(outcome="HELPFUL")
+        policy = self.review().current_serving_policy
+        self.assertEqual("DELAY", policy.derivation)
+        self.assertFalse(policy.automatic_derivation_supported)
+        self.assertFalse(policy.complete_state_machine_implemented)
+
+    def test_reused_does_not_imply_injection(self) -> None:
+        self.append(outcome="HELPFUL")
+        packet = self.review()
+        self.assertEqual("REUSED", packet.evidence_maturity.state)
+        self.assertIsNone(packet.current_serving_policy.automatic_injection)
+
+    def test_canonical_authority_remains_above_advisory_field_notes(self) -> None:
+        packet = self.review()
+        self.assertEqual(
+            ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE"),
+            packet.current_serving_policy.authority_precedence,
+        )
+        self.assertIn(
+            "TOPMOST_CANONICAL > ADVISORY_FIELD_NOTE",
+            packet.render_text(),
+        )
+
+    def test_full_note_body_is_absent_from_serialized_and_text_review(self) -> None:
+        self.append()
+        packet = self.review()
+        private_text = PRIVATE_BODY.decode("utf-8")
+        full_note = NOTE_BYTES.decode("utf-8")
+        self.assertNotIn(private_text, packet.serialize())
+        self.assertNotIn(private_text, packet.render_text())
+        self.assertNotIn(full_note, packet.serialize())
+        self.assertFalse(packet.claim_boundary.full_note_contents_included)
+
+    def test_historical_evidence_is_not_current_truth(self) -> None:
+        self.append(outcome="HELPFUL")
+        boundary = self.review().claim_boundary
+        self.assertEqual("HISTORICAL_AS_OF_RECORDS", boundary.evidence_scope)
+        self.assertEqual("NOT_ESTABLISHED", boundary.current_usefulness)
+        self.assertEqual("NOT_PERFORMED", boundary.promotion_decision)
+        self.assertFalse(boundary.serving_policy_derived)
+
+
+class FieldNotesMaturityReviewIntegrityTests(MaturityReviewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.append(outcome="HARMFUL")
+
+    def test_malformed_a4_history_fails_closed(self) -> None:
+        raw = self.ledger.events_path.read_bytes()
+        self.ledger.events_path.write_bytes(raw[:-1])
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.review()
+
+    def test_tampered_event_fails_closed(self) -> None:
+        events = self.parsed_events()
+        events[0]["receipt"]["outcome"] = "HELPFUL"
+        self.rewrite_events(events)
+        with self.assertRaises(FieldNoteMaturityLedgerIntegrityError):
+            self.review()
+
+    def test_cross_note_partition_fails_closed(self) -> None:
+        other = note_identity(
+            field_note_id="fn_a6_other",
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-04-a6-other-bbbbbbbbbb.md"
+            ),
+        )
+        other_ledger = FieldNoteMaturityLedger(self.root, other)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "different A4 Note partition",
+        ):
+            review_field_note_maturity(
+                other_ledger,
+                self.note,
+                note_bytes=NOTE_BYTES,
+                review_as_of=REVIEW_AS_OF,
+            )
+
+    def test_changed_note_bytes_fail_closed(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "do not match",
+        ):
+            review_field_note_maturity(
+                self.ledger,
+                self.note,
+                note_bytes=NOTE_BYTES + b"changed",
+                review_as_of=REVIEW_AS_OF,
+            )
+
+    def test_unsupported_ledger_schema_fails_closed(self) -> None:
+        events = self.parsed_events()
+        events[0]["schema"] = "decision-os.unsupported.v9"
+        self.rewrite_events(events)
+        with self.assertRaisesRegex(
+            FieldNoteMaturityLedgerIntegrityError,
+            "Unsupported",
+        ):
+            self.review()
+
+    def test_invalid_review_as_of_fails_closed(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "RFC 3339",
+        ):
+            self.review(review_as_of="not-a-timestamp")
+
+    def test_untyped_ledger_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteMaturityReviewValidationError,
+            "typed A4 ledger",
+        ):
+            review_field_note_maturity(
+                object(),  # type: ignore[arg-type]
+                self.note,
+                note_bytes=NOTE_BYTES,
+                review_as_of=REVIEW_AS_OF,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Field Notes Lite A6 Maturity Evidence Review Surface v0.1 as a pure, read-only A4-to-A6 projection, including the bounded temporal As-of repair.

- Accepts one explicit exact Field Note identity, exact Note bytes, a typed A4 ledger, and an explicit Review As-of.
- Uses A4 reconstruction as the only authoritative evidence source, so event schema, chain, head, partition, receipt, and structure-binding integrity are verified before projection.
- Validates Review As-of plus every included recorded-at, use-evidence As-of, and outcome-evidence As-of as bounded timezone-aware RFC 3339 values.
- Fails closed unless Review As-of is at or after every included evidence instant; equivalent timezone offsets compare by instant and equality is allowed.
- Enforces the same temporal invariant in the frozen typed packet, so direct packet construction cannot attach future-dated evidence.
- Produces exact Note and ledger identities, Evidence Maturity, separate Current Serving Policy, deterministic aggregate signals, sequence-ordered event reviews, and a fixed claim boundary.
- Preserves positive, negative, uncertain, intervention-affected, HOLD, STOP, and REVISE history without filtering events, reconstructing a historical prefix, scoring, recommending promotion, or deriving serving.
- Provides canonical JSON serialization and a bounded human-readable projection containing identities and typed evidence only, never full Note or artifact contents.

## Base and head

- Base/main: `e1e577c55bd2058ce3e8bf490627395a63732158`
- Reviewed head before temporal repair: `c46e8aba8d7d8493f1b6f068c1577b3447adf98d`
- Current head: `a7a8f8284c19226c3e1cef66e7ba9d1f84ff15a0`

## Delta

- `decision_os/companion/field_notes_maturity_review.py` — typed A6 projection plus shared timestamp parsing and packet-level temporal integrity.
- `tests/test_field_notes_maturity_review.py` — 54 deterministic projection, evidence-retention, temporal-boundary, read-only, and integrity tests.

No A1-A5 source changes, event filtering, point-in-time prefix reconstruction, historical chain-head derivation, A4 rewrite, current-time lookup, automatic clock, time-window scoring, UI/server route, runtime wiring, installation, Companion restart, live Run, promotion threshold, Serving Policy implementation, automatic injection, release, or publication is included.

## Validation

- `python -m unittest tests.test_field_notes_maturity_review` — 54/54 PASS
- `python -m unittest tests.test_field_notes_maturity_commit` — 49/49 PASS
- `python -m unittest tests.test_field_notes_maturity_ledger` — 40/40 PASS
- `python -m unittest tests.test_field_notes_reuse` — 45/45 PASS
- `python -m unittest tests.test_field_notes_lite` — 25/25 PASS
- `python -m unittest tests.test_field_notes_reconnect` — 36/36 PASS
- `python -m unittest tests.test_companion_controller` — 27/27 PASS
- `python -m unittest tests.test_companion_server` — 35/35 PASS
- `python -m unittest` — 946/946 PASS
- `python -m unittest discover -s tests -p test_*.py` — 946/946 PASS
- Normalized default/explicit test IDs — MATCH; SHA-256 `56ccc7609ac99d90e09e4e3079fa8414f0f734e0fcd037a90aadd8d29a12b3dd`; no one-sided IDs
- `python -m py_compile decision_os/companion/field_notes_maturity_review.py tests/test_field_notes_maturity_review.py` — PASS
- `git diff --check` — PASS
- Protected creator Note and four validation artifacts — SHA-256, size, mode, mtime, and inode unchanged from preflight

## Claim boundary

Supported: A6 provides a deterministic, read-only review surface that presents verified durable Field Note maturity evidence only when the explicit Review As-of is not earlier than any included evidence instant.

Not claimed: historical filtering or reconstruction; any real Note is REUSED or helpful; PROMOTABLE; promotion readiness; automatic promotion; mandatory or default injection; successful intelligence transplant; generalization; performance improvement; measured savings; or external adoption.
