### PR TITLE
Add Field Notes A7 whole-flow proof contract

### DIFF
--- a/decision_os/companion/field_notes_whole_flow.py
+++ b/decision_os/companion/field_notes_whole_flow.py
@@ -1,0 +1,1370 @@
+"""Field Notes Lite A7 bounded A1-A6 Whole-Flow proof contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import re
+from typing import Any, Literal
+
+from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.companion.field_notes_maturity_commit import (
+    FieldNoteMaturityCommitResult,
+)
+from decision_os.companion.field_notes_maturity_ledger import (
+    GENESIS_EVENT_SHA256,
+    LEDGER_EVENT_KIND,
+    LEDGER_EVENT_SCHEMA,
+    FieldNoteMaturityLedgerEvent,
+    FieldNoteMaturityLedgerSnapshot,
+)
+from decision_os.companion.field_notes_maturity_review import (
+    FieldNoteMaturityReviewPacket,
+)
+from decision_os.companion.field_notes_model import (
+    FIELD_NOTE_SCHEMA_VERSION,
+    FieldNoteDraft,
+    canonical_json,
+    validate_compiled_markdown,
+)
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteReuseReceipt,
+    PromotionPolicyBoundary,
+)
+
+
+WHOLE_FLOW_SCHEMA = "decision-os.field-note-whole-flow-proof.v0.1"
+WHOLE_FLOW_TRACE_SCHEMA = "decision-os.field-note-whole-flow-trace-event.v0.1"
+WAREHOUSE_MANIFEST_SCHEMA = (
+    "decision-os.portable-candidate-warehouse-manifest.v0.1"
+)
+PORTABLE_ASSET_SCHEMA = "decision-os.portable-field-note-asset.v0.1"
+TRACE_GENESIS_SHA256 = "0" * 64
+
+WholeFlowState = Literal["NOT_READY", "PASS", "FAIL"]
+WholeFlowMode = Literal["FIXTURE", "CREATOR_LIVE"]
+WholeFlowBoundary = Literal[
+    "A1_CAPTURE",
+    "RUN_SEPARATION",
+    "MODEL_IDENTITY",
+    "REPOSITORY_IDENTITY",
+    "A2_RECONNECT",
+    "A3_REUSE",
+    "A4_DURABILITY",
+    "A5_CONFIRMATION",
+    "A6_REVIEW",
+    "HUMAN_REPAIR",
+    "PROOF_AS_OF",
+]
+HumanRepairResult = Literal[
+    "NOT_EVALUATED",
+    "INCOMPLETE",
+    "TYPED_TRACE_VERIFIED",
+    "REPAIR_DETECTED",
+]
+TraceStage = Literal[
+    "A1_CAPTURE",
+    "A2_RECONNECT",
+    "A3_REUSE",
+    "A4_DURABILITY",
+    "A5_CONFIRMATION",
+    "A6_REVIEW",
+]
+RepairAction = Literal[
+    "NONE",
+    "NOTE_EDIT",
+    "EVIDENCE_MANUFACTURE",
+    "RECEIPT_REWRITE",
+    "LEDGER_REWRITE",
+    "EVENT_ID_CHANGE",
+    "TIMESTAMP_CHANGE",
+    "EVIDENCE_DELETION",
+    "RETRY_REPLACEMENT",
+]
+
+_TRACE_STAGES: tuple[TraceStage, ...] = (
+    "A1_CAPTURE",
+    "A2_RECONNECT",
+    "A3_REUSE",
+    "A4_DURABILITY",
+    "A5_CONFIRMATION",
+    "A6_REVIEW",
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY_RE = re.compile(r"^repo:v1:[0-9a-f]{64}$")
+
+
+class FieldNoteWholeFlowError(RuntimeError):
+    """Base error for an invalid A7 contract operation."""
+
+
+class FieldNoteWholeFlowValidationError(FieldNoteWholeFlowError, ValueError):
+    """A top-level A7 value is malformed rather than incomplete evidence."""
+
+
+def _bounded_text(value: Any, label: str, *, maximum: int = 256) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > maximum
+        or "\x00" in value
+    ):
+        raise FieldNoteWholeFlowValidationError(
+            f"{label} is outside its bounded schema."
+        )
+    return value.strip()
+
+
+def _parse_time(value: Any, label: str) -> tuple[str, datetime]:
+    normalized = _bounded_text(value, label, maximum=64)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise FieldNoteWholeFlowValidationError(
+            f"{label} must be an RFC 3339 timestamp."
+        ) from exc
+    if parsed.tzinfo is None:
+        raise FieldNoteWholeFlowValidationError(
+            f"{label} must be timezone-aware."
+        )
+    return normalized, parsed
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _canonical_sha256(value: dict[str, Any]) -> str:
+    return _sha256_bytes(canonical_json(value).encode("utf-8"))
+
+
+def _require_sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise FieldNoteWholeFlowValidationError(
+            f"{label} must be a lowercase SHA-256 digest."
+        )
+    return value
+
+
+def _runtime_as_dict(value: CodexRuntimeIdentity) -> dict[str, str]:
+    return {
+        "model": value.model,
+        "reasoning_effort": value.reasoning_effort,
+        "service_tier": value.service_tier,
+        "codex_cli_version": value.codex_cli_version,
+        "account_type": value.account_type,
+    }
+
+
+def _validate_runtime(value: Any) -> CodexRuntimeIdentity:
+    if not isinstance(value, CodexRuntimeIdentity):
+        raise FieldNoteWholeFlowValidationError(
+            "Whole-Flow Run lacks a typed runtime identity."
+        )
+    for field, item in _runtime_as_dict(value).items():
+        _bounded_text(item, f"Runtime {field}", maximum=128)
+    return value
+
+
+@dataclass(frozen=True)
+class FieldNoteSourceRepositoryIdentity:
+    """Credential-free repository identity plus one immutable source commit."""
+
+    repository_id: str
+    source_commit: str
+
+    def __post_init__(self) -> None:
+        if _REPOSITORY_RE.fullmatch(self.repository_id) is None:
+            raise FieldNoteWholeFlowValidationError(
+                "Source repository identity is invalid."
+            )
+        if _COMMIT_RE.fullmatch(self.source_commit) is None:
+            raise FieldNoteWholeFlowValidationError(
+                "Source repository commit is invalid."
+            )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "repository_id": self.repository_id,
+            "source_commit": self.source_commit,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteWholeFlowAttempt:
+    """Caller-supplied identity and explicit As-of for one bounded proof."""
+
+    proof_attempt_id: str
+    proof_mode: WholeFlowMode
+    creator_id: str
+    proof_as_of: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "proof_attempt_id",
+            _bounded_text(self.proof_attempt_id, "Proof attempt ID"),
+        )
+        object.__setattr__(
+            self,
+            "creator_id",
+            _bounded_text(self.creator_id, "Creator identity"),
+        )
+        if self.proof_mode not in {"FIXTURE", "CREATOR_LIVE"}:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow proof mode is invalid."
+            )
+        normalized, _ = _parse_time(self.proof_as_of, "Proof As-of")
+        object.__setattr__(self, "proof_as_of", normalized)
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "proof_attempt_id": self.proof_attempt_id,
+            "proof_mode": self.proof_mode,
+            "creator_id": self.creator_id,
+            "proof_as_of": self.proof_as_of,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteWholeFlowRunIdentity:
+    """One fresh Run bound to the proof, repository, and exact runtime."""
+
+    proof_attempt_id: str
+    run_id: str
+    started_at: str
+    repository: FieldNoteSourceRepositoryIdentity
+    runtime: CodexRuntimeIdentity
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "proof_attempt_id",
+            _bounded_text(self.proof_attempt_id, "Proof attempt ID"),
+        )
+        object.__setattr__(
+            self,
+            "run_id",
+            _bounded_text(self.run_id, "Run ID"),
+        )
+        normalized, _ = _parse_time(self.started_at, "Run start time")
+        object.__setattr__(self, "started_at", normalized)
+        if not isinstance(self.repository, FieldNoteSourceRepositoryIdentity):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow Run lacks a typed repository identity."
+            )
+        _validate_runtime(self.runtime)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "proof_attempt_id": self.proof_attempt_id,
+            "run_id": self.run_id,
+            "started_at": self.started_at,
+            "repository": self.repository.as_dict(),
+            "runtime": _runtime_as_dict(self.runtime),
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteWholeFlowTraceEvent:
+    """One runtime checkpoint in the bounded, exact-evidence proof chain."""
+
+    sequence: int
+    stage: TraceStage
+    run_id: str
+    observed_at: str
+    evidence_sha256: str
+    previous_trace_sha256: str
+    repair_action: RepairAction = "NONE"
+    emitter: Literal["COMPANION_RUNTIME"] = "COMPANION_RUNTIME"
+
+    def __post_init__(self) -> None:
+        if type(self.sequence) is not int or self.sequence < 0:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow trace sequence is invalid."
+            )
+        if self.stage not in _TRACE_STAGES:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow trace stage is invalid."
+            )
+        object.__setattr__(self, "run_id", _bounded_text(self.run_id, "Run ID"))
+        normalized, _ = _parse_time(self.observed_at, "Trace observation time")
+        object.__setattr__(self, "observed_at", normalized)
+        _require_sha256(self.evidence_sha256, "Trace evidence identity")
+        _require_sha256(self.previous_trace_sha256, "Previous trace identity")
+        if self.repair_action not in {
+            "NONE",
+            "NOTE_EDIT",
+            "EVIDENCE_MANUFACTURE",
+            "RECEIPT_REWRITE",
+            "LEDGER_REWRITE",
+            "EVENT_ID_CHANGE",
+            "TIMESTAMP_CHANGE",
+            "EVIDENCE_DELETION",
+            "RETRY_REPLACEMENT",
+        }:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow repair action is invalid."
+            )
+        if self.emitter != "COMPANION_RUNTIME":
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow trace emitter is invalid."
+            )
+
+    @property
+    def trace_sha256(self) -> str:
+        return _canonical_sha256(self._body())
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "schema": WHOLE_FLOW_TRACE_SCHEMA,
+            "sequence": self.sequence,
+            "stage": self.stage,
+            "run_id": self.run_id,
+            "observed_at": self.observed_at,
+            "evidence_sha256": self.evidence_sha256,
+            "previous_trace_sha256": self.previous_trace_sha256,
+            "repair_action": self.repair_action,
+            "emitter": self.emitter,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._body(), "trace_sha256": self.trace_sha256}
+
+
+@dataclass(frozen=True)
+class FieldNoteWholeFlowEvidenceBundle:
+    """Existing A1-A6 values plus the smallest typed no-repair trace."""
+
+    attempt: FieldNoteWholeFlowAttempt
+    source_repository: FieldNoteSourceRepositoryIdentity
+    run_1: FieldNoteWholeFlowRunIdentity
+    run_2: FieldNoteWholeFlowRunIdentity
+    note: FieldNoteIdentity
+    note_bytes: bytes
+    a1_capture: FieldNoteDraft | None
+    a2_reconnect: FieldNoteReconnectReceipt | None
+    a3_assessment: FieldNoteReuseReceipt | None
+    a4_snapshot: FieldNoteMaturityLedgerSnapshot | None
+    a5_commit: FieldNoteMaturityCommitResult | None
+    a6_review: FieldNoteMaturityReviewPacket | None
+    proof_trace: tuple[FieldNoteWholeFlowTraceEvent, ...]
+
+    def __post_init__(self) -> None:
+        required = (
+            (self.attempt, FieldNoteWholeFlowAttempt, "proof attempt"),
+            (
+                self.source_repository,
+                FieldNoteSourceRepositoryIdentity,
+                "source repository",
+            ),
+            (self.run_1, FieldNoteWholeFlowRunIdentity, "Run 1"),
+            (self.run_2, FieldNoteWholeFlowRunIdentity, "Run 2"),
+            (self.note, FieldNoteIdentity, "Field Note identity"),
+        )
+        for value, expected, label in required:
+            if not isinstance(value, expected):
+                raise FieldNoteWholeFlowValidationError(
+                    f"Whole-Flow bundle lacks a typed {label}."
+                )
+        if not isinstance(self.note_bytes, bytes):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow Note bytes must be bytes."
+            )
+        optional = (
+            (self.a1_capture, FieldNoteDraft, "A1 capture"),
+            (self.a2_reconnect, FieldNoteReconnectReceipt, "A2 receipt"),
+            (self.a3_assessment, FieldNoteReuseReceipt, "A3 assessment"),
+            (self.a4_snapshot, FieldNoteMaturityLedgerSnapshot, "A4 snapshot"),
+            (self.a5_commit, FieldNoteMaturityCommitResult, "A5 result"),
+            (self.a6_review, FieldNoteMaturityReviewPacket, "A6 packet"),
+        )
+        for value, expected, label in optional:
+            if value is not None and not isinstance(value, expected):
+                raise FieldNoteWholeFlowValidationError(
+                    f"Whole-Flow bundle has an untyped {label}."
+                )
+        if not isinstance(self.proof_trace, tuple) or any(
+            not isinstance(item, FieldNoteWholeFlowTraceEvent)
+            for item in self.proof_trace
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow proof trace is not typed."
+            )
+
+
+@dataclass(frozen=True)
+class FieldNoteOutcomeSummary:
+    helpful: int
+    not_helpful: int
+    harmful: int
+    unknown: int
+
+    def __post_init__(self) -> None:
+        values = (self.helpful, self.not_helpful, self.harmful, self.unknown)
+        if any(type(value) is not int or value < 0 for value in values):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow outcome summary is invalid."
+            )
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "helpful": self.helpful,
+            "not_helpful": self.not_helpful,
+            "harmful": self.harmful,
+            "unknown": self.unknown,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteWholeFlowClaimBoundary:
+    scope: Literal["ONE_CREATOR_ONE_REPOSITORY_ONE_MODEL_TWO_RUNS"] = (
+        "ONE_CREATOR_ONE_REPOSITORY_ONE_MODEL_TWO_RUNS"
+    )
+    usefulness_separate: Literal[True] = True
+    a2_authoritative_for_maturity: Literal[False] = False
+    promotable_policy: Literal["UNSET"] = "UNSET"
+    serving_policy: Literal["DELAY"] = "DELAY"
+    automatic_injection_derived: Literal[False] = False
+    portability_state: Literal["PORTABLE_CANDIDATE"] = "PORTABLE_CANDIDATE"
+    portability_proven: Literal[False] = False
+    creator_live_proof_inferred_from_fixture: Literal[False] = False
+
+    def __post_init__(self) -> None:
+        if self.as_dict() != {
+            "scope": "ONE_CREATOR_ONE_REPOSITORY_ONE_MODEL_TWO_RUNS",
+            "usefulness_separate": True,
+            "a2_authoritative_for_maturity": False,
+            "promotable_policy": "UNSET",
+            "serving_policy": "DELAY",
+            "automatic_injection_derived": False,
+            "portability_state": "PORTABLE_CANDIDATE",
+            "portability_proven": False,
+            "creator_live_proof_inferred_from_fixture": False,
+        }:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow claim boundary is invalid."
+            )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "scope": self.scope,
+            "usefulness_separate": self.usefulness_separate,
+            "a2_authoritative_for_maturity": self.a2_authoritative_for_maturity,
+            "promotable_policy": self.promotable_policy,
+            "serving_policy": self.serving_policy,
+            "automatic_injection_derived": self.automatic_injection_derived,
+            "portability_state": self.portability_state,
+            "portability_proven": self.portability_proven,
+            "creator_live_proof_inferred_from_fixture": (
+                self.creator_live_proof_inferred_from_fixture
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteWholeFlowProofReceipt:
+    """Deterministic bounded result of verifying one exact A1-A6 lineage."""
+
+    schema: Literal["decision-os.field-note-whole-flow-proof.v0.1"]
+    proof_attempt_id: str
+    proof_mode: WholeFlowMode
+    proof_as_of: str
+    creator_id: str
+    source_repository: FieldNoteSourceRepositoryIdentity
+    source_runtime: CodexRuntimeIdentity
+    run_1_id: str
+    run_2_id: str
+    note: FieldNoteIdentity
+    note_byte_count: int
+    reused_structure_id: str | None
+    reused_structure_sha256: str | None
+    reused_structure_binding_sha256: str | None
+    a1_evidence_sha256: str | None
+    a2_receipt_sha256: str | None
+    a3_reuse_event_id: str | None
+    a4_partition_sha256: str | None
+    a4_event_sha256: str | None
+    a4_event_count: int | None
+    a4_chain_head_sha256: str | None
+    a4_snapshot_sha256: str | None
+    a5_status: str | None
+    a5_durable_commit_confirmed: bool | None
+    a5_confirmation_sha256: str | None
+    a6_packet_sha256: str | None
+    a6_review_as_of: str | None
+    maturity_state: str | None
+    effective_outcome: str | None
+    outcome_summary: FieldNoteOutcomeSummary | None
+    human_intervention: str | None
+    next_disposition: str | None
+    human_repair_result: HumanRepairResult
+    state: WholeFlowState
+    failed_boundary: WholeFlowBoundary | None
+    failure_reason: str | None
+    claim_boundary: FieldNoteWholeFlowClaimBoundary
+
+    def __post_init__(self) -> None:
+        if self.schema != WHOLE_FLOW_SCHEMA:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt schema is unsupported."
+            )
+        _bounded_text(self.proof_attempt_id, "Proof attempt ID")
+        _bounded_text(self.creator_id, "Creator identity")
+        _bounded_text(self.run_1_id, "Run 1 ID")
+        _bounded_text(self.run_2_id, "Run 2 ID")
+        _parse_time(self.proof_as_of, "Proof As-of")
+        if self.proof_mode not in {"FIXTURE", "CREATOR_LIVE"}:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow proof mode is invalid."
+            )
+        if not isinstance(self.source_repository, FieldNoteSourceRepositoryIdentity):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt repository identity is invalid."
+            )
+        _validate_runtime(self.source_runtime)
+        if not isinstance(self.note, FieldNoteIdentity):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt Note identity is invalid."
+            )
+        if type(self.note_byte_count) is not int or self.note_byte_count <= 0:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt Note byte count is invalid."
+            )
+        for value, label in (
+            (self.reused_structure_sha256, "Reused structure identity"),
+            (
+                self.reused_structure_binding_sha256,
+                "Reused structure binding identity",
+            ),
+            (self.a1_evidence_sha256, "A1 evidence identity"),
+            (self.a2_receipt_sha256, "A2 receipt identity"),
+            (self.a3_reuse_event_id, "A3 reuse event identity"),
+            (self.a4_partition_sha256, "A4 partition identity"),
+            (self.a4_event_sha256, "A4 event identity"),
+            (self.a4_chain_head_sha256, "A4 chain-head identity"),
+            (self.a4_snapshot_sha256, "A4 snapshot identity"),
+            (self.a5_confirmation_sha256, "A5 confirmation identity"),
+            (self.a6_packet_sha256, "A6 packet identity"),
+        ):
+            if value is not None:
+                _require_sha256(value, label)
+        if self.a4_event_count is not None and (
+            type(self.a4_event_count) is not int or self.a4_event_count < 0
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow A4 event count is invalid."
+            )
+        if self.a5_durable_commit_confirmed is not None and type(
+            self.a5_durable_commit_confirmed
+        ) is not bool:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow A5 confirmation state is invalid."
+            )
+        if self.outcome_summary is not None and not isinstance(
+            self.outcome_summary,
+            FieldNoteOutcomeSummary,
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow outcome summary is not typed."
+            )
+        if self.reused_structure_id is not None:
+            _bounded_text(
+                self.reused_structure_id,
+                "Reused structure ID",
+            )
+        if self.a5_status is not None and self.a5_status not in {
+            "NOT_REUSED",
+            "RECORDED",
+            "ALREADY_RECORDED",
+        }:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow A5 status is invalid."
+            )
+        if self.failure_reason is not None:
+            _bounded_text(
+                self.failure_reason,
+                "Whole-Flow failure reason",
+            )
+        if self.human_repair_result not in {
+            "NOT_EVALUATED",
+            "INCOMPLETE",
+            "TYPED_TRACE_VERIFIED",
+            "REPAIR_DETECTED",
+        }:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow human-repair result is invalid."
+            )
+        if self.state not in {"NOT_READY", "PASS", "FAIL"}:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow proof state is invalid."
+            )
+        if self.failed_boundary is not None and self.failed_boundary not in {
+            "A1_CAPTURE",
+            "RUN_SEPARATION",
+            "MODEL_IDENTITY",
+            "REPOSITORY_IDENTITY",
+            "A2_RECONNECT",
+            "A3_REUSE",
+            "A4_DURABILITY",
+            "A5_CONFIRMATION",
+            "A6_REVIEW",
+            "HUMAN_REPAIR",
+            "PROOF_AS_OF",
+        }:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow failed boundary is invalid."
+            )
+        if (
+            self.state == "PASS"
+            and (self.failed_boundary is not None or self.failure_reason is not None)
+        ) or (
+            self.state != "PASS"
+            and (self.failed_boundary is None or self.failure_reason is None)
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow state and failed boundary disagree."
+            )
+        if self.state == "PASS":
+            required = (
+                self.reused_structure_id,
+                self.reused_structure_sha256,
+                self.reused_structure_binding_sha256,
+                self.a1_evidence_sha256,
+                self.a2_receipt_sha256,
+                self.a3_reuse_event_id,
+                self.a4_partition_sha256,
+                self.a4_event_sha256,
+                self.a4_event_count,
+                self.a4_chain_head_sha256,
+                self.a4_snapshot_sha256,
+                self.a5_status,
+                self.a5_durable_commit_confirmed,
+                self.a5_confirmation_sha256,
+                self.a6_packet_sha256,
+                self.a6_review_as_of,
+                self.maturity_state,
+                self.effective_outcome,
+                self.outcome_summary,
+                self.human_intervention,
+                self.next_disposition,
+            )
+            if (
+                any(value is None for value in required)
+                or self.a4_event_count != 1
+                or self.a4_chain_head_sha256 != self.a4_event_sha256
+                or self.a5_status not in {"RECORDED", "ALREADY_RECORDED"}
+                or self.a5_durable_commit_confirmed is not True
+                or self.maturity_state != "REUSED"
+                or self.human_repair_result != "TYPED_TRACE_VERIFIED"
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "PASS receipt lacks complete fixed-scope evidence."
+                )
+        if not isinstance(self.claim_boundary, FieldNoteWholeFlowClaimBoundary):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt claim boundary is invalid."
+            )
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proof_attempt_id": self.proof_attempt_id,
+            "proof_mode": self.proof_mode,
+            "proof_as_of": self.proof_as_of,
+            "creator_id": self.creator_id,
+            "source_repository": self.source_repository.as_dict(),
+            "source_runtime": _runtime_as_dict(self.source_runtime),
+            "run_1_id": self.run_1_id,
+            "run_2_id": self.run_2_id,
+            "note": self.note.as_dict(),
+            "note_byte_count": self.note_byte_count,
+            "reused_structure": {
+                "structure_id": self.reused_structure_id,
+                "structure_sha256": self.reused_structure_sha256,
+                "binding_sha256": self.reused_structure_binding_sha256,
+            },
+            "a1_evidence_sha256": self.a1_evidence_sha256,
+            "a2_receipt_sha256": self.a2_receipt_sha256,
+            "a3_reuse_event_id": self.a3_reuse_event_id,
+            "a4": {
+                "partition_sha256": self.a4_partition_sha256,
+                "event_sha256": self.a4_event_sha256,
+                "event_count": self.a4_event_count,
+                "chain_head_sha256": self.a4_chain_head_sha256,
+                "snapshot_sha256": self.a4_snapshot_sha256,
+            },
+            "a5": {
+                "status": self.a5_status,
+                "durable_commit_confirmed": self.a5_durable_commit_confirmed,
+                "confirmation_sha256": self.a5_confirmation_sha256,
+            },
+            "a6": {
+                "packet_sha256": self.a6_packet_sha256,
+                "review_as_of": self.a6_review_as_of,
+            },
+            "maturity_state": self.maturity_state,
+            "effective_outcome": self.effective_outcome,
+            "outcome_summary": (
+                self.outcome_summary.as_dict()
+                if self.outcome_summary is not None
+                else None
+            ),
+            "human_intervention": self.human_intervention,
+            "next_disposition": self.next_disposition,
+            "human_repair_result": self.human_repair_result,
+            "state": self.state,
+            "failed_boundary": self.failed_boundary,
+            "failure_reason": self.failure_reason,
+            "claim_boundary": self.claim_boundary.as_dict(),
+        }
+
+    @property
+    def receipt_sha256(self) -> str:
+        return _canonical_sha256(self._body())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._body(), "receipt_sha256": self.receipt_sha256}
+
+    def serialize(self) -> str:
+        return canonical_json(self.as_dict())
+
+    def render_text(self) -> str:
+        return "\n".join(
+            (
+                "Field Note Whole-Flow Proof Receipt v0.1",
+                f"State: {self.state}",
+                f"Proof mode: {self.proof_mode}",
+                f"Proof As-of: {self.proof_as_of}",
+                f"Proof attempt: {self.proof_attempt_id}",
+                f"Creator: {self.creator_id}",
+                f"Run 1: {self.run_1_id}",
+                f"Run 2: {self.run_2_id}",
+                f"Field Note: {self.note.note_path}",
+                f"Outcome: {self.effective_outcome or 'NOT_ESTABLISHED'}",
+                f"Disposition: {self.next_disposition or 'NOT_ESTABLISHED'}",
+                f"Failed boundary: {self.failed_boundary or 'NONE'}",
+                "PROMOTABLE: UNSET",
+                "Serving Policy: DELAY",
+                "Authority: TOPMOST_CANONICAL > ADVISORY_FIELD_NOTE",
+                f"Receipt SHA-256: {self.receipt_sha256}",
+                "",
+            )
+        )
+
+
+@dataclass(frozen=True)
+class PortableCandidateClaimBoundary:
+    portability_state: Literal["PORTABLE_CANDIDATE"] = "PORTABLE_CANDIDATE"
+    portability_proven: Literal[False] = False
+    cross_repository_import_verified: Literal[False] = False
+    cross_model_reuse_verified: Literal[False] = False
+    external_user_reuse_verified: Literal[False] = False
+    source_evidence_immutable: Literal[True] = True
+    future_evidence_scope: Literal["TARGET_REPOSITORY_LOCAL"] = (
+        "TARGET_REPOSITORY_LOCAL"
+    )
+    explicit_import_receipt_required: Literal[True] = True
+    shared_mutable_ledger: Literal[False] = False
+    diverged_ledger_merge_supported: Literal[False] = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "portability_state": self.portability_state,
+            "portability_proven": self.portability_proven,
+            "cross_repository_import_verified": (
+                self.cross_repository_import_verified
+            ),
+            "cross_model_reuse_verified": self.cross_model_reuse_verified,
+            "external_user_reuse_verified": self.external_user_reuse_verified,
+            "source_evidence_immutable": self.source_evidence_immutable,
+            "future_evidence_scope": self.future_evidence_scope,
+            "explicit_import_receipt_required": (
+                self.explicit_import_receipt_required
+            ),
+            "shared_mutable_ledger": self.shared_mutable_ledger,
+            "diverged_ledger_merge_supported": (
+                self.diverged_ledger_merge_supported
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class PortableCandidateWarehouseManifest:
+    """Portable immutable label; future evidence remains repository-local."""
+
+    proof_receipt: FieldNoteWholeFlowProofReceipt
+    claim_boundary: PortableCandidateClaimBoundary = (
+        PortableCandidateClaimBoundary()
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.proof_receipt, FieldNoteWholeFlowProofReceipt)
+            or self.proof_receipt.state != "PASS"
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Warehouse manifest requires one PASS proof receipt."
+            )
+        if not isinstance(self.claim_boundary, PortableCandidateClaimBoundary):
+            raise FieldNoteWholeFlowValidationError(
+                "Warehouse portability claim boundary is invalid."
+            )
+        if self.claim_boundary.as_dict() != PortableCandidateClaimBoundary().as_dict():
+            raise FieldNoteWholeFlowValidationError(
+                "Warehouse portability claim boundary was widened."
+            )
+
+    @property
+    def portable_asset_id(self) -> str:
+        receipt = self.proof_receipt
+        return _canonical_sha256(
+            {
+                "schema": PORTABLE_ASSET_SCHEMA,
+                "note": receipt.note.as_dict(),
+                "note_byte_count": receipt.note_byte_count,
+                "origin_run_id": receipt.note.origin_run_id,
+                "source_repository": receipt.source_repository.as_dict(),
+                "source_runtime": _runtime_as_dict(receipt.source_runtime),
+            }
+        )
+
+    def _body(self) -> dict[str, Any]:
+        receipt = self.proof_receipt
+        if receipt.outcome_summary is None:
+            raise FieldNoteWholeFlowValidationError(
+                "Warehouse manifest lacks a bounded outcome summary."
+            )
+        return {
+            "schema": WAREHOUSE_MANIFEST_SCHEMA,
+            "portable_asset_id": self.portable_asset_id,
+            "source_note": receipt.note.as_dict(),
+            "note_sha256": receipt.note.note_sha256,
+            "note_byte_count": receipt.note_byte_count,
+            "origin_run_id": receipt.note.origin_run_id,
+            "source_repository": receipt.source_repository.as_dict(),
+            "source_runtime": _runtime_as_dict(receipt.source_runtime),
+            "whole_flow_proof_receipt_sha256": receipt.receipt_sha256,
+            "proof_mode": receipt.proof_mode,
+            "a4_evidence_snapshot_sha256": receipt.a4_snapshot_sha256,
+            "a6_review_packet_sha256": receipt.a6_packet_sha256,
+            "verified_coverage": {
+                "repositories": 1,
+                "model_identities": 1,
+                "verified_later_reuse_runs": 1,
+            },
+            "maturity_state": receipt.maturity_state,
+            "outcome_summary": receipt.outcome_summary.as_dict(),
+            "effective_outcome": receipt.effective_outcome,
+            "human_intervention": receipt.human_intervention,
+            "next_disposition": receipt.next_disposition,
+            "promotable_policy": "UNSET",
+            "serving_policy": "DELAY",
+            "automatic_injection": None,
+            "authority_precedence": [
+                "TOPMOST_CANONICAL",
+                "ADVISORY_FIELD_NOTE",
+            ],
+            "claim_boundary": self.claim_boundary.as_dict(),
+            "future_evidence_extension": (
+                "TARGET_LOCAL_LEDGER_WITH_EXPLICIT_IMPORT_REQUIRED"
+            ),
+        }
+
+    @property
+    def manifest_id(self) -> str:
+        return _canonical_sha256(self._body())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._body(), "manifest_id": self.manifest_id}
+
+    def serialize(self) -> str:
+        return canonical_json(self.as_dict())
+
+    def render_text(self) -> str:
+        return "\n".join(
+            (
+                "Portable Candidate Warehouse Manifest v0.1",
+                "State: PORTABLE_CANDIDATE",
+                f"Asset: {self.portable_asset_id}",
+                f"Field Note: {self.proof_receipt.note.note_path}",
+                "Verified repositories: 1",
+                "Verified model identities: 1",
+                "Verified later reuse Runs: 1",
+                "PROMOTABLE: UNSET",
+                "Serving Policy: DELAY",
+                "Portability proven: false",
+                "Future evidence: target-repository-local with explicit import",
+                f"Manifest SHA-256: {self.manifest_id}",
+                "",
+            )
+        )
+
+
+def _a1_evidence_sha256(draft: FieldNoteDraft) -> str:
+    return _canonical_sha256(
+        {
+            "schema": FIELD_NOTE_SCHEMA_VERSION,
+            "title": draft.title,
+            "value_level": draft.value_level,
+            "source_model_class": draft.source_model_class,
+            "target_model_class": draft.target_model_class,
+            "source_run_id": draft.source_run_id,
+            "created_at": draft.created_at,
+            "field_note_id": draft.field_note_id,
+            "relative_path": draft.relative_path,
+            "note_sha256": draft.sha256,
+            "note_byte_count": len(draft.markdown),
+        }
+    )
+
+
+def _a2_receipt_sha256(receipt: FieldNoteReconnectReceipt) -> str:
+    return _canonical_sha256(receipt.as_dict())
+
+
+def _a5_confirmation_sha256(result: FieldNoteMaturityCommitResult) -> str:
+    return _canonical_sha256(result.as_dict())
+
+
+def _a6_packet_sha256(packet: FieldNoteMaturityReviewPacket) -> str:
+    return _sha256_bytes(packet.serialize().encode("utf-8"))
+
+
+def _event_receipt_sha256(event: FieldNoteMaturityLedgerEvent) -> str:
+    return _canonical_sha256(event.receipt.as_dict())
+
+
+def _event_sha256(event: FieldNoteMaturityLedgerEvent) -> str:
+    body = {
+        "schema": LEDGER_EVENT_SCHEMA,
+        "event_kind": LEDGER_EVENT_KIND,
+        "sequence": event.sequence,
+        "recorded_at": event.recorded_at,
+        "note_partition_sha256": event.note_partition_sha256,
+        "previous_event_sha256": event.previous_event_sha256,
+        "event_id": event.event_id,
+        "receipt": event.receipt.as_dict(),
+        "receipt_sha256": event.receipt_sha256,
+    }
+    return _canonical_sha256(body)
+
+
+def _expected_reuse_event_id(receipt: FieldNoteReuseReceipt) -> str:
+    if receipt.use_evidence is None:
+        return ""
+    return _canonical_sha256(
+        {
+            "note": receipt.note.as_dict(),
+            "reusing_run_id": receipt.reusing_run_id,
+            "use_evidence": receipt.use_evidence.as_dict(),
+        }
+    )
+
+
+def _outcome_summary(packet: FieldNoteMaturityReviewPacket) -> FieldNoteOutcomeSummary:
+    signals = packet.aggregate_evidence_signals
+    return FieldNoteOutcomeSummary(
+        helpful=signals.helpful_outcomes,
+        not_helpful=signals.not_helpful_outcomes,
+        harmful=signals.harmful_outcomes,
+        unknown=signals.unknown_outcomes,
+    )
+
+
+def _receipt(
+    bundle: FieldNoteWholeFlowEvidenceBundle,
+    *,
+    state: WholeFlowState,
+    failed_boundary: WholeFlowBoundary | None,
+    failure_reason: str | None,
+    human_repair_result: HumanRepairResult = "NOT_EVALUATED",
+) -> FieldNoteWholeFlowProofReceipt:
+    a1 = bundle.a1_capture
+    a2 = bundle.a2_reconnect
+    a3 = bundle.a3_assessment
+    a4 = bundle.a4_snapshot
+    a5 = bundle.a5_commit
+    a6 = bundle.a6_review
+    binding = a3.use_evidence.structure_binding if (
+        a3 is not None and a3.use_evidence is not None
+    ) else None
+    first_event = a4.events[0] if a4 is not None and a4.events else None
+    return FieldNoteWholeFlowProofReceipt(
+        schema=WHOLE_FLOW_SCHEMA,
+        proof_attempt_id=bundle.attempt.proof_attempt_id,
+        proof_mode=bundle.attempt.proof_mode,
+        proof_as_of=bundle.attempt.proof_as_of,
+        creator_id=bundle.attempt.creator_id,
+        source_repository=bundle.source_repository,
+        source_runtime=bundle.run_1.runtime,
+        run_1_id=bundle.run_1.run_id,
+        run_2_id=bundle.run_2.run_id,
+        note=bundle.note,
+        note_byte_count=len(bundle.note_bytes),
+        reused_structure_id=binding.structure_id if binding else None,
+        reused_structure_sha256=binding.structure_sha256 if binding else None,
+        reused_structure_binding_sha256=(
+            binding.binding_sha256 if binding else None
+        ),
+        a1_evidence_sha256=_a1_evidence_sha256(a1) if a1 else None,
+        a2_receipt_sha256=_a2_receipt_sha256(a2) if a2 else None,
+        a3_reuse_event_id=a3.reuse_event_id if a3 else None,
+        a4_partition_sha256=(
+            first_event.note_partition_sha256 if first_event else None
+        ),
+        a4_event_sha256=first_event.event_sha256 if first_event else None,
+        a4_event_count=len(a4.events) if a4 else None,
+        a4_chain_head_sha256=a4.chain_head_sha256 if a4 else None,
+        a4_snapshot_sha256=(
+            _canonical_sha256(a4.as_dict()) if a4 else None
+        ),
+        a5_status=a5.status if a5 else None,
+        a5_durable_commit_confirmed=(
+            a5.durable_commit_confirmed if a5 else None
+        ),
+        a5_confirmation_sha256=(
+            _a5_confirmation_sha256(a5) if a5 else None
+        ),
+        a6_packet_sha256=_a6_packet_sha256(a6) if a6 else None,
+        a6_review_as_of=a6.review_as_of if a6 else None,
+        maturity_state=a6.evidence_maturity.state if a6 else None,
+        effective_outcome=a3.outcome if a3 else None,
+        outcome_summary=_outcome_summary(a6) if a6 else None,
+        human_intervention=a3.human_intervention if a3 else None,
+        next_disposition=a3.next_action if a3 else None,
+        human_repair_result=human_repair_result,
+        state=state,
+        failed_boundary=failed_boundary,
+        failure_reason=failure_reason,
+        claim_boundary=FieldNoteWholeFlowClaimBoundary(),
+    )
+
+
+def _not_ready(
+    bundle: FieldNoteWholeFlowEvidenceBundle,
+    boundary: WholeFlowBoundary,
+    reason: str,
+) -> FieldNoteWholeFlowProofReceipt:
+    return _receipt(
+        bundle,
+        state="NOT_READY",
+        failed_boundary=boundary,
+        failure_reason=reason,
+        human_repair_result=(
+            "INCOMPLETE" if boundary == "HUMAN_REPAIR" else "NOT_EVALUATED"
+        ),
+    )
+
+
+def _fail(
+    bundle: FieldNoteWholeFlowEvidenceBundle,
+    boundary: WholeFlowBoundary,
+    reason: str,
+    *,
+    human_repair_result: HumanRepairResult = "NOT_EVALUATED",
+) -> FieldNoteWholeFlowProofReceipt:
+    return _receipt(
+        bundle,
+        state="FAIL",
+        failed_boundary=boundary,
+        failure_reason=reason,
+        human_repair_result=human_repair_result,
+    )
+
+
+def verify_field_note_whole_flow(
+    bundle: FieldNoteWholeFlowEvidenceBundle,
+) -> FieldNoteWholeFlowProofReceipt:
+    """Verify one fixed A1-A6 lineage without writing, retrying, or repairing."""
+
+    if not isinstance(bundle, FieldNoteWholeFlowEvidenceBundle):
+        raise FieldNoteWholeFlowValidationError(
+            "Whole-Flow verifier requires a typed evidence bundle."
+        )
+    for value, boundary, reason in (
+        (bundle.a1_capture, "A1_CAPTURE", "A1_EVIDENCE_MISSING"),
+        (bundle.a2_reconnect, "A2_RECONNECT", "A2_EVIDENCE_MISSING"),
+        (bundle.a3_assessment, "A3_REUSE", "A3_EVIDENCE_MISSING"),
+        (bundle.a4_snapshot, "A4_DURABILITY", "A4_EVIDENCE_MISSING"),
+        (bundle.a5_commit, "A5_CONFIRMATION", "A5_EVIDENCE_MISSING"),
+        (bundle.a6_review, "A6_REVIEW", "A6_EVIDENCE_MISSING"),
+    ):
+        if value is None:
+            return _not_ready(bundle, boundary, reason)  # type: ignore[arg-type]
+    if len(bundle.proof_trace) < len(_TRACE_STAGES):
+        return _not_ready(
+            bundle,
+            "HUMAN_REPAIR",
+            "TYPED_PROOF_TRACE_INCOMPLETE",
+        )
+
+    assert bundle.a1_capture is not None
+    assert bundle.a2_reconnect is not None
+    assert bundle.a3_assessment is not None
+    assert bundle.a4_snapshot is not None
+    assert bundle.a5_commit is not None
+    assert bundle.a6_review is not None
+    a1 = bundle.a1_capture
+    a2 = bundle.a2_reconnect
+    a3 = bundle.a3_assessment
+    a4 = bundle.a4_snapshot
+    a5 = bundle.a5_commit
+    a6 = bundle.a6_review
+
+    if (
+        bundle.run_1.proof_attempt_id != bundle.attempt.proof_attempt_id
+        or bundle.run_2.proof_attempt_id != bundle.attempt.proof_attempt_id
+    ):
+        return _fail(bundle, "RUN_SEPARATION", "RUN_ATTEMPT_MISMATCH")
+    if bundle.run_1.run_id == bundle.run_2.run_id:
+        return _fail(bundle, "RUN_SEPARATION", "RUN_IDENTITIES_NOT_DISTINCT")
+    _, run_1_time = _parse_time(bundle.run_1.started_at, "Run 1 start")
+    _, run_2_time = _parse_time(bundle.run_2.started_at, "Run 2 start")
+    if run_2_time <= run_1_time:
+        return _fail(bundle, "RUN_SEPARATION", "RUN_ORDER_INVALID")
+    if bundle.run_1.runtime != bundle.run_2.runtime:
+        return _fail(bundle, "MODEL_IDENTITY", "MODEL_RUNTIME_MISMATCH")
+    if (
+        bundle.run_1.repository != bundle.source_repository
+        or bundle.run_2.repository != bundle.source_repository
+    ):
+        return _fail(
+            bundle,
+            "REPOSITORY_IDENTITY",
+            "SOURCE_REPOSITORY_MISMATCH",
+        )
+
+    try:
+        validate_compiled_markdown(a1.markdown)
+    except ValueError:
+        return _fail(bundle, "A1_CAPTURE", "A1_CAPTURE_INVALID")
+    _, a1_time = _parse_time(a1.created_at, "A1 capture time")
+    expected_note = FieldNoteIdentity(
+        note_path=a1.relative_path,
+        field_note_id=a1.field_note_id,
+        note_sha256=a1.sha256,
+        origin_run_id=a1.source_run_id,
+    )
+    if (
+        a1.source_run_id != bundle.run_1.run_id
+        or bundle.note.origin_run_id != bundle.run_1.run_id
+    ):
+        return _fail(bundle, "A1_CAPTURE", "A1_RUN_MISMATCH")
+    if (
+        bundle.note != expected_note
+        or bundle.note_bytes != a1.markdown
+        or len(bundle.note_bytes) != len(a1.markdown)
+        or _sha256_bytes(bundle.note_bytes) != bundle.note.note_sha256
+        or _sha256_bytes(a1.markdown) != a1.sha256
+    ):
+        return _fail(bundle, "A1_CAPTURE", "A1_NOTE_IDENTITY_MISMATCH")
+    if a1_time < run_1_time or a1_time >= run_2_time:
+        return _fail(bundle, "A1_CAPTURE", "A1_NOT_NEW_FOR_PROOF_ATTEMPT")
+
+    if a2.run_id != bundle.run_2.run_id:
+        return _fail(bundle, "A2_RECONNECT", "A2_RUN_MISMATCH")
+    if (
+        a2.state not in {"INJECTED", "ACTIVATION_UNKNOWN"}
+        or a2.full_notes_injected != 1
+        or a2.failure_reason is not None
+    ):
+        return _fail(bundle, "A2_RECONNECT", "A2_NOT_INJECTED")
+    if (
+        a2.selected_field_note_path != bundle.note.note_path
+        or a2.selected_field_note_id != bundle.note.field_note_id
+        or a2.selected_full_note_sha256 != bundle.note.note_sha256
+        or a2.full_note_bytes_read != len(bundle.note_bytes)
+    ):
+        return _fail(bundle, "A2_RECONNECT", "A2_EXACT_NOTE_MISMATCH")
+
+    if a3.state != "REUSED" or a3.use_evidence is None:
+        return _fail(bundle, "A3_REUSE", "A3_NOT_DEMONSTRABLY_REUSED")
+    if a3.note != bundle.note:
+        return _fail(bundle, "A3_REUSE", "A3_EXACT_NOTE_MISMATCH")
+    if (
+        a3.reusing_run_id != bundle.run_2.run_id
+        or a3.use_evidence.reusing_run_id != bundle.run_2.run_id
+    ):
+        return _fail(bundle, "A3_REUSE", "A3_RUN_MISMATCH")
+    if not a3.use_evidence.structure_binding.verifies(
+        bundle.note,
+        bundle.note_bytes,
+    ):
+        return _fail(bundle, "A3_REUSE", "A3_STRUCTURE_BINDING_INVALID")
+    if a3.reuse_event_id != _expected_reuse_event_id(a3):
+        return _fail(bundle, "A3_REUSE", "A3_REUSE_EVENT_ID_INVALID")
+    if a3.promotion != PromotionPolicyBoundary():
+        return _fail(bundle, "A3_REUSE", "A3_PROMOTABLE_POLICY_WIDENED")
+    _, use_time = _parse_time(a3.use_evidence.as_of, "A3 use evidence As-of")
+    _, outcome_time = _parse_time(a3.outcome_as_of, "A3 outcome As-of")
+    if use_time < run_2_time or outcome_time < use_time:
+        return _fail(bundle, "A3_REUSE", "A3_EVIDENCE_TIME_ORDER_INVALID")
+
+    expected_partition = _canonical_sha256(bundle.note.as_dict())
+    if len(a4.events) != 1:
+        return _fail(bundle, "A4_DURABILITY", "A4_EVENT_COUNT_NOT_EXACTLY_ONE")
+    event = a4.events[0]
+    if (
+        a4.note != bundle.note
+        or event.sequence != 0
+        or event.previous_event_sha256 != GENESIS_EVENT_SHA256
+        or event.note_partition_sha256 != expected_partition
+        or event.event_id != a3.reuse_event_id
+        or event.receipt != a3
+        or event.receipt_sha256 != _event_receipt_sha256(event)
+        or event.event_sha256 != _event_sha256(event)
+        or a4.chain_head_sha256 != event.event_sha256
+        or a4.evidence_maturity.note != bundle.note
+        or a4.evidence_maturity.state != "REUSED"
+        or a4.evidence_maturity.reuse_event_ids != (a3.reuse_event_id,)
+    ):
+        return _fail(bundle, "A4_DURABILITY", "A4_EXACT_EVENT_INTEGRITY_INVALID")
+    _, recorded_time = _parse_time(event.recorded_at, "A4 recorded-at")
+    if recorded_time < outcome_time or recorded_time < use_time:
+        return _fail(bundle, "A4_DURABILITY", "A4_EVENT_TIME_ORDER_INVALID")
+
+    if (
+        a5.status not in {"RECORDED", "ALREADY_RECORDED"}
+        or not a5.durable_commit_confirmed
+        or a5.append_result is None
+        or a5.durable_snapshot is None
+    ):
+        return _fail(bundle, "A5_CONFIRMATION", "A5_APPEND_NOT_CONFIRMED")
+    if (
+        a5.assessment != a3
+        or a5.delivery_context != a2
+        or a5.append_result.event != event
+        or a5.append_result.appended != (a5.status == "RECORDED")
+        or a5.durable_snapshot != a4
+    ):
+        return _fail(bundle, "A5_CONFIRMATION", "A5_READ_BACK_LINEAGE_MISMATCH")
+
+    if a6.note_identity != bundle.note:
+        return _fail(bundle, "A6_REVIEW", "A6_EXACT_NOTE_MISMATCH")
+    if (
+        a6.ledger_identity.note_partition_sha256 != expected_partition
+        or a6.ledger_identity.durable_event_count != 1
+        or a6.ledger_identity.chain_head_sha256 != event.event_sha256
+        or len(a6.ordered_event_reviews) != 1
+    ):
+        return _fail(bundle, "A6_REVIEW", "A6_LEDGER_IDENTITY_MISMATCH")
+    review = a6.ordered_event_reviews[0]
+    if (
+        review.sequence != event.sequence
+        or review.recorded_at != event.recorded_at
+        or review.event_id != event.event_id
+        or review.previous_event_sha256 != event.previous_event_sha256
+        or review.event_sha256 != event.event_sha256
+        or review.reusing_run_id != a3.reusing_run_id
+        or review.structure_id != a3.use_evidence.structure_id
+        or review.structure_sha256 != a3.use_evidence.structure_sha256
+        or review.structure_binding_sha256
+        != a3.use_evidence.structure_binding.binding_sha256
+        or review.evidence_class != a3.use_evidence.evidence_class
+        or review.evidence_ref != a3.use_evidence.evidence_ref
+        or review.evidence_sha256 != a3.use_evidence.evidence_sha256
+        or review.use_evidence_as_of != a3.use_evidence.as_of
+        or review.claimed_outcome != a3.claimed_outcome
+        or review.effective_outcome != a3.outcome
+        or review.outcome_as_of != a3.outcome_as_of
+        or review.human_intervention != a3.human_intervention
+        or review.next_action != a3.next_action
+        or review.reevaluation_condition != a3.reevaluation_condition
+        or review.stop_scope != a3.stop_scope
+        or review.revision != a3.revision
+    ):
+        return _fail(bundle, "A6_REVIEW", "A6_EXACT_EVENT_MISMATCH")
+    if (
+        a6.evidence_maturity.state != "REUSED"
+        or a6.evidence_maturity.reuse_event_ids != (a3.reuse_event_id,)
+        or a6.evidence_maturity.promotion != PromotionPolicyBoundary()
+        or a6.current_serving_policy.derivation != "DELAY"
+        or a6.current_serving_policy.automatic_injection is not None
+        or a6.current_serving_policy.authority_precedence
+        != ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE")
+    ):
+        return _fail(bundle, "A6_REVIEW", "A6_POLICY_BOUNDARY_WIDENED")
+    _, review_time = _parse_time(a6.review_as_of, "A6 Review As-of")
+    if review_time < max(recorded_time, use_time, outcome_time):
+        return _fail(bundle, "A6_REVIEW", "A6_FUTURE_DATED_EVIDENCE")
+    _, proof_time = _parse_time(bundle.attempt.proof_as_of, "Proof As-of")
+    if proof_time < review_time:
+        return _fail(bundle, "PROOF_AS_OF", "PROOF_AS_OF_PRECEDES_A6_REVIEW")
+
+    expected_evidence = (
+        _a1_evidence_sha256(a1),
+        _a2_receipt_sha256(a2),
+        a3.reuse_event_id,
+        event.event_sha256,
+        _a5_confirmation_sha256(a5),
+        _a6_packet_sha256(a6),
+    )
+    expected_runs = (
+        bundle.run_1.run_id,
+        bundle.run_2.run_id,
+        bundle.run_2.run_id,
+        bundle.run_2.run_id,
+        bundle.run_2.run_id,
+        bundle.run_2.run_id,
+    )
+    minimum_times = (
+        a1_time,
+        run_2_time,
+        max(use_time, outcome_time),
+        recorded_time,
+        recorded_time,
+        review_time,
+    )
+    if len(bundle.proof_trace) != len(_TRACE_STAGES):
+        return _fail(bundle, "HUMAN_REPAIR", "TYPED_PROOF_TRACE_INVALID")
+    previous = TRACE_GENESIS_SHA256
+    previous_time: datetime | None = None
+    for index, trace in enumerate(bundle.proof_trace):
+        _, trace_time = _parse_time(trace.observed_at, "Trace observation time")
+        if (
+            trace.sequence != index
+            or trace.stage != _TRACE_STAGES[index]
+            or trace.run_id != expected_runs[index]
+            or trace.evidence_sha256 != expected_evidence[index]
+            or trace.previous_trace_sha256 != previous
+            or trace_time < minimum_times[index]
+            or trace_time > proof_time
+            or (previous_time is not None and trace_time < previous_time)
+        ):
+            return _fail(
+                bundle,
+                "HUMAN_REPAIR",
+                "TYPED_PROOF_TRACE_INVALID",
+            )
+        if trace.repair_action != "NONE":
+            return _fail(
+                bundle,
+                "HUMAN_REPAIR",
+                "HUMAN_REPAIR_DETECTED",
+                human_repair_result="REPAIR_DETECTED",
+            )
+        previous = trace.trace_sha256
+        previous_time = trace_time
+
+    return _receipt(
+        bundle,
+        state="PASS",
+        failed_boundary=None,
+        failure_reason=None,
+        human_repair_result="TYPED_TRACE_VERIFIED",
+    )
+
+
+def build_portable_candidate_warehouse_manifest(
+    receipt: FieldNoteWholeFlowProofReceipt,
+) -> PortableCandidateWarehouseManifest:
+    """Create a portable candidate label only from one A7 PASS receipt."""
+
+    return PortableCandidateWarehouseManifest(receipt)

--- a/decision_os/companion/field_notes_whole_flow.py
+++ b/decision_os/companion/field_notes_whole_flow.py
@@ -49,6 +49,7 @@ TRACE_GENESIS_SHA256 = "0" * 64
 WholeFlowState = Literal["NOT_READY", "PASS", "FAIL"]
 WholeFlowMode = Literal["FIXTURE", "CREATOR_LIVE"]
 WholeFlowBoundary = Literal[
+    "RUNTIME_ENFORCEMENT",
     "A1_CAPTURE",
     "RUN_SEPARATION",
     "MODEL_IDENTITY",
@@ -479,8 +480,8 @@ class FieldNoteWholeFlowProofReceipt:
     creator_id: str
     source_repository: FieldNoteSourceRepositoryIdentity
     source_runtime: CodexRuntimeIdentity
-    run_1_id: str
-    run_2_id: str
+    run_1: FieldNoteWholeFlowRunIdentity
+    run_2: FieldNoteWholeFlowRunIdentity
     note: FieldNoteIdentity
     note_byte_count: int
     reused_structure_id: str | None
@@ -504,6 +505,12 @@ class FieldNoteWholeFlowProofReceipt:
     outcome_summary: FieldNoteOutcomeSummary | None
     human_intervention: str | None
     next_disposition: str | None
+    proof_trace_schema: Literal[
+        "decision-os.field-note-whole-flow-trace-event.v0.1"
+    ]
+    proof_trace_event_count: int
+    proof_trace_chain_head_sha256: str | None
+    proof_trace: tuple[FieldNoteWholeFlowTraceEvent, ...]
     human_repair_result: HumanRepairResult
     state: WholeFlowState
     failed_boundary: WholeFlowBoundary | None
@@ -517,8 +524,6 @@ class FieldNoteWholeFlowProofReceipt:
             )
         _bounded_text(self.proof_attempt_id, "Proof attempt ID")
         _bounded_text(self.creator_id, "Creator identity")
-        _bounded_text(self.run_1_id, "Run 1 ID")
-        _bounded_text(self.run_2_id, "Run 2 ID")
         _parse_time(self.proof_as_of, "Proof As-of")
         if self.proof_mode not in {"FIXTURE", "CREATOR_LIVE"}:
             raise FieldNoteWholeFlowValidationError(
@@ -529,6 +534,16 @@ class FieldNoteWholeFlowProofReceipt:
                 "Whole-Flow receipt repository identity is invalid."
             )
         _validate_runtime(self.source_runtime)
+        if not isinstance(
+            self.run_1,
+            FieldNoteWholeFlowRunIdentity,
+        ) or not isinstance(
+            self.run_2,
+            FieldNoteWholeFlowRunIdentity,
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt Run identity is invalid."
+            )
         if not isinstance(self.note, FieldNoteIdentity):
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow receipt Note identity is invalid."
@@ -552,6 +567,10 @@ class FieldNoteWholeFlowProofReceipt:
             (self.a4_snapshot_sha256, "A4 snapshot identity"),
             (self.a5_confirmation_sha256, "A5 confirmation identity"),
             (self.a6_packet_sha256, "A6 packet identity"),
+            (
+                self.proof_trace_chain_head_sha256,
+                "Proof trace chain-head identity",
+            ),
         ):
             if value is not None:
                 _require_sha256(value, label)
@@ -601,11 +620,13 @@ class FieldNoteWholeFlowProofReceipt:
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow human-repair result is invalid."
             )
+        self._validate_proof_trace_identity()
         if self.state not in {"NOT_READY", "PASS", "FAIL"}:
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow proof state is invalid."
             )
         if self.failed_boundary is not None and self.failed_boundary not in {
+            "RUNTIME_ENFORCEMENT",
             "A1_CAPTURE",
             "RUN_SEPARATION",
             "MODEL_IDENTITY",
@@ -657,6 +678,7 @@ class FieldNoteWholeFlowProofReceipt:
             )
             if (
                 any(value is None for value in required)
+                or self.proof_mode != "FIXTURE"
                 or self.a4_event_count != 1
                 or self.a4_chain_head_sha256 != self.a4_event_sha256
                 or self.a5_status not in {"RECORDED", "ALREADY_RECORDED"}
@@ -667,10 +689,122 @@ class FieldNoteWholeFlowProofReceipt:
                 raise FieldNoteWholeFlowValidationError(
                     "PASS receipt lacks complete fixed-scope evidence."
                 )
+            self._validate_complete_run_binding()
+        if (
+            self.human_repair_result == "TYPED_TRACE_VERIFIED"
+            and self.state != "PASS"
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Typed proof trace verification requires a PASS receipt."
+            )
         if not isinstance(self.claim_boundary, FieldNoteWholeFlowClaimBoundary):
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow receipt claim boundary is invalid."
             )
+
+    @property
+    def run_1_id(self) -> str:
+        return self.run_1.run_id
+
+    @property
+    def run_2_id(self) -> str:
+        return self.run_2.run_id
+
+    def _validate_complete_run_binding(self) -> None:
+        _, run_1_time = _parse_time(self.run_1.started_at, "Run 1 start time")
+        _, run_2_time = _parse_time(self.run_2.started_at, "Run 2 start time")
+        if (
+            self.run_1.run_id == self.run_2.run_id
+            or run_2_time <= run_1_time
+            or self.run_1.proof_attempt_id != self.proof_attempt_id
+            or self.run_2.proof_attempt_id != self.proof_attempt_id
+            or self.run_1.repository != self.source_repository
+            or self.run_2.repository != self.source_repository
+            or self.run_1.runtime != self.source_runtime
+            or self.run_2.runtime != self.source_runtime
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "PASS receipt Run identities are not exactly cross-bound."
+            )
+
+    def _validate_proof_trace_identity(self) -> None:
+        if self.proof_trace_schema != WHOLE_FLOW_TRACE_SCHEMA:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt proof trace schema is unsupported."
+            )
+        if (
+            not isinstance(self.proof_trace, tuple)
+            or any(
+                not isinstance(item, FieldNoteWholeFlowTraceEvent)
+                for item in self.proof_trace
+            )
+            or type(self.proof_trace_event_count) is not int
+            or self.proof_trace_event_count != len(self.proof_trace)
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt proof trace count is invalid."
+            )
+        expected_head = (
+            self.proof_trace[-1].trace_sha256 if self.proof_trace else None
+        )
+        if self.proof_trace_chain_head_sha256 != expected_head:
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow receipt proof trace head is invalid."
+            )
+        if self.human_repair_result != "TYPED_TRACE_VERIFIED":
+            return
+        expected_evidence = (
+            self.a1_evidence_sha256,
+            self.a2_receipt_sha256,
+            self.a3_reuse_event_id,
+            self.a4_event_sha256,
+            self.a5_confirmation_sha256,
+            self.a6_packet_sha256,
+        )
+        expected_runs = (
+            self.run_1.run_id,
+            self.run_2.run_id,
+            self.run_2.run_id,
+            self.run_2.run_id,
+            self.run_2.run_id,
+            self.run_2.run_id,
+        )
+        previous = TRACE_GENESIS_SHA256
+        _, proof_time = _parse_time(self.proof_as_of, "Proof As-of")
+        _, run_1_time = _parse_time(self.run_1.started_at, "Run 1 start time")
+        _, run_2_time = _parse_time(self.run_2.started_at, "Run 2 start time")
+        previous_time: datetime | None = None
+        if self.proof_trace_event_count != len(_TRACE_STAGES) or any(
+            evidence is None for evidence in expected_evidence
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Typed proof trace lacks its exact six-checkpoint identity."
+            )
+        for index, event in enumerate(self.proof_trace):
+            _, event_time = _parse_time(
+                event.observed_at,
+                "Trace observation time",
+            )
+            minimum_time = run_1_time if index == 0 else run_2_time
+            if (
+                event.sequence != index
+                or event.stage != _TRACE_STAGES[index]
+                or event.run_id != expected_runs[index]
+                or event.evidence_sha256 != expected_evidence[index]
+                or event.previous_trace_sha256 != previous
+                or event.repair_action != "NONE"
+                or event_time < minimum_time
+                or event_time > proof_time
+                or (
+                    previous_time is not None
+                    and event_time < previous_time
+                )
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "Typed proof trace identity is invalid."
+                )
+            previous = event.trace_sha256
+            previous_time = event_time
 
     def _body(self) -> dict[str, Any]:
         return {
@@ -681,8 +815,8 @@ class FieldNoteWholeFlowProofReceipt:
             "creator_id": self.creator_id,
             "source_repository": self.source_repository.as_dict(),
             "source_runtime": _runtime_as_dict(self.source_runtime),
-            "run_1_id": self.run_1_id,
-            "run_2_id": self.run_2_id,
+            "run_1": self.run_1.as_dict(),
+            "run_2": self.run_2.as_dict(),
             "note": self.note.as_dict(),
             "note_byte_count": self.note_byte_count,
             "reused_structure": {
@@ -718,6 +852,12 @@ class FieldNoteWholeFlowProofReceipt:
             ),
             "human_intervention": self.human_intervention,
             "next_disposition": self.next_disposition,
+            "proof_trace_schema": self.proof_trace_schema,
+            "proof_trace_event_count": self.proof_trace_event_count,
+            "proof_trace_chain_head_sha256": (
+                self.proof_trace_chain_head_sha256
+            ),
+            "proof_trace": [event.as_dict() for event in self.proof_trace],
             "human_repair_result": self.human_repair_result,
             "state": self.state,
             "failed_boundary": self.failed_boundary,
@@ -746,6 +886,11 @@ class FieldNoteWholeFlowProofReceipt:
                 f"Creator: {self.creator_id}",
                 f"Run 1: {self.run_1_id}",
                 f"Run 2: {self.run_2_id}",
+                f"Proof trace events: {self.proof_trace_event_count}",
+                (
+                    "Proof trace head: "
+                    f"{self.proof_trace_chain_head_sha256 or 'NONE'}"
+                ),
                 f"Field Note: {self.note.note_path}",
                 f"Outcome: {self.effective_outcome or 'NOT_ESTABLISHED'}",
                 f"Disposition: {self.next_disposition or 'NOT_ESTABLISHED'}",
@@ -795,7 +940,7 @@ class PortableCandidateClaimBoundary:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class PortableCandidateWarehouseManifest:
     """Portable immutable label; future evidence remains repository-local."""
 
@@ -804,13 +949,34 @@ class PortableCandidateWarehouseManifest:
         PortableCandidateClaimBoundary()
     )
 
-    def __post_init__(self) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise FieldNoteWholeFlowValidationError(
+            "Warehouse manifests must be built from a verified evidence bundle."
+        )
+
+    @classmethod
+    def _from_verified_receipt(
+        cls,
+        receipt: FieldNoteWholeFlowProofReceipt,
+    ) -> PortableCandidateWarehouseManifest:
+        manifest = object.__new__(cls)
+        object.__setattr__(manifest, "proof_receipt", receipt)
+        object.__setattr__(
+            manifest,
+            "claim_boundary",
+            PortableCandidateClaimBoundary(),
+        )
+        manifest._validate()
+        return manifest
+
+    def _validate(self) -> None:
         if (
             not isinstance(self.proof_receipt, FieldNoteWholeFlowProofReceipt)
             or self.proof_receipt.state != "PASS"
+            or self.proof_receipt.proof_mode != "FIXTURE"
         ):
             raise FieldNoteWholeFlowValidationError(
-                "Warehouse manifest requires one PASS proof receipt."
+                "Warehouse manifest requires one verified FIXTURE PASS receipt."
             )
         if not isinstance(self.claim_boundary, PortableCandidateClaimBoundary):
             raise FieldNoteWholeFlowValidationError(
@@ -852,8 +1018,15 @@ class PortableCandidateWarehouseManifest:
             "source_runtime": _runtime_as_dict(receipt.source_runtime),
             "whole_flow_proof_receipt_sha256": receipt.receipt_sha256,
             "proof_mode": receipt.proof_mode,
+            "proof_trace": {
+                "schema": receipt.proof_trace_schema,
+                "event_count": receipt.proof_trace_event_count,
+                "chain_head_sha256": receipt.proof_trace_chain_head_sha256,
+            },
             "a4_evidence_snapshot_sha256": receipt.a4_snapshot_sha256,
             "a6_review_packet_sha256": receipt.a6_packet_sha256,
+            "coverage_evidence_mode": "FIXTURE",
+            "creator_live_coverage_verified": False,
             "verified_coverage": {
                 "repositories": 1,
                 "model_identities": 1,
@@ -894,9 +1067,15 @@ class PortableCandidateWarehouseManifest:
                 "State: PORTABLE_CANDIDATE",
                 f"Asset: {self.portable_asset_id}",
                 f"Field Note: {self.proof_receipt.note.note_path}",
-                "Verified repositories: 1",
-                "Verified model identities: 1",
-                "Verified later reuse Runs: 1",
+                "Coverage evidence mode: FIXTURE",
+                "Creator-live coverage verified: false",
+                "Fixture-covered repositories: 1",
+                "Fixture-covered model identities: 1",
+                "Fixture-covered later reuse Runs: 1",
+                (
+                    "Proof trace head: "
+                    f"{self.proof_receipt.proof_trace_chain_head_sha256}"
+                ),
                 "PROMOTABLE: UNSET",
                 "Serving Policy: DELAY",
                 "Portability proven: false",
@@ -1004,8 +1183,8 @@ def _receipt(
         creator_id=bundle.attempt.creator_id,
         source_repository=bundle.source_repository,
         source_runtime=bundle.run_1.runtime,
-        run_1_id=bundle.run_1.run_id,
-        run_2_id=bundle.run_2.run_id,
+        run_1=bundle.run_1,
+        run_2=bundle.run_2,
         note=bundle.note,
         note_byte_count=len(bundle.note_bytes),
         reused_structure_id=binding.structure_id if binding else None,
@@ -1039,6 +1218,14 @@ def _receipt(
         outcome_summary=_outcome_summary(a6) if a6 else None,
         human_intervention=a3.human_intervention if a3 else None,
         next_disposition=a3.next_action if a3 else None,
+        proof_trace_schema=WHOLE_FLOW_TRACE_SCHEMA,
+        proof_trace_event_count=len(bundle.proof_trace),
+        proof_trace_chain_head_sha256=(
+            bundle.proof_trace[-1].trace_sha256
+            if bundle.proof_trace
+            else None
+        ),
+        proof_trace=bundle.proof_trace,
         human_repair_result=human_repair_result,
         state=state,
         failed_boundary=failed_boundary,
@@ -1087,6 +1274,12 @@ def verify_field_note_whole_flow(
     if not isinstance(bundle, FieldNoteWholeFlowEvidenceBundle):
         raise FieldNoteWholeFlowValidationError(
             "Whole-Flow verifier requires a typed evidence bundle."
+        )
+    if bundle.attempt.proof_mode == "CREATOR_LIVE":
+        return _not_ready(
+            bundle,
+            "RUNTIME_ENFORCEMENT",
+            "CREATOR_LIVE_RUNTIME_ENFORCEMENT_NOT_IMPLEMENTED",
         )
     for value, boundary, reason in (
         (bundle.a1_capture, "A1_CAPTURE", "A1_EVIDENCE_MISSING"),
@@ -1268,12 +1461,23 @@ def verify_field_note_whole_flow(
         or review.structure_binding_sha256
         != a3.use_evidence.structure_binding.binding_sha256
         or review.evidence_class != a3.use_evidence.evidence_class
+        or review.evidence_origin != a3.use_evidence.evidence_origin
         or review.evidence_ref != a3.use_evidence.evidence_ref
         or review.evidence_sha256 != a3.use_evidence.evidence_sha256
+        or review.use_evidence_observer_id != a3.use_evidence.observer_id
+        or review.use_evidence_observer_relation
+        != a3.use_evidence.observer_relation
         or review.use_evidence_as_of != a3.use_evidence.as_of
         or review.claimed_outcome != a3.claimed_outcome
         or review.effective_outcome != a3.outcome
+        or review.outcome_scope != a3.outcome_scope
+        or review.causal_evidence_ref != a3.causal_evidence_ref
+        or review.causal_evidence_sha256 != a3.causal_evidence_sha256
+        or review.outcome_observer_id != a3.outcome_observer_id
+        or review.outcome_observer_relation != a3.outcome_observer_relation
+        or review.outcome_confirmation != a3.outcome_confirmation
         or review.outcome_as_of != a3.outcome_as_of
+        or review.contribution_separated != a3.contribution_separated
         or review.human_intervention != a3.human_intervention
         or review.next_action != a3.next_action
         or review.reevaluation_condition != a3.reevaluation_condition
@@ -1363,8 +1567,13 @@ def verify_field_note_whole_flow(
 
 
 def build_portable_candidate_warehouse_manifest(
-    receipt: FieldNoteWholeFlowProofReceipt,
+    bundle: FieldNoteWholeFlowEvidenceBundle,
 ) -> PortableCandidateWarehouseManifest:
-    """Create a portable candidate label only from one A7 PASS receipt."""
+    """Reverify one bundle before creating its fixture-labelled candidate."""
 
-    return PortableCandidateWarehouseManifest(receipt)
+    receipt = verify_field_note_whole_flow(bundle)
+    if receipt.state != "PASS":
+        raise FieldNoteWholeFlowValidationError(
+            "Warehouse manifest requires a bundle that verifies to PASS."
+        )
+    return PortableCandidateWarehouseManifest._from_verified_receipt(receipt)

--- a/tests/test_field_notes_whole_flow.py
+++ b/tests/test_field_notes_whole_flow.py
@@ -1,0 +1,878 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.companion import field_notes_whole_flow as whole_flow
+from decision_os.companion.field_notes_maturity_commit import (
+    FieldNoteMaturityCommitRequest,
+    commit_field_note_maturity,
+)
+from decision_os.companion.field_notes_maturity_ledger import (
+    GENESIS_EVENT_SHA256,
+    FieldNoteMaturityLedger,
+)
+from decision_os.companion.field_notes_maturity_review import (
+    review_field_note_maturity,
+)
+from decision_os.companion.field_notes_model import canonical_json, compile_draft
+from decision_os.companion.field_notes_reconnect import FieldNoteReconnectReceipt
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseClaim,
+    FieldNoteReuseDisposition,
+    FieldNoteUseEvidence,
+    assess_field_note_reuse,
+    bind_field_note_structure,
+)
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowAttempt,
+    FieldNoteWholeFlowEvidenceBundle,
+    FieldNoteWholeFlowProofReceipt,
+    FieldNoteWholeFlowRunIdentity,
+    FieldNoteWholeFlowTraceEvent,
+    FieldNoteWholeFlowValidationError,
+    PortableCandidateWarehouseManifest,
+    build_portable_candidate_warehouse_manifest,
+    verify_field_note_whole_flow,
+)
+
+
+RUN_1_STARTED = "2026-08-05T10:00:00Z"
+A1_CREATED = "2026-08-05T10:01:00Z"
+RUN_2_STARTED = "2026-08-05T11:00:00Z"
+USE_AS_OF = "2026-08-05T11:10:00Z"
+OUTCOME_AS_OF = "2026-08-05T11:20:00Z"
+RECORDED_AT = "2026-08-05T11:30:00Z"
+REVIEW_AS_OF = "2026-08-05T11:40:00Z"
+PROOF_AS_OF = "2026-08-05T12:00:00Z"
+RUN_1_ID = "run_a7_capture"
+RUN_2_ID = "run_a7_reuse"
+ATTEMPT_ID = "proof_a7_fixture_001"
+PRIVATE_NOTE_TEXT = "Private creator context must never enter the manifest."
+ARTIFACT_SECRET = "private output artifact contents"
+STRUCTURE_TEXT = "Verify exact state before any restart or irreversible action."
+
+
+def digest(value: bytes | str) -> str:
+    if isinstance(value, str):
+        value = value.encode("utf-8")
+    return hashlib.sha256(value).hexdigest()
+
+
+def proposal() -> dict:
+    return {
+        "title": "A7 Whole Flow Proof Fixture",
+        "value_level": 1,
+        "source_model_class": "UNKNOWN",
+        "target_model_class": "UNKNOWN",
+        "trigger_terms": ["whole flow", "restart guard"],
+        "scope": {
+            "task_family": "bounded-whole-flow-proof",
+            "path_prefixes": ["decision_os/companion"],
+            "exclude_terms": ["live proof"],
+        },
+        "body": {
+            "trigger": "A bounded proof needs exact cross-layer identity.",
+            "reusable_structure": STRUCTURE_TEXT,
+            "scope": "One creator, repository, model identity, Note, and reuse.",
+            "do_not_apply_when": "Any proof evidence was manually repaired.",
+            "procedure": "Bind each typed receipt to one immutable lineage.",
+            "acceptance": "Every A1 through A6 boundary agrees exactly.",
+            "evidence": "Typed receipts, durable read-back, and review identity.",
+            "remaining_unknowns": PRIVATE_NOTE_TEXT,
+        },
+    }
+
+
+def runtime(*, model: str = "gpt-5.6-codex") -> CodexRuntimeIdentity:
+    return CodexRuntimeIdentity(
+        model=model,
+        reasoning_effort="high",
+        service_tier="priority",
+        codex_cli_version="0.120.0",
+        account_type="chatgpt",
+    )
+
+
+def source_repository(*, suffix: str = "a") -> FieldNoteSourceRepositoryIdentity:
+    return FieldNoteSourceRepositoryIdentity(
+        repository_id=f"repo:v1:{suffix * 64}",
+        source_commit="b" * 40,
+    )
+
+
+def trace_for(
+    bundle: FieldNoteWholeFlowEvidenceBundle,
+    *,
+    repair_stage: str | None = None,
+) -> tuple[FieldNoteWholeFlowTraceEvent, ...]:
+    assert bundle.a1_capture is not None
+    assert bundle.a2_reconnect is not None
+    assert bundle.a3_assessment is not None
+    assert bundle.a4_snapshot is not None
+    assert bundle.a5_commit is not None
+    assert bundle.a6_review is not None
+    evidence = (
+        whole_flow._a1_evidence_sha256(bundle.a1_capture),
+        whole_flow._a2_receipt_sha256(bundle.a2_reconnect),
+        bundle.a3_assessment.reuse_event_id,
+        bundle.a4_snapshot.events[0].event_sha256,
+        whole_flow._a5_confirmation_sha256(bundle.a5_commit),
+        whole_flow._a6_packet_sha256(bundle.a6_review),
+    )
+    stages = (
+        "A1_CAPTURE",
+        "A2_RECONNECT",
+        "A3_REUSE",
+        "A4_DURABILITY",
+        "A5_CONFIRMATION",
+        "A6_REVIEW",
+    )
+    runs = (RUN_1_ID, RUN_2_ID, RUN_2_ID, RUN_2_ID, RUN_2_ID, RUN_2_ID)
+    observed = (
+        "2026-08-05T10:02:00Z",
+        "2026-08-05T11:05:00Z",
+        "2026-08-05T11:21:00Z",
+        "2026-08-05T11:31:00Z",
+        "2026-08-05T11:32:00Z",
+        "2026-08-05T11:41:00Z",
+    )
+    result = []
+    previous = whole_flow.TRACE_GENESIS_SHA256
+    for index, stage in enumerate(stages):
+        event = FieldNoteWholeFlowTraceEvent(
+            sequence=index,
+            stage=stage,  # type: ignore[arg-type]
+            run_id=runs[index],
+            observed_at=observed[index],
+            evidence_sha256=evidence[index],
+            previous_trace_sha256=previous,
+            repair_action=(
+                "NOTE_EDIT" if stage == repair_stage else "NONE"
+            ),
+        )
+        result.append(event)
+        previous = event.trace_sha256
+    return tuple(result)
+
+
+def build_bundle(
+    root: Path,
+    *,
+    outcome: str = "HELPFUL",
+    action: str | None = None,
+    human_intervention: str = "NONE",
+    evidence_class: str = "RULE_TRACE",
+    already_recorded: bool = False,
+) -> tuple[FieldNoteWholeFlowEvidenceBundle, FieldNoteMaturityLedger]:
+    repository = source_repository()
+    exact_runtime = runtime()
+    attempt = FieldNoteWholeFlowAttempt(
+        proof_attempt_id=ATTEMPT_ID,
+        proof_mode="FIXTURE",
+        creator_id="Shin",
+        proof_as_of=PROOF_AS_OF,
+    )
+    run_1 = FieldNoteWholeFlowRunIdentity(
+        proof_attempt_id=ATTEMPT_ID,
+        run_id=RUN_1_ID,
+        started_at=RUN_1_STARTED,
+        repository=repository,
+        runtime=exact_runtime,
+    )
+    run_2 = FieldNoteWholeFlowRunIdentity(
+        proof_attempt_id=ATTEMPT_ID,
+        run_id=RUN_2_ID,
+        started_at=RUN_2_STARTED,
+        repository=repository,
+        runtime=exact_runtime,
+    )
+    draft = compile_draft(
+        proposal(),
+        source_run_id=RUN_1_ID,
+        created_at=A1_CREATED,
+        field_note_id="fn_a7_whole_flow_fixture",
+    )
+    note = FieldNoteIdentity(
+        note_path=draft.relative_path,
+        field_note_id=draft.field_note_id,
+        note_sha256=draft.sha256,
+        origin_run_id=draft.source_run_id,
+    )
+    reconnect = FieldNoteReconnectReceipt(
+        run_id=RUN_2_ID,
+        state="ACTIVATION_UNKNOWN",
+        failure_reason=None,
+        metadata_entries_seen=1,
+        metadata_candidate_files_seen=1,
+        metadata_files_valid=1,
+        metadata_bytes_read=640,
+        selected_field_note_path=note.note_path,
+        selected_field_note_id=note.field_note_id,
+        selected_metadata_sha256=digest("a7 metadata"),
+        selected_full_note_sha256=note.note_sha256,
+        full_note_bytes_read=len(draft.markdown),
+        full_notes_injected=1,
+        ordinary_distinct_paths_consumed=1,
+    )
+    structure_bytes = STRUCTURE_TEXT.encode("utf-8")
+    start = draft.markdown.index(structure_bytes)
+    binding = bind_field_note_structure(
+        note,
+        draft.markdown,
+        structure_id="exact-state-before-irreversible-action",
+        start_byte=start,
+        end_byte=start + len(structure_bytes),
+    )
+    use_evidence = FieldNoteUseEvidence(
+        evidence_class=evidence_class,  # type: ignore[arg-type]
+        evidence_origin="IMMEDIATE_COMPLETION_RECORD",
+        reusing_run_id=RUN_2_ID,
+        structure_binding=binding,
+        evidence_ref="run:run_a7_reuse/evidence:exact-state-rule",
+        evidence_sha256=digest("bounded A7 use evidence"),
+        observer_id="a7_fixture_observer",
+        observer_relation="INDEPENDENT",
+        as_of=USE_AS_OF,
+    )
+    causal = outcome in {"HELPFUL", "HARMFUL"}
+    evaluation = FieldNoteOutcomeEvaluation(
+        outcome=outcome,  # type: ignore[arg-type]
+        scope="The exact bounded A7 fixture task.",
+        observer_id="a7_outcome_observer",
+        observer_relation="INDEPENDENT",
+        as_of=OUTCOME_AS_OF,
+        causal_evidence_ref=(
+            "run:run_a7_reuse/causal:exact-state-rule" if causal else None
+        ),
+        causal_evidence_sha256=(
+            digest("bounded A7 causal evidence") if causal else None
+        ),
+        contribution_separated=True,
+    )
+    if action is None:
+        if outcome == "HELPFUL":
+            action = "KEEP"
+        elif outcome in {"NOT_HELPFUL", "HARMFUL"}:
+            action = "STOP"
+    disposition = None
+    if action == "KEEP":
+        disposition = FieldNoteReuseDisposition(action="KEEP")
+    elif action == "STOP":
+        disposition = FieldNoteReuseDisposition(
+            action="STOP",
+            stop_scope="Only the exact A7 fixture task family.",
+        )
+    elif action == "REVISE":
+        successor_bytes = b"A7 successor candidate"
+        disposition = FieldNoteReuseDisposition(
+            action="REVISE",
+            revision_candidate=FieldNoteIdentity(
+                note_path=(
+                    ".decision-os/field-notes/"
+                    "2026-08-05-a7-successor-aaaaaaaaaa.md"
+                ),
+                field_note_id="fn_a7_successor",
+                note_sha256=digest(successor_bytes),
+                origin_run_id=RUN_2_ID,
+            ),
+        )
+    claim = FieldNoteReuseClaim(
+        claimed_note=note,
+        reusing_run_id=RUN_2_ID,
+        use_evidence=use_evidence,
+        outcome_evaluation=evaluation,
+        human_intervention=human_intervention,  # type: ignore[arg-type]
+        disposition=disposition,
+    )
+    ledger = FieldNoteMaturityLedger(root / "maturity-ledger-v0.1", note)
+    request = FieldNoteMaturityCommitRequest(
+        note=note,
+        note_bytes=draft.markdown,
+        reuse_claim=claim,
+        recorded_at=RECORDED_AT,
+        delivery_context=reconnect,
+    )
+    commit = commit_field_note_maturity(ledger, request)
+    if already_recorded:
+        commit = commit_field_note_maturity(ledger, request)
+    assert commit.durable_snapshot is not None
+    assessment = commit.assessment
+    review = review_field_note_maturity(
+        ledger,
+        note,
+        note_bytes=draft.markdown,
+        review_as_of=REVIEW_AS_OF,
+    )
+    bundle = FieldNoteWholeFlowEvidenceBundle(
+        attempt=attempt,
+        source_repository=repository,
+        run_1=run_1,
+        run_2=run_2,
+        note=note,
+        note_bytes=draft.markdown,
+        a1_capture=draft,
+        a2_reconnect=reconnect,
+        a3_assessment=assessment,
+        a4_snapshot=commit.durable_snapshot,
+        a5_commit=commit,
+        a6_review=review,
+        proof_trace=(),
+    )
+    return replace(bundle, proof_trace=trace_for(bundle)), ledger
+
+
+class WholeFlowTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.bundle, self.ledger = build_bundle(self.root)
+
+    def verify(self, bundle=None) -> FieldNoteWholeFlowProofReceipt:
+        return verify_field_note_whole_flow(bundle or self.bundle)
+
+
+class FieldNoteWholeFlowPassTests(WholeFlowTestCase):
+    def test_complete_valid_fixture_produces_typed_pass(self) -> None:
+        receipt = self.verify()
+        self.assertIsInstance(receipt, FieldNoteWholeFlowProofReceipt)
+        self.assertEqual("PASS", receipt.state)
+        self.assertIsNone(receipt.failed_boundary)
+        self.assertEqual("TYPED_TRACE_VERIFIED", receipt.human_repair_result)
+
+    def test_fixture_pass_is_not_a_creator_live_proof(self) -> None:
+        receipt = self.verify()
+        self.assertEqual("FIXTURE", receipt.proof_mode)
+        self.assertFalse(
+            receipt.claim_boundary.creator_live_proof_inferred_from_fixture
+        )
+
+    def test_helpful_outcome_can_pass_without_becoming_flow_identity(self) -> None:
+        receipt = self.verify()
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("HELPFUL", receipt.effective_outcome)
+        self.assertEqual("KEEP", receipt.next_disposition)
+        self.assertTrue(receipt.claim_boundary.usefulness_separate)
+
+    def test_unknown_hold_can_pass(self) -> None:
+        bundle, _ = build_bundle(self.root / "unknown", outcome="UNKNOWN")
+        receipt = self.verify(bundle)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("UNKNOWN", receipt.effective_outcome)
+        self.assertEqual("HOLD", receipt.next_disposition)
+
+    def test_not_helpful_stop_or_revise_can_pass(self) -> None:
+        for action in ("STOP", "REVISE"):
+            with self.subTest(action=action):
+                bundle, _ = build_bundle(
+                    self.root / action.lower(),
+                    outcome="NOT_HELPFUL",
+                    action=action,
+                )
+                receipt = self.verify(bundle)
+                self.assertEqual("PASS", receipt.state)
+                self.assertEqual("NOT_HELPFUL", receipt.effective_outcome)
+                self.assertEqual(action, receipt.next_disposition)
+
+    def test_harmful_stop_or_revise_can_pass(self) -> None:
+        for action in ("STOP", "REVISE"):
+            with self.subTest(action=action):
+                bundle, _ = build_bundle(
+                    self.root / f"harmful-{action.lower()}",
+                    outcome="HARMFUL",
+                    action=action,
+                )
+                receipt = self.verify(bundle)
+                self.assertEqual("PASS", receipt.state)
+                self.assertEqual("HARMFUL", receipt.effective_outcome)
+                self.assertEqual(action, receipt.next_disposition)
+
+    def test_negative_outcome_remains_in_receipt_and_manifest(self) -> None:
+        bundle, _ = build_bundle(self.root / "negative", outcome="HARMFUL")
+        receipt = self.verify(bundle)
+        manifest = build_portable_candidate_warehouse_manifest(receipt)
+        self.assertEqual("HARMFUL", receipt.effective_outcome)
+        self.assertEqual(1, manifest.as_dict()["outcome_summary"]["harmful"])
+        self.assertEqual("HARMFUL", manifest.as_dict()["effective_outcome"])
+
+    def test_human_intervention_remains_visible(self) -> None:
+        bundle, _ = build_bundle(
+            self.root / "intervention",
+            human_intervention="MATERIAL",
+        )
+        receipt = self.verify(bundle)
+        manifest = build_portable_candidate_warehouse_manifest(receipt)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("MATERIAL", receipt.human_intervention)
+        self.assertEqual("MATERIAL", manifest.as_dict()["human_intervention"])
+
+    def test_repeated_receipt_generation_is_deterministic(self) -> None:
+        first = self.verify()
+        second = self.verify()
+        self.assertEqual(first, second)
+        self.assertEqual(first.receipt_sha256, second.receipt_sha256)
+        self.assertEqual(first.serialize(), second.serialize())
+        self.assertEqual(first.render_text(), second.render_text())
+
+    def test_receipt_projection_is_canonical_and_bounded(self) -> None:
+        receipt = self.verify()
+        self.assertEqual(canonical_json(receipt.as_dict()), receipt.serialize())
+        self.assertTrue(receipt.render_text().endswith("\n"))
+        self.assertNotIn(PRIVATE_NOTE_TEXT, receipt.serialize())
+        self.assertNotIn(ARTIFACT_SECRET, receipt.serialize())
+
+    def test_verification_is_read_only_over_a1_through_a6_artifacts(self) -> None:
+        paths = (
+            self.ledger.events_path,
+            self.ledger.head_path,
+            self.ledger.lock_path,
+        )
+        before = {
+            path: (
+                path.read_bytes(),
+                path.stat().st_mode,
+                path.stat().st_mtime_ns,
+                path.stat().st_ino,
+            )
+            for path in paths
+        }
+        note_before = bytes(self.bundle.note_bytes)
+        receipt = self.verify()
+        build_portable_candidate_warehouse_manifest(receipt)
+        after = {
+            path: (
+                path.read_bytes(),
+                path.stat().st_mode,
+                path.stat().st_mtime_ns,
+                path.stat().st_ino,
+            )
+            for path in paths
+        }
+        self.assertEqual(before, after)
+        self.assertEqual(note_before, self.bundle.note_bytes)
+
+
+class FieldNoteWholeFlowReadinessTests(WholeFlowTestCase):
+    def test_missing_a1_is_not_ready_at_exact_boundary(self) -> None:
+        receipt = self.verify(replace(self.bundle, a1_capture=None))
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual("A1_CAPTURE", receipt.failed_boundary)
+        self.assertEqual("A1_EVIDENCE_MISSING", receipt.failure_reason)
+
+    def test_missing_a2_is_not_ready_at_exact_boundary(self) -> None:
+        receipt = self.verify(replace(self.bundle, a2_reconnect=None))
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual("A2_RECONNECT", receipt.failed_boundary)
+        self.assertEqual("A2_EVIDENCE_MISSING", receipt.failure_reason)
+
+    def test_a2_injection_alone_cannot_satisfy_missing_a3(self) -> None:
+        receipt = self.verify(replace(self.bundle, a3_assessment=None))
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual("A3_REUSE", receipt.failed_boundary)
+        self.assertEqual("A3_EVIDENCE_MISSING", receipt.failure_reason)
+
+    def test_missing_a4_a5_or_a6_is_not_ready(self) -> None:
+        cases = (
+            ("a4_snapshot", "A4_DURABILITY"),
+            ("a5_commit", "A5_CONFIRMATION"),
+            ("a6_review", "A6_REVIEW"),
+        )
+        for field, boundary in cases:
+            with self.subTest(field=field):
+                receipt = self.verify(replace(self.bundle, **{field: None}))
+                self.assertEqual("NOT_READY", receipt.state)
+                self.assertEqual(boundary, receipt.failed_boundary)
+
+    def test_candidate_a3_cannot_pass(self) -> None:
+        candidate = assess_field_note_reuse(
+            self.bundle.note,
+            None,
+            note_bytes=self.bundle.note_bytes,
+        )
+        receipt = self.verify(
+            replace(self.bundle, a3_assessment=candidate)
+        )
+        self.assertEqual("FAIL", receipt.state)
+        self.assertEqual("A3_REUSE", receipt.failed_boundary)
+        self.assertEqual("A3_NOT_DEMONSTRABLY_REUSED", receipt.failure_reason)
+
+    def test_narrative_use_claim_cannot_pass(self) -> None:
+        claim = FieldNoteReuseClaim(
+            claimed_note=self.bundle.note,
+            reusing_run_id=RUN_2_ID,
+            use_evidence=None,
+            outcome_evaluation=None,
+            human_intervention="NONE",
+            disposition=None,
+            narrative_claim="The Note was reused; trust this sentence.",
+        )
+        candidate = assess_field_note_reuse(
+            self.bundle.note,
+            claim,
+            note_bytes=self.bundle.note_bytes,
+        )
+        receipt = self.verify(
+            replace(self.bundle, a3_assessment=candidate)
+        )
+        self.assertEqual("FAIL", receipt.state)
+        self.assertEqual("A3_NOT_DEMONSTRABLY_REUSED", receipt.failure_reason)
+
+    def test_free_form_no_repair_attestation_is_not_an_input(self) -> None:
+        with self.assertRaises(TypeError):
+            FieldNoteWholeFlowEvidenceBundle(
+                **self.bundle.__dict__,
+                no_repair_attestation="no repair occurred",
+            )
+        receipt = self.verify(replace(self.bundle, proof_trace=()))
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual("HUMAN_REPAIR", receipt.failed_boundary)
+
+
+class FieldNoteWholeFlowBindingTests(WholeFlowTestCase):
+    def test_run_1_and_run_2_must_be_distinct(self) -> None:
+        run_2 = replace(self.bundle.run_2, run_id=RUN_1_ID)
+        receipt = self.verify(replace(self.bundle, run_2=run_2))
+        self.assertEqual("RUN_IDENTITIES_NOT_DISTINCT", receipt.failure_reason)
+
+    def test_run_2_must_be_later(self) -> None:
+        run_2 = replace(
+            self.bundle.run_2,
+            started_at="2026-08-05T09:59:00Z",
+        )
+        receipt = self.verify(replace(self.bundle, run_2=run_2))
+        self.assertEqual("RUN_ORDER_INVALID", receipt.failure_reason)
+
+    def test_both_runs_must_belong_to_the_same_attempt(self) -> None:
+        run_2 = replace(self.bundle.run_2, proof_attempt_id="other_attempt")
+        receipt = self.verify(replace(self.bundle, run_2=run_2))
+        self.assertEqual("RUN_ATTEMPT_MISMATCH", receipt.failure_reason)
+
+    def test_model_runtime_identities_must_match_exactly(self) -> None:
+        run_2 = replace(self.bundle.run_2, runtime=runtime(model="other-model"))
+        receipt = self.verify(replace(self.bundle, run_2=run_2))
+        self.assertEqual("MODEL_IDENTITY", receipt.failed_boundary)
+        self.assertEqual("MODEL_RUNTIME_MISMATCH", receipt.failure_reason)
+
+    def test_cross_repository_evidence_cannot_pass(self) -> None:
+        run_2 = replace(self.bundle.run_2, repository=source_repository(suffix="c"))
+        receipt = self.verify(replace(self.bundle, run_2=run_2))
+        self.assertEqual("REPOSITORY_IDENTITY", receipt.failed_boundary)
+        self.assertEqual("SOURCE_REPOSITORY_MISMATCH", receipt.failure_reason)
+
+    def test_a1_note_rewrite_cannot_pass(self) -> None:
+        receipt = self.verify(
+            replace(self.bundle, note_bytes=self.bundle.note_bytes + b"rewrite")
+        )
+        self.assertEqual("A1_CAPTURE", receipt.failed_boundary)
+        self.assertEqual("A1_NOTE_IDENTITY_MISMATCH", receipt.failure_reason)
+
+    def test_a1_must_originate_in_run_1(self) -> None:
+        wrong_note = replace(self.bundle.note, origin_run_id="other_origin")
+        receipt = self.verify(replace(self.bundle, note=wrong_note))
+        self.assertEqual("A1_RUN_MISMATCH", receipt.failure_reason)
+
+    def test_a2_exact_note_mismatch_cannot_pass(self) -> None:
+        assert self.bundle.a2_reconnect is not None
+        for field, value in (
+            ("selected_field_note_path", ".decision-os/field-notes/other.md"),
+            ("selected_field_note_id", "fn_other"),
+            ("selected_full_note_sha256", "c" * 64),
+            ("full_note_bytes_read", len(self.bundle.note_bytes) + 1),
+        ):
+            with self.subTest(field=field):
+                a2 = replace(self.bundle.a2_reconnect, **{field: value})
+                receipt = self.verify(replace(self.bundle, a2_reconnect=a2))
+                self.assertEqual("A2_RECONNECT", receipt.failed_boundary)
+                self.assertEqual("A2_EXACT_NOTE_MISMATCH", receipt.failure_reason)
+
+    def test_a2_run_mismatch_cannot_pass(self) -> None:
+        assert self.bundle.a2_reconnect is not None
+        a2 = replace(self.bundle.a2_reconnect, run_id="other_run")
+        receipt = self.verify(replace(self.bundle, a2_reconnect=a2))
+        self.assertEqual("A2_RUN_MISMATCH", receipt.failure_reason)
+
+    def test_a2_selected_but_not_injected_cannot_pass(self) -> None:
+        assert self.bundle.a2_reconnect is not None
+        a2 = replace(
+            self.bundle.a2_reconnect,
+            state="SELECTED",
+            selected_full_note_sha256=None,
+            full_note_bytes_read=0,
+            full_notes_injected=0,
+        )
+        receipt = self.verify(replace(self.bundle, a2_reconnect=a2))
+        self.assertEqual("A2_NOT_INJECTED", receipt.failure_reason)
+
+    def test_a3_exact_note_mismatch_cannot_pass(self) -> None:
+        assert self.bundle.a3_assessment is not None
+        other = replace(self.bundle.note, field_note_id="fn_other")
+        a3 = replace(self.bundle.a3_assessment, note=other)
+        receipt = self.verify(replace(self.bundle, a3_assessment=a3))
+        self.assertEqual("A3_EXACT_NOTE_MISMATCH", receipt.failure_reason)
+
+    def test_a3_run_mismatch_cannot_pass(self) -> None:
+        assert self.bundle.a3_assessment is not None
+        a3 = replace(self.bundle.a3_assessment, reusing_run_id="other_run")
+        receipt = self.verify(replace(self.bundle, a3_assessment=a3))
+        self.assertEqual("A3_RUN_MISMATCH", receipt.failure_reason)
+
+    def test_wrong_specific_structure_cannot_pass(self) -> None:
+        assert self.bundle.a3_assessment is not None
+        assert self.bundle.a3_assessment.use_evidence is not None
+        evidence = self.bundle.a3_assessment.use_evidence
+        bad_binding = replace(
+            evidence.structure_binding,
+            structure_sha256="d" * 64,
+        )
+        bad_evidence = replace(evidence, structure_binding=bad_binding)
+        a3 = replace(self.bundle.a3_assessment, use_evidence=bad_evidence)
+        receipt = self.verify(replace(self.bundle, a3_assessment=a3))
+        self.assertEqual("A3_STRUCTURE_BINDING_INVALID", receipt.failure_reason)
+
+    def test_a3_evidence_time_order_must_be_valid(self) -> None:
+        assert self.bundle.a3_assessment is not None
+        assert self.bundle.a3_assessment.use_evidence is not None
+        evidence = replace(
+            self.bundle.a3_assessment.use_evidence,
+            as_of="2026-08-05T11:25:00Z",
+        )
+        a3 = replace(self.bundle.a3_assessment, use_evidence=evidence)
+        a3 = replace(
+            a3,
+            reuse_event_id=whole_flow._expected_reuse_event_id(a3),
+        )
+        receipt = self.verify(replace(self.bundle, a3_assessment=a3))
+        self.assertEqual("A3_EVIDENCE_TIME_ORDER_INVALID", receipt.failure_reason)
+
+    def test_a4_missing_exact_event_cannot_pass(self) -> None:
+        assert self.bundle.a4_snapshot is not None
+        a4 = replace(
+            self.bundle.a4_snapshot,
+            events=(),
+            chain_head_sha256=GENESIS_EVENT_SHA256,
+        )
+        receipt = self.verify(replace(self.bundle, a4_snapshot=a4))
+        self.assertEqual("A4_EVENT_COUNT_NOT_EXACTLY_ONE", receipt.failure_reason)
+
+    def test_a4_extra_history_is_not_silently_accepted(self) -> None:
+        assert self.bundle.a4_snapshot is not None
+        event = self.bundle.a4_snapshot.events[0]
+        a4 = replace(self.bundle.a4_snapshot, events=(event, event))
+        receipt = self.verify(replace(self.bundle, a4_snapshot=a4))
+        self.assertEqual("A4_EVENT_COUNT_NOT_EXACTLY_ONE", receipt.failure_reason)
+
+    def test_a4_tampering_cannot_pass(self) -> None:
+        assert self.bundle.a4_snapshot is not None
+        event = replace(
+            self.bundle.a4_snapshot.events[0],
+            event_sha256="e" * 64,
+        )
+        a4 = replace(
+            self.bundle.a4_snapshot,
+            events=(event,),
+            chain_head_sha256="e" * 64,
+        )
+        receipt = self.verify(replace(self.bundle, a4_snapshot=a4))
+        self.assertEqual("A4_EXACT_EVENT_INTEGRITY_INVALID", receipt.failure_reason)
+
+    def test_a4_recorded_at_must_follow_reuse_evidence(self) -> None:
+        assert self.bundle.a4_snapshot is not None
+        event = replace(
+            self.bundle.a4_snapshot.events[0],
+            recorded_at="2026-08-05T11:15:00Z",
+        )
+        event = replace(
+            event,
+            event_sha256=whole_flow._event_sha256(event),
+        )
+        a4 = replace(
+            self.bundle.a4_snapshot,
+            events=(event,),
+            chain_head_sha256=event.event_sha256,
+        )
+        receipt = self.verify(replace(self.bundle, a4_snapshot=a4))
+        self.assertEqual("A4_EVENT_TIME_ORDER_INVALID", receipt.failure_reason)
+
+    def test_a5_unconfirmed_append_cannot_pass(self) -> None:
+        assert self.bundle.a5_commit is not None
+        object.__setattr__(self.bundle.a5_commit, "durable_snapshot", None)
+        receipt = self.verify()
+        self.assertEqual("A5_APPEND_NOT_CONFIRMED", receipt.failure_reason)
+
+    def test_a5_response_loss_reconciliation_can_pass_after_read_back(self) -> None:
+        bundle, _ = build_bundle(self.root / "already", already_recorded=True)
+        receipt = self.verify(bundle)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("ALREADY_RECORDED", receipt.a5_status)
+        self.assertTrue(receipt.a5_durable_commit_confirmed)
+
+    def test_a5_must_preserve_a2_delivery_lineage(self) -> None:
+        assert self.bundle.a5_commit is not None
+        object.__setattr__(self.bundle.a5_commit, "delivery_context", None)
+        receipt = self.verify()
+        self.assertEqual("A5_READ_BACK_LINEAGE_MISMATCH", receipt.failure_reason)
+
+    def test_a6_exact_note_mismatch_cannot_pass(self) -> None:
+        assert self.bundle.a6_review is not None
+        other = replace(self.bundle.note, field_note_id="fn_other_a6")
+        object.__setattr__(self.bundle.a6_review, "note_identity", other)
+        receipt = self.verify()
+        self.assertEqual("A6_EXACT_NOTE_MISMATCH", receipt.failure_reason)
+
+    def test_a6_chain_head_mismatch_cannot_pass(self) -> None:
+        assert self.bundle.a6_review is not None
+        identity = replace(
+            self.bundle.a6_review.ledger_identity,
+            chain_head_sha256="f" * 64,
+        )
+        object.__setattr__(self.bundle.a6_review, "ledger_identity", identity)
+        receipt = self.verify()
+        self.assertEqual("A6_LEDGER_IDENTITY_MISMATCH", receipt.failure_reason)
+
+    def test_a6_future_dated_evidence_cannot_pass(self) -> None:
+        assert self.bundle.a6_review is not None
+        object.__setattr__(
+            self.bundle.a6_review,
+            "review_as_of",
+            "2026-08-05T11:29:59Z",
+        )
+        receipt = self.verify()
+        self.assertEqual("A6_FUTURE_DATED_EVIDENCE", receipt.failure_reason)
+
+    def test_proof_as_of_must_not_precede_a6(self) -> None:
+        attempt = replace(
+            self.bundle.attempt,
+            proof_as_of="2026-08-05T11:39:59Z",
+        )
+        receipt = self.verify(replace(self.bundle, attempt=attempt))
+        self.assertEqual("PROOF_AS_OF", receipt.failed_boundary)
+        self.assertEqual("PROOF_AS_OF_PRECEDES_A6_REVIEW", receipt.failure_reason)
+
+    def test_human_repair_evidence_causes_fail(self) -> None:
+        trace = trace_for(self.bundle, repair_stage="A3_REUSE")
+        receipt = self.verify(replace(self.bundle, proof_trace=trace))
+        self.assertEqual("FAIL", receipt.state)
+        self.assertEqual("HUMAN_REPAIR", receipt.failed_boundary)
+        self.assertEqual("HUMAN_REPAIR_DETECTED", receipt.failure_reason)
+        self.assertEqual("REPAIR_DETECTED", receipt.human_repair_result)
+
+    def test_trace_must_bind_each_exact_layer_identity(self) -> None:
+        trace = list(self.bundle.proof_trace)
+        trace[3] = replace(trace[3], evidence_sha256="f" * 64)
+        receipt = self.verify(replace(self.bundle, proof_trace=tuple(trace)))
+        self.assertEqual("TYPED_PROOF_TRACE_INVALID", receipt.failure_reason)
+
+
+class PortableCandidateWarehouseManifestTests(WholeFlowTestCase):
+    def manifest(self) -> PortableCandidateWarehouseManifest:
+        return build_portable_candidate_warehouse_manifest(self.verify())
+
+    def test_pass_produces_one_typed_manifest(self) -> None:
+        manifest = self.manifest()
+        self.assertIsInstance(manifest, PortableCandidateWarehouseManifest)
+        self.assertEqual("PORTABLE_CANDIDATE", manifest.claim_boundary.portability_state)
+
+    def test_repeated_manifest_generation_is_deterministic(self) -> None:
+        first = self.manifest()
+        second = self.manifest()
+        self.assertEqual(first, second)
+        self.assertEqual(first.manifest_id, second.manifest_id)
+        self.assertEqual(first.serialize(), second.serialize())
+        self.assertEqual(first.render_text(), second.render_text())
+
+    def test_manifest_identity_is_stable_for_identical_immutable_evidence(self) -> None:
+        receipt = self.verify()
+        first = build_portable_candidate_warehouse_manifest(receipt)
+        second = build_portable_candidate_warehouse_manifest(receipt)
+        self.assertEqual(first.portable_asset_id, second.portable_asset_id)
+        self.assertEqual(first.manifest_id, second.manifest_id)
+
+    def test_changed_note_bytes_invalidate_portable_identity_generation(self) -> None:
+        changed = replace(
+            self.bundle,
+            note_bytes=self.bundle.note_bytes + b"changed",
+        )
+        receipt = self.verify(changed)
+        self.assertEqual("FAIL", receipt.state)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            build_portable_candidate_warehouse_manifest(receipt)
+
+    def test_manifest_coverage_is_exactly_one_one_one(self) -> None:
+        coverage = self.manifest().as_dict()["verified_coverage"]
+        self.assertEqual(
+            {
+                "repositories": 1,
+                "model_identities": 1,
+                "verified_later_reuse_runs": 1,
+            },
+            coverage,
+        )
+
+    def test_manifest_is_candidate_not_portability_proven(self) -> None:
+        boundary = self.manifest().claim_boundary
+        self.assertEqual("PORTABLE_CANDIDATE", boundary.portability_state)
+        self.assertFalse(boundary.portability_proven)
+        self.assertFalse(boundary.cross_repository_import_verified)
+        self.assertFalse(boundary.cross_model_reuse_verified)
+
+    def test_manifest_excludes_full_note_contents(self) -> None:
+        manifest = self.manifest()
+        self.assertNotIn(PRIVATE_NOTE_TEXT, manifest.serialize())
+        self.assertNotIn(self.bundle.note_bytes.decode("utf-8"), manifest.serialize())
+
+    def test_manifest_excludes_output_artifact_contents(self) -> None:
+        bundle, _ = build_bundle(
+            self.root / "artifact",
+            evidence_class="OUTPUT_ARTIFACT",
+        )
+        manifest = build_portable_candidate_warehouse_manifest(self.verify(bundle))
+        self.assertNotIn(ARTIFACT_SECRET, manifest.serialize())
+
+    def test_promotable_remains_unset(self) -> None:
+        manifest = self.manifest().as_dict()
+        self.assertEqual("UNSET", manifest["promotable_policy"])
+        self.assertEqual("UNSET", self.verify().claim_boundary.promotable_policy)
+
+    def test_serving_policy_remains_separate_and_delayed(self) -> None:
+        manifest = self.manifest().as_dict()
+        self.assertEqual("DELAY", manifest["serving_policy"])
+        self.assertEqual("DELAY", self.verify().claim_boundary.serving_policy)
+
+    def test_no_automatic_injection_is_derived(self) -> None:
+        manifest = self.manifest().as_dict()
+        self.assertIsNone(manifest["automatic_injection"])
+        self.assertFalse(self.verify().claim_boundary.automatic_injection_derived)
+
+    def test_canonical_authority_remains_above_advisory_note(self) -> None:
+        manifest = self.manifest().as_dict()
+        self.assertEqual(
+            ["TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE"],
+            manifest["authority_precedence"],
+        )
+
+    def test_future_evidence_is_target_local_not_a_shared_mutable_chain(self) -> None:
+        manifest = self.manifest()
+        boundary = manifest.claim_boundary
+        self.assertTrue(boundary.source_evidence_immutable)
+        self.assertEqual("TARGET_REPOSITORY_LOCAL", boundary.future_evidence_scope)
+        self.assertTrue(boundary.explicit_import_receipt_required)
+        self.assertFalse(boundary.shared_mutable_ledger)
+        self.assertFalse(boundary.diverged_ledger_merge_supported)
+
+    def test_manifest_serialization_is_canonical_and_bounded(self) -> None:
+        manifest = self.manifest()
+        self.assertEqual(canonical_json(manifest.as_dict()), manifest.serialize())
+        self.assertTrue(manifest.render_text().endswith("\n"))
+        self.assertNotIn("PORTABILITY_PROVEN", manifest.serialize())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_field_notes_whole_flow.py
+++ b/tests/test_field_notes_whole_flow.py
@@ -398,7 +398,7 @@ class FieldNoteWholeFlowPassTests(WholeFlowTestCase):
     def test_negative_outcome_remains_in_receipt_and_manifest(self) -> None:
         bundle, _ = build_bundle(self.root / "negative", outcome="HARMFUL")
         receipt = self.verify(bundle)
-        manifest = build_portable_candidate_warehouse_manifest(receipt)
+        manifest = build_portable_candidate_warehouse_manifest(bundle)
         self.assertEqual("HARMFUL", receipt.effective_outcome)
         self.assertEqual(1, manifest.as_dict()["outcome_summary"]["harmful"])
         self.assertEqual("HARMFUL", manifest.as_dict()["effective_outcome"])
@@ -409,7 +409,7 @@ class FieldNoteWholeFlowPassTests(WholeFlowTestCase):
             human_intervention="MATERIAL",
         )
         receipt = self.verify(bundle)
-        manifest = build_portable_candidate_warehouse_manifest(receipt)
+        manifest = build_portable_candidate_warehouse_manifest(bundle)
         self.assertEqual("PASS", receipt.state)
         self.assertEqual("MATERIAL", receipt.human_intervention)
         self.assertEqual("MATERIAL", manifest.as_dict()["human_intervention"])
@@ -445,8 +445,8 @@ class FieldNoteWholeFlowPassTests(WholeFlowTestCase):
             for path in paths
         }
         note_before = bytes(self.bundle.note_bytes)
-        receipt = self.verify()
-        build_portable_candidate_warehouse_manifest(receipt)
+        self.verify()
+        build_portable_candidate_warehouse_manifest(self.bundle)
         after = {
             path: (
                 path.read_bytes(),
@@ -458,6 +458,120 @@ class FieldNoteWholeFlowPassTests(WholeFlowTestCase):
         }
         self.assertEqual(before, after)
         self.assertEqual(note_before, self.bundle.note_bytes)
+
+
+class FieldNoteWholeFlowProofSealingTests(WholeFlowTestCase):
+    def test_pass_receipt_seals_exact_six_checkpoint_trace(self) -> None:
+        receipt = self.verify()
+        self.assertEqual(whole_flow.WHOLE_FLOW_TRACE_SCHEMA, receipt.proof_trace_schema)
+        self.assertEqual(6, receipt.proof_trace_event_count)
+        self.assertEqual(self.bundle.proof_trace, receipt.proof_trace)
+        self.assertEqual(
+            self.bundle.proof_trace[-1].trace_sha256,
+            receipt.proof_trace_chain_head_sha256,
+        )
+        self.assertEqual(
+            receipt.proof_trace_chain_head_sha256,
+            receipt.as_dict()["proof_trace_chain_head_sha256"],
+        )
+
+    def test_valid_checkpoint_identity_change_changes_receipt_identity(self) -> None:
+        original = self.verify()
+        changed_trace = (
+            *self.bundle.proof_trace[:-1],
+            replace(
+                self.bundle.proof_trace[-1],
+                observed_at="2026-08-05T11:42:00Z",
+            ),
+        )
+        changed = self.verify(replace(self.bundle, proof_trace=changed_trace))
+        self.assertEqual("PASS", changed.state)
+        self.assertNotEqual(
+            original.proof_trace_chain_head_sha256,
+            changed.proof_trace_chain_head_sha256,
+        )
+        self.assertNotEqual(original.receipt_sha256, changed.receipt_sha256)
+
+    def test_direct_receipt_cannot_claim_verified_without_trace_identity(self) -> None:
+        receipt = self.verify()
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            replace(
+                receipt,
+                proof_trace=(),
+                proof_trace_event_count=0,
+                proof_trace_chain_head_sha256=None,
+            )
+
+    def test_receipt_seals_complete_run_identities(self) -> None:
+        receipt = self.verify()
+        self.assertEqual(self.bundle.run_1, receipt.run_1)
+        self.assertEqual(self.bundle.run_2, receipt.run_2)
+        self.assertEqual(RUN_1_ID, receipt.run_1_id)
+        self.assertEqual(RUN_2_ID, receipt.run_2_id)
+        self.assertEqual(
+            self.bundle.run_1.as_dict(),
+            receipt.as_dict()["run_1"],
+        )
+        self.assertEqual(
+            self.bundle.run_2.as_dict(),
+            receipt.as_dict()["run_2"],
+        )
+
+    def test_direct_pass_receipt_rejects_inconsistent_run_identities(self) -> None:
+        receipt = self.verify()
+        cases = (
+            ("same_run", replace(receipt.run_2, run_id=receipt.run_1_id)),
+            (
+                "not_later",
+                replace(receipt.run_2, started_at=receipt.run_1.started_at),
+            ),
+            (
+                "other_attempt",
+                replace(receipt.run_2, proof_attempt_id="other_attempt"),
+            ),
+            (
+                "other_repository",
+                replace(receipt.run_2, repository=source_repository(suffix="c")),
+            ),
+            (
+                "other_runtime",
+                replace(receipt.run_2, runtime=runtime(model="other-model")),
+            ),
+        )
+        for label, run_2 in cases:
+            with self.subTest(label=label):
+                with self.assertRaises(FieldNoteWholeFlowValidationError):
+                    replace(receipt, run_2=run_2)
+
+    def test_creator_live_mode_is_exactly_not_ready(self) -> None:
+        live_attempt = replace(self.bundle.attempt, proof_mode="CREATOR_LIVE")
+        receipt = self.verify(replace(self.bundle, attempt=live_attempt))
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual("RUNTIME_ENFORCEMENT", receipt.failed_boundary)
+        self.assertEqual(
+            "CREATOR_LIVE_RUNTIME_ENFORCEMENT_NOT_IMPLEMENTED",
+            receipt.failure_reason,
+        )
+
+    def test_hand_built_six_checkpoint_trace_cannot_enable_creator_live(self) -> None:
+        self.assertEqual(6, len(self.bundle.proof_trace))
+        self.assertTrue(
+            all(
+                event.emitter == "COMPANION_RUNTIME"
+                for event in self.bundle.proof_trace
+            )
+        )
+        live_attempt = replace(self.bundle.attempt, proof_mode="CREATOR_LIVE")
+        live_bundle = replace(
+            self.bundle,
+            attempt=live_attempt,
+            proof_trace=trace_for(self.bundle),
+        )
+        receipt = self.verify(live_bundle)
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertNotEqual("TYPED_TRACE_VERIFIED", receipt.human_repair_result)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            build_portable_candidate_warehouse_manifest(live_bundle)
 
 
 class FieldNoteWholeFlowReadinessTests(WholeFlowTestCase):
@@ -737,6 +851,64 @@ class FieldNoteWholeFlowBindingTests(WholeFlowTestCase):
         receipt = self.verify()
         self.assertEqual("A6_LEDGER_IDENTITY_MISMATCH", receipt.failure_reason)
 
+    def test_a6_must_exactly_match_every_projected_a3_evidence_axis(self) -> None:
+        assert self.bundle.a6_review is not None
+        review = self.bundle.a6_review.ordered_event_reviews[0]
+        cases = (
+            ("evidence_origin", {"evidence_origin": "REUSING_RUN"}),
+            (
+                "use_observer_id",
+                {"use_evidence_observer_id": "other_use_observer"},
+            ),
+            (
+                "use_observer_relation",
+                {"use_evidence_observer_relation": "REUSING_RUN_SELF"},
+            ),
+            ("outcome_scope", {"outcome_scope": "A different task scope."}),
+            (
+                "causal_evidence_ref",
+                {"causal_evidence_ref": "run:other/causal:evidence"},
+            ),
+            (
+                "causal_evidence_sha256",
+                {"causal_evidence_sha256": "f" * 64},
+            ),
+            (
+                "outcome_observer_id",
+                {"outcome_observer_id": "other_outcome_observer"},
+            ),
+            (
+                "outcome_observer_relation",
+                {"outcome_observer_relation": "REUSING_RUN_PARTICIPANT"},
+            ),
+            (
+                "outcome_confirmation",
+                {"outcome_confirmation": "RUN_RELATED_CLAIM"},
+            ),
+            (
+                "contribution_separated",
+                {"contribution_separated": False},
+            ),
+        )
+        for label, mutation in cases:
+            with self.subTest(label=label):
+                changed_review = replace(review, **mutation)
+                changed_a6 = replace(self.bundle.a6_review)
+                object.__setattr__(
+                    changed_a6,
+                    "ordered_event_reviews",
+                    (changed_review,),
+                )
+                receipt = self.verify(
+                    replace(self.bundle, a6_review=changed_a6)
+                )
+                self.assertEqual("FAIL", receipt.state)
+                self.assertEqual("A6_REVIEW", receipt.failed_boundary)
+                self.assertEqual(
+                    "A6_EXACT_EVENT_MISMATCH",
+                    receipt.failure_reason,
+                )
+
     def test_a6_future_dated_evidence_cannot_pass(self) -> None:
         assert self.bundle.a6_review is not None
         object.__setattr__(
@@ -773,12 +945,52 @@ class FieldNoteWholeFlowBindingTests(WholeFlowTestCase):
 
 class PortableCandidateWarehouseManifestTests(WholeFlowTestCase):
     def manifest(self) -> PortableCandidateWarehouseManifest:
-        return build_portable_candidate_warehouse_manifest(self.verify())
+        return build_portable_candidate_warehouse_manifest(self.bundle)
 
     def test_pass_produces_one_typed_manifest(self) -> None:
         manifest = self.manifest()
         self.assertIsInstance(manifest, PortableCandidateWarehouseManifest)
-        self.assertEqual("PORTABLE_CANDIDATE", manifest.claim_boundary.portability_state)
+        self.assertEqual(
+            "PORTABLE_CANDIDATE",
+            manifest.claim_boundary.portability_state,
+        )
+
+    def test_arbitrary_pass_receipt_cannot_mint_a_manifest(self) -> None:
+        arbitrary = replace(self.verify(), effective_outcome="HARMFUL")
+        self.assertEqual("PASS", arbitrary.state)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            PortableCandidateWarehouseManifest(arbitrary)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            build_portable_candidate_warehouse_manifest(
+                arbitrary  # type: ignore[arg-type]
+            )
+
+    def test_failed_or_not_ready_bundle_cannot_mint_a_manifest(self) -> None:
+        cases = (
+            replace(
+                self.bundle,
+                note_bytes=self.bundle.note_bytes + b"changed",
+            ),
+            replace(self.bundle, a1_capture=None),
+        )
+        for bundle in cases:
+            with self.subTest(state=self.verify(bundle).state):
+                with self.assertRaises(FieldNoteWholeFlowValidationError):
+                    build_portable_candidate_warehouse_manifest(bundle)
+
+    def test_bundle_mutation_cannot_reuse_an_old_receipt(self) -> None:
+        old_receipt = self.verify()
+        changed = replace(
+            self.bundle,
+            note_bytes=self.bundle.note_bytes + b"post-receipt mutation",
+        )
+        self.assertEqual("FAIL", self.verify(changed).state)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            build_portable_candidate_warehouse_manifest(changed)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            build_portable_candidate_warehouse_manifest(
+                old_receipt  # type: ignore[arg-type]
+            )
 
     def test_repeated_manifest_generation_is_deterministic(self) -> None:
         first = self.manifest()
@@ -789,9 +1001,8 @@ class PortableCandidateWarehouseManifestTests(WholeFlowTestCase):
         self.assertEqual(first.render_text(), second.render_text())
 
     def test_manifest_identity_is_stable_for_identical_immutable_evidence(self) -> None:
-        receipt = self.verify()
-        first = build_portable_candidate_warehouse_manifest(receipt)
-        second = build_portable_candidate_warehouse_manifest(receipt)
+        first = build_portable_candidate_warehouse_manifest(self.bundle)
+        second = build_portable_candidate_warehouse_manifest(self.bundle)
         self.assertEqual(first.portable_asset_id, second.portable_asset_id)
         self.assertEqual(first.manifest_id, second.manifest_id)
 
@@ -803,10 +1014,12 @@ class PortableCandidateWarehouseManifestTests(WholeFlowTestCase):
         receipt = self.verify(changed)
         self.assertEqual("FAIL", receipt.state)
         with self.assertRaises(FieldNoteWholeFlowValidationError):
-            build_portable_candidate_warehouse_manifest(receipt)
+            build_portable_candidate_warehouse_manifest(changed)
 
     def test_manifest_coverage_is_exactly_one_one_one(self) -> None:
-        coverage = self.manifest().as_dict()["verified_coverage"]
+        manifest = self.manifest()
+        body = manifest.as_dict()
+        coverage = body["verified_coverage"]
         self.assertEqual(
             {
                 "repositories": 1,
@@ -814,6 +1027,42 @@ class PortableCandidateWarehouseManifestTests(WholeFlowTestCase):
                 "verified_later_reuse_runs": 1,
             },
             coverage,
+        )
+        self.assertEqual("FIXTURE", body["coverage_evidence_mode"])
+        self.assertFalse(body["creator_live_coverage_verified"])
+        self.assertIn("Fixture-covered repositories: 1", manifest.render_text())
+        self.assertNotIn("Verified repositories: 1", manifest.render_text())
+
+    def test_fixture_receipt_and_manifest_emit_no_creator_live_claim(self) -> None:
+        receipt = self.verify()
+        manifest = self.manifest()
+        self.assertEqual("FIXTURE", receipt.proof_mode)
+        self.assertFalse(
+            receipt.claim_boundary.creator_live_proof_inferred_from_fixture
+        )
+        self.assertEqual("FIXTURE", manifest.as_dict()["coverage_evidence_mode"])
+        self.assertFalse(
+            manifest.as_dict()["creator_live_coverage_verified"]
+        )
+        self.assertNotIn('"proof_mode":"CREATOR_LIVE"', receipt.serialize())
+        self.assertNotIn('"proof_mode":"CREATOR_LIVE"', manifest.serialize())
+
+    def test_manifest_is_bound_to_trace_sealed_receipt(self) -> None:
+        receipt = self.verify()
+        manifest = self.manifest()
+        proof_trace = manifest.as_dict()["proof_trace"]
+        self.assertEqual(receipt, manifest.proof_receipt)
+        self.assertEqual(
+            {
+                "schema": receipt.proof_trace_schema,
+                "event_count": receipt.proof_trace_event_count,
+                "chain_head_sha256": receipt.proof_trace_chain_head_sha256,
+            },
+            proof_trace,
+        )
+        self.assertEqual(
+            receipt.receipt_sha256,
+            manifest.as_dict()["whole_flow_proof_receipt_sha256"],
         )
 
     def test_manifest_is_candidate_not_portability_proven(self) -> None:
@@ -833,7 +1082,7 @@ class PortableCandidateWarehouseManifestTests(WholeFlowTestCase):
             self.root / "artifact",
             evidence_class="OUTPUT_ARTIFACT",
         )
-        manifest = build_portable_candidate_warehouse_manifest(self.verify(bundle))
+        manifest = build_portable_candidate_warehouse_manifest(bundle)
         self.assertNotIn(ARTIFACT_SECRET, manifest.serialize())
 
     def test_promotable_remains_unset(self) -> None:


### PR DESCRIPTION
## Summary

Implements Field Notes Lite A7 Whole-Flow Proof Contract v0.1 as a typed, deterministic, read-only FIXTURE verifier over existing A1-A6 evidence.

- Reuses the existing A1 `FieldNoteDraft`, A2 reconnect receipt, A3 reuse receipt and specific structure binding, A4 snapshot/event, A5 confirmed commit result, A6 review packet, and Codex runtime identity.
- Requires two distinct ordered Runs in one proof attempt, one source repository, and one exact model/runtime identity.
- Requires one exact Note capture, one injected A2 receipt, one demonstrable A3 REUSED event, exactly one canonical A4 event, confirmed A5 read-back, and an exact A6 review.
- Seals both complete typed Run identities and the exact six-checkpoint hash-chained proof trace into the Whole-Flow Proof Receipt.
- Compares every A3 evidence axis projected through the A6 event review.
- Builds a Portable Candidate Warehouse Manifest only by re-verifying the exact evidence bundle.
- Keeps future evidence target-repository-local and requires a future explicit import receipt; no shared mutable or merged ledger is introduced.

## Bounded proof-sealing repair

- `proof_mode=CREATOR_LIVE` always returns typed `NOT_READY` at `RUNTIME_ENFORCEMENT` with `CREATOR_LIVE_RUNTIME_ENFORCEMENT_NOT_IMPLEMENTED`.
- The literal fixture emitter value `COMPANION_RUNTIME` is not treated as independent runtime attestation.
- PASS Receipts bind `proof_trace_schema`, exact event count 6, exact final chain head, and the complete typed trace; Receipt identity changes with trace identity.
- PASS Receipts bind complete Run 1 and Run 2 identities, including proof attempt, Run ID, started-at, repository, and runtime.
- A3→A6 checks now include evidence origin, use observer identity/relation, outcome scope, causal evidence identity, outcome observer identity/relation, confirmation, and contribution separation.
- The public Manifest builder accepts a bundle, re-verifies it, requires FIXTURE PASS, and uses only an internal Receipt constructor.
- Manifest coverage is explicitly `FIXTURE`; `creator_live_coverage_verified` is false and all 1/1/1 counts are fixture-labelled.

## Base and head

- Base/main: `7a696ea3e2ddbb86fd672c01e1d65e5392968dce`
- Reviewed head before repair: `1a95ea3c76eb3c667689719668b9944c8569f629`
- Current head: `5752616952018256826c7ecb56f2caabbb0b6a14`

## Delta

- `decision_os/companion/field_notes_whole_flow.py` — A7 evidence bundle, identity contracts, trace sealing, fail-closed verifier, Whole-Flow receipt, and bundle-reverified portable candidate manifest.
- `tests/test_field_notes_whole_flow.py` — 72 deterministic tests covering FIXTURE PASS, live NOT_READY, exact trace/Run sealing, complete A3→A6 comparison, Manifest bypass prevention, fixture coverage labelling, and existing boundaries.

No A1-A6 source changes, existing A1-A6 test changes, UI/server route, runtime wiring, creator live proof execution, Companion Run, installer/restart, real Field Note creation, export/import, cross-model execution, cross-repository aggregation, automatic retry, Note repair, PROMOTABLE policy, Serving Policy implementation, automatic injection, release, or publication is included.

## Proof and portability boundary

A FIXTURE contract PASS remains supported. CREATOR_LIVE cannot PASS in A7 v0.1 because runtime evidence acquisition and enforcement are not implemented.

A Manifest is `PORTABLE_CANDIDATE`, never portability proven. Its structural coverage is exactly one fixture repository, one fixture model identity, and one fixture later reuse Run. PROMOTABLE remains UNSET, Serving Policy remains DELAY, automatic injection remains unset, and canonical authority remains above the advisory Field Note.

## Validation

- `python -m unittest tests.test_field_notes_whole_flow` — 72/72 PASS
- `python -m unittest tests.test_field_notes_maturity_review` — 54/54 PASS
- `python -m unittest tests.test_field_notes_maturity_commit` — 49/49 PASS
- `python -m unittest tests.test_field_notes_maturity_ledger` — 40/40 PASS
- `python -m unittest tests.test_field_notes_reuse` — 45/45 PASS
- `python -m unittest tests.test_field_notes_reconnect` — 36/36 PASS
- `python -m unittest tests.test_field_notes_lite` — 25/25 PASS
- `python -m unittest tests.test_companion_controller` — 27/27 PASS
- `python -m unittest tests.test_companion_server` — 35/35 PASS
- `python -m unittest` — 1018/1018 PASS
- `python -m unittest discover -s tests -p 'test_*.py'` — 1018/1018 PASS
- Normalized default/explicit test IDs — MATCH; SHA-256 `b8c430b4ad9f3ab6194157355c4d25b568b944c7f81d48b6ab49816f78daddf3`; no one-sided IDs
- `python -m py_compile decision_os/companion/field_notes_whole_flow.py tests/test_field_notes_whole_flow.py` — PASS
- `git diff --check` — PASS
- Protected creator Note and four validation artifacts — SHA-256, size, mode, mtime, and inode unchanged from preflight

## Claim boundary

Supported: A7 v0.1 provides a typed deterministic FIXTURE contract for verifying one bounded A1-A6 Whole Flow and generating a fixture-labelled portable candidate identity from complete re-verified evidence.

Not claimed: creator-live runtime enforcement; a creator live proof; a real new Note creation or reuse; usefulness; cross-repository import; cross-model reuse; portability execution; generalization; performance improvement; external adoption; PROMOTABLE; promotion readiness; serving; or automatic injection.
