### PR TITLE
Add A7 creator-live runtime evidence enforcement

### DIFF
--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -51,6 +51,7 @@ from decision_os.companion.field_notes_whole_flow import (
     _RUNTIME_PROVENANCE_AUTHORITY,
     _a1_evidence_sha256,
     _a2_receipt_sha256,
+    _a3_receipt_sha256,
     _a5_confirmation_sha256,
     _a6_packet_sha256,
     _canonical_sha256,
@@ -72,8 +73,13 @@ CREATOR_LIVE_RECORD_SCHEMA = (
 CREATOR_LIVE_READBACK_SCHEMA = (
     "decision-os.field-note-creator-live-proof-readback.v0.1"
 )
+CREATOR_LIVE_ANCHOR_SCHEMA = (
+    "decision-os.field-note-creator-live-proof-anchor.v0.1"
+)
 CREATOR_LIVE_JOURNAL_FILENAME = "creator-live-proof-v0.1.jsonl"
+CREATOR_LIVE_ANCHOR_FILENAME = "creator-live-proof-v0.1.anchor.jsonl"
 JOURNAL_GENESIS_SHA256 = "0" * 64
+ANCHOR_GENESIS_SHA256 = "0" * 64
 
 CreatorLiveAttemptState = Literal[
     "OPEN",
@@ -306,6 +312,71 @@ class _JournalRecord:
         return (canonical_json(self.as_dict()) + "\n").encode("utf-8")
 
 
+@dataclass(frozen=True)
+class _AnchorRecord:
+    generation: int
+    proof_attempt_id: str
+    journal_record_count: int
+    journal_byte_length: int
+    journal_record_chain_head_sha256: str
+    journal_sha256: str
+    previous_anchor_sha256: str
+    anchor_sha256: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        generation: int,
+        proof_attempt_id: str,
+        journal_raw: bytes,
+        journal_records: tuple[_JournalRecord, ...],
+        previous_anchor_sha256: str,
+    ) -> _AnchorRecord:
+        body = {
+            "schema": CREATOR_LIVE_ANCHOR_SCHEMA,
+            "generation": generation,
+            "proof_attempt_id": proof_attempt_id,
+            "journal_record_count": len(journal_records),
+            "journal_byte_length": len(journal_raw),
+            "journal_record_chain_head_sha256": (
+                journal_records[-1].record_sha256
+            ),
+            "journal_sha256": hashlib.sha256(journal_raw).hexdigest(),
+            "previous_anchor_sha256": previous_anchor_sha256,
+        }
+        return cls(
+            generation=generation,
+            proof_attempt_id=proof_attempt_id,
+            journal_record_count=len(journal_records),
+            journal_byte_length=len(journal_raw),
+            journal_record_chain_head_sha256=(
+                journal_records[-1].record_sha256
+            ),
+            journal_sha256=hashlib.sha256(journal_raw).hexdigest(),
+            previous_anchor_sha256=previous_anchor_sha256,
+            anchor_sha256=_canonical_sha256(body),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": CREATOR_LIVE_ANCHOR_SCHEMA,
+            "generation": self.generation,
+            "proof_attempt_id": self.proof_attempt_id,
+            "journal_record_count": self.journal_record_count,
+            "journal_byte_length": self.journal_byte_length,
+            "journal_record_chain_head_sha256": (
+                self.journal_record_chain_head_sha256
+            ),
+            "journal_sha256": self.journal_sha256,
+            "previous_anchor_sha256": self.previous_anchor_sha256,
+            "anchor_sha256": self.anchor_sha256,
+        }
+
+    def serialize_line(self) -> bytes:
+        return (canonical_json(self.as_dict()) + "\n").encode("utf-8")
+
+
 def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
     if not raw or not raw.endswith(b"\n"):
         raise _JournalIntegrityError(
@@ -388,6 +459,122 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
         records.append(record)
         previous = expected_sha
     return tuple(records)
+
+
+def _parse_anchors(raw: bytes) -> tuple[_AnchorRecord, ...]:
+    if not raw or not raw.endswith(b"\n"):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_DURABLE_ANCHOR_TRUNCATED",
+            repair_action="EVIDENCE_DELETION",
+        )
+    anchors: list[_AnchorRecord] = []
+    previous = ANCHOR_GENESIS_SHA256
+    for generation, line in enumerate(raw.splitlines()):
+        try:
+            text = line.decode("utf-8")
+            value = json.loads(text)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_ANCHOR_TAMPERED",
+                repair_action="RECEIPT_REWRITE",
+            ) from exc
+        required = {
+            "schema",
+            "generation",
+            "proof_attempt_id",
+            "journal_record_count",
+            "journal_byte_length",
+            "journal_record_chain_head_sha256",
+            "journal_sha256",
+            "previous_anchor_sha256",
+            "anchor_sha256",
+        }
+        if (
+            not isinstance(value, dict)
+            or set(value) != required
+            or canonical_json(value) != text
+        ):
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_ANCHOR_TAMPERED",
+                repair_action="RECEIPT_REWRITE",
+            )
+        body = {key: value[key] for key in required - {"anchor_sha256"}}
+        expected_sha = _canonical_sha256(body)
+        if (
+            value["schema"] != CREATOR_LIVE_ANCHOR_SCHEMA
+            or value["generation"] != generation
+            or value["previous_anchor_sha256"] != previous
+            or value["anchor_sha256"] != expected_sha
+            or not isinstance(value["proof_attempt_id"], str)
+            or not value["proof_attempt_id"]
+            or type(value["journal_record_count"]) is not int
+            or value["journal_record_count"] <= 0
+            or type(value["journal_byte_length"]) is not int
+            or value["journal_byte_length"] <= 0
+        ):
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_ANCHOR_CHAIN_INVALID",
+                repair_action="EVENT_ID_CHANGE",
+            )
+        for key in (
+            "journal_record_chain_head_sha256",
+            "journal_sha256",
+            "previous_anchor_sha256",
+            "anchor_sha256",
+        ):
+            digest = value[key]
+            if (
+                not isinstance(digest, str)
+                or len(digest) != 64
+                or any(character not in "0123456789abcdef" for character in digest)
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_DURABLE_ANCHOR_CHAIN_INVALID",
+                    repair_action="EVENT_ID_CHANGE",
+                )
+        anchor = _AnchorRecord(
+            generation=generation,
+            proof_attempt_id=value["proof_attempt_id"],
+            journal_record_count=value["journal_record_count"],
+            journal_byte_length=value["journal_byte_length"],
+            journal_record_chain_head_sha256=(
+                value["journal_record_chain_head_sha256"]
+            ),
+            journal_sha256=value["journal_sha256"],
+            previous_anchor_sha256=previous,
+            anchor_sha256=expected_sha,
+        )
+        anchors.append(anchor)
+        previous = expected_sha
+    return tuple(anchors)
+
+
+def _verify_journal_anchor(
+    journal_raw: bytes,
+    records: tuple[_JournalRecord, ...],
+    anchors: tuple[_AnchorRecord, ...],
+    *,
+    proof_attempt_id: str,
+) -> None:
+    if not anchors or any(
+        anchor.proof_attempt_id != proof_attempt_id for anchor in anchors
+    ):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_DURABLE_ANCHOR_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    anchor = anchors[-1]
+    if (
+        anchor.journal_record_count != len(records)
+        or anchor.journal_byte_length != len(journal_raw)
+        or anchor.journal_record_chain_head_sha256
+        != records[-1].record_sha256
+        or anchor.journal_sha256 != hashlib.sha256(journal_raw).hexdigest()
+    ):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_DURABLE_JOURNAL_ANCHOR_MISMATCH",
+            repair_action="EVIDENCE_DELETION",
+        )
 
 
 def _note_from_dict(value: Any) -> FieldNoteIdentity:
@@ -507,8 +694,7 @@ class FieldNoteCreatorLiveTraceReadback:
     schema: Literal[
         "decision-os.field-note-creator-live-proof-readback.v0.1"
     ]
-    proof_attempt_id: str
-    creator_id: str
+    attempt: FieldNoteWholeFlowAttempt
     source_repository: FieldNoteSourceRepositoryIdentity
     runtime: CodexRuntimeIdentity
     runtime_provenance: FieldNoteCreatorLiveRuntimeProvenance
@@ -516,6 +702,7 @@ class FieldNoteCreatorLiveTraceReadback:
     run_2: FieldNoteWholeFlowRunIdentity | None
     captured_note: FieldNoteIdentity | None
     captured_note_byte_count: int | None
+    a3_reuse_event_id: str | None
     current_stage: TraceStage | None
     trace_event_count: int
     trace_chain_head_sha256: str
@@ -526,8 +713,12 @@ class FieldNoteCreatorLiveTraceReadback:
     repair_action: RepairAction
     one_attempt_no_retry: Literal[True]
     journal_record_count: int
+    journal_byte_length: int
     journal_chain_head_sha256: str
     journal_sha256: str
+    anchor_record_count: int
+    anchor_chain_head_sha256: str
+    anchor_sha256: str
     durable_readback_verified: bool
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -548,6 +739,7 @@ class FieldNoteCreatorLiveTraceReadback:
         run_2: FieldNoteWholeFlowRunIdentity | None,
         captured_note: FieldNoteIdentity | None,
         captured_note_byte_count: int | None,
+        a3_reuse_event_id: str | None,
         current_stage: TraceStage | None,
         events: tuple[FieldNoteWholeFlowTraceEvent, ...],
         state: CreatorLiveAttemptState,
@@ -555,8 +747,12 @@ class FieldNoteCreatorLiveTraceReadback:
         failure_reason: str | None,
         repair_action: RepairAction,
         journal_record_count: int,
+        journal_byte_length: int,
         journal_chain_head_sha256: str,
         journal_sha256: str,
+        anchor_record_count: int,
+        anchor_chain_head_sha256: str,
+        anchor_sha256: str,
         durable_readback_verified: bool,
     ) -> FieldNoteCreatorLiveTraceReadback:
         if authority is not _READBACK_AUTHORITY:
@@ -566,8 +762,7 @@ class FieldNoteCreatorLiveTraceReadback:
         value = object.__new__(cls)
         fields = {
             "schema": CREATOR_LIVE_READBACK_SCHEMA,
-            "proof_attempt_id": attempt.proof_attempt_id,
-            "creator_id": attempt.creator_id,
+            "attempt": attempt,
             "source_repository": source_repository,
             "runtime": runtime,
             "runtime_provenance": runtime_provenance,
@@ -575,6 +770,7 @@ class FieldNoteCreatorLiveTraceReadback:
             "run_2": run_2,
             "captured_note": captured_note,
             "captured_note_byte_count": captured_note_byte_count,
+            "a3_reuse_event_id": a3_reuse_event_id,
             "current_stage": current_stage,
             "trace_event_count": len(events),
             "trace_chain_head_sha256": (
@@ -587,19 +783,30 @@ class FieldNoteCreatorLiveTraceReadback:
             "repair_action": repair_action,
             "one_attempt_no_retry": True,
             "journal_record_count": journal_record_count,
+            "journal_byte_length": journal_byte_length,
             "journal_chain_head_sha256": journal_chain_head_sha256,
             "journal_sha256": journal_sha256,
+            "anchor_record_count": anchor_record_count,
+            "anchor_chain_head_sha256": anchor_chain_head_sha256,
+            "anchor_sha256": anchor_sha256,
             "durable_readback_verified": durable_readback_verified,
         }
         for field, item in fields.items():
             object.__setattr__(value, field, item)
         return value
 
+    @property
+    def proof_attempt_id(self) -> str:
+        return self.attempt.proof_attempt_id
+
+    @property
+    def creator_id(self) -> str:
+        return self.attempt.creator_id
+
     def _body(self) -> dict[str, Any]:
         return {
             "schema": self.schema,
-            "proof_attempt_id": self.proof_attempt_id,
-            "creator_id": self.creator_id,
+            "attempt": self.attempt.as_dict(),
             "source_repository": self.source_repository.as_dict(),
             "runtime": _runtime_as_dict(self.runtime),
             "runtime_provenance": self.runtime_provenance.as_dict(),
@@ -609,6 +816,7 @@ class FieldNoteCreatorLiveTraceReadback:
                 self.captured_note.as_dict() if self.captured_note else None
             ),
             "captured_note_byte_count": self.captured_note_byte_count,
+            "a3_reuse_event_id": self.a3_reuse_event_id,
             "current_stage": self.current_stage,
             "trace_event_count": self.trace_event_count,
             "trace_chain_head_sha256": self.trace_chain_head_sha256,
@@ -619,8 +827,12 @@ class FieldNoteCreatorLiveTraceReadback:
             "repair_action": self.repair_action,
             "one_attempt_no_retry": self.one_attempt_no_retry,
             "journal_record_count": self.journal_record_count,
+            "journal_byte_length": self.journal_byte_length,
             "journal_chain_head_sha256": self.journal_chain_head_sha256,
             "journal_sha256": self.journal_sha256,
+            "anchor_record_count": self.anchor_record_count,
+            "anchor_chain_head_sha256": self.anchor_chain_head_sha256,
+            "anchor_sha256": self.anchor_sha256,
             "durable_readback_verified": self.durable_readback_verified,
         }
 
@@ -634,7 +846,7 @@ class FieldNoteCreatorLiveTraceReadback:
     def matches_admission(
         self,
         *,
-        proof_attempt_id: str,
+        attempt: FieldNoteWholeFlowAttempt,
         source_repository: FieldNoteSourceRepositoryIdentity,
         runtime: CodexRuntimeIdentity,
         run_1: FieldNoteWholeFlowRunIdentity,
@@ -647,14 +859,17 @@ class FieldNoteCreatorLiveTraceReadback:
             and self.failure_boundary is None
             and self.failure_reason is None
             and self.repair_action == "NONE"
-            and self.proof_attempt_id == proof_attempt_id
+            and self.attempt == attempt
             and self.source_repository == source_repository
             and self.runtime == runtime
             and self.run_1 == run_1
             and self.run_2 == run_2
+            and self.a3_reuse_event_id is not None
             and self.events == proof_trace
             and self.trace_event_count == len(_STAGES)
             and self.trace_chain_head_sha256 == proof_trace[-1].trace_sha256
+            and self.anchor_record_count == self.journal_record_count
+            and self.journal_byte_length > 0
             and all(
                 event.runtime_provenance == self.runtime_provenance
                 for event in proof_trace
@@ -726,14 +941,23 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
 
 
 def _project_records(
-    raw: bytes,
+    journal_raw: bytes,
     records: tuple[_JournalRecord, ...],
+    anchor_raw: bytes,
+    anchors: tuple[_AnchorRecord, ...],
     static: _StaticIdentity,
 ) -> FieldNoteCreatorLiveTraceReadback:
+    _verify_journal_anchor(
+        journal_raw,
+        records,
+        anchors,
+        proof_attempt_id=static.attempt.proof_attempt_id,
+    )
     run_2: FieldNoteWholeFlowRunIdentity | None = None
     events: list[FieldNoteWholeFlowTraceEvent] = []
     captured_note: FieldNoteIdentity | None = None
     captured_note_byte_count: int | None = None
+    a3_reuse_event_id: str | None = None
     state: CreatorLiveAttemptState = "OPEN"
     failure_boundary: WholeFlowBoundary | None = None
     failure_reason: str | None = None
@@ -835,6 +1059,30 @@ def _project_records(
                         repair_action="RECEIPT_REWRITE",
                     )
                 captured_note_byte_count = count
+            elif index == 2:
+                if set(binding) != {
+                    "evidence_type",
+                    "evidence_sha256",
+                    "reuse_event_id",
+                } or binding["evidence_type"] != "FieldNoteReuseReceipt":
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A3_BINDING_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    )
+                reuse_event_id = binding["reuse_event_id"]
+                if (
+                    not isinstance(reuse_event_id, str)
+                    or len(reuse_event_id) != 64
+                    or any(
+                        character not in "0123456789abcdef"
+                        for character in reuse_event_id
+                    )
+                ):
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A3_BINDING_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    )
+                a3_reuse_event_id = reuse_event_id
             elif set(binding) != {"evidence_type", "evidence_sha256"}:
                 raise _JournalIntegrityError(
                     "CREATOR_LIVE_STAGE_BINDING_INVALID",
@@ -897,6 +1145,7 @@ def _project_records(
             } or (
                 len(events) != len(_STAGES)
                 or run_2 is None
+                or a3_reuse_event_id is None
                 or payload["trace_event_count"] != len(_STAGES)
                 or payload["trace_chain_head_sha256"] != previous_trace
                 or payload["runtime_provenance_id"]
@@ -929,6 +1178,7 @@ def _project_records(
         run_2=run_2,
         captured_note=captured_note,
         captured_note_byte_count=captured_note_byte_count,
+        a3_reuse_event_id=a3_reuse_event_id,
         current_stage=current_stage,
         events=tuple(events),
         state=state,
@@ -936,15 +1186,20 @@ def _project_records(
         failure_reason=failure_reason,
         repair_action=repair_action,
         journal_record_count=len(records),
+        journal_byte_length=len(journal_raw),
         journal_chain_head_sha256=records[-1].record_sha256,
-        journal_sha256=hashlib.sha256(raw).hexdigest(),
+        journal_sha256=hashlib.sha256(journal_raw).hexdigest(),
+        anchor_record_count=len(anchors),
+        anchor_chain_head_sha256=anchors[-1].anchor_sha256,
+        anchor_sha256=hashlib.sha256(anchor_raw).hexdigest(),
         durable_readback_verified=True,
     )
 
 
 def _failed_readback(
     *,
-    raw: bytes,
+    journal_raw: bytes,
+    anchor_raw: bytes,
     static: _StaticIdentity,
     reason: str,
     repair_action: RepairAction,
@@ -959,6 +1214,7 @@ def _failed_readback(
         run_2=None,
         captured_note=None,
         captured_note_byte_count=None,
+        a3_reuse_event_id=None,
         current_stage=None,
         events=(),
         state="FAILED",
@@ -966,8 +1222,12 @@ def _failed_readback(
         failure_reason=reason,
         repair_action=repair_action,
         journal_record_count=0,
+        journal_byte_length=len(journal_raw),
         journal_chain_head_sha256=JOURNAL_GENESIS_SHA256,
-        journal_sha256=hashlib.sha256(raw).hexdigest(),
+        journal_sha256=hashlib.sha256(journal_raw).hexdigest(),
+        anchor_record_count=0,
+        anchor_chain_head_sha256=ANCHOR_GENESIS_SHA256,
+        anchor_sha256=hashlib.sha256(anchor_raw).hexdigest(),
         durable_readback_verified=False,
     )
 
@@ -988,12 +1248,17 @@ class FieldNoteCreatorLiveProofRuntime:
     ) -> None:
         self._storage_root = storage_root
         self._journal_path = storage_root / CREATOR_LIVE_JOURNAL_FILENAME
+        self._anchor_path = storage_root / CREATOR_LIVE_ANCHOR_FILENAME
         self._static = static
         self._lock = threading.Lock()
 
     @property
     def journal_path(self) -> Path:
         return self._journal_path
+
+    @property
+    def anchor_path(self) -> Path:
+        return self._anchor_path
 
     @classmethod
     def open_attempt(
@@ -1084,12 +1349,45 @@ class FieldNoteCreatorLiveProofRuntime:
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+        anchor = _AnchorRecord.create(
+            generation=0,
+            proof_attempt_id=attempt.proof_attempt_id,
+            journal_raw=line,
+            journal_records=(record,),
+            previous_anchor_sha256=ANCHOR_GENESIS_SHA256,
+        )
+        anchor_path = root / CREATOR_LIVE_ANCHOR_FILENAME
+        try:
+            anchor_descriptor = os.open(
+                anchor_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError as exc:
+            raise FieldNoteCreatorLiveAttemptExistsError(
+                "Creator-live one-attempt anchor already exists."
+            ) from exc
+        try:
+            anchor_line = anchor.serialize_line()
+            anchor_written = os.write(anchor_descriptor, anchor_line)
+            if anchor_written != len(anchor_line):
+                raise FieldNoteCreatorLiveDurabilityError(
+                    "Creator-live attempt anchor write was incomplete."
+                )
+            os.fsync(anchor_descriptor)
+        finally:
+            os.close(anchor_descriptor)
         directory = os.open(root, os.O_RDONLY)
         try:
             os.fsync(directory)
         finally:
             os.close(directory)
-        return cls(storage_root=root, static=static)
+        runtime_path = cls(storage_root=root, static=static)
+        if not runtime_path.read_back().durable_readback_verified:
+            raise FieldNoteCreatorLiveDurabilityError(
+                "Creator-live attempt did not survive exact durable read-back."
+            )
+        return runtime_path
 
     @classmethod
     def load_attempt(
@@ -1098,9 +1396,18 @@ class FieldNoteCreatorLiveProofRuntime:
     ) -> FieldNoteCreatorLiveProofRuntime:
         root = Path(storage_root)
         path = root / CREATOR_LIVE_JOURNAL_FILENAME
-        raw = path.read_bytes()
-        records = _parse_records(raw)
+        anchor_path = root / CREATOR_LIVE_ANCHOR_FILENAME
+        journal_raw = path.read_bytes()
+        anchor_raw = anchor_path.read_bytes()
+        records = _parse_records(journal_raw)
         static = _static_identity(records)
+        anchors = _parse_anchors(anchor_raw)
+        _verify_journal_anchor(
+            journal_raw,
+            records,
+            anchors,
+            proof_attempt_id=static.attempt.proof_attempt_id,
+        )
         return cls(storage_root=root, static=static)
 
     def _read_raw_locked(self, descriptor: int) -> bytes:
@@ -1114,25 +1421,49 @@ class FieldNoteCreatorLiveProofRuntime:
 
     def read_back(self) -> FieldNoteCreatorLiveTraceReadback:
         with self._lock:
-            descriptor = os.open(self._journal_path, os.O_RDONLY)
+            journal_descriptor = os.open(self._journal_path, os.O_RDONLY)
             try:
-                fcntl.flock(descriptor, fcntl.LOCK_SH)
-                raw = self._read_raw_locked(descriptor)
+                try:
+                    anchor_descriptor = os.open(self._anchor_path, os.O_RDONLY)
+                except OSError:
+                    return _failed_readback(
+                        journal_raw=self._read_raw_locked(journal_descriptor),
+                        anchor_raw=b"",
+                        static=self._static,
+                        reason="CREATOR_LIVE_DURABLE_ANCHOR_MISSING",
+                        repair_action="EVIDENCE_DELETION",
+                    )
+                try:
+                    fcntl.flock(journal_descriptor, fcntl.LOCK_SH)
+                    fcntl.flock(anchor_descriptor, fcntl.LOCK_SH)
+                    journal_raw = self._read_raw_locked(journal_descriptor)
+                    anchor_raw = self._read_raw_locked(anchor_descriptor)
+                finally:
+                    fcntl.flock(anchor_descriptor, fcntl.LOCK_UN)
+                    os.close(anchor_descriptor)
             finally:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
-                os.close(descriptor)
+                fcntl.flock(journal_descriptor, fcntl.LOCK_UN)
+                os.close(journal_descriptor)
         try:
-            records = _parse_records(raw)
+            records = _parse_records(journal_raw)
+            anchors = _parse_anchors(anchor_raw)
             static = _static_identity(records)
             if static != self._static:
                 raise _JournalIntegrityError(
                     "CREATOR_LIVE_STATIC_IDENTITY_CHANGED",
                     repair_action="RECEIPT_REWRITE",
                 )
-            return _project_records(raw, records, static)
+            return _project_records(
+                journal_raw,
+                records,
+                anchor_raw,
+                anchors,
+                static,
+            )
         except _JournalIntegrityError as exc:
             return _failed_readback(
-                raw=raw,
+                journal_raw=journal_raw,
+                anchor_raw=anchor_raw,
                 static=self._static,
                 reason=exc.reason,
                 repair_action=exc.repair_action,
@@ -1144,14 +1475,38 @@ class FieldNoteCreatorLiveProofRuntime:
         payload: dict[str, Any],
     ) -> FieldNoteCreatorLiveTraceReadback:
         with self._lock:
-            descriptor = os.open(self._journal_path, os.O_RDWR | os.O_APPEND)
+            journal_descriptor: int | None = None
             try:
-                fcntl.flock(descriptor, fcntl.LOCK_EX)
-                raw = self._read_raw_locked(descriptor)
+                journal_descriptor = os.open(
+                    self._journal_path,
+                    os.O_RDWR | os.O_APPEND,
+                )
+                anchor_descriptor = os.open(
+                    self._anchor_path,
+                    os.O_RDWR | os.O_APPEND,
+                )
+            except OSError as exc:
+                if journal_descriptor is not None:
+                    os.close(journal_descriptor)
+                raise FieldNoteCreatorLiveDurabilityError(
+                    "Creator-live durable journal or anchor is missing."
+                ) from exc
+            try:
+                fcntl.flock(journal_descriptor, fcntl.LOCK_EX)
+                fcntl.flock(anchor_descriptor, fcntl.LOCK_EX)
+                journal_raw = self._read_raw_locked(journal_descriptor)
+                anchor_raw = self._read_raw_locked(anchor_descriptor)
                 try:
-                    records = _parse_records(raw)
+                    records = _parse_records(journal_raw)
+                    anchors = _parse_anchors(anchor_raw)
                     static = _static_identity(records)
-                    readback = _project_records(raw, records, static)
+                    readback = _project_records(
+                        journal_raw,
+                        records,
+                        anchor_raw,
+                        anchors,
+                        static,
+                    )
                 except _JournalIntegrityError as exc:
                     raise FieldNoteCreatorLiveDurabilityError(
                         exc.reason
@@ -1171,15 +1526,33 @@ class FieldNoteCreatorLiveProofRuntime:
                     previous_record_sha256=records[-1].record_sha256,
                 )
                 line = record.serialize_line()
-                written = os.write(descriptor, line)
+                written = os.write(journal_descriptor, line)
                 if written != len(line):
                     raise FieldNoteCreatorLiveDurabilityError(
                         "Creator-live journal append was incomplete."
                     )
-                os.fsync(descriptor)
+                os.fsync(journal_descriptor)
+                next_journal_raw = journal_raw + line
+                next_records = records + (record,)
+                anchor = _AnchorRecord.create(
+                    generation=len(anchors),
+                    proof_attempt_id=self._static.attempt.proof_attempt_id,
+                    journal_raw=next_journal_raw,
+                    journal_records=next_records,
+                    previous_anchor_sha256=anchors[-1].anchor_sha256,
+                )
+                anchor_line = anchor.serialize_line()
+                anchor_written = os.write(anchor_descriptor, anchor_line)
+                if anchor_written != len(anchor_line):
+                    raise FieldNoteCreatorLiveDurabilityError(
+                        "Creator-live durable anchor append was incomplete."
+                    )
+                os.fsync(anchor_descriptor)
             finally:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
-                os.close(descriptor)
+                fcntl.flock(anchor_descriptor, fcntl.LOCK_UN)
+                fcntl.flock(journal_descriptor, fcntl.LOCK_UN)
+                os.close(anchor_descriptor)
+                os.close(journal_descriptor)
         return self.read_back()
 
     def _terminal_failure(
@@ -1460,12 +1833,14 @@ class FieldNoteCreatorLiveProofRuntime:
         if receipt.promotion != PromotionPolicyBoundary():
             self._terminal_failure("A3_REUSE", "A3_PROMOTABLE_POLICY_WIDENED")
         assert receipt.reuse_event_id is not None
+        receipt_sha256 = _a3_receipt_sha256(receipt)
         return self._emit(
             "A3_REUSE",
-            evidence_sha256=receipt.reuse_event_id,
+            evidence_sha256=receipt_sha256,
             binding={
                 "evidence_type": "FieldNoteReuseReceipt",
-                "evidence_sha256": receipt.reuse_event_id,
+                "evidence_sha256": receipt_sha256,
+                "reuse_event_id": receipt.reuse_event_id,
             },
         )
 
@@ -1482,14 +1857,19 @@ class FieldNoteCreatorLiveProofRuntime:
                 "A4_EVENT_COUNT_NOT_EXACTLY_ONE",
             )
         event = snapshot.events[0]
-        a3_identity = readback.events[2].evidence_sha256
+        a3_receipt_identity = readback.events[2].evidence_sha256
+        a3_reuse_event_id = readback.a3_reuse_event_id
         if (
             snapshot.note != readback.captured_note
+            or a3_reuse_event_id is None
             or event.sequence != 0
             or event.previous_event_sha256 != GENESIS_EVENT_SHA256
-            or event.event_id != a3_identity
-            or event.receipt.reuse_event_id != a3_identity
-            or event.receipt_sha256 != _event_receipt_sha256(event)
+            or event.event_id != event.receipt.reuse_event_id
+            or event.receipt.reuse_event_id != a3_reuse_event_id
+            or event.receipt.reuse_event_id
+            != _expected_reuse_event_id(event.receipt)
+            or event.receipt_sha256 != a3_receipt_identity
+            or _event_receipt_sha256(event) != a3_receipt_identity
             or event.event_sha256 != _event_sha256(event)
             or snapshot.chain_head_sha256 != event.event_sha256
             or snapshot.evidence_maturity.state != "REUSED"
@@ -1526,13 +1906,19 @@ class FieldNoteCreatorLiveProofRuntime:
                 "A5_APPEND_NOT_CONFIRMED",
             )
         a2_identity = readback.events[1].evidence_sha256
-        a3_identity = readback.events[2].evidence_sha256
+        a3_receipt_identity = readback.events[2].evidence_sha256
         a4_identity = readback.events[3].evidence_sha256
         if (
-            result.assessment.reuse_event_id != a3_identity
+            readback.a3_reuse_event_id is None
+            or result.assessment.reuse_event_id
+            != readback.a3_reuse_event_id
+            or _a3_receipt_sha256(result.assessment)
+            != a3_receipt_identity
             or result.delivery_context is None
             or _a2_receipt_sha256(result.delivery_context) != a2_identity
             or result.append_result.event.event_sha256 != a4_identity
+            or result.append_result.event.receipt_sha256
+            != a3_receipt_identity
             or len(result.durable_snapshot.events) != 1
             or result.durable_snapshot.events[0].event_sha256 != a4_identity
         ):
@@ -1558,12 +1944,13 @@ class FieldNoteCreatorLiveProofRuntime:
         readback = self._require_stage("A6_REVIEW")
         if not isinstance(packet, FieldNoteMaturityReviewPacket):
             self._terminal_failure("A6_REVIEW", "A6_EVIDENCE_INVALID")
-        a3_identity = readback.events[2].evidence_sha256
         a4_identity = readback.events[3].evidence_sha256
         if (
             packet.note_identity != readback.captured_note
+            or readback.a3_reuse_event_id is None
             or len(packet.ordered_event_reviews) != 1
-            or packet.ordered_event_reviews[0].event_id != a3_identity
+            or packet.ordered_event_reviews[0].event_id
+            != readback.a3_reuse_event_id
             or packet.ordered_event_reviews[0].event_sha256 != a4_identity
             or packet.ledger_identity.chain_head_sha256 != a4_identity
             or packet.evidence_maturity.state != "REUSED"

--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -1,0 +1,1617 @@
+"""Runtime-owned, append-only A7 creator-live proof trace acquisition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import threading
+from typing import Any, Literal
+
+from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.companion.field_notes_maturity_commit import (
+    FieldNoteMaturityCommitResult,
+)
+from decision_os.companion.field_notes_maturity_ledger import (
+    GENESIS_EVENT_SHA256,
+    FieldNoteMaturityLedgerSnapshot,
+)
+from decision_os.companion.field_notes_maturity_review import (
+    FieldNoteMaturityReviewPacket,
+)
+from decision_os.companion.field_notes_model import (
+    FieldNoteDraft,
+    canonical_json,
+    validate_compiled_markdown,
+)
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteReconnectReceipt,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteReuseReceipt,
+    PromotionPolicyBoundary,
+)
+from decision_os.companion.field_notes_whole_flow import (
+    TRACE_GENESIS_SHA256,
+    WHOLE_FLOW_TRACE_SCHEMA,
+    FieldNoteCreatorLiveRuntimeProvenance,
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowAttempt,
+    FieldNoteWholeFlowRunIdentity,
+    FieldNoteWholeFlowTraceEvent,
+    FieldNoteWholeFlowValidationError,
+    RepairAction,
+    TraceStage,
+    WholeFlowBoundary,
+    _RUNTIME_PROVENANCE_AUTHORITY,
+    _a1_evidence_sha256,
+    _a2_receipt_sha256,
+    _a5_confirmation_sha256,
+    _a6_packet_sha256,
+    _canonical_sha256,
+    _event_receipt_sha256,
+    _event_sha256,
+    _expected_reuse_event_id,
+    _parse_time,
+    _runtime_as_dict,
+    _sha256_bytes,
+)
+
+
+CREATOR_LIVE_JOURNAL_SCHEMA = (
+    "decision-os.field-note-creator-live-proof-journal.v0.1"
+)
+CREATOR_LIVE_RECORD_SCHEMA = (
+    "decision-os.field-note-creator-live-proof-record.v0.1"
+)
+CREATOR_LIVE_READBACK_SCHEMA = (
+    "decision-os.field-note-creator-live-proof-readback.v0.1"
+)
+CREATOR_LIVE_JOURNAL_FILENAME = "creator-live-proof-v0.1.jsonl"
+JOURNAL_GENESIS_SHA256 = "0" * 64
+
+CreatorLiveAttemptState = Literal[
+    "OPEN",
+    "NOT_READY",
+    "FAILED",
+    "TRACE_COMPLETE",
+]
+JournalRecordKind = Literal[
+    "ATTEMPT_OPENED",
+    "RUN_2_OPENED",
+    "CHECKPOINT",
+    "ATTEMPT_FAILED",
+    "TRACE_COMPLETED",
+]
+
+_STAGES: tuple[TraceStage, ...] = (
+    "A1_CAPTURE",
+    "A2_RECONNECT",
+    "A3_REUSE",
+    "A4_DURABILITY",
+    "A5_CONFIRMATION",
+    "A6_REVIEW",
+)
+_READBACK_AUTHORITY = object()
+
+
+class FieldNoteCreatorLiveError(RuntimeError):
+    """Base error for the bounded creator-live runtime path."""
+
+
+class FieldNoteCreatorLiveValidationError(
+    FieldNoteCreatorLiveError,
+    ValueError,
+):
+    """The caller supplied an invalid identity or typed stage result."""
+
+
+class FieldNoteCreatorLiveStageError(FieldNoteCreatorLiveError):
+    """A stage failed and the one-attempt journal is terminal."""
+
+
+class FieldNoteCreatorLiveDurabilityError(FieldNoteCreatorLiveError):
+    """The durable journal cannot be trusted or extended."""
+
+
+class FieldNoteCreatorLiveAttemptExistsError(FieldNoteCreatorLiveError):
+    """The one-attempt journal already exists and cannot be replaced."""
+
+
+class _JournalIntegrityError(ValueError):
+    def __init__(
+        self,
+        reason: str,
+        *,
+        repair_action: RepairAction,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.repair_action = repair_action
+
+
+def _utc_now_rfc3339() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _bounded_reason(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value) > 256
+        or "\x00" in value
+    ):
+        raise FieldNoteCreatorLiveValidationError(
+            "Creator-live failure reason is outside its bounded schema."
+        )
+    return value.strip()
+
+
+def _runtime_from_dict(value: Any) -> CodexRuntimeIdentity:
+    if not isinstance(value, dict) or set(value) != {
+        "model",
+        "reasoning_effort",
+        "service_tier",
+        "codex_cli_version",
+        "account_type",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUNTIME_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        return CodexRuntimeIdentity(**value)
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUNTIME_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+
+
+def _repository_from_dict(value: Any) -> FieldNoteSourceRepositoryIdentity:
+    if not isinstance(value, dict) or set(value) != {
+        "repository_id",
+        "source_commit",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_REPOSITORY_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        return FieldNoteSourceRepositoryIdentity(**value)
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_REPOSITORY_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+
+
+def _run_from_dict(
+    value: Any,
+    *,
+    repository: FieldNoteSourceRepositoryIdentity,
+    runtime: CodexRuntimeIdentity,
+) -> FieldNoteWholeFlowRunIdentity:
+    if not isinstance(value, dict) or set(value) != {
+        "proof_attempt_id",
+        "run_id",
+        "started_at",
+        "repository",
+        "runtime",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUN_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    if value["repository"] != repository.as_dict() or value["runtime"] != (
+        _runtime_as_dict(runtime)
+    ):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUN_IDENTITY_MISMATCH",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        return FieldNoteWholeFlowRunIdentity(
+            proof_attempt_id=value["proof_attempt_id"],
+            run_id=value["run_id"],
+            started_at=value["started_at"],
+            repository=repository,
+            runtime=runtime,
+        )
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUN_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+
+
+def _attempt_from_dict(value: Any) -> FieldNoteWholeFlowAttempt:
+    if not isinstance(value, dict) or set(value) != {
+        "proof_attempt_id",
+        "proof_mode",
+        "creator_id",
+        "proof_as_of",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        attempt = FieldNoteWholeFlowAttempt(**value)
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+    if attempt.proof_mode != "CREATOR_LIVE":
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_MODE_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    return attempt
+
+
+@dataclass(frozen=True)
+class _JournalRecord:
+    sequence: int
+    kind: JournalRecordKind
+    payload: dict[str, Any]
+    previous_record_sha256: str
+    record_sha256: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        sequence: int,
+        kind: JournalRecordKind,
+        payload: dict[str, Any],
+        previous_record_sha256: str,
+    ) -> _JournalRecord:
+        body = {
+            "schema": CREATOR_LIVE_RECORD_SCHEMA,
+            "sequence": sequence,
+            "kind": kind,
+            "payload": payload,
+            "previous_record_sha256": previous_record_sha256,
+        }
+        return cls(
+            sequence=sequence,
+            kind=kind,
+            payload=payload,
+            previous_record_sha256=previous_record_sha256,
+            record_sha256=_canonical_sha256(body),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": CREATOR_LIVE_RECORD_SCHEMA,
+            "sequence": self.sequence,
+            "kind": self.kind,
+            "payload": self.payload,
+            "previous_record_sha256": self.previous_record_sha256,
+            "record_sha256": self.record_sha256,
+        }
+
+    def serialize_line(self) -> bytes:
+        return (canonical_json(self.as_dict()) + "\n").encode("utf-8")
+
+
+def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
+    if not raw or not raw.endswith(b"\n"):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_DURABLE_TRACE_TRUNCATED",
+            repair_action="EVIDENCE_DELETION",
+        )
+    records: list[_JournalRecord] = []
+    previous = JOURNAL_GENESIS_SHA256
+    for index, line in enumerate(raw.splitlines()):
+        try:
+            text = line.decode("utf-8")
+            value = json.loads(text)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_TRACE_TAMPERED",
+                repair_action="RECEIPT_REWRITE",
+            ) from exc
+        if not isinstance(value, dict) or canonical_json(value) != text:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_TRACE_TAMPERED",
+                repair_action="RECEIPT_REWRITE",
+            )
+        if set(value) != {
+            "schema",
+            "sequence",
+            "kind",
+            "payload",
+            "previous_record_sha256",
+            "record_sha256",
+        }:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_TRACE_TAMPERED",
+                repair_action="RECEIPT_REWRITE",
+            )
+        kind = value["kind"]
+        if kind not in {
+            "ATTEMPT_OPENED",
+            "RUN_2_OPENED",
+            "CHECKPOINT",
+            "ATTEMPT_FAILED",
+            "TRACE_COMPLETED",
+        }:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_DURABLE_TRACE_TAMPERED",
+                repair_action="RECEIPT_REWRITE",
+            )
+        body = {
+            "schema": value["schema"],
+            "sequence": value["sequence"],
+            "kind": kind,
+            "payload": value["payload"],
+            "previous_record_sha256": value["previous_record_sha256"],
+        }
+        expected_sha = _canonical_sha256(body)
+        if (
+            value["schema"] != CREATOR_LIVE_RECORD_SCHEMA
+            or value["sequence"] != index
+            or value["previous_record_sha256"] != previous
+            or value["record_sha256"] != expected_sha
+            or not isinstance(value["payload"], dict)
+        ):
+            reason = (
+                "CREATOR_LIVE_DURABLE_TRACE_DUPLICATED"
+                if value["sequence"] != index
+                else "CREATOR_LIVE_DURABLE_CHAIN_HEAD_MISMATCH"
+            )
+            action: RepairAction = (
+                "RETRY_REPLACEMENT"
+                if value["sequence"] != index
+                else "EVENT_ID_CHANGE"
+            )
+            raise _JournalIntegrityError(reason, repair_action=action)
+        record = _JournalRecord(
+            sequence=index,
+            kind=kind,
+            payload=value["payload"],
+            previous_record_sha256=previous,
+            record_sha256=expected_sha,
+        )
+        records.append(record)
+        previous = expected_sha
+    return tuple(records)
+
+
+def _note_from_dict(value: Any) -> FieldNoteIdentity:
+    if not isinstance(value, dict) or set(value) != {
+        "note_path",
+        "field_note_id",
+        "note_sha256",
+        "origin_run_id",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_CAPTURED_NOTE_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        return FieldNoteIdentity(**value)
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_CAPTURED_NOTE_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+
+
+def _provenance_from_dict(
+    value: Any,
+    *,
+    attempt: FieldNoteWholeFlowAttempt,
+    repository: FieldNoteSourceRepositoryIdentity,
+    runtime: CodexRuntimeIdentity,
+    run_1: FieldNoteWholeFlowRunIdentity,
+) -> FieldNoteCreatorLiveRuntimeProvenance:
+    provenance = FieldNoteCreatorLiveRuntimeProvenance._issue(
+        authority=_RUNTIME_PROVENANCE_AUTHORITY,
+        proof_attempt_id=attempt.proof_attempt_id,
+        source_repository=repository,
+        runtime=runtime,
+        issued_for_run_1_id=run_1.run_id,
+    )
+    if value != provenance.as_dict():
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUNTIME_PROVENANCE_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    return provenance
+
+
+def _event_from_dict(
+    value: Any,
+    *,
+    attempt: FieldNoteWholeFlowAttempt,
+    repository: FieldNoteSourceRepositoryIdentity,
+    runtime: CodexRuntimeIdentity,
+    provenance: FieldNoteCreatorLiveRuntimeProvenance,
+) -> FieldNoteWholeFlowTraceEvent:
+    if not isinstance(value, dict) or set(value) != {
+        "schema",
+        "sequence",
+        "stage",
+        "run_id",
+        "observed_at",
+        "evidence_sha256",
+        "previous_trace_sha256",
+        "repair_action",
+        "emitter",
+        "proof_attempt_id",
+        "runtime",
+        "source_repository",
+        "runtime_provenance",
+        "trace_sha256",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_CHECKPOINT_SHAPE_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    if (
+        value["schema"] != WHOLE_FLOW_TRACE_SCHEMA
+        or value["proof_attempt_id"] != attempt.proof_attempt_id
+        or value["runtime"] != _runtime_as_dict(runtime)
+        or value["source_repository"] != repository.as_dict()
+        or value["runtime_provenance"] != provenance.as_dict()
+    ):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_CHECKPOINT_PROVENANCE_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        event = FieldNoteWholeFlowTraceEvent(
+            sequence=value["sequence"],
+            stage=value["stage"],
+            run_id=value["run_id"],
+            observed_at=value["observed_at"],
+            evidence_sha256=value["evidence_sha256"],
+            previous_trace_sha256=value["previous_trace_sha256"],
+            repair_action=value["repair_action"],
+            emitter=value["emitter"],
+            proof_attempt_id=attempt.proof_attempt_id,
+            runtime=runtime,
+            source_repository=repository,
+            runtime_provenance=provenance,
+        )
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_CHECKPOINT_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+    if event.trace_sha256 != value["trace_sha256"]:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_CHECKPOINT_IDENTITY_CHANGED",
+            repair_action="EVENT_ID_CHANGE",
+        )
+    return event
+
+
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveTraceReadback:
+    """Sealed projection of exact durable journal bytes."""
+
+    schema: Literal[
+        "decision-os.field-note-creator-live-proof-readback.v0.1"
+    ]
+    proof_attempt_id: str
+    creator_id: str
+    source_repository: FieldNoteSourceRepositoryIdentity
+    runtime: CodexRuntimeIdentity
+    runtime_provenance: FieldNoteCreatorLiveRuntimeProvenance
+    run_1: FieldNoteWholeFlowRunIdentity
+    run_2: FieldNoteWholeFlowRunIdentity | None
+    captured_note: FieldNoteIdentity | None
+    captured_note_byte_count: int | None
+    current_stage: TraceStage | None
+    trace_event_count: int
+    trace_chain_head_sha256: str
+    events: tuple[FieldNoteWholeFlowTraceEvent, ...]
+    state: CreatorLiveAttemptState
+    failure_boundary: WholeFlowBoundary | None
+    failure_reason: str | None
+    repair_action: RepairAction
+    one_attempt_no_retry: Literal[True]
+    journal_record_count: int
+    journal_chain_head_sha256: str
+    journal_sha256: str
+    durable_readback_verified: bool
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise FieldNoteCreatorLiveValidationError(
+            "Creator-live durable read-back cannot be caller-constructed."
+        )
+
+    @classmethod
+    def _create(
+        cls,
+        *,
+        authority: object,
+        attempt: FieldNoteWholeFlowAttempt,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        runtime: CodexRuntimeIdentity,
+        runtime_provenance: FieldNoteCreatorLiveRuntimeProvenance,
+        run_1: FieldNoteWholeFlowRunIdentity,
+        run_2: FieldNoteWholeFlowRunIdentity | None,
+        captured_note: FieldNoteIdentity | None,
+        captured_note_byte_count: int | None,
+        current_stage: TraceStage | None,
+        events: tuple[FieldNoteWholeFlowTraceEvent, ...],
+        state: CreatorLiveAttemptState,
+        failure_boundary: WholeFlowBoundary | None,
+        failure_reason: str | None,
+        repair_action: RepairAction,
+        journal_record_count: int,
+        journal_chain_head_sha256: str,
+        journal_sha256: str,
+        durable_readback_verified: bool,
+    ) -> FieldNoteCreatorLiveTraceReadback:
+        if authority is not _READBACK_AUTHORITY:
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live read-back authority is invalid."
+            )
+        value = object.__new__(cls)
+        fields = {
+            "schema": CREATOR_LIVE_READBACK_SCHEMA,
+            "proof_attempt_id": attempt.proof_attempt_id,
+            "creator_id": attempt.creator_id,
+            "source_repository": source_repository,
+            "runtime": runtime,
+            "runtime_provenance": runtime_provenance,
+            "run_1": run_1,
+            "run_2": run_2,
+            "captured_note": captured_note,
+            "captured_note_byte_count": captured_note_byte_count,
+            "current_stage": current_stage,
+            "trace_event_count": len(events),
+            "trace_chain_head_sha256": (
+                events[-1].trace_sha256 if events else TRACE_GENESIS_SHA256
+            ),
+            "events": events,
+            "state": state,
+            "failure_boundary": failure_boundary,
+            "failure_reason": failure_reason,
+            "repair_action": repair_action,
+            "one_attempt_no_retry": True,
+            "journal_record_count": journal_record_count,
+            "journal_chain_head_sha256": journal_chain_head_sha256,
+            "journal_sha256": journal_sha256,
+            "durable_readback_verified": durable_readback_verified,
+        }
+        for field, item in fields.items():
+            object.__setattr__(value, field, item)
+        return value
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proof_attempt_id": self.proof_attempt_id,
+            "creator_id": self.creator_id,
+            "source_repository": self.source_repository.as_dict(),
+            "runtime": _runtime_as_dict(self.runtime),
+            "runtime_provenance": self.runtime_provenance.as_dict(),
+            "run_1": self.run_1.as_dict(),
+            "run_2": self.run_2.as_dict() if self.run_2 else None,
+            "captured_note": (
+                self.captured_note.as_dict() if self.captured_note else None
+            ),
+            "captured_note_byte_count": self.captured_note_byte_count,
+            "current_stage": self.current_stage,
+            "trace_event_count": self.trace_event_count,
+            "trace_chain_head_sha256": self.trace_chain_head_sha256,
+            "events": [event.as_dict() for event in self.events],
+            "state": self.state,
+            "failure_boundary": self.failure_boundary,
+            "failure_reason": self.failure_reason,
+            "repair_action": self.repair_action,
+            "one_attempt_no_retry": self.one_attempt_no_retry,
+            "journal_record_count": self.journal_record_count,
+            "journal_chain_head_sha256": self.journal_chain_head_sha256,
+            "journal_sha256": self.journal_sha256,
+            "durable_readback_verified": self.durable_readback_verified,
+        }
+
+    @property
+    def readback_sha256(self) -> str:
+        return _canonical_sha256(self._body())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._body(), "readback_sha256": self.readback_sha256}
+
+    def matches_admission(
+        self,
+        *,
+        proof_attempt_id: str,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        runtime: CodexRuntimeIdentity,
+        run_1: FieldNoteWholeFlowRunIdentity,
+        run_2: FieldNoteWholeFlowRunIdentity,
+        proof_trace: tuple[FieldNoteWholeFlowTraceEvent, ...],
+    ) -> bool:
+        return (
+            self.state == "TRACE_COMPLETE"
+            and self.durable_readback_verified
+            and self.failure_boundary is None
+            and self.failure_reason is None
+            and self.repair_action == "NONE"
+            and self.proof_attempt_id == proof_attempt_id
+            and self.source_repository == source_repository
+            and self.runtime == runtime
+            and self.run_1 == run_1
+            and self.run_2 == run_2
+            and self.events == proof_trace
+            and self.trace_event_count == len(_STAGES)
+            and self.trace_chain_head_sha256 == proof_trace[-1].trace_sha256
+            and all(
+                event.runtime_provenance == self.runtime_provenance
+                for event in proof_trace
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _StaticIdentity:
+    attempt: FieldNoteWholeFlowAttempt
+    repository: FieldNoteSourceRepositoryIdentity
+    runtime: CodexRuntimeIdentity
+    run_1: FieldNoteWholeFlowRunIdentity
+    provenance: FieldNoteCreatorLiveRuntimeProvenance
+
+
+def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
+    if not records or records[0].kind != "ATTEMPT_OPENED":
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_RECORD_MISSING",
+            repair_action="EVIDENCE_DELETION",
+        )
+    payload = records[0].payload
+    if set(payload) != {
+        "journal_schema",
+        "attempt",
+        "source_repository",
+        "runtime",
+        "run_1",
+        "runtime_provenance",
+        "one_attempt_no_retry",
+    } or payload["journal_schema"] != CREATOR_LIVE_JOURNAL_SCHEMA:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_RECORD_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    if payload["one_attempt_no_retry"] is not True:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RETRY_BOUNDARY_INVALID",
+            repair_action="RETRY_REPLACEMENT",
+        )
+    attempt = _attempt_from_dict(payload["attempt"])
+    repository = _repository_from_dict(payload["source_repository"])
+    runtime = _runtime_from_dict(payload["runtime"])
+    run_1 = _run_from_dict(
+        payload["run_1"],
+        repository=repository,
+        runtime=runtime,
+    )
+    if run_1.proof_attempt_id != attempt.proof_attempt_id:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_RUN_ATTEMPT_MISMATCH",
+            repair_action="RECEIPT_REWRITE",
+        )
+    provenance = _provenance_from_dict(
+        payload["runtime_provenance"],
+        attempt=attempt,
+        repository=repository,
+        runtime=runtime,
+        run_1=run_1,
+    )
+    return _StaticIdentity(
+        attempt=attempt,
+        repository=repository,
+        runtime=runtime,
+        run_1=run_1,
+        provenance=provenance,
+    )
+
+
+def _project_records(
+    raw: bytes,
+    records: tuple[_JournalRecord, ...],
+    static: _StaticIdentity,
+) -> FieldNoteCreatorLiveTraceReadback:
+    run_2: FieldNoteWholeFlowRunIdentity | None = None
+    events: list[FieldNoteWholeFlowTraceEvent] = []
+    captured_note: FieldNoteIdentity | None = None
+    captured_note_byte_count: int | None = None
+    state: CreatorLiveAttemptState = "OPEN"
+    failure_boundary: WholeFlowBoundary | None = None
+    failure_reason: str | None = None
+    repair_action: RepairAction = "NONE"
+    previous_trace = TRACE_GENESIS_SHA256
+
+    for record in records[1:]:
+        if state in {"FAILED", "TRACE_COMPLETE"}:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_TERMINAL_STATE_EXTENDED",
+                repair_action="RETRY_REPLACEMENT",
+            )
+        payload = record.payload
+        if record.kind == "RUN_2_OPENED":
+            if run_2 is not None or len(events) != 1:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_2_ORDER_INVALID",
+                    repair_action="RETRY_REPLACEMENT",
+                )
+            if set(payload) != {"run_2"}:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_2_RECORD_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            run_2 = _run_from_dict(
+                payload["run_2"],
+                repository=static.repository,
+                runtime=static.runtime,
+            )
+            if (
+                run_2.proof_attempt_id != static.attempt.proof_attempt_id
+                or run_2.run_id == static.run_1.run_id
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_2_IDENTITY_INVALID",
+                    repair_action="RETRY_REPLACEMENT",
+                )
+            _, run_1_time = _parse_time(
+                static.run_1.started_at,
+                "Run 1 start",
+            )
+            _, run_2_time = _parse_time(run_2.started_at, "Run 2 start")
+            if run_2_time <= run_1_time:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_ORDER_INVALID",
+                    repair_action="TIMESTAMP_CHANGE",
+                )
+            continue
+        if record.kind == "CHECKPOINT":
+            if set(payload) != {"event", "binding"}:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_CHECKPOINT_RECORD_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            event = _event_from_dict(
+                payload["event"],
+                attempt=static.attempt,
+                repository=static.repository,
+                runtime=static.runtime,
+                provenance=static.provenance,
+            )
+            index = len(events)
+            expected_run = (
+                static.run_1.run_id
+                if index == 0
+                else run_2.run_id if run_2 else None
+            )
+            binding = payload["binding"]
+            if (
+                index >= len(_STAGES)
+                or event.sequence != index
+                or event.stage != _STAGES[index]
+                or event.run_id != expected_run
+                or event.previous_trace_sha256 != previous_trace
+                or event.repair_action != "NONE"
+                or not isinstance(binding, dict)
+                or binding.get("evidence_sha256") != event.evidence_sha256
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_CHECKPOINT_ORDER_OR_IDENTITY_INVALID",
+                    repair_action="EVENT_ID_CHANGE",
+                )
+            if index == 0:
+                if set(binding) != {
+                    "evidence_type",
+                    "evidence_sha256",
+                    "note",
+                    "note_byte_count",
+                } or binding["evidence_type"] != "FieldNoteDraft":
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A1_BINDING_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    )
+                captured_note = _note_from_dict(binding["note"])
+                count = binding["note_byte_count"]
+                if type(count) is not int or count <= 0:
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A1_BYTE_COUNT_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    )
+                captured_note_byte_count = count
+            elif set(binding) != {"evidence_type", "evidence_sha256"}:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_STAGE_BINDING_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            events.append(event)
+            previous_trace = event.trace_sha256
+            continue
+        if record.kind == "ATTEMPT_FAILED":
+            if set(payload) != {
+                "failure_boundary",
+                "failure_reason",
+                "repair_action",
+            }:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_FAILURE_RECORD_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            boundary = payload["failure_boundary"]
+            action = payload["repair_action"]
+            if boundary not in {
+                "RUNTIME_ENFORCEMENT",
+                "A1_CAPTURE",
+                "RUN_SEPARATION",
+                "MODEL_IDENTITY",
+                "REPOSITORY_IDENTITY",
+                "A2_RECONNECT",
+                "A3_REUSE",
+                "A4_DURABILITY",
+                "A5_CONFIRMATION",
+                "A6_REVIEW",
+                "HUMAN_REPAIR",
+                "PROOF_AS_OF",
+            } or action not in {
+                "NONE",
+                "NOTE_EDIT",
+                "EVIDENCE_MANUFACTURE",
+                "RECEIPT_REWRITE",
+                "LEDGER_REWRITE",
+                "EVENT_ID_CHANGE",
+                "TIMESTAMP_CHANGE",
+                "EVIDENCE_DELETION",
+                "RETRY_REPLACEMENT",
+            }:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_FAILURE_RECORD_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            state = "FAILED"
+            failure_boundary = boundary
+            failure_reason = _bounded_reason(payload["failure_reason"])
+            repair_action = action
+            continue
+        if record.kind == "TRACE_COMPLETED":
+            if set(payload) != {
+                "trace_event_count",
+                "trace_chain_head_sha256",
+                "runtime_provenance_id",
+                "no_repair_verified",
+            } or (
+                len(events) != len(_STAGES)
+                or run_2 is None
+                or payload["trace_event_count"] != len(_STAGES)
+                or payload["trace_chain_head_sha256"] != previous_trace
+                or payload["runtime_provenance_id"]
+                != static.provenance.runtime_provenance_id
+                or payload["no_repair_verified"] is not True
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_COMPLETION_RECORD_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            state = "TRACE_COMPLETE"
+            continue
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_JOURNAL_ORDER_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+
+    current_stage = (
+        _STAGES[len(events)]
+        if state == "OPEN" and len(events) < len(_STAGES)
+        else None
+    )
+    return FieldNoteCreatorLiveTraceReadback._create(
+        authority=_READBACK_AUTHORITY,
+        attempt=static.attempt,
+        source_repository=static.repository,
+        runtime=static.runtime,
+        runtime_provenance=static.provenance,
+        run_1=static.run_1,
+        run_2=run_2,
+        captured_note=captured_note,
+        captured_note_byte_count=captured_note_byte_count,
+        current_stage=current_stage,
+        events=tuple(events),
+        state=state,
+        failure_boundary=failure_boundary,
+        failure_reason=failure_reason,
+        repair_action=repair_action,
+        journal_record_count=len(records),
+        journal_chain_head_sha256=records[-1].record_sha256,
+        journal_sha256=hashlib.sha256(raw).hexdigest(),
+        durable_readback_verified=True,
+    )
+
+
+def _failed_readback(
+    *,
+    raw: bytes,
+    static: _StaticIdentity,
+    reason: str,
+    repair_action: RepairAction,
+) -> FieldNoteCreatorLiveTraceReadback:
+    return FieldNoteCreatorLiveTraceReadback._create(
+        authority=_READBACK_AUTHORITY,
+        attempt=static.attempt,
+        source_repository=static.repository,
+        runtime=static.runtime,
+        runtime_provenance=static.provenance,
+        run_1=static.run_1,
+        run_2=None,
+        captured_note=None,
+        captured_note_byte_count=None,
+        current_stage=None,
+        events=(),
+        state="FAILED",
+        failure_boundary="RUNTIME_ENFORCEMENT",
+        failure_reason=reason,
+        repair_action=repair_action,
+        journal_record_count=0,
+        journal_chain_head_sha256=JOURNAL_GENESIS_SHA256,
+        journal_sha256=hashlib.sha256(raw).hexdigest(),
+        durable_readback_verified=False,
+    )
+
+
+class FieldNoteCreatorLiveProofRuntime:
+    """The only public path that can append creator-live checkpoints.
+
+    Trust is bounded to this in-process implementation plus exact durable
+    read-back. No signature, hardware root, separate observer, or adversarial
+    local-process resistance is claimed.
+    """
+
+    def __init__(
+        self,
+        *,
+        storage_root: Path,
+        static: _StaticIdentity,
+    ) -> None:
+        self._storage_root = storage_root
+        self._journal_path = storage_root / CREATOR_LIVE_JOURNAL_FILENAME
+        self._static = static
+        self._lock = threading.Lock()
+
+    @property
+    def journal_path(self) -> Path:
+        return self._journal_path
+
+    @classmethod
+    def open_attempt(
+        cls,
+        storage_root: Path,
+        *,
+        attempt: FieldNoteWholeFlowAttempt,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        run_1: FieldNoteWholeFlowRunIdentity,
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        if not isinstance(attempt, FieldNoteWholeFlowAttempt) or (
+            attempt.proof_mode != "CREATOR_LIVE"
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live runtime requires a CREATOR_LIVE attempt."
+            )
+        if not isinstance(
+            source_repository,
+            FieldNoteSourceRepositoryIdentity,
+        ) or not isinstance(run_1, FieldNoteWholeFlowRunIdentity):
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live runtime identity is not typed."
+            )
+        if (
+            run_1.proof_attempt_id != attempt.proof_attempt_id
+            or run_1.repository != source_repository
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Run 1 is cross-bound to the creator-live attempt."
+            )
+        root = Path(storage_root)
+        if not root.is_absolute():
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live storage root must be absolute."
+            )
+        if root.exists() and root.is_symlink():
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live storage root cannot be a symlink."
+            )
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        provenance = FieldNoteCreatorLiveRuntimeProvenance._issue(
+            authority=_RUNTIME_PROVENANCE_AUTHORITY,
+            proof_attempt_id=attempt.proof_attempt_id,
+            source_repository=source_repository,
+            runtime=run_1.runtime,
+            issued_for_run_1_id=run_1.run_id,
+        )
+        static = _StaticIdentity(
+            attempt=attempt,
+            repository=source_repository,
+            runtime=run_1.runtime,
+            run_1=run_1,
+            provenance=provenance,
+        )
+        payload = {
+            "journal_schema": CREATOR_LIVE_JOURNAL_SCHEMA,
+            "attempt": attempt.as_dict(),
+            "source_repository": source_repository.as_dict(),
+            "runtime": _runtime_as_dict(run_1.runtime),
+            "run_1": run_1.as_dict(),
+            "runtime_provenance": provenance.as_dict(),
+            "one_attempt_no_retry": True,
+        }
+        record = _JournalRecord.create(
+            sequence=0,
+            kind="ATTEMPT_OPENED",
+            payload=payload,
+            previous_record_sha256=JOURNAL_GENESIS_SHA256,
+        )
+        path = root / CREATOR_LIVE_JOURNAL_FILENAME
+        try:
+            descriptor = os.open(
+                path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError as exc:
+            raise FieldNoteCreatorLiveAttemptExistsError(
+                "Creator-live one-attempt journal already exists."
+            ) from exc
+        try:
+            line = record.serialize_line()
+            written = os.write(descriptor, line)
+            if written != len(line):
+                raise FieldNoteCreatorLiveDurabilityError(
+                    "Creator-live attempt record write was incomplete."
+                )
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        directory = os.open(root, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+        return cls(storage_root=root, static=static)
+
+    @classmethod
+    def load_attempt(
+        cls,
+        storage_root: Path,
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        root = Path(storage_root)
+        path = root / CREATOR_LIVE_JOURNAL_FILENAME
+        raw = path.read_bytes()
+        records = _parse_records(raw)
+        static = _static_identity(records)
+        return cls(storage_root=root, static=static)
+
+    def _read_raw_locked(self, descriptor: int) -> bytes:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+
+    def read_back(self) -> FieldNoteCreatorLiveTraceReadback:
+        with self._lock:
+            descriptor = os.open(self._journal_path, os.O_RDONLY)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_SH)
+                raw = self._read_raw_locked(descriptor)
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                os.close(descriptor)
+        try:
+            records = _parse_records(raw)
+            static = _static_identity(records)
+            if static != self._static:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_STATIC_IDENTITY_CHANGED",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            return _project_records(raw, records, static)
+        except _JournalIntegrityError as exc:
+            return _failed_readback(
+                raw=raw,
+                static=self._static,
+                reason=exc.reason,
+                repair_action=exc.repair_action,
+            )
+
+    def _append(
+        self,
+        kind: JournalRecordKind,
+        payload: dict[str, Any],
+    ) -> FieldNoteCreatorLiveTraceReadback:
+        with self._lock:
+            descriptor = os.open(self._journal_path, os.O_RDWR | os.O_APPEND)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+                raw = self._read_raw_locked(descriptor)
+                try:
+                    records = _parse_records(raw)
+                    static = _static_identity(records)
+                    readback = _project_records(raw, records, static)
+                except _JournalIntegrityError as exc:
+                    raise FieldNoteCreatorLiveDurabilityError(
+                        exc.reason
+                    ) from exc
+                if static != self._static or not readback.durable_readback_verified:
+                    raise FieldNoteCreatorLiveDurabilityError(
+                        "Creator-live durable identity changed before append."
+                    )
+                if readback.state in {"FAILED", "TRACE_COMPLETE"}:
+                    raise FieldNoteCreatorLiveStageError(
+                        "Creator-live attempt is terminal and cannot continue."
+                    )
+                record = _JournalRecord.create(
+                    sequence=len(records),
+                    kind=kind,
+                    payload=payload,
+                    previous_record_sha256=records[-1].record_sha256,
+                )
+                line = record.serialize_line()
+                written = os.write(descriptor, line)
+                if written != len(line):
+                    raise FieldNoteCreatorLiveDurabilityError(
+                        "Creator-live journal append was incomplete."
+                    )
+                os.fsync(descriptor)
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                os.close(descriptor)
+        return self.read_back()
+
+    def _terminal_failure(
+        self,
+        boundary: WholeFlowBoundary,
+        reason: str,
+        *,
+        repair_action: RepairAction = "NONE",
+    ) -> None:
+        bounded = _bounded_reason(reason)
+        readback = self.read_back()
+        if readback.state in {"FAILED", "TRACE_COMPLETE"}:
+            raise FieldNoteCreatorLiveStageError(
+                "Creator-live attempt is terminal and cannot be reset."
+            )
+        self._append(
+            "ATTEMPT_FAILED",
+            {
+                "failure_boundary": boundary,
+                "failure_reason": bounded,
+                "repair_action": repair_action,
+            },
+        )
+        raise FieldNoteCreatorLiveStageError(bounded)
+
+    def _require_stage(self, stage: TraceStage) -> FieldNoteCreatorLiveTraceReadback:
+        readback = self.read_back()
+        if not readback.durable_readback_verified:
+            raise FieldNoteCreatorLiveDurabilityError(
+                readback.failure_reason or "Creator-live read-back failed."
+            )
+        if readback.state in {"FAILED", "TRACE_COMPLETE"}:
+            raise FieldNoteCreatorLiveStageError(
+                "Creator-live attempt is terminal and cannot continue."
+            )
+        if readback.current_stage != stage:
+            retry = stage in _STAGES[: readback.trace_event_count]
+            self._terminal_failure(
+                "RUNTIME_ENFORCEMENT",
+                "CREATOR_LIVE_STAGE_ORDER_INVALID",
+                repair_action=("RETRY_REPLACEMENT" if retry else "NONE"),
+            )
+        return readback
+
+    def _emit(
+        self,
+        stage: TraceStage,
+        *,
+        evidence_sha256: str,
+        binding: dict[str, Any],
+    ) -> FieldNoteWholeFlowTraceEvent:
+        readback = self._require_stage(stage)
+        index = readback.trace_event_count
+        run = readback.run_1 if index == 0 else readback.run_2
+        if run is None:
+            self._terminal_failure(
+                "RUN_SEPARATION",
+                "CREATOR_LIVE_RUN_2_NOT_OPEN",
+            )
+        assert run is not None
+        event = FieldNoteWholeFlowTraceEvent(
+            sequence=index,
+            stage=stage,
+            run_id=run.run_id,
+            observed_at=_utc_now_rfc3339(),
+            evidence_sha256=evidence_sha256,
+            previous_trace_sha256=readback.trace_chain_head_sha256,
+            repair_action="NONE",
+            proof_attempt_id=self._static.attempt.proof_attempt_id,
+            runtime=self._static.runtime,
+            source_repository=self._static.repository,
+            runtime_provenance=self._static.provenance,
+        )
+        self._append(
+            "CHECKPOINT",
+            {"event": event.as_dict(), "binding": binding},
+        )
+        if stage == "A6_REVIEW":
+            completed = self.read_back()
+            self._append(
+                "TRACE_COMPLETED",
+                {
+                    "trace_event_count": len(_STAGES),
+                    "trace_chain_head_sha256": (
+                        completed.trace_chain_head_sha256
+                    ),
+                    "runtime_provenance_id": (
+                        self._static.provenance.runtime_provenance_id
+                    ),
+                    "no_repair_verified": True,
+                },
+            )
+        return event
+
+    def open_run_2(
+        self,
+        run_2: FieldNoteWholeFlowRunIdentity,
+    ) -> FieldNoteCreatorLiveTraceReadback:
+        readback = self.read_back()
+        if readback.state != "OPEN":
+            raise FieldNoteCreatorLiveStageError(
+                "Creator-live attempt is terminal and cannot continue."
+            )
+        if readback.trace_event_count != 1 or readback.current_stage != (
+            "A2_RECONNECT"
+        ):
+            self._terminal_failure(
+                "RUN_SEPARATION",
+                "CREATOR_LIVE_RUN_2_BEFORE_A1_CLOSURE",
+            )
+        if not isinstance(run_2, FieldNoteWholeFlowRunIdentity):
+            self._terminal_failure(
+                "RUN_SEPARATION",
+                "CREATOR_LIVE_RUN_2_IDENTITY_INVALID",
+            )
+        if run_2.run_id == self._static.run_1.run_id:
+            self._terminal_failure(
+                "RUN_SEPARATION",
+                "RUN_IDENTITIES_NOT_DISTINCT",
+                repair_action="RETRY_REPLACEMENT",
+            )
+        if run_2.proof_attempt_id != self._static.attempt.proof_attempt_id:
+            self._terminal_failure(
+                "RUN_SEPARATION",
+                "RUN_ATTEMPT_MISMATCH",
+                repair_action="RETRY_REPLACEMENT",
+            )
+        if run_2.runtime != self._static.runtime:
+            self._terminal_failure(
+                "MODEL_IDENTITY",
+                "MODEL_RUNTIME_MISMATCH",
+                repair_action="RETRY_REPLACEMENT",
+            )
+        if run_2.repository != self._static.repository:
+            self._terminal_failure(
+                "REPOSITORY_IDENTITY",
+                "SOURCE_REPOSITORY_MISMATCH",
+                repair_action="RETRY_REPLACEMENT",
+            )
+        _, run_1_time = _parse_time(
+            self._static.run_1.started_at,
+            "Run 1 start",
+        )
+        _, run_2_time = _parse_time(run_2.started_at, "Run 2 start")
+        if run_2_time <= run_1_time:
+            self._terminal_failure(
+                "RUN_SEPARATION",
+                "RUN_ORDER_INVALID",
+                repair_action="TIMESTAMP_CHANGE",
+            )
+        return self._append("RUN_2_OPENED", {"run_2": run_2.as_dict()})
+
+    def record_a1_capture(self, draft: FieldNoteDraft) -> FieldNoteWholeFlowTraceEvent:
+        self._require_stage("A1_CAPTURE")
+        if not isinstance(draft, FieldNoteDraft):
+            self._terminal_failure("A1_CAPTURE", "A1_CAPTURE_INVALID")
+        try:
+            validate_compiled_markdown(draft.markdown)
+        except ValueError:
+            self._terminal_failure("A1_CAPTURE", "A1_CAPTURE_INVALID")
+        if (
+            draft.source_run_id != self._static.run_1.run_id
+            or _sha256_bytes(draft.markdown) != draft.sha256
+        ):
+            self._terminal_failure("A1_CAPTURE", "A1_NOTE_IDENTITY_MISMATCH")
+        note = FieldNoteIdentity(
+            note_path=draft.relative_path,
+            field_note_id=draft.field_note_id,
+            note_sha256=draft.sha256,
+            origin_run_id=draft.source_run_id,
+        )
+        evidence_sha256 = _a1_evidence_sha256(draft)
+        return self._emit(
+            "A1_CAPTURE",
+            evidence_sha256=evidence_sha256,
+            binding={
+                "evidence_type": "FieldNoteDraft",
+                "evidence_sha256": evidence_sha256,
+                "note": note.as_dict(),
+                "note_byte_count": len(draft.markdown),
+            },
+        )
+
+    def _require_exact_note(
+        self,
+        readback: FieldNoteCreatorLiveTraceReadback,
+        note: FieldNoteIdentity,
+        note_bytes: bytes,
+        *,
+        boundary: WholeFlowBoundary,
+    ) -> None:
+        if (
+            not isinstance(note, FieldNoteIdentity)
+            or not isinstance(note_bytes, bytes)
+            or readback.captured_note != note
+            or readback.captured_note_byte_count != len(note_bytes)
+            or _sha256_bytes(note_bytes) != note.note_sha256
+        ):
+            self._terminal_failure(
+                boundary,
+                "CREATOR_LIVE_EXACT_NOTE_MISMATCH",
+                repair_action="NOTE_EDIT",
+            )
+
+    def record_a2_reconnect(
+        self,
+        receipt: FieldNoteReconnectReceipt,
+        *,
+        note: FieldNoteIdentity,
+        note_bytes: bytes,
+    ) -> FieldNoteWholeFlowTraceEvent:
+        readback = self._require_stage("A2_RECONNECT")
+        self._require_exact_note(
+            readback,
+            note,
+            note_bytes,
+            boundary="A2_RECONNECT",
+        )
+        if not isinstance(receipt, FieldNoteReconnectReceipt):
+            self._terminal_failure("A2_RECONNECT", "A2_EVIDENCE_INVALID")
+        if readback.run_2 is None or receipt.run_id != readback.run_2.run_id:
+            self._terminal_failure("A2_RECONNECT", "A2_RUN_MISMATCH")
+        if (
+            receipt.state not in {"INJECTED", "ACTIVATION_UNKNOWN"}
+            or receipt.full_notes_injected != 1
+            or receipt.failure_reason is not None
+        ):
+            self._terminal_failure("A2_RECONNECT", "A2_NOT_INJECTED")
+        if (
+            receipt.selected_field_note_path != note.note_path
+            or receipt.selected_field_note_id != note.field_note_id
+            or receipt.selected_full_note_sha256 != note.note_sha256
+            or receipt.full_note_bytes_read != len(note_bytes)
+        ):
+            self._terminal_failure("A2_RECONNECT", "A2_EXACT_NOTE_MISMATCH")
+        evidence_sha256 = _a2_receipt_sha256(receipt)
+        return self._emit(
+            "A2_RECONNECT",
+            evidence_sha256=evidence_sha256,
+            binding={
+                "evidence_type": "FieldNoteReconnectReceipt",
+                "evidence_sha256": evidence_sha256,
+            },
+        )
+
+    def record_a3_reuse(
+        self,
+        receipt: FieldNoteReuseReceipt,
+        *,
+        note: FieldNoteIdentity,
+        note_bytes: bytes,
+    ) -> FieldNoteWholeFlowTraceEvent:
+        readback = self._require_stage("A3_REUSE")
+        self._require_exact_note(
+            readback,
+            note,
+            note_bytes,
+            boundary="A3_REUSE",
+        )
+        if not isinstance(receipt, FieldNoteReuseReceipt):
+            self._terminal_failure("A3_REUSE", "A3_EVIDENCE_INVALID")
+        if receipt.state != "REUSED" or receipt.use_evidence is None:
+            self._terminal_failure("A3_REUSE", "A3_NOT_DEMONSTRABLY_REUSED")
+        if receipt.note != note:
+            self._terminal_failure("A3_REUSE", "A3_EXACT_NOTE_MISMATCH")
+        if readback.run_2 is None or (
+            receipt.reusing_run_id != readback.run_2.run_id
+            or receipt.use_evidence.reusing_run_id != readback.run_2.run_id
+        ):
+            self._terminal_failure("A3_REUSE", "A3_RUN_MISMATCH")
+        if not receipt.use_evidence.structure_binding.verifies(note, note_bytes):
+            self._terminal_failure(
+                "A3_REUSE",
+                "A3_STRUCTURE_BINDING_INVALID",
+            )
+        if receipt.reuse_event_id != _expected_reuse_event_id(receipt):
+            self._terminal_failure("A3_REUSE", "A3_REUSE_EVENT_ID_INVALID")
+        if receipt.promotion != PromotionPolicyBoundary():
+            self._terminal_failure("A3_REUSE", "A3_PROMOTABLE_POLICY_WIDENED")
+        assert receipt.reuse_event_id is not None
+        return self._emit(
+            "A3_REUSE",
+            evidence_sha256=receipt.reuse_event_id,
+            binding={
+                "evidence_type": "FieldNoteReuseReceipt",
+                "evidence_sha256": receipt.reuse_event_id,
+            },
+        )
+
+    def record_a4_durability(
+        self,
+        snapshot: FieldNoteMaturityLedgerSnapshot,
+    ) -> FieldNoteWholeFlowTraceEvent:
+        readback = self._require_stage("A4_DURABILITY")
+        if not isinstance(snapshot, FieldNoteMaturityLedgerSnapshot):
+            self._terminal_failure("A4_DURABILITY", "A4_EVIDENCE_INVALID")
+        if len(snapshot.events) != 1 or readback.captured_note is None:
+            self._terminal_failure(
+                "A4_DURABILITY",
+                "A4_EVENT_COUNT_NOT_EXACTLY_ONE",
+            )
+        event = snapshot.events[0]
+        a3_identity = readback.events[2].evidence_sha256
+        if (
+            snapshot.note != readback.captured_note
+            or event.sequence != 0
+            or event.previous_event_sha256 != GENESIS_EVENT_SHA256
+            or event.event_id != a3_identity
+            or event.receipt.reuse_event_id != a3_identity
+            or event.receipt_sha256 != _event_receipt_sha256(event)
+            or event.event_sha256 != _event_sha256(event)
+            or snapshot.chain_head_sha256 != event.event_sha256
+            or snapshot.evidence_maturity.state != "REUSED"
+        ):
+            self._terminal_failure(
+                "A4_DURABILITY",
+                "A4_EXACT_EVENT_INTEGRITY_INVALID",
+                repair_action="LEDGER_REWRITE",
+            )
+        return self._emit(
+            "A4_DURABILITY",
+            evidence_sha256=event.event_sha256,
+            binding={
+                "evidence_type": "FieldNoteMaturityLedgerEvent",
+                "evidence_sha256": event.event_sha256,
+            },
+        )
+
+    def record_a5_confirmation(
+        self,
+        result: FieldNoteMaturityCommitResult,
+    ) -> FieldNoteWholeFlowTraceEvent:
+        readback = self._require_stage("A5_CONFIRMATION")
+        if not isinstance(result, FieldNoteMaturityCommitResult):
+            self._terminal_failure("A5_CONFIRMATION", "A5_EVIDENCE_INVALID")
+        if (
+            result.status not in {"RECORDED", "ALREADY_RECORDED"}
+            or not result.durable_commit_confirmed
+            or result.append_result is None
+            or result.durable_snapshot is None
+        ):
+            self._terminal_failure(
+                "A5_CONFIRMATION",
+                "A5_APPEND_NOT_CONFIRMED",
+            )
+        a2_identity = readback.events[1].evidence_sha256
+        a3_identity = readback.events[2].evidence_sha256
+        a4_identity = readback.events[3].evidence_sha256
+        if (
+            result.assessment.reuse_event_id != a3_identity
+            or result.delivery_context is None
+            or _a2_receipt_sha256(result.delivery_context) != a2_identity
+            or result.append_result.event.event_sha256 != a4_identity
+            or len(result.durable_snapshot.events) != 1
+            or result.durable_snapshot.events[0].event_sha256 != a4_identity
+        ):
+            self._terminal_failure(
+                "A5_CONFIRMATION",
+                "A5_READ_BACK_LINEAGE_MISMATCH",
+                repair_action="RECEIPT_REWRITE",
+            )
+        identity = _a5_confirmation_sha256(result)
+        return self._emit(
+            "A5_CONFIRMATION",
+            evidence_sha256=identity,
+            binding={
+                "evidence_type": "FieldNoteMaturityCommitResult",
+                "evidence_sha256": identity,
+            },
+        )
+
+    def record_a6_review(
+        self,
+        packet: FieldNoteMaturityReviewPacket,
+    ) -> FieldNoteWholeFlowTraceEvent:
+        readback = self._require_stage("A6_REVIEW")
+        if not isinstance(packet, FieldNoteMaturityReviewPacket):
+            self._terminal_failure("A6_REVIEW", "A6_EVIDENCE_INVALID")
+        a3_identity = readback.events[2].evidence_sha256
+        a4_identity = readback.events[3].evidence_sha256
+        if (
+            packet.note_identity != readback.captured_note
+            or len(packet.ordered_event_reviews) != 1
+            or packet.ordered_event_reviews[0].event_id != a3_identity
+            or packet.ordered_event_reviews[0].event_sha256 != a4_identity
+            or packet.ledger_identity.chain_head_sha256 != a4_identity
+            or packet.evidence_maturity.state != "REUSED"
+            or packet.current_serving_policy.derivation != "DELAY"
+            or packet.current_serving_policy.automatic_injection is not None
+        ):
+            self._terminal_failure(
+                "A6_REVIEW",
+                "A6_EXACT_PACKET_MISMATCH",
+                repair_action="RECEIPT_REWRITE",
+            )
+        identity = _a6_packet_sha256(packet)
+        return self._emit(
+            "A6_REVIEW",
+            evidence_sha256=identity,
+            binding={
+                "evidence_type": "FieldNoteMaturityReviewPacket",
+                "evidence_sha256": identity,
+            },
+        )
+
+    def record_stage_failure(
+        self,
+        boundary: WholeFlowBoundary,
+        reason: str,
+    ) -> None:
+        self._terminal_failure(boundary, reason)
+
+    def record_repair(
+        self,
+        boundary: WholeFlowBoundary,
+        reason: str,
+        *,
+        repair_action: RepairAction,
+    ) -> None:
+        if repair_action == "NONE":
+            raise FieldNoteCreatorLiveValidationError(
+                "Repair recording requires a prohibited repair action."
+            )
+        self._terminal_failure(
+            boundary,
+            reason,
+            repair_action=repair_action,
+        )
+
+    def record_retry_replacement(self, reason: str) -> None:
+        self._terminal_failure(
+            "RUNTIME_ENFORCEMENT",
+            reason,
+            repair_action="RETRY_REPLACEMENT",
+        )

--- a/decision_os/companion/field_notes_whole_flow.py
+++ b/decision_os/companion/field_notes_whole_flow.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import hashlib
 import re
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
 from decision_os.companion.field_notes_maturity_commit import (
@@ -37,6 +37,11 @@ from decision_os.companion.field_notes_reuse import (
     PromotionPolicyBoundary,
 )
 
+if TYPE_CHECKING:
+    from decision_os.companion.field_notes_creator_live import (
+        FieldNoteCreatorLiveTraceReadback,
+    )
+
 
 WHOLE_FLOW_SCHEMA = "decision-os.field-note-whole-flow-proof.v0.1"
 WHOLE_FLOW_TRACE_SCHEMA = "decision-os.field-note-whole-flow-trace-event.v0.1"
@@ -44,6 +49,9 @@ WAREHOUSE_MANIFEST_SCHEMA = (
     "decision-os.portable-candidate-warehouse-manifest.v0.1"
 )
 PORTABLE_ASSET_SCHEMA = "decision-os.portable-field-note-asset.v0.1"
+CREATOR_LIVE_PROVENANCE_SCHEMA = (
+    "decision-os.field-note-creator-live-runtime-provenance.v0.1"
+)
 TRACE_GENESIS_SHA256 = "0" * 64
 
 WholeFlowState = Literal["NOT_READY", "PASS", "FAIL"]
@@ -272,6 +280,95 @@ class FieldNoteWholeFlowRunIdentity:
         }
 
 
+_RUNTIME_PROVENANCE_AUTHORITY = object()
+
+
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveRuntimeProvenance:
+    """In-process runtime capability identity, not external attestation.
+
+    Normal construction is deliberately unavailable. The creator-live runtime
+    issues this value while opening its append-only journal. Its identity proves
+    only that this repository's runtime path produced the typed projection and
+    later verified the same durable bytes; it is neither a signature nor an
+    independent cryptographic attestation against a hostile local process.
+    """
+
+    schema: Literal[
+        "decision-os.field-note-creator-live-runtime-provenance.v0.1"
+    ]
+    proof_attempt_id: str
+    source_repository: FieldNoteSourceRepositoryIdentity
+    runtime: CodexRuntimeIdentity
+    issued_for_run_1_id: str
+    trust_boundary: Literal[
+        "IN_PROCESS_RUNTIME_CAPABILITY_WITH_DURABLE_READ_BACK"
+    ]
+    runtime_provenance_id: str
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise FieldNoteWholeFlowValidationError(
+            "Creator-live runtime provenance cannot be caller-constructed."
+        )
+
+    @classmethod
+    def _issue(
+        cls,
+        *,
+        authority: object,
+        proof_attempt_id: str,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        runtime: CodexRuntimeIdentity,
+        issued_for_run_1_id: str,
+    ) -> FieldNoteCreatorLiveRuntimeProvenance:
+        if authority is not _RUNTIME_PROVENANCE_AUTHORITY:
+            raise FieldNoteWholeFlowValidationError(
+                "Creator-live runtime provenance authority is invalid."
+            )
+        attempt_id = _bounded_text(proof_attempt_id, "Proof attempt ID")
+        run_id = _bounded_text(issued_for_run_1_id, "Run 1 ID")
+        if not isinstance(source_repository, FieldNoteSourceRepositoryIdentity):
+            raise FieldNoteWholeFlowValidationError(
+                "Runtime provenance repository identity is invalid."
+            )
+        _validate_runtime(runtime)
+        trust_boundary = (
+            "IN_PROCESS_RUNTIME_CAPABILITY_WITH_DURABLE_READ_BACK"
+        )
+        body = {
+            "schema": CREATOR_LIVE_PROVENANCE_SCHEMA,
+            "proof_attempt_id": attempt_id,
+            "source_repository": source_repository.as_dict(),
+            "runtime": _runtime_as_dict(runtime),
+            "issued_for_run_1_id": run_id,
+            "trust_boundary": trust_boundary,
+        }
+        value = object.__new__(cls)
+        object.__setattr__(value, "schema", CREATOR_LIVE_PROVENANCE_SCHEMA)
+        object.__setattr__(value, "proof_attempt_id", attempt_id)
+        object.__setattr__(value, "source_repository", source_repository)
+        object.__setattr__(value, "runtime", runtime)
+        object.__setattr__(value, "issued_for_run_1_id", run_id)
+        object.__setattr__(value, "trust_boundary", trust_boundary)
+        object.__setattr__(
+            value,
+            "runtime_provenance_id",
+            _canonical_sha256(body),
+        )
+        return value
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proof_attempt_id": self.proof_attempt_id,
+            "source_repository": self.source_repository.as_dict(),
+            "runtime": _runtime_as_dict(self.runtime),
+            "issued_for_run_1_id": self.issued_for_run_1_id,
+            "trust_boundary": self.trust_boundary,
+            "runtime_provenance_id": self.runtime_provenance_id,
+        }
+
+
 @dataclass(frozen=True)
 class FieldNoteWholeFlowTraceEvent:
     """One runtime checkpoint in the bounded, exact-evidence proof chain."""
@@ -284,6 +381,10 @@ class FieldNoteWholeFlowTraceEvent:
     previous_trace_sha256: str
     repair_action: RepairAction = "NONE"
     emitter: Literal["COMPANION_RUNTIME"] = "COMPANION_RUNTIME"
+    proof_attempt_id: str | None = None
+    runtime: CodexRuntimeIdentity | None = None
+    source_repository: FieldNoteSourceRepositoryIdentity | None = None
+    runtime_provenance: FieldNoteCreatorLiveRuntimeProvenance | None = None
 
     def __post_init__(self) -> None:
         if type(self.sequence) is not int or self.sequence < 0:
@@ -317,13 +418,55 @@ class FieldNoteWholeFlowTraceEvent:
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow trace emitter is invalid."
             )
+        live_values = (
+            self.proof_attempt_id,
+            self.runtime,
+            self.source_repository,
+            self.runtime_provenance,
+        )
+        if self.runtime_provenance is None:
+            if any(value is not None for value in live_values[:-1]):
+                raise FieldNoteWholeFlowValidationError(
+                    "Fixture trace contains incomplete runtime provenance."
+                )
+            return
+        if (
+            not isinstance(
+                self.runtime_provenance,
+                FieldNoteCreatorLiveRuntimeProvenance,
+            )
+            or self.proof_attempt_id is None
+            or self.runtime is None
+            or self.source_repository is None
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Creator-live trace lacks typed runtime provenance."
+            )
+        _bounded_text(self.proof_attempt_id, "Proof attempt ID")
+        _validate_runtime(self.runtime)
+        if not isinstance(
+            self.source_repository,
+            FieldNoteSourceRepositoryIdentity,
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Creator-live trace repository identity is invalid."
+            )
+        provenance = self.runtime_provenance
+        if (
+            provenance.proof_attempt_id != self.proof_attempt_id
+            or provenance.source_repository != self.source_repository
+            or provenance.runtime != self.runtime
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Creator-live trace provenance is cross-bound."
+            )
 
     @property
     def trace_sha256(self) -> str:
         return _canonical_sha256(self._body())
 
     def _body(self) -> dict[str, Any]:
-        return {
+        body = {
             "schema": WHOLE_FLOW_TRACE_SCHEMA,
             "sequence": self.sequence,
             "stage": self.stage,
@@ -334,6 +477,19 @@ class FieldNoteWholeFlowTraceEvent:
             "repair_action": self.repair_action,
             "emitter": self.emitter,
         }
+        if self.runtime_provenance is not None:
+            assert self.proof_attempt_id is not None
+            assert self.runtime is not None
+            assert self.source_repository is not None
+            body.update(
+                {
+                    "proof_attempt_id": self.proof_attempt_id,
+                    "runtime": _runtime_as_dict(self.runtime),
+                    "source_repository": self.source_repository.as_dict(),
+                    "runtime_provenance": self.runtime_provenance.as_dict(),
+                }
+            )
+        return body
 
     def as_dict(self) -> dict[str, Any]:
         return {**self._body(), "trace_sha256": self.trace_sha256}
@@ -356,6 +512,7 @@ class FieldNoteWholeFlowEvidenceBundle:
     a5_commit: FieldNoteMaturityCommitResult | None
     a6_review: FieldNoteMaturityReviewPacket | None
     proof_trace: tuple[FieldNoteWholeFlowTraceEvent, ...]
+    creator_live_readback: FieldNoteCreatorLiveTraceReadback | None = None
 
     def __post_init__(self) -> None:
         required = (
@@ -397,6 +554,25 @@ class FieldNoteWholeFlowEvidenceBundle:
         ):
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow proof trace is not typed."
+            )
+        if self.creator_live_readback is not None:
+            from decision_os.companion.field_notes_creator_live import (
+                FieldNoteCreatorLiveTraceReadback,
+            )
+
+            if not isinstance(
+                self.creator_live_readback,
+                FieldNoteCreatorLiveTraceReadback,
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "Creator-live durable read-back is not typed."
+                )
+        if (
+            self.attempt.proof_mode == "FIXTURE"
+            and self.creator_live_readback is not None
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "FIXTURE evidence cannot attach creator-live read-back."
             )
 
 
@@ -511,6 +687,7 @@ class FieldNoteWholeFlowProofReceipt:
     proof_trace_event_count: int
     proof_trace_chain_head_sha256: str | None
     proof_trace: tuple[FieldNoteWholeFlowTraceEvent, ...]
+    creator_live_readback: FieldNoteCreatorLiveTraceReadback | None
     human_repair_result: HumanRepairResult
     state: WholeFlowState
     failed_boundary: WholeFlowBoundary | None
@@ -621,6 +798,25 @@ class FieldNoteWholeFlowProofReceipt:
                 "Whole-Flow human-repair result is invalid."
             )
         self._validate_proof_trace_identity()
+        if self.creator_live_readback is not None:
+            from decision_os.companion.field_notes_creator_live import (
+                FieldNoteCreatorLiveTraceReadback,
+            )
+
+            if not isinstance(
+                self.creator_live_readback,
+                FieldNoteCreatorLiveTraceReadback,
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "Receipt creator-live durable read-back is not typed."
+                )
+        if (
+            self.proof_mode == "FIXTURE"
+            and self.creator_live_readback is not None
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "FIXTURE receipt cannot attach creator-live read-back."
+            )
         if self.state not in {"NOT_READY", "PASS", "FAIL"}:
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow proof state is invalid."
@@ -678,7 +874,6 @@ class FieldNoteWholeFlowProofReceipt:
             )
             if (
                 any(value is None for value in required)
-                or self.proof_mode != "FIXTURE"
                 or self.a4_event_count != 1
                 or self.a4_chain_head_sha256 != self.a4_event_sha256
                 or self.a5_status not in {"RECORDED", "ALREADY_RECORDED"}
@@ -690,6 +885,7 @@ class FieldNoteWholeFlowProofReceipt:
                     "PASS receipt lacks complete fixed-scope evidence."
                 )
             self._validate_complete_run_binding()
+            self._validate_creator_live_admission()
         if (
             self.human_repair_result == "TYPED_TRACE_VERIFIED"
             and self.state != "PASS"
@@ -725,6 +921,33 @@ class FieldNoteWholeFlowProofReceipt:
         ):
             raise FieldNoteWholeFlowValidationError(
                 "PASS receipt Run identities are not exactly cross-bound."
+            )
+
+    def _validate_creator_live_admission(self) -> None:
+        if self.proof_mode == "FIXTURE":
+            if any(
+                event.runtime_provenance is not None
+                for event in self.proof_trace
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "FIXTURE receipt contains creator-live provenance."
+                )
+            return
+        readback = self.creator_live_readback
+        if readback is None:
+            raise FieldNoteWholeFlowValidationError(
+                "CREATOR_LIVE PASS lacks durable runtime read-back."
+            )
+        if not readback.matches_admission(
+            proof_attempt_id=self.proof_attempt_id,
+            source_repository=self.source_repository,
+            runtime=self.source_runtime,
+            run_1=self.run_1,
+            run_2=self.run_2,
+            proof_trace=self.proof_trace,
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "CREATOR_LIVE PASS durable runtime identity is invalid."
             )
 
     def _validate_proof_trace_identity(self) -> None:
@@ -807,7 +1030,7 @@ class FieldNoteWholeFlowProofReceipt:
             previous_time = event_time
 
     def _body(self) -> dict[str, Any]:
-        return {
+        body = {
             "schema": self.schema,
             "proof_attempt_id": self.proof_attempt_id,
             "proof_mode": self.proof_mode,
@@ -864,6 +1087,13 @@ class FieldNoteWholeFlowProofReceipt:
             "failure_reason": self.failure_reason,
             "claim_boundary": self.claim_boundary.as_dict(),
         }
+        if self.proof_mode == "CREATOR_LIVE":
+            body["creator_live_readback"] = (
+                self.creator_live_readback.as_dict()
+                if self.creator_live_readback is not None
+                else None
+            )
+        return body
 
     @property
     def receipt_sha256(self) -> str:
@@ -973,10 +1203,9 @@ class PortableCandidateWarehouseManifest:
         if (
             not isinstance(self.proof_receipt, FieldNoteWholeFlowProofReceipt)
             or self.proof_receipt.state != "PASS"
-            or self.proof_receipt.proof_mode != "FIXTURE"
         ):
             raise FieldNoteWholeFlowValidationError(
-                "Warehouse manifest requires one verified FIXTURE PASS receipt."
+                "Warehouse manifest requires one verified PASS receipt."
             )
         if not isinstance(self.claim_boundary, PortableCandidateClaimBoundary):
             raise FieldNoteWholeFlowValidationError(
@@ -1025,8 +1254,10 @@ class PortableCandidateWarehouseManifest:
             },
             "a4_evidence_snapshot_sha256": receipt.a4_snapshot_sha256,
             "a6_review_packet_sha256": receipt.a6_packet_sha256,
-            "coverage_evidence_mode": "FIXTURE",
-            "creator_live_coverage_verified": False,
+            "coverage_evidence_mode": receipt.proof_mode,
+            "creator_live_coverage_verified": (
+                receipt.proof_mode == "CREATOR_LIVE"
+            ),
             "verified_coverage": {
                 "repositories": 1,
                 "model_identities": 1,
@@ -1061,17 +1292,24 @@ class PortableCandidateWarehouseManifest:
         return canonical_json(self.as_dict())
 
     def render_text(self) -> str:
+        mode = self.proof_receipt.proof_mode
+        coverage_label = (
+            "Fixture-covered" if mode == "FIXTURE" else "Creator-live-covered"
+        )
         return "\n".join(
             (
                 "Portable Candidate Warehouse Manifest v0.1",
                 "State: PORTABLE_CANDIDATE",
                 f"Asset: {self.portable_asset_id}",
                 f"Field Note: {self.proof_receipt.note.note_path}",
-                "Coverage evidence mode: FIXTURE",
-                "Creator-live coverage verified: false",
-                "Fixture-covered repositories: 1",
-                "Fixture-covered model identities: 1",
-                "Fixture-covered later reuse Runs: 1",
+                f"Coverage evidence mode: {mode}",
+                (
+                    "Creator-live coverage verified: "
+                    f"{'true' if mode == 'CREATOR_LIVE' else 'false'}"
+                ),
+                f"{coverage_label} repositories: 1",
+                f"{coverage_label} model identities: 1",
+                f"{coverage_label} later reuse Runs: 1",
                 (
                     "Proof trace head: "
                     f"{self.proof_receipt.proof_trace_chain_head_sha256}"
@@ -1226,6 +1464,7 @@ def _receipt(
             else None
         ),
         proof_trace=bundle.proof_trace,
+        creator_live_readback=bundle.creator_live_readback,
         human_repair_result=human_repair_result,
         state=state,
         failed_boundary=failed_boundary,
@@ -1276,11 +1515,43 @@ def verify_field_note_whole_flow(
             "Whole-Flow verifier requires a typed evidence bundle."
         )
     if bundle.attempt.proof_mode == "CREATOR_LIVE":
-        return _not_ready(
-            bundle,
-            "RUNTIME_ENFORCEMENT",
-            "CREATOR_LIVE_RUNTIME_ENFORCEMENT_NOT_IMPLEMENTED",
-        )
+        readback = bundle.creator_live_readback
+        if readback is None:
+            return _not_ready(
+                bundle,
+                "RUNTIME_ENFORCEMENT",
+                "CREATOR_LIVE_RUNTIME_EVIDENCE_MISSING",
+            )
+        if readback.state == "FAILED" or not readback.durable_readback_verified:
+            return _fail(
+                bundle,
+                readback.failure_boundary or "RUNTIME_ENFORCEMENT",
+                readback.failure_reason or "CREATOR_LIVE_DURABLE_READ_BACK_FAILED",
+                human_repair_result=(
+                    "REPAIR_DETECTED"
+                    if readback.repair_action != "NONE"
+                    else "NOT_EVALUATED"
+                ),
+            )
+        if readback.state != "TRACE_COMPLETE":
+            return _not_ready(
+                bundle,
+                "RUNTIME_ENFORCEMENT",
+                "CREATOR_LIVE_TRACE_INCOMPLETE",
+            )
+        if not readback.matches_admission(
+            proof_attempt_id=bundle.attempt.proof_attempt_id,
+            source_repository=bundle.source_repository,
+            runtime=bundle.run_1.runtime,
+            run_1=bundle.run_1,
+            run_2=bundle.run_2,
+            proof_trace=bundle.proof_trace,
+        ):
+            return _fail(
+                bundle,
+                "RUNTIME_ENFORCEMENT",
+                "CREATOR_LIVE_RUNTIME_IDENTITY_MISMATCH",
+            )
     for value, boundary, reason in (
         (bundle.a1_capture, "A1_CAPTURE", "A1_EVIDENCE_MISSING"),
         (bundle.a2_reconnect, "A2_RECONNECT", "A2_EVIDENCE_MISSING"),
@@ -1569,7 +1840,7 @@ def verify_field_note_whole_flow(
 def build_portable_candidate_warehouse_manifest(
     bundle: FieldNoteWholeFlowEvidenceBundle,
 ) -> PortableCandidateWarehouseManifest:
-    """Reverify one bundle before creating its fixture-labelled candidate."""
+    """Reverify one bundle before creating its evidence-labelled candidate."""
 
     receipt = verify_field_note_whole_flow(bundle)
     if receipt.state != "PASS":

--- a/decision_os/companion/field_notes_whole_flow.py
+++ b/decision_os/companion/field_notes_whole_flow.py
@@ -666,6 +666,7 @@ class FieldNoteWholeFlowProofReceipt:
     a1_evidence_sha256: str | None
     a2_receipt_sha256: str | None
     a3_reuse_event_id: str | None
+    a3_receipt_sha256: str | None
     a4_partition_sha256: str | None
     a4_event_sha256: str | None
     a4_event_count: int | None
@@ -738,6 +739,7 @@ class FieldNoteWholeFlowProofReceipt:
             (self.a1_evidence_sha256, "A1 evidence identity"),
             (self.a2_receipt_sha256, "A2 receipt identity"),
             (self.a3_reuse_event_id, "A3 reuse event identity"),
+            (self.a3_receipt_sha256, "A3 complete receipt identity"),
             (self.a4_partition_sha256, "A4 partition identity"),
             (self.a4_event_sha256, "A4 event identity"),
             (self.a4_chain_head_sha256, "A4 chain-head identity"),
@@ -874,6 +876,10 @@ class FieldNoteWholeFlowProofReceipt:
             )
             if (
                 any(value is None for value in required)
+                or (
+                    self.proof_mode == "CREATOR_LIVE"
+                    and self.a3_receipt_sha256 is None
+                )
                 or self.a4_event_count != 1
                 or self.a4_chain_head_sha256 != self.a4_event_sha256
                 or self.a5_status not in {"RECORDED", "ALREADY_RECORDED"}
@@ -939,7 +945,7 @@ class FieldNoteWholeFlowProofReceipt:
                 "CREATOR_LIVE PASS lacks durable runtime read-back."
             )
         if not readback.matches_admission(
-            proof_attempt_id=self.proof_attempt_id,
+            attempt=self.attempt,
             source_repository=self.source_repository,
             runtime=self.source_runtime,
             run_1=self.run_1,
@@ -979,7 +985,11 @@ class FieldNoteWholeFlowProofReceipt:
         expected_evidence = (
             self.a1_evidence_sha256,
             self.a2_receipt_sha256,
-            self.a3_reuse_event_id,
+            (
+                self.a3_receipt_sha256
+                if self.proof_mode == "CREATOR_LIVE"
+                else self.a3_reuse_event_id
+            ),
             self.a4_event_sha256,
             self.a5_confirmation_sha256,
             self.a6_packet_sha256,
@@ -1028,6 +1038,17 @@ class FieldNoteWholeFlowProofReceipt:
                 )
             previous = event.trace_sha256
             previous_time = event_time
+
+    @property
+    def attempt(self) -> FieldNoteWholeFlowAttempt:
+        """Return the exact typed attempt identity preserved by this receipt."""
+
+        return FieldNoteWholeFlowAttempt(
+            proof_attempt_id=self.proof_attempt_id,
+            proof_mode=self.proof_mode,
+            creator_id=self.creator_id,
+            proof_as_of=self.proof_as_of,
+        )
 
     def _body(self) -> dict[str, Any]:
         body = {
@@ -1088,6 +1109,7 @@ class FieldNoteWholeFlowProofReceipt:
             "claim_boundary": self.claim_boundary.as_dict(),
         }
         if self.proof_mode == "CREATOR_LIVE":
+            body["a3_receipt_sha256"] = self.a3_receipt_sha256
             body["creator_live_readback"] = (
                 self.creator_live_readback.as_dict()
                 if self.creator_live_readback is not None
@@ -1346,6 +1368,10 @@ def _a2_receipt_sha256(receipt: FieldNoteReconnectReceipt) -> str:
     return _canonical_sha256(receipt.as_dict())
 
 
+def _a3_receipt_sha256(receipt: FieldNoteReuseReceipt) -> str:
+    return _canonical_sha256(receipt.as_dict())
+
+
 def _a5_confirmation_sha256(result: FieldNoteMaturityCommitResult) -> str:
     return _canonical_sha256(result.as_dict())
 
@@ -1433,6 +1459,11 @@ def _receipt(
         a1_evidence_sha256=_a1_evidence_sha256(a1) if a1 else None,
         a2_receipt_sha256=_a2_receipt_sha256(a2) if a2 else None,
         a3_reuse_event_id=a3.reuse_event_id if a3 else None,
+        a3_receipt_sha256=(
+            _a3_receipt_sha256(a3)
+            if a3 is not None and bundle.attempt.proof_mode == "CREATOR_LIVE"
+            else None
+        ),
         a4_partition_sha256=(
             first_event.note_partition_sha256 if first_event else None
         ),
@@ -1540,7 +1571,7 @@ def verify_field_note_whole_flow(
                 "CREATOR_LIVE_TRACE_INCOMPLETE",
             )
         if not readback.matches_admission(
-            proof_attempt_id=bundle.attempt.proof_attempt_id,
+            attempt=bundle.attempt,
             source_repository=bundle.source_repository,
             runtime=bundle.run_1.runtime,
             run_1=bundle.run_1,
@@ -1776,7 +1807,11 @@ def verify_field_note_whole_flow(
     expected_evidence = (
         _a1_evidence_sha256(a1),
         _a2_receipt_sha256(a2),
-        a3.reuse_event_id,
+        (
+            _a3_receipt_sha256(a3)
+            if bundle.attempt.proof_mode == "CREATOR_LIVE"
+            else a3.reuse_event_id
+        ),
         event.event_sha256,
         _a5_confirmation_sha256(a5),
         _a6_packet_sha256(a6),

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import hashlib
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -10,6 +11,7 @@ from decision_os.companion import field_notes_creator_live as creator_live
 from decision_os.companion import field_notes_whole_flow as whole_flow
 from decision_os.companion.field_notes_creator_live import (
     FieldNoteCreatorLiveAttemptExistsError,
+    FieldNoteCreatorLiveDurabilityError,
     FieldNoteCreatorLiveProofRuntime,
     FieldNoteCreatorLiveStageError,
     FieldNoteCreatorLiveTraceReadback,
@@ -356,7 +358,7 @@ class CreatorLiveStageAcquisitionTests(CreatorLiveTestCase):
             (
                 whole_flow._a1_evidence_sha256(evidence.a1_capture),
                 whole_flow._a2_receipt_sha256(evidence.a2_reconnect),
-                evidence.a3_assessment.reuse_event_id,
+                whole_flow._a3_receipt_sha256(evidence.a3_assessment),
                 evidence.a4_snapshot.events[0].event_sha256,
                 whole_flow._a5_confirmation_sha256(evidence.a5_commit),
                 whole_flow._a6_packet_sha256(evidence.a6_review),
@@ -435,26 +437,125 @@ class CreatorLiveStageAcquisitionTests(CreatorLiveTestCase):
             runtime_path.read_back().failure_reason,
         )
 
-    def runtime_through_a3(self, label: str):
-        runtime_path = self.ready_for_a2(label)
-        assert self.bundle.a2_reconnect is not None
-        assert self.bundle.a3_assessment is not None
+    def runtime_through_a3(self, label: str, *, bundle=None):
+        evidence = bundle or self.bundle
+        runtime_path = self.ready_for_a2(label, bundle=evidence)
+        assert evidence.a2_reconnect is not None
+        assert evidence.a3_assessment is not None
         with patch.object(
             creator_live,
             "_utc_now_rfc3339",
             side_effect=OBSERVED_AT[1:3],
         ):
             runtime_path.record_a2_reconnect(
-                self.bundle.a2_reconnect,
-                note=self.bundle.note,
-                note_bytes=self.bundle.note_bytes,
+                evidence.a2_reconnect,
+                note=evidence.note,
+                note_bytes=evidence.note_bytes,
             )
             runtime_path.record_a3_reuse(
-                self.bundle.a3_assessment,
-                note=self.bundle.note,
-                note_bytes=self.bundle.note_bytes,
+                evidence.a3_assessment,
+                note=evidence.note,
+                note_bytes=evidence.note_bytes,
             )
         return runtime_path
+
+    def mutated_a4_snapshot(self, bundle, **changes):
+        assert bundle.a3_assessment is not None
+        assert bundle.a4_snapshot is not None
+        receipt = replace(bundle.a3_assessment)
+        for field, value in changes.items():
+            object.__setattr__(receipt, field, value)
+        event = replace(bundle.a4_snapshot.events[0])
+        object.__setattr__(event, "receipt", receipt)
+        object.__setattr__(
+            event,
+            "receipt_sha256",
+            whole_flow._event_receipt_sha256(event),
+        )
+        object.__setattr__(event, "event_sha256", whole_flow._event_sha256(event))
+        snapshot = replace(bundle.a4_snapshot)
+        object.__setattr__(snapshot, "events", (event,))
+        object.__setattr__(snapshot, "chain_head_sha256", event.event_sha256)
+        return snapshot
+
+    def assert_a3_mutation_stops_at_a4(
+        self,
+        label: str,
+        bundle,
+        **changes,
+    ) -> None:
+        runtime_path = self.runtime_through_a3(label, bundle=bundle)
+        changed = self.mutated_a4_snapshot(bundle, **changes)
+        assert bundle.a3_assessment is not None
+        self.assertEqual(
+            bundle.a3_assessment.reuse_event_id,
+            changed.events[0].receipt.reuse_event_id,
+        )
+        self.assertNotEqual(
+            whole_flow._a3_receipt_sha256(bundle.a3_assessment),
+            changed.events[0].receipt_sha256,
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a4_durability(changed)
+        self.assertEqual("FAILED", runtime_path.read_back().state)
+        assert bundle.a5_commit is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a5_confirmation(bundle.a5_commit)
+        assert bundle.a6_review is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a6_review(bundle.a6_review)
+
+    def test_complete_a3_receipt_axes_cannot_be_substituted(self) -> None:
+        mutations = {
+            "claimed-outcome": {"claimed_outcome": "HARMFUL"},
+            "effective-outcome": {"outcome": "HARMFUL"},
+            "outcome-scope": {"outcome_scope": "A changed bounded scope."},
+            "causal-evidence": {"causal_evidence_sha256": "f" * 64},
+            "outcome-observer": {"outcome_observer_id": "other_observer"},
+            "outcome-confirmation": {
+                "outcome_confirmation": "SAME_RUN_CLAIM"
+            },
+            "contribution": {"contribution_separated": False},
+            "intervention": {"human_intervention": "MATERIAL"},
+            "disposition": {"next_action": "STOP"},
+        }
+        for label, changes in mutations.items():
+            with self.subTest(axis=label):
+                self.assert_a3_mutation_stops_at_a4(
+                    f"a3-mutation-{label}",
+                    self.bundle,
+                    **changes,
+                )
+
+    def test_stop_scope_substitution_cannot_continue(self) -> None:
+        bundle, _ = build_bundle(self.root / "stop-source", outcome="HARMFUL")
+        self.assert_a3_mutation_stops_at_a4(
+            "stop-scope-mutation",
+            bundle,
+            stop_scope="A substituted STOP scope.",
+        )
+
+    def test_revise_lineage_substitution_cannot_continue(self) -> None:
+        bundle, _ = build_bundle(
+            self.root / "revise-source",
+            outcome="NOT_HELPFUL",
+            action="REVISE",
+        )
+        assert bundle.a3_assessment is not None
+        assert bundle.a3_assessment.revision is not None
+        successor = replace(
+            bundle.a3_assessment.revision.successor,
+            field_note_id="fn_a7_substituted_successor",
+        )
+        revision = replace(
+            bundle.a3_assessment.revision,
+            successor=successor,
+        )
+        self.assert_a3_mutation_stops_at_a4(
+            "revision-lineage-mutation",
+            bundle,
+            revision=revision,
+        )
 
     def test_a4_tampered_durability_is_rejected(self) -> None:
         runtime_path = self.runtime_through_a3("a4")
@@ -529,15 +630,157 @@ class CreatorLiveStageAcquisitionTests(CreatorLiveTestCase):
 
 
 class CreatorLiveDurabilityTests(CreatorLiveTestCase):
+    def runtime_through_a2(
+        self,
+        label: str,
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        runtime_path = self.ready_for_a2(label)
+        assert self.bundle.a2_reconnect is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value=OBSERVED_AT[1],
+        ):
+            runtime_path.record_a2_reconnect(
+                self.bundle.a2_reconnect,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        return runtime_path
+
+    def remove_journal_tail(
+        self,
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        count: int = 1,
+    ) -> None:
+        lines = runtime_path.journal_path.read_bytes().splitlines(keepends=True)
+        runtime_path.journal_path.write_bytes(b"".join(lines[:-count]))
+
+    def remove_anchor_tail(
+        self,
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        count: int = 1,
+    ) -> None:
+        lines = runtime_path.anchor_path.read_bytes().splitlines(keepends=True)
+        runtime_path.anchor_path.write_bytes(b"".join(lines[:-count]))
+
     def test_trace_persistence_is_append_only(self) -> None:
         runtime_path = self.open_runtime()
         initial = runtime_path.journal_path.read_bytes()
+        initial_anchor = runtime_path.anchor_path.read_bytes()
         self.record_a1(runtime_path)
         after_a1 = runtime_path.journal_path.read_bytes()
+        after_a1_anchor = runtime_path.anchor_path.read_bytes()
         self.open_run_2(runtime_path)
         after_run_2 = runtime_path.journal_path.read_bytes()
+        after_run_2_anchor = runtime_path.anchor_path.read_bytes()
         self.assertTrue(after_a1.startswith(initial))
         self.assertTrue(after_run_2.startswith(after_a1))
+        self.assertTrue(after_a1_anchor.startswith(initial_anchor))
+        self.assertTrue(after_run_2_anchor.startswith(after_a1_anchor))
+
+    def test_deleting_last_complete_checkpoint_fails_closed(self) -> None:
+        runtime_path = self.runtime_through_a2("drop-checkpoint")
+        self.remove_journal_tail(runtime_path)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual(
+            "CREATOR_LIVE_DURABLE_JOURNAL_ANCHOR_MISMATCH",
+            readback.failure_reason,
+        )
+
+    def test_deleting_complete_failure_record_fails_closed(self) -> None:
+        runtime_path = self.open_runtime("drop-failure")
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        self.remove_journal_tail(runtime_path)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+
+    def test_deleting_complete_trace_completion_fails_closed(self) -> None:
+        runtime_path, _ = self.complete_runtime("drop-completion")
+        self.remove_journal_tail(runtime_path)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("EVIDENCE_DELETION", readback.repair_action)
+
+    def test_deleting_multiple_complete_tail_records_fails_closed(self) -> None:
+        runtime_path, _ = self.complete_runtime("drop-multiple")
+        self.remove_journal_tail(runtime_path, 3)
+        self.assertEqual("FAILED", runtime_path.read_back().state)
+
+    def test_journal_ahead_of_anchor_fails_closed(self) -> None:
+        runtime_path = self.runtime_through_a2("journal-ahead")
+        self.remove_anchor_tail(runtime_path)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual(
+            "CREATOR_LIVE_DURABLE_JOURNAL_ANCHOR_MISMATCH",
+            readback.failure_reason,
+        )
+
+    def test_anchor_ahead_of_journal_fails_closed(self) -> None:
+        runtime_path = self.runtime_through_a2("anchor-ahead")
+        self.remove_journal_tail(runtime_path)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+
+    def test_anchor_tampering_fails_closed(self) -> None:
+        runtime_path = self.runtime_through_a2("anchor-tamper")
+        raw = runtime_path.anchor_path.read_bytes()
+        marker = b'"journal_sha256":"'
+        start = raw.rindex(marker) + len(marker)
+        replacement = b"f" if raw[start : start + 1] != b"f" else b"e"
+        runtime_path.anchor_path.write_bytes(
+            raw[:start] + replacement + raw[start + 1 :]
+        )
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("EVENT_ID_CHANGE", readback.repair_action)
+
+    def test_anchor_truncation_fails_closed(self) -> None:
+        runtime_path = self.runtime_through_a2("anchor-truncate")
+        raw = runtime_path.anchor_path.read_bytes()
+        runtime_path.anchor_path.write_bytes(raw[:-1])
+        readback = runtime_path.read_back()
+        self.assertEqual(
+            "CREATOR_LIVE_DURABLE_ANCHOR_TRUNCATED",
+            readback.failure_reason,
+        )
+
+    def test_truncated_prefix_cannot_be_appended_to(self) -> None:
+        runtime_path = self.runtime_through_a2("blocked-prefix")
+        self.remove_journal_tail(runtime_path)
+        journal_before = runtime_path.journal_path.read_bytes()
+        anchor_before = runtime_path.anchor_path.read_bytes()
+        assert self.bundle.a2_reconnect is not None
+        with self.assertRaises(FieldNoteCreatorLiveDurabilityError):
+            runtime_path.record_a2_reconnect(
+                self.bundle.a2_reconnect,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual(journal_before, runtime_path.journal_path.read_bytes())
+        self.assertEqual(anchor_before, runtime_path.anchor_path.read_bytes())
+
+    def test_removed_failure_cannot_reopen_attempt(self) -> None:
+        runtime_path = self.open_runtime("failure-reopen")
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        self.remove_journal_tail(runtime_path)
+        with self.assertRaises(FieldNoteCreatorLiveDurabilityError):
+            self.record_a1(runtime_path)
+        self.assertEqual("FAILED", runtime_path.read_back().state)
+
+    def test_removed_completion_cannot_resume_attempt(self) -> None:
+        runtime_path, _ = self.complete_runtime("completion-resume")
+        self.remove_journal_tail(runtime_path)
+        assert self.bundle.a6_review is not None
+        with self.assertRaises(FieldNoteCreatorLiveDurabilityError):
+            runtime_path.record_a6_review(self.bundle.a6_review)
+        self.assertEqual("FAILED", runtime_path.read_back().state)
 
     def test_durable_exact_readback_reaches_trace_complete(self) -> None:
         runtime_path, _ = self.complete_runtime()
@@ -545,6 +788,19 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
         self.assertEqual("TRACE_COMPLETE", readback.state)
         self.assertTrue(readback.durable_readback_verified)
         self.assertEqual(6, readback.trace_event_count)
+        self.assertEqual(readback.journal_record_count, readback.anchor_record_count)
+        self.assertEqual(
+            len(runtime_path.journal_path.read_bytes()),
+            readback.journal_byte_length,
+        )
+        self.assertEqual(
+            hashlib.sha256(runtime_path.journal_path.read_bytes()).hexdigest(),
+            readback.journal_sha256,
+        )
+        self.assertEqual(
+            hashlib.sha256(runtime_path.anchor_path.read_bytes()).hexdigest(),
+            readback.anchor_sha256,
+        )
         self.assertEqual(
             readback.events[-1].trace_sha256,
             readback.trace_chain_head_sha256,
@@ -637,8 +893,12 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
         second, _ = self.complete_runtime("second")
         first_bytes = first.journal_path.read_bytes()
         second_bytes = second.journal_path.read_bytes()
+        first_anchor_bytes = first.anchor_path.read_bytes()
+        second_anchor_bytes = second.anchor_path.read_bytes()
         self.assertEqual(first_bytes, second_bytes)
+        self.assertEqual(first_anchor_bytes, second_anchor_bytes)
         self.assertLess(len(first_bytes), 100_000)
+        self.assertLess(len(first_anchor_bytes), 100_000)
         self.assertEqual(first.read_back(), second.read_back())
 
     def test_trace_storage_excludes_full_note_contents(self) -> None:
@@ -680,8 +940,44 @@ class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):
         receipt = verify_field_note_whole_flow(live)
         self.assertEqual("PASS", receipt.state)
         self.assertEqual("CREATOR_LIVE", receipt.proof_mode)
+        self.assertEqual(live.attempt, runtime_path.read_back().attempt)
+        self.assertEqual(live.attempt, receipt.attempt)
         self.assertEqual("TYPED_TRACE_VERIFIED", receipt.human_repair_result)
         self.assertIsNotNone(receipt.creator_live_readback)
+
+    def assert_attempt_substitution_fails(self, **changes) -> None:
+        runtime_path, _ = self.complete_runtime(
+            "attempt-" + "-".join(sorted(changes))
+        )
+        readback = runtime_path.read_back()
+        live = self.live_bundle(readback)
+        changed = replace(live, attempt=replace(live.attempt, **changes))
+        receipt = verify_field_note_whole_flow(changed)
+        self.assertEqual("FAIL", receipt.state)
+        self.assertEqual(
+            "CREATOR_LIVE_RUNTIME_IDENTITY_MISMATCH",
+            receipt.failure_reason,
+        )
+
+    def test_changed_creator_identity_cannot_enter_a7(self) -> None:
+        self.assert_attempt_substitution_fails(creator_id="Other Creator")
+
+    def test_changed_proof_as_of_cannot_enter_a7(self) -> None:
+        self.assert_attempt_substitution_fails(
+            proof_as_of="2026-08-05T12:01:00Z"
+        )
+
+    def test_changed_attempt_id_cannot_enter_a7(self) -> None:
+        self.assert_attempt_substitution_fails(proof_attempt_id="other_attempt")
+
+    def test_changed_proof_mode_cannot_attach_live_readback(self) -> None:
+        runtime_path, _ = self.complete_runtime("attempt-mode")
+        live = self.live_bundle(runtime_path.read_back())
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            replace(
+                live,
+                attempt=replace(live.attempt, proof_mode="FIXTURE"),
+            )
 
     def test_creator_live_manifest_is_readback_and_trace_bound(self) -> None:
         runtime_path, _ = self.complete_runtime()

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -1,0 +1,764 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from decision_os.companion import field_notes_creator_live as creator_live
+from decision_os.companion import field_notes_whole_flow as whole_flow
+from decision_os.companion.field_notes_creator_live import (
+    FieldNoteCreatorLiveAttemptExistsError,
+    FieldNoteCreatorLiveProofRuntime,
+    FieldNoteCreatorLiveStageError,
+    FieldNoteCreatorLiveTraceReadback,
+    FieldNoteCreatorLiveValidationError,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    assess_field_note_reuse,
+)
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteCreatorLiveRuntimeProvenance,
+    FieldNoteWholeFlowTraceEvent,
+    FieldNoteWholeFlowValidationError,
+    build_portable_candidate_warehouse_manifest,
+    verify_field_note_whole_flow,
+)
+from tests.test_field_notes_whole_flow import (
+    ARTIFACT_SECRET,
+    PRIVATE_NOTE_TEXT,
+    build_bundle,
+    runtime,
+    source_repository,
+)
+
+
+OBSERVED_AT = (
+    "2026-08-05T10:02:00Z",
+    "2026-08-05T11:05:00Z",
+    "2026-08-05T11:21:00Z",
+    "2026-08-05T11:31:00Z",
+    "2026-08-05T11:32:00Z",
+    "2026-08-05T11:41:00Z",
+)
+
+
+class CreatorLiveTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.bundle, self.ledger = build_bundle(self.root / "evidence")
+        self.live_attempt = replace(
+            self.bundle.attempt,
+            proof_mode="CREATOR_LIVE",
+        )
+
+    def open_runtime(
+        self,
+        label: str = "attempt",
+        *,
+        bundle=None,
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        evidence = bundle or self.bundle
+        attempt = replace(evidence.attempt, proof_mode="CREATOR_LIVE")
+        return FieldNoteCreatorLiveProofRuntime.open_attempt(
+            self.root / label,
+            attempt=attempt,
+            source_repository=evidence.source_repository,
+            run_1=evidence.run_1,
+        )
+
+    def record_a1(
+        self,
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        *,
+        observed_at: str = OBSERVED_AT[0],
+        bundle=None,
+    ) -> None:
+        evidence = bundle or self.bundle
+        assert evidence.a1_capture is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value=observed_at,
+        ):
+            runtime_path.record_a1_capture(evidence.a1_capture)
+
+    def open_run_2(
+        self,
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        *,
+        bundle=None,
+    ) -> None:
+        runtime_path.open_run_2((bundle or self.bundle).run_2)
+
+    def ready_for_a2(
+        self,
+        label: str = "attempt",
+        *,
+        bundle=None,
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        runtime_path = self.open_runtime(label, bundle=bundle)
+        self.record_a1(runtime_path, bundle=bundle)
+        self.open_run_2(runtime_path, bundle=bundle)
+        return runtime_path
+
+    def complete_runtime(
+        self,
+        label: str = "complete",
+        *,
+        bundle=None,
+    ) -> tuple[FieldNoteCreatorLiveProofRuntime, object]:
+        evidence = bundle or self.bundle
+        runtime_path = self.open_runtime(label, bundle=evidence)
+        assert evidence.a1_capture is not None
+        assert evidence.a2_reconnect is not None
+        assert evidence.a3_assessment is not None
+        assert evidence.a4_snapshot is not None
+        assert evidence.a5_commit is not None
+        assert evidence.a6_review is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=OBSERVED_AT,
+        ):
+            runtime_path.record_a1_capture(evidence.a1_capture)
+            runtime_path.open_run_2(evidence.run_2)
+            runtime_path.record_a2_reconnect(
+                evidence.a2_reconnect,
+                note=evidence.note,
+                note_bytes=evidence.note_bytes,
+            )
+            runtime_path.record_a3_reuse(
+                evidence.a3_assessment,
+                note=evidence.note,
+                note_bytes=evidence.note_bytes,
+            )
+            runtime_path.record_a4_durability(evidence.a4_snapshot)
+            runtime_path.record_a5_confirmation(evidence.a5_commit)
+            runtime_path.record_a6_review(evidence.a6_review)
+        return runtime_path, evidence
+
+    def live_bundle(self, readback, *, bundle=None):
+        evidence = bundle or self.bundle
+        return replace(
+            evidence,
+            attempt=replace(evidence.attempt, proof_mode="CREATOR_LIVE"),
+            proof_trace=readback.events,
+            creator_live_readback=readback,
+        )
+
+
+class CreatorLiveProvenanceTests(CreatorLiveTestCase):
+    def test_fixture_pass_remains_unchanged(self) -> None:
+        receipt = verify_field_note_whole_flow(self.bundle)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("FIXTURE", receipt.proof_mode)
+        self.assertIsNone(receipt.creator_live_readback)
+
+    def test_hand_built_trace_cannot_satisfy_creator_live(self) -> None:
+        live = replace(self.bundle, attempt=self.live_attempt)
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual(
+            "CREATOR_LIVE_RUNTIME_EVIDENCE_MISSING",
+            receipt.failure_reason,
+        )
+
+    def test_runtime_provenance_cannot_be_directly_constructed(self) -> None:
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            FieldNoteCreatorLiveRuntimeProvenance()
+
+    def test_string_cannot_mint_runtime_provenance(self) -> None:
+        fixture = self.bundle.proof_trace[0]
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            replace(
+                fixture,
+                proof_attempt_id=self.live_attempt.proof_attempt_id,
+                runtime=self.bundle.run_1.runtime,
+                source_repository=self.bundle.source_repository,
+                runtime_provenance="COMPANION_RUNTIME",  # type: ignore[arg-type]
+            )
+
+    def test_readback_cannot_be_directly_constructed(self) -> None:
+        with self.assertRaises(FieldNoteCreatorLiveValidationError):
+            FieldNoteCreatorLiveTraceReadback()
+
+    def test_runtime_provenance_states_exact_trust_boundary(self) -> None:
+        runtime_path = self.open_runtime()
+        provenance = runtime_path.read_back().runtime_provenance
+        self.assertEqual(
+            "IN_PROCESS_RUNTIME_CAPABILITY_WITH_DURABLE_READ_BACK",
+            provenance.trust_boundary,
+        )
+        self.assertNotIn("signature", provenance.runtime_provenance_id)
+
+
+class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
+    def test_attempt_opens_with_exact_repository_and_runtime(self) -> None:
+        readback = self.open_runtime().read_back()
+        self.assertEqual("OPEN", readback.state)
+        self.assertEqual(self.live_attempt.proof_attempt_id, readback.proof_attempt_id)
+        self.assertEqual(self.bundle.source_repository, readback.source_repository)
+        self.assertEqual(self.bundle.run_1.runtime, readback.runtime)
+        self.assertEqual(self.bundle.run_1, readback.run_1)
+        self.assertIsNone(readback.run_2)
+        self.assertEqual("A1_CAPTURE", readback.current_stage)
+        self.assertTrue(readback.one_attempt_no_retry)
+
+    def test_run_1_and_run_2_must_be_distinct(self) -> None:
+        runtime_path = self.open_runtime()
+        self.record_a1(runtime_path)
+        same_run = replace(
+            self.bundle.run_2,
+            run_id=self.bundle.run_1.run_id,
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.open_run_2(same_run)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("RETRY_REPLACEMENT", readback.repair_action)
+
+    def test_run_2_cannot_open_before_a1_closure(self) -> None:
+        runtime_path = self.open_runtime()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.open_run_2(self.bundle.run_2)
+        self.assertEqual("FAILED", runtime_path.read_back().state)
+
+    def test_runtime_identity_cannot_change_between_runs(self) -> None:
+        runtime_path = self.open_runtime()
+        self.record_a1(runtime_path)
+        changed = replace(
+            self.bundle.run_2,
+            runtime=runtime(model="other-model"),
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.open_run_2(changed)
+        self.assertEqual(
+            "MODEL_RUNTIME_MISMATCH",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_repository_identity_cannot_change_between_runs(self) -> None:
+        runtime_path = self.open_runtime()
+        self.record_a1(runtime_path)
+        changed = replace(
+            self.bundle.run_2,
+            repository=source_repository(suffix="c"),
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.open_run_2(changed)
+        self.assertEqual(
+            "SOURCE_REPOSITORY_MISMATCH",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_cross_attempt_run_2_is_rejected(self) -> None:
+        runtime_path = self.open_runtime()
+        self.record_a1(runtime_path)
+        changed = replace(
+            self.bundle.run_2,
+            proof_attempt_id="other_attempt",
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.open_run_2(changed)
+        self.assertEqual(
+            "RUN_ATTEMPT_MISMATCH",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_stage_cannot_be_skipped(self) -> None:
+        runtime_path = self.open_runtime()
+        assert self.bundle.a3_assessment is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a3_reuse(
+                self.bundle.a3_assessment,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual("FAILED", runtime_path.read_back().state)
+
+    def test_stage_cannot_be_reordered(self) -> None:
+        runtime_path = self.ready_for_a2()
+        assert self.bundle.a3_assessment is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a3_reuse(
+                self.bundle.a3_assessment,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual(
+            "CREATOR_LIVE_STAGE_ORDER_INVALID",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_stage_cannot_be_emitted_twice(self) -> None:
+        runtime_path = self.open_runtime()
+        self.record_a1(runtime_path)
+        assert self.bundle.a1_capture is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a1_capture(self.bundle.a1_capture)
+        self.assertEqual("RETRY_REPLACEMENT", runtime_path.read_back().repair_action)
+
+    def test_failed_stage_cannot_later_emit_success(self) -> None:
+        runtime_path = self.ready_for_a2()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure(
+                "A2_RECONNECT",
+                "A2_OPERATION_FAILED",
+            )
+        assert self.bundle.a2_reconnect is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a2_reconnect(
+                self.bundle.a2_reconnect,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual(1, runtime_path.read_back().trace_event_count)
+
+    def test_failed_attempt_cannot_be_reset_to_open(self) -> None:
+        runtime_path = self.open_runtime()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        loaded = FieldNoteCreatorLiveProofRuntime.load_attempt(
+            runtime_path.journal_path.parent
+        )
+        self.assertEqual("FAILED", loaded.read_back().state)
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            self.record_a1(loaded)
+
+    def test_second_attempt_is_not_started_automatically(self) -> None:
+        runtime_path = self.open_runtime()
+        with self.assertRaises(FieldNoteCreatorLiveAttemptExistsError):
+            FieldNoteCreatorLiveProofRuntime.open_attempt(
+                runtime_path.journal_path.parent,
+                attempt=self.live_attempt,
+                source_repository=self.bundle.source_repository,
+                run_1=self.bundle.run_1,
+            )
+        self.assertEqual("OPEN", runtime_path.read_back().state)
+
+
+class CreatorLiveStageAcquisitionTests(CreatorLiveTestCase):
+    def test_each_checkpoint_binds_exact_typed_stage_evidence(self) -> None:
+        runtime_path, evidence = self.complete_runtime()
+        readback = runtime_path.read_back()
+        assert evidence.a1_capture is not None
+        assert evidence.a2_reconnect is not None
+        assert evidence.a3_assessment is not None
+        assert evidence.a4_snapshot is not None
+        assert evidence.a5_commit is not None
+        assert evidence.a6_review is not None
+        self.assertEqual(
+            (
+                whole_flow._a1_evidence_sha256(evidence.a1_capture),
+                whole_flow._a2_receipt_sha256(evidence.a2_reconnect),
+                evidence.a3_assessment.reuse_event_id,
+                evidence.a4_snapshot.events[0].event_sha256,
+                whole_flow._a5_confirmation_sha256(evidence.a5_commit),
+                whole_flow._a6_packet_sha256(evidence.a6_review),
+            ),
+            tuple(event.evidence_sha256 for event in readback.events),
+        )
+
+    def test_cross_run_a2_evidence_is_rejected(self) -> None:
+        runtime_path = self.ready_for_a2()
+        assert self.bundle.a2_reconnect is not None
+        changed = replace(self.bundle.a2_reconnect, run_id="other_run")
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a2_reconnect(
+                changed,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual("A2_RUN_MISMATCH", runtime_path.read_back().failure_reason)
+
+    def test_changed_note_bytes_are_rejected(self) -> None:
+        runtime_path = self.ready_for_a2()
+        assert self.bundle.a2_reconnect is not None
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a2_reconnect(
+                self.bundle.a2_reconnect,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes + b"changed",
+            )
+        self.assertEqual("NOTE_EDIT", runtime_path.read_back().repair_action)
+
+    def test_a2_exact_note_mismatch_is_rejected(self) -> None:
+        runtime_path = self.ready_for_a2()
+        assert self.bundle.a2_reconnect is not None
+        changed = replace(
+            self.bundle.a2_reconnect,
+            selected_field_note_id="other_note",
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a2_reconnect(
+                changed,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual(
+            "A2_EXACT_NOTE_MISMATCH",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_a3_non_reused_evidence_is_rejected(self) -> None:
+        runtime_path = self.ready_for_a2()
+        assert self.bundle.a2_reconnect is not None
+        assert self.bundle.a3_assessment is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value=OBSERVED_AT[1],
+        ):
+            runtime_path.record_a2_reconnect(
+                self.bundle.a2_reconnect,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        candidate = assess_field_note_reuse(
+            self.bundle.note,
+            None,
+            note_bytes=self.bundle.note_bytes,
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a3_reuse(
+                candidate,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        self.assertEqual(
+            "A3_NOT_DEMONSTRABLY_REUSED",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def runtime_through_a3(self, label: str):
+        runtime_path = self.ready_for_a2(label)
+        assert self.bundle.a2_reconnect is not None
+        assert self.bundle.a3_assessment is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=OBSERVED_AT[1:3],
+        ):
+            runtime_path.record_a2_reconnect(
+                self.bundle.a2_reconnect,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+            runtime_path.record_a3_reuse(
+                self.bundle.a3_assessment,
+                note=self.bundle.note,
+                note_bytes=self.bundle.note_bytes,
+            )
+        return runtime_path
+
+    def test_a4_tampered_durability_is_rejected(self) -> None:
+        runtime_path = self.runtime_through_a3("a4")
+        assert self.bundle.a4_snapshot is not None
+        event = replace(
+            self.bundle.a4_snapshot.events[0],
+            event_sha256="f" * 64,
+        )
+        changed = replace(
+            self.bundle.a4_snapshot,
+            events=(event,),
+            chain_head_sha256="f" * 64,
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a4_durability(changed)
+        self.assertEqual("LEDGER_REWRITE", runtime_path.read_back().repair_action)
+
+    def runtime_through_a4(self, label: str):
+        runtime_path = self.runtime_through_a3(label)
+        assert self.bundle.a4_snapshot is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value=OBSERVED_AT[3],
+        ):
+            runtime_path.record_a4_durability(self.bundle.a4_snapshot)
+        return runtime_path
+
+    def test_a5_unconfirmed_readback_is_rejected(self) -> None:
+        runtime_path = self.runtime_through_a4("a5")
+        assert self.bundle.a5_commit is not None
+        changed = type(self.bundle.a5_commit)(
+            status="NOT_REUSED",
+            assessment=assess_field_note_reuse(
+                self.bundle.a5_commit.assessment.note,
+                None,
+            ),
+            delivery_context=None,
+            append_result=None,
+            durable_snapshot=None,
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a5_confirmation(changed)
+        self.assertEqual(
+            "A5_APPEND_NOT_CONFIRMED",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def runtime_through_a5(self, label: str):
+        runtime_path = self.runtime_through_a4(label)
+        assert self.bundle.a5_commit is not None
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value=OBSERVED_AT[4],
+        ):
+            runtime_path.record_a5_confirmation(self.bundle.a5_commit)
+        return runtime_path
+
+    def test_a6_mismatched_packet_is_rejected(self) -> None:
+        runtime_path = self.runtime_through_a5("a6")
+        assert self.bundle.a6_review is not None
+        other = replace(self.bundle.note, field_note_id="other_note")
+        changed = replace(self.bundle.a6_review)
+        object.__setattr__(changed, "note_identity", other)
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a6_review(changed)
+        self.assertEqual(
+            "A6_EXACT_PACKET_MISMATCH",
+            runtime_path.read_back().failure_reason,
+        )
+
+
+class CreatorLiveDurabilityTests(CreatorLiveTestCase):
+    def test_trace_persistence_is_append_only(self) -> None:
+        runtime_path = self.open_runtime()
+        initial = runtime_path.journal_path.read_bytes()
+        self.record_a1(runtime_path)
+        after_a1 = runtime_path.journal_path.read_bytes()
+        self.open_run_2(runtime_path)
+        after_run_2 = runtime_path.journal_path.read_bytes()
+        self.assertTrue(after_a1.startswith(initial))
+        self.assertTrue(after_run_2.startswith(after_a1))
+
+    def test_durable_exact_readback_reaches_trace_complete(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        readback = runtime_path.read_back()
+        self.assertEqual("TRACE_COMPLETE", readback.state)
+        self.assertTrue(readback.durable_readback_verified)
+        self.assertEqual(6, readback.trace_event_count)
+        self.assertEqual(
+            readback.events[-1].trace_sha256,
+            readback.trace_chain_head_sha256,
+        )
+        loaded = FieldNoteCreatorLiveProofRuntime.load_attempt(
+            runtime_path.journal_path.parent
+        )
+        self.assertEqual(readback, loaded.read_back())
+
+    def test_trace_tampering_fails_closed(self) -> None:
+        runtime_path = self.ready_for_a2()
+        raw = runtime_path.journal_path.read_bytes()
+        marker = b'"evidence_sha256":"'
+        start = raw.index(marker) + len(marker)
+        replacement = b"f" if raw[start : start + 1] != b"f" else b"e"
+        changed = raw[:start] + replacement + raw[start + 1 :]
+        runtime_path.journal_path.write_bytes(changed)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+
+    def test_trace_truncation_fails_closed(self) -> None:
+        runtime_path = self.ready_for_a2()
+        raw = runtime_path.journal_path.read_bytes()
+        runtime_path.journal_path.write_bytes(raw[:-1])
+        readback = runtime_path.read_back()
+        self.assertEqual(
+            "CREATOR_LIVE_DURABLE_TRACE_TRUNCATED",
+            readback.failure_reason,
+        )
+        self.assertEqual("EVIDENCE_DELETION", readback.repair_action)
+
+    def test_trace_duplication_fails_closed(self) -> None:
+        runtime_path = self.ready_for_a2()
+        raw = runtime_path.journal_path.read_bytes()
+        last = raw.splitlines(keepends=True)[-1]
+        runtime_path.journal_path.write_bytes(raw + last)
+        readback = runtime_path.read_back()
+        self.assertEqual(
+            "CREATOR_LIVE_DURABLE_TRACE_DUPLICATED",
+            readback.failure_reason,
+        )
+        self.assertEqual("RETRY_REPLACEMENT", readback.repair_action)
+
+    def test_chain_head_mismatch_fails_closed(self) -> None:
+        runtime_path = self.ready_for_a2()
+        raw = runtime_path.journal_path.read_bytes()
+        marker = b'"previous_record_sha256":"'
+        first = raw.index(marker) + len(marker)
+        second = raw.index(marker, first) + len(marker)
+        changed = raw[:second] + b"f" + raw[second + 1:]
+        runtime_path.journal_path.write_bytes(changed)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+
+    def test_in_memory_six_events_without_readback_cannot_pass(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        readback = runtime_path.read_back()
+        live = replace(
+            self.bundle,
+            attempt=self.live_attempt,
+            proof_trace=readback.events,
+            creator_live_readback=None,
+        )
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("NOT_READY", receipt.state)
+
+    def test_repair_marker_causes_fail(self) -> None:
+        runtime_path = self.open_runtime()
+        self.record_a1(runtime_path)
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_repair(
+                "HUMAN_REPAIR",
+                "NOTE_EDIT_AFTER_CAPTURE",
+                repair_action="NOTE_EDIT",
+            )
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("NOTE_EDIT", readback.repair_action)
+
+    def test_retry_replacement_causes_fail(self) -> None:
+        runtime_path = self.open_runtime()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_retry_replacement("RUN_REPLACEMENT_ATTEMPTED")
+        self.assertEqual("RETRY_REPLACEMENT", runtime_path.read_back().repair_action)
+
+    def test_proof_artifacts_are_deterministic_and_bounded(self) -> None:
+        first, _ = self.complete_runtime("first")
+        second, _ = self.complete_runtime("second")
+        first_bytes = first.journal_path.read_bytes()
+        second_bytes = second.journal_path.read_bytes()
+        self.assertEqual(first_bytes, second_bytes)
+        self.assertLess(len(first_bytes), 100_000)
+        self.assertEqual(first.read_back(), second.read_back())
+
+    def test_trace_storage_excludes_full_note_contents(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        text = runtime_path.journal_path.read_text(encoding="utf-8")
+        self.assertNotIn(PRIVATE_NOTE_TEXT, text)
+        self.assertNotIn(self.bundle.note_bytes.decode("utf-8"), text)
+
+    def test_trace_storage_excludes_output_artifact_contents(self) -> None:
+        bundle, _ = build_bundle(
+            self.root / "output-evidence",
+            evidence_class="OUTPUT_ARTIFACT",
+        )
+        runtime_path, _ = self.complete_runtime("output", bundle=bundle)
+        text = runtime_path.journal_path.read_text(encoding="utf-8")
+        self.assertNotIn(ARTIFACT_SECRET, text)
+
+
+class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):
+    def test_open_attempt_is_not_ready_not_fail(self) -> None:
+        runtime_path = self.open_runtime()
+        live = self.live_bundle(runtime_path.read_back())
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual("CREATOR_LIVE_TRACE_INCOMPLETE", receipt.failure_reason)
+
+    def test_failed_attempt_enters_a7_as_fail(self) -> None:
+        runtime_path = self.open_runtime()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        live = self.live_bundle(runtime_path.read_back())
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("FAIL", receipt.state)
+        self.assertEqual("A1_FAILED", receipt.failure_reason)
+
+    def test_trace_complete_creator_live_evidence_can_enter_a7(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        live = self.live_bundle(runtime_path.read_back())
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("CREATOR_LIVE", receipt.proof_mode)
+        self.assertEqual("TYPED_TRACE_VERIFIED", receipt.human_repair_result)
+        self.assertIsNotNone(receipt.creator_live_readback)
+
+    def test_creator_live_manifest_is_readback_and_trace_bound(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        live = self.live_bundle(runtime_path.read_back())
+        manifest = build_portable_candidate_warehouse_manifest(live)
+        body = manifest.as_dict()
+        self.assertEqual("CREATOR_LIVE", body["coverage_evidence_mode"])
+        self.assertTrue(body["creator_live_coverage_verified"])
+        self.assertEqual(
+            runtime_path.read_back().trace_chain_head_sha256,
+            body["proof_trace"]["chain_head_sha256"],
+        )
+
+    def test_cross_bound_readback_cannot_admit_other_attempt(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        readback = runtime_path.read_back()
+        other_attempt = replace(
+            self.live_attempt,
+            proof_attempt_id="other_attempt",
+        )
+        other_run_1 = replace(
+            self.bundle.run_1,
+            proof_attempt_id="other_attempt",
+        )
+        other_run_2 = replace(
+            self.bundle.run_2,
+            proof_attempt_id="other_attempt",
+        )
+        live = replace(
+            self.bundle,
+            attempt=other_attempt,
+            run_1=other_run_1,
+            run_2=other_run_2,
+            proof_trace=readback.events,
+            creator_live_readback=readback,
+        )
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("FAIL", receipt.state)
+        self.assertEqual(
+            "CREATOR_LIVE_RUNTIME_IDENTITY_MISMATCH",
+            receipt.failure_reason,
+        )
+
+    def test_unknown_outcome_remains_supported(self) -> None:
+        bundle, _ = build_bundle(self.root / "unknown", outcome="UNKNOWN")
+        runtime_path, _ = self.complete_runtime("unknown-live", bundle=bundle)
+        live = self.live_bundle(runtime_path.read_back(), bundle=bundle)
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("UNKNOWN", receipt.effective_outcome)
+        self.assertEqual("HOLD", receipt.next_disposition)
+
+    def test_negative_outcome_remains_supported(self) -> None:
+        bundle, _ = build_bundle(self.root / "harmful", outcome="HARMFUL")
+        runtime_path, _ = self.complete_runtime("harmful-live", bundle=bundle)
+        live = self.live_bundle(runtime_path.read_back(), bundle=bundle)
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("PASS", receipt.state)
+        self.assertEqual("HARMFUL", receipt.effective_outcome)
+        self.assertEqual("STOP", receipt.next_disposition)
+
+    def test_promotable_remains_unset(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        receipt = verify_field_note_whole_flow(
+            self.live_bundle(runtime_path.read_back())
+        )
+        self.assertEqual("UNSET", receipt.claim_boundary.promotable_policy)
+
+    def test_serving_policy_remains_delayed_and_separate(self) -> None:
+        runtime_path, _ = self.complete_runtime()
+        live = self.live_bundle(runtime_path.read_back())
+        receipt = verify_field_note_whole_flow(live)
+        manifest = build_portable_candidate_warehouse_manifest(live)
+        self.assertEqual("DELAY", receipt.claim_boundary.serving_policy)
+        self.assertEqual("DELAY", manifest.as_dict()["serving_policy"])
+        self.assertIsNone(manifest.as_dict()["automatic_injection"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_field_notes_whole_flow.py
+++ b/tests/test_field_notes_whole_flow.py
@@ -549,7 +549,7 @@ class FieldNoteWholeFlowProofSealingTests(WholeFlowTestCase):
         self.assertEqual("NOT_READY", receipt.state)
         self.assertEqual("RUNTIME_ENFORCEMENT", receipt.failed_boundary)
         self.assertEqual(
-            "CREATOR_LIVE_RUNTIME_ENFORCEMENT_NOT_IMPLEMENTED",
+            "CREATOR_LIVE_RUNTIME_EVIDENCE_MISSING",
             receipt.failure_reason,
         )
 


### PR DESCRIPTION
## Summary

- add the bounded runtime-owned A7 creator-live proof-attempt path for exact A1–A6 typed checkpoint acquisition
- persist canonical JSONL journal records plus a separately durable append-only anchor chain
- bind attempt, Run, repository, runtime, evidence, observation-time, provenance, ordering, chain heads, full journal identity, and repair state
- admit CREATOR_LIVE to A7 only through complete exact durable read-back
- preserve existing FIXTURE behavior and all A1–A7 claim boundaries

## Durable proof-closure repair

Reviewed head before repair: `cbd6ee67142d4dd8f2e0efa0590149c28ca24706`

Repair head: `7dcff8698b93956b69a9db4f5edc63dca7c09c48`

### Complete-record tail deletion

Each fsynced journal append now receives a separately fsynced canonical anchor record binding:

- proof attempt ID
- journal record count
- journal byte length
- journal record-chain head
- complete journal SHA-256
- anchor generation
- previous anchor identity

Every read-back and append requires the journal to match the latest anchor exactly. Complete deletion of checkpoints, terminal failures, TRACE_COMPLETED, or multiple tail records fails closed. Journal-ahead, anchor-ahead, anchor tamper, and anchor truncation states cannot continue or reopen an attempt. No automatic repair, rollback, roll-forward, or anchor recreation exists.

### Complete A3 receipt binding

CREATOR_LIVE A3 checkpoints now use:

`SHA256(canonical_json(FieldNoteReuseReceipt.as_dict()))`

The canonical reuse-event ID remains separately durable and continues to identify the A4 event and A7 Receipt. A4 acquisition requires the event's complete receipt digest to equal the A3 checkpoint digest and independently revalidates its canonical reuse-event ID. A5 and A6 preserve the same lineage. Mutation coverage seals claimed/effective outcome, scope, causal evidence, observer, confirmation, contribution separation, intervention, disposition, STOP scope, and REVISE lineage.

FIXTURE trace identity remains unchanged.

### Complete attempt identity

Durable read-back now carries the complete typed `FieldNoteWholeFlowAttempt`. A7 admission requires exact equality with the bundle attempt, including proof-attempt ID, proof mode, creator identity, and proof As-of. The final typed Receipt exposes the same exact attempt projection.

## Provenance and trust boundary

The provenance remains an in-process runtime capability coupled to exact durable journal and anchor read-back. It does not claim a signature, independent cryptographic attestation, hardware root, or hostile-process resistance.

## Validation

- `python -m unittest tests.test_field_notes_creator_live` — 65 PASS
- `python -m unittest tests.test_field_notes_whole_flow` — 72 PASS
- `python -m unittest tests.test_field_notes_maturity_review` — 54 PASS
- `python -m unittest tests.test_field_notes_maturity_commit` — 49 PASS
- `python -m unittest tests.test_field_notes_maturity_ledger` — 40 PASS
- `python -m unittest tests.test_field_notes_reuse` — 45 PASS
- `python -m unittest tests.test_field_notes_reconnect` — 36 PASS
- `python -m unittest tests.test_field_notes_lite` — 25 PASS
- `python -m unittest tests.test_companion_controller` — 27 PASS
- `python -m unittest tests.test_companion_server` — 35 PASS
- `python -m unittest` — 1,083 PASS
- `python -m unittest discover -s tests -p 'test_*.py'` — 1,083 PASS
- normalized suite identities — MATCH, 1,083 IDs, SHA-256 `89739f9bdb207120df63c653b4150a3279fe67f4f6da765d03b776bf2b8397f9`
- `python -m compileall -q decision_os tests` — PASS
- `git diff --check` — PASS

The protected creator Note and four protected validation artifacts retain their exact preflight hashes, sizes, modes, mtimes, and inodes. The PR delta remains exactly four files.

## Claim boundary

The repository implements a bounded runtime-owned evidence and exact durable journal-and-anchor read-back path capable of admitting a future creator-live two-Run evidence bundle to A7 verification.

No creator-live Run, real Note, reuse event, Warehouse Import Contract, portability execution, release, publication, PROMOTABLE threshold, or Serving Policy behavior was performed or claimed.