### PR TITLE
Add A7 creator-live A1 capture bridge

### DIFF
--- a/decision_os/companion/field_notes_adapter.py
+++ b/decision_os/companion/field_notes_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass
 import json
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from decision_os.acceleration import codex_adapter as codex
 from decision_os.acceleration.codex_adapter import CodexAdapter, CodexRunResult
@@ -31,6 +31,46 @@ _FIELD_NOTE_PROPOSAL_INSTRUCTIONS = (
     "call it twice."
 )
 
+_CREATOR_LIVE_A1_CAPTURE_INSTRUCTIONS = (
+    "This is a bounded creator-live A1 capture Run. Perform only the "
+    "requested bounded reasoning task in read-only mode. Do not use shell "
+    "commands. Use read_repository_text_file only for bounded repository "
+    "evidence needed by the task. You must call "
+    "propose_field_note_candidate exactly once with the reusable insight. "
+    "The proposal tool is the only capture path. Do not create, update, "
+    "modify, delete, patch, or otherwise write any repository file. Do not emit "
+    "the candidate as raw Markdown or JSON. Stop normally after the one "
+    "proposal call and the bounded read-only task."
+)
+
+_DIRECT_MUTATION_REASONS = frozenset(
+    {
+        "additional_file_action_item",
+        "duplicate_file_action_item_after_completion",
+        "modify_requires_repository_read",
+        "read_preimage_changed_before_approval",
+        "read_write_path_mismatch",
+        "unapproved_file_completion",
+        "unsupported_dynamic_tool",
+        "unsupported_file_change_shape",
+        "unsupported_request_method:other",
+        "unsupported_request_method:commandExecution",
+        "unsupported_item_type:commandExecution",
+        "unsupported_item_type:mcpToolCall",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveA1CaptureConfig:
+    """One predeclared Run identity for the bounded creator-live A1 lane."""
+
+    run_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_id, str) or not self.run_id.strip():
+            raise ValueError("Creator-live A1 capture Run ID is invalid.")
+
 
 @dataclass(frozen=True)
 class _ProposalResponse:
@@ -44,6 +84,9 @@ class _ProposalResponse:
 class FieldNoteCodexRunResult(CodexRunResult):
     field_note_proposal: FieldNoteDraft | None = None
     reconnect_receipt: FieldNoteReconnectReceipt | None = None
+    creator_live_a1_capture: bool = False
+    creator_live_a1_failure_reason: str | None = None
+    creator_live_a1_proposal_attempts: int = 0
 
 
 class FieldNotesCodexAdapter(CodexAdapter):
@@ -54,6 +97,9 @@ class FieldNotesCodexAdapter(CodexAdapter):
         *args: Any,
         trusted_source_model_class: str = "UNKNOWN",
         trusted_target_model_class: str = "UNKNOWN",
+        creator_live_a1_capture_provider: Callable[
+            [], FieldNoteCreatorLiveA1CaptureConfig | None
+        ] | None = None,
         **kwargs: Any,
     ) -> None:
         self._reconnect_prompt: str | None = None
@@ -64,10 +110,24 @@ class FieldNotesCodexAdapter(CodexAdapter):
         self.trusted_target_model_class = configured_model_class(
             trusted_target_model_class
         )
+        self._creator_live_a1_capture_provider = (
+            creator_live_a1_capture_provider or (lambda: None)
+        )
         super().__init__(*args, **kwargs)
 
     def _reset_run(self) -> None:
         super()._reset_run()
+        capture = self._creator_live_a1_capture_provider()
+        if capture is not None and not isinstance(
+            capture,
+            FieldNoteCreatorLiveA1CaptureConfig,
+        ):
+            raise codex.CodexAdapterFailure(
+                "Creator-live A1 capture configuration is invalid."
+            )
+        self._creator_live_a1_capture = capture
+        if capture is not None:
+            self._run_id = capture.run_id
         self._field_note_gate = FieldNoteProposalGate(
             self._run_id,
             trusted_source_model_class=self.trusted_source_model_class,
@@ -77,8 +137,13 @@ class FieldNotesCodexAdapter(CodexAdapter):
         self._proposal_request_ids: dict[str | int, str | None] = {}
         self._resolved_proposal_requests: set[str | int] = set()
         self._completed_proposal_items: set[str] = set()
+        self._capture_proposal_call_ids: set[str] = set()
+        self._capture_proposal_malformed = False
         prompt = self._reconnect_prompt
-        if isinstance(prompt, str):
+        if (
+            isinstance(prompt, str)
+            and self._creator_live_a1_capture is None
+        ):
             self._reconnect_plan = prepare_field_note_reconnect(
                 self.engine.store.repository,
                 prompt,
@@ -88,7 +153,14 @@ class FieldNotesCodexAdapter(CodexAdapter):
             self._reconnect_plan = None
 
     def _developer_instructions(self) -> str:
-        existing = codex._DEVELOPER_INSTRUCTIONS + _FIELD_NOTE_PROPOSAL_INSTRUCTIONS
+        existing = (
+            _CREATOR_LIVE_A1_CAPTURE_INSTRUCTIONS
+            if self._creator_live_a1_capture is not None
+            else (
+                codex._DEVELOPER_INSTRUCTIONS
+                + _FIELD_NOTE_PROPOSAL_INSTRUCTIONS
+            )
+        )
         plan = self._reconnect_plan
         if plan is None or plan.envelope is None:
             return existing
@@ -260,6 +332,11 @@ class FieldNotesCodexAdapter(CodexAdapter):
             return
         safe_call_id = call_id if isinstance(call_id, str) else "invalid-proposal"
         safe_arguments = arguments if isinstance(arguments, dict) else {}
+        if self._creator_live_a1_capture is not None:
+            if isinstance(call_id, str) and call_id:
+                self._capture_proposal_call_ids.add(call_id)
+            else:
+                self._capture_proposal_malformed = True
         if request_id in self._proposal_request_ids:
             if self._proposal_request_ids[request_id] != call_id:
                 self._failed_proposal_response(
@@ -294,6 +371,8 @@ class FieldNotesCodexAdapter(CodexAdapter):
             and item.get("arguments") == arguments
         )
         if not valid_shape:
+            if self._creator_live_a1_capture is not None:
+                self._capture_proposal_malformed = True
             self._failed_proposal_response(
                 request_id=request_id,
                 call_id=safe_call_id,
@@ -332,6 +411,31 @@ class FieldNotesCodexAdapter(CodexAdapter):
         )
         self._proposal_responses[safe_call_id] = response
         self._send_proposal_response(request_id, response)
+
+    def _creator_live_a1_failure(
+        self,
+        result: CodexRunResult,
+        *,
+        all_proposals_completed: bool,
+    ) -> str | None:
+        if self._creator_live_a1_capture is None:
+            return None
+        if result.file_actions or result.unsupported_reason in _DIRECT_MUTATION_REASONS:
+            return "A1_DIRECT_WRITE_REQUESTED"
+        attempts = len(self._capture_proposal_call_ids)
+        if attempts == 0:
+            return "A1_PROPOSAL_MISSING"
+        if attempts != 1:
+            return "A1_PROPOSAL_DUPLICATE"
+        if (
+            self._capture_proposal_malformed
+            or self._field_note_gate.accepted is None
+            or not all_proposals_completed
+        ):
+            return "A1_PROPOSAL_INVALID"
+        if not result.normal_terminal or result.turn_status != "completed":
+            return "A1_RUN_INCOMPLETE"
+        return None
 
     def _cache_item(self, params: dict[str, Any]) -> None:
         item = params.get("item")
@@ -434,12 +538,24 @@ class FieldNotesCodexAdapter(CodexAdapter):
         all_proposals_completed = set(self._proposal_responses).issubset(
             self._completed_proposal_items
         )
+        capture_failure = self._creator_live_a1_failure(
+            result,
+            all_proposals_completed=all_proposals_completed,
+        )
         proposal = (
             self._field_note_gate.accepted
-            if result.normal_terminal and all_proposals_completed
+            if (
+                result.normal_terminal
+                and all_proposals_completed
+                and capture_failure is None
+            )
             else None
         )
-        normal_terminal = result.normal_terminal and all_proposals_completed
+        normal_terminal = (
+            result.normal_terminal
+            and all_proposals_completed
+            and capture_failure is None
+        )
         if self._reconnect_plan is not None:
             self._reconnect_plan = self._reconnect_plan.finalized(
                 normal_terminal=normal_terminal,
@@ -455,12 +571,16 @@ class FieldNotesCodexAdapter(CodexAdapter):
             normal_terminal=normal_terminal,
             status=(
                 result.status
-                if all_proposals_completed
+                if (
+                    all_proposals_completed
+                    and capture_failure is None
+                )
+                or result.unsupported_reason is not None
                 else "ABNORMAL_TERMINAL"
             ),
             error_type=(
                 result.error_type
-                if all_proposals_completed
+                if all_proposals_completed and capture_failure is None
                 else "FieldNoteProposalCompletionError"
             ),
             turn_status=result.turn_status,
@@ -473,4 +593,11 @@ class FieldNotesCodexAdapter(CodexAdapter):
             failure_diagnostic=result.failure_diagnostic,
             field_note_proposal=proposal,
             reconnect_receipt=reconnect_receipt,
+            creator_live_a1_capture=(
+                self._creator_live_a1_capture is not None
+            ),
+            creator_live_a1_failure_reason=capture_failure,
+            creator_live_a1_proposal_attempts=len(
+                self._capture_proposal_call_ids
+            ),
         )

--- a/decision_os/companion/field_notes_adapter.py
+++ b/decision_os/companion/field_notes_adapter.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
+import hashlib
 import json
 from typing import Any, Callable, Mapping
 
 from decision_os.acceleration import codex_adapter as codex
-from decision_os.acceleration.codex_adapter import CodexAdapter, CodexRunResult
+from decision_os.acceleration.codex_adapter import (
+    CodexAdapter,
+    CodexRunResult,
+    CodexRuntimeIdentity,
+)
 from decision_os.companion.field_notes_model import (
     FIELD_NOTE_TOOL_NAME,
     FIELD_NOTE_TOOL_SPEC,
@@ -66,9 +71,17 @@ class FieldNoteCreatorLiveA1CaptureConfig:
     """One predeclared Run identity for the bounded creator-live A1 lane."""
 
     run_id: str
+    expected_runtime_identity: CodexRuntimeIdentity
 
     def __post_init__(self) -> None:
-        if not isinstance(self.run_id, str) or not self.run_id.strip():
+        if (
+            not isinstance(self.run_id, str)
+            or not self.run_id.strip()
+            or not isinstance(
+                self.expected_runtime_identity,
+                CodexRuntimeIdentity,
+            )
+        ):
             raise ValueError("Creator-live A1 capture Run ID is invalid.")
 
 
@@ -87,6 +100,7 @@ class FieldNoteCodexRunResult(CodexRunResult):
     creator_live_a1_capture: bool = False
     creator_live_a1_failure_reason: str | None = None
     creator_live_a1_proposal_attempts: int = 0
+    creator_live_a1_task_sha256: str | None = None
 
 
 class FieldNotesCodexAdapter(CodexAdapter):
@@ -433,6 +447,18 @@ class FieldNotesCodexAdapter(CodexAdapter):
             or not all_proposals_completed
         ):
             return "A1_PROPOSAL_INVALID"
+        if any(
+            evidence.status != "succeeded"
+            for evidence in result.read_evidence
+        ):
+            return "A1_READ_EVIDENCE_FAILED"
+        if result.runtime_identity is None:
+            return "A1_ACTUAL_RUNTIME_IDENTITY_MISSING"
+        if (
+            result.runtime_identity
+            != self._creator_live_a1_capture.expected_runtime_identity
+        ):
+            return "A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH"
         if not result.normal_terminal or result.turn_status != "completed":
             return "A1_RUN_INCOMPLETE"
         return None
@@ -599,5 +625,10 @@ class FieldNotesCodexAdapter(CodexAdapter):
             creator_live_a1_failure_reason=capture_failure,
             creator_live_a1_proposal_attempts=len(
                 self._capture_proposal_call_ids
+            ),
+            creator_live_a1_task_sha256=(
+                hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+                if self._creator_live_a1_capture is not None
+                else None
             ),
         )

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -24,11 +24,13 @@ from decision_os.companion.controller import (
     CompanionError,
 )
 from decision_os.companion.field_notes_adapter import (
+    FieldNoteCreatorLiveA1CaptureConfig,
     FieldNoteCodexRunResult,
     FieldNotesCodexAdapter,
 )
 from decision_os.companion.field_notes_model import (
     FieldNoteDraft,
+    canonical_json,
     compile_draft,
     configured_model_class,
     validate_compiled_markdown,
@@ -49,6 +51,7 @@ def _field_notes_adapter_factory(
     *,
     trusted_source_model_class: str = "UNKNOWN",
     trusted_target_model_class: str = "UNKNOWN",
+    creator_live_a1_capture_provider: Any = None,
 ) -> FieldNotesCodexAdapter:
     return FieldNotesCodexAdapter(
         engine,
@@ -58,6 +61,7 @@ def _field_notes_adapter_factory(
         lifecycle_sink=lifecycle_sink,
         trusted_source_model_class=trusted_source_model_class,
         trusted_target_model_class=trusted_target_model_class,
+        creator_live_a1_capture_provider=creator_live_a1_capture_provider,
     )
 
 
@@ -75,6 +79,12 @@ class FieldNotesCompanionController(CompanionController):
     def __init__(self, **kwargs: Any) -> None:
         self._field_note_draft: FieldNoteDraft | None = None
         self._field_note_pending: _PendingSave | None = None
+        self._creator_live_a1_capture_config: (
+            FieldNoteCreatorLiveA1CaptureConfig | None
+        ) = None
+        self._creator_live_a1_completed_run_id: str | None = None
+        self._creator_live_a1_failure_reason: str | None = None
+        self._creator_live_a1_direct_write_identity: str | None = None
         trusted_source_model_class = configured_model_class(
             kwargs.pop("trusted_source_model_class", "UNKNOWN")
         )
@@ -86,8 +96,17 @@ class FieldNotesCompanionController(CompanionController):
                 _field_notes_adapter_factory,
                 trusted_source_model_class=trusted_source_model_class,
                 trusted_target_model_class=trusted_target_model_class,
+                creator_live_a1_capture_provider=(
+                    self._active_creator_live_a1_capture
+                ),
             )
         super().__init__(**kwargs)
+
+    def _active_creator_live_a1_capture(
+        self,
+    ) -> FieldNoteCreatorLiveA1CaptureConfig | None:
+        with self._condition:
+            return self._creator_live_a1_capture_config
 
     @staticmethod
     def _empty_run() -> dict[str, Any]:
@@ -107,15 +126,46 @@ class FieldNotesCompanionController(CompanionController):
             self._clear_field_note_locked()
         return super().start_run(task, task_mode=task_mode)
 
+    def start_creator_live_a1_capture(
+        self,
+        task: str,
+        *,
+        run_id: str,
+    ) -> dict[str, Any]:
+        """Start one read-only Run whose only capture path is the A1 tool."""
+
+        config = FieldNoteCreatorLiveA1CaptureConfig(run_id=run_id)
+        with self._condition:
+            self._require_no_active_run()
+            self._clear_field_note_locked()
+            self._creator_live_a1_capture_config = config
+            self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_failure_reason = None
+            self._creator_live_a1_direct_write_identity = None
+        try:
+            return super().start_run(task, task_mode="manual")
+        except Exception:
+            with self._condition:
+                self._creator_live_a1_capture_config = None
+            raise
+
     def new_run(self) -> dict[str, Any]:
         with self._condition:
             self._clear_field_note_locked()
+            self._creator_live_a1_capture_config = None
+            self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_failure_reason = None
+            self._creator_live_a1_direct_write_identity = None
         return super().new_run()
 
     def select_repository(self, candidate: str | Path) -> dict[str, Any]:
         super().select_repository(candidate)
         with self._condition:
             self._clear_field_note_locked()
+            self._creator_live_a1_capture_config = None
+            self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_failure_reason = None
+            self._creator_live_a1_direct_write_identity = None
             return self._snapshot_locked()
 
     @staticmethod
@@ -158,7 +208,22 @@ class FieldNotesCompanionController(CompanionController):
         repository: Path,
         result: CodexRunResult,
     ) -> None:
-        draft = self._eligible_draft(result)
+        capture = self._creator_live_a1_capture_config
+        capture_failure = getattr(
+            result,
+            "creator_live_a1_failure_reason",
+            None,
+        )
+        if capture is not None and (
+            getattr(result, "creator_live_a1_capture", False) is not True
+            or result.run_id != capture.run_id
+        ):
+            capture_failure = "A1_CAPTURE_IDENTITY_MISMATCH"
+        draft = (
+            self._eligible_draft(result)
+            if capture_failure is None
+            else None
+        )
         reconnect_receipt = getattr(result, "reconnect_receipt", None)
         reconnect_projection = (
             reconnect_receipt.as_dict()
@@ -168,6 +233,10 @@ class FieldNotesCompanionController(CompanionController):
         )
         with self._condition:
             super()._complete_run(repository, result)
+            if capture is not None:
+                self._creator_live_a1_completed_run_id = capture.run_id
+                self._creator_live_a1_capture_config = None
+            self._creator_live_a1_failure_reason = capture_failure
             self._run["field_note_reconnect"] = reconnect_projection
             if draft is None:
                 self._clear_field_note_locked()
@@ -177,9 +246,60 @@ class FieldNotesCompanionController(CompanionController):
                 self._run["field_note"] = draft.public_candidate()
             self._condition.notify_all()
 
+    def _approval_provider(self, approval: CodexApproval) -> str | None:
+        with self._condition:
+            capture_active = self._creator_live_a1_capture_config is not None
+        if not capture_active:
+            return super()._approval_provider(approval)
+        if not isinstance(approval, CodexApproval):
+            raise FieldNoteError("Malformed creator-live file request.")
+        diagnostic = {
+            "action": str(approval.action),
+            "path": str(approval.normalized_scope),
+            "repository": str(approval.repository_name),
+        }
+        identity = hashlib.sha256(
+            canonical_json(diagnostic).encode("utf-8")
+        ).hexdigest()
+        with self._condition:
+            self._creator_live_a1_direct_write_identity = identity
+        return "3"
+
+    def creator_live_a1_capture_candidate(self) -> FieldNoteDraft:
+        """Return the exact eligible capture candidate without exposing a body."""
+
+        with self._condition:
+            run_id = self._creator_live_a1_completed_run_id
+            if run_id is None:
+                raise FieldNoteError("No creator-live A1 capture is active.")
+            if self._run.get("state") == "running":
+                raise FieldNoteError("Creator-live A1 capture is still running.")
+            if self._creator_live_a1_failure_reason is not None:
+                suffix = (
+                    f":{self._creator_live_a1_direct_write_identity}"
+                    if self._creator_live_a1_failure_reason
+                    == "A1_DIRECT_WRITE_REQUESTED"
+                    and self._creator_live_a1_direct_write_identity is not None
+                    else ""
+                )
+                raise FieldNoteError(
+                    f"{self._creator_live_a1_failure_reason}{suffix}"
+                )
+            if self._field_note_draft is None:
+                raise FieldNoteError("A1_PROPOSAL_INVALID")
+            if self._field_note_draft.source_run_id != run_id:
+                raise FieldNoteError("A1_CAPTURE_IDENTITY_MISMATCH")
+            return self._field_note_draft
+
     def _fail_run(self, repository: Path, exc: Exception) -> None:
         super()._fail_run(repository, exc)
         with self._condition:
+            if self._creator_live_a1_capture_config is not None:
+                self._creator_live_a1_completed_run_id = (
+                    self._creator_live_a1_capture_config.run_id
+                )
+                self._creator_live_a1_capture_config = None
+                self._creator_live_a1_failure_reason = "A1_RUN_FAILED"
             self._clear_field_note_locked()
             self._condition.notify_all()
 

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -16,7 +16,11 @@ from decision_os.acceleration.codex_adapter import (
     CODEX_CLI_VERSION,
     CodexApproval,
     CodexLifecycleEvent,
+    CodexReadEvidence,
     CodexRunResult,
+    CodexRuntimeIdentity,
+    _READ_MAX_BYTES,
+    _READ_MAX_DISTINCT_PATHS,
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.companion.controller import (
@@ -73,6 +77,37 @@ class _PendingSave:
     field_notes_directory_identity: tuple[int, int] | None
 
 
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveA1RunCompletion:
+    """Typed facts observed from one completed creator-live Run 1."""
+
+    run_id: str
+    task_sha256: str
+    actual_runtime_identity: CodexRuntimeIdentity
+    proposal_attempts: int
+    successful_read_count: int
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.run_id, str)
+            or not self.run_id.strip()
+            or len(self.task_sha256) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.task_sha256
+            )
+            or not isinstance(
+                self.actual_runtime_identity,
+                CodexRuntimeIdentity,
+            )
+            or self.proposal_attempts != 1
+            or type(self.successful_read_count) is not int
+            or self.successful_read_count < 0
+            or self.successful_read_count > _READ_MAX_DISTINCT_PATHS
+        ):
+            raise ValueError("Creator-live A1 Run completion is invalid.")
+
+
 class FieldNotesCompanionController(CompanionController):
     """Companion controller extended only with Field Notes Lite Capture."""
 
@@ -83,6 +118,9 @@ class FieldNotesCompanionController(CompanionController):
             FieldNoteCreatorLiveA1CaptureConfig | None
         ) = None
         self._creator_live_a1_completed_run_id: str | None = None
+        self._creator_live_a1_run_completion: (
+            FieldNoteCreatorLiveA1RunCompletion | None
+        ) = None
         self._creator_live_a1_failure_reason: str | None = None
         self._creator_live_a1_direct_write_identity: str | None = None
         trusted_source_model_class = configured_model_class(
@@ -131,15 +169,20 @@ class FieldNotesCompanionController(CompanionController):
         task: str,
         *,
         run_id: str,
+        expected_runtime_identity: CodexRuntimeIdentity,
     ) -> dict[str, Any]:
         """Start one read-only Run whose only capture path is the A1 tool."""
 
-        config = FieldNoteCreatorLiveA1CaptureConfig(run_id=run_id)
+        config = FieldNoteCreatorLiveA1CaptureConfig(
+            run_id=run_id,
+            expected_runtime_identity=expected_runtime_identity,
+        )
         with self._condition:
             self._require_no_active_run()
             self._clear_field_note_locked()
             self._creator_live_a1_capture_config = config
             self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_run_completion = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
         try:
@@ -154,6 +197,7 @@ class FieldNotesCompanionController(CompanionController):
             self._clear_field_note_locked()
             self._creator_live_a1_capture_config = None
             self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_run_completion = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
         return super().new_run()
@@ -164,6 +208,7 @@ class FieldNotesCompanionController(CompanionController):
             self._clear_field_note_locked()
             self._creator_live_a1_capture_config = None
             self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_run_completion = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
             return self._snapshot_locked()
@@ -203,6 +248,86 @@ class FieldNotesCompanionController(CompanionController):
             return None
         return draft
 
+    @staticmethod
+    def _creator_live_successful_read(
+        evidence: CodexReadEvidence,
+    ) -> bool:
+        return bool(
+            isinstance(evidence, CodexReadEvidence)
+            and evidence.status == "succeeded"
+            and isinstance(evidence.path, str)
+            and evidence.path
+            and type(evidence.byte_count) is int
+            and evidence.byte_count >= 0
+            and evidence.byte_count <= _READ_MAX_BYTES
+            and isinstance(evidence.sha256, str)
+            and len(evidence.sha256) == 64
+            and all(
+                character in "0123456789abcdef"
+                for character in evidence.sha256
+            )
+            and isinstance(evidence.repository_identity, str)
+            and bool(evidence.repository_identity)
+            and evidence.reason is None
+        )
+
+    @classmethod
+    def _eligible_creator_live_draft(
+        cls,
+        result: CodexRunResult,
+        *,
+        expected_runtime_identity: CodexRuntimeIdentity,
+    ) -> FieldNoteDraft | None:
+        draft = getattr(result, "field_note_proposal", None)
+        task_sha256 = getattr(
+            result,
+            "creator_live_a1_task_sha256",
+            None,
+        )
+        if not isinstance(draft, FieldNoteDraft):
+            return None
+        try:
+            validate_compiled_markdown(draft.markdown)
+        except ValueError:
+            return None
+        if (
+            getattr(result, "creator_live_a1_capture", False) is not True
+            or getattr(result, "creator_live_a1_failure_reason", None)
+            is not None
+            or getattr(result, "creator_live_a1_proposal_attempts", 0) != 1
+            or not isinstance(task_sha256, str)
+            or len(task_sha256) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in task_sha256
+            )
+            or result.runtime_identity != expected_runtime_identity
+            or draft.source_run_id != result.run_id
+            or hashlib.sha256(draft.markdown).hexdigest() != draft.sha256
+            or not result.normal_terminal
+            or result.turn_status != "completed"
+            or result.status
+            not in {"NORMAL_TERMINAL", "VERIFIED_SAVE", "VERIFIED_REUSE"}
+            or result.failure_diagnostic is not None
+            or result.file_actions
+            or result.checkpoint_outcomes
+            or len(result.read_evidence) > _READ_MAX_DISTINCT_PATHS
+            or len(
+                {
+                    evidence.path
+                    for evidence in result.read_evidence
+                }
+            ) != len(result.read_evidence)
+            or any(
+                not cls._creator_live_successful_read(evidence)
+                for evidence in result.read_evidence
+            )
+            or not draft.body_value("evidence").strip()
+            or not draft.body_value("remaining_unknowns").strip()
+        ):
+            return None
+        return draft
+
     def _complete_run(
         self,
         repository: Path,
@@ -214,16 +339,52 @@ class FieldNotesCompanionController(CompanionController):
             "creator_live_a1_failure_reason",
             None,
         )
-        if capture is not None and (
-            getattr(result, "creator_live_a1_capture", False) is not True
-            or result.run_id != capture.run_id
-        ):
-            capture_failure = "A1_CAPTURE_IDENTITY_MISMATCH"
-        draft = (
-            self._eligible_draft(result)
-            if capture_failure is None
-            else None
-        )
+        completion: FieldNoteCreatorLiveA1RunCompletion | None = None
+        if capture is not None:
+            if (
+                getattr(result, "creator_live_a1_capture", False) is not True
+                or result.run_id != capture.run_id
+            ):
+                capture_failure = "A1_CAPTURE_IDENTITY_MISMATCH"
+            elif capture_failure is None and result.runtime_identity is None:
+                capture_failure = "A1_ACTUAL_RUNTIME_IDENTITY_MISSING"
+            elif capture_failure is None and (
+                result.runtime_identity
+                != capture.expected_runtime_identity
+            ):
+                capture_failure = "A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH"
+            elif capture_failure is None and any(
+                evidence.status != "succeeded"
+                for evidence in result.read_evidence
+            ):
+                capture_failure = "A1_READ_EVIDENCE_FAILED"
+            draft = (
+                self._eligible_creator_live_draft(
+                    result,
+                    expected_runtime_identity=(
+                        capture.expected_runtime_identity
+                    ),
+                )
+                if capture_failure is None
+                else None
+            )
+            if draft is not None:
+                assert result.runtime_identity is not None
+                completion = FieldNoteCreatorLiveA1RunCompletion(
+                    run_id=result.run_id,
+                    task_sha256=getattr(
+                        result,
+                        "creator_live_a1_task_sha256",
+                    ),
+                    actual_runtime_identity=result.runtime_identity,
+                    proposal_attempts=getattr(
+                        result,
+                        "creator_live_a1_proposal_attempts",
+                    ),
+                    successful_read_count=len(result.read_evidence),
+                )
+        else:
+            draft = self._eligible_draft(result)
         reconnect_receipt = getattr(result, "reconnect_receipt", None)
         reconnect_projection = (
             reconnect_receipt.as_dict()
@@ -236,6 +397,7 @@ class FieldNotesCompanionController(CompanionController):
             if capture is not None:
                 self._creator_live_a1_completed_run_id = capture.run_id
                 self._creator_live_a1_capture_config = None
+            self._creator_live_a1_run_completion = completion
             self._creator_live_a1_failure_reason = capture_failure
             self._run["field_note_reconnect"] = reconnect_projection
             if draft is None:
@@ -291,6 +453,22 @@ class FieldNotesCompanionController(CompanionController):
                 raise FieldNoteError("A1_CAPTURE_IDENTITY_MISMATCH")
             return self._field_note_draft
 
+    def creator_live_a1_run_completion(
+        self,
+    ) -> FieldNoteCreatorLiveA1RunCompletion:
+        """Return the exact typed Run-1 completion consumed by the bridge."""
+
+        with self._condition:
+            completion = self._creator_live_a1_run_completion
+            if completion is None:
+                reason = self._creator_live_a1_failure_reason
+                if reason is not None:
+                    raise FieldNoteError(reason)
+                raise FieldNoteError(
+                    "Creator-live A1 Run completion is unavailable."
+                )
+            return completion
+
     def _fail_run(self, repository: Path, exc: Exception) -> None:
         super()._fail_run(repository, exc)
         with self._condition:
@@ -300,6 +478,7 @@ class FieldNotesCompanionController(CompanionController):
                 )
                 self._creator_live_a1_capture_config = None
                 self._creator_live_a1_failure_reason = "A1_RUN_FAILED"
+                self._creator_live_a1_run_completion = None
             self._clear_field_note_locked()
             self._condition.notify_all()
 

--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -142,9 +142,13 @@ class FieldNoteCreatorLiveA1CaptureCommitReceipt:
     ]
     proof_attempt_id: str
     run_id: str
+    task_sha256: str
+    actual_runtime_identity: CodexRuntimeIdentity
     source_repository: FieldNoteSourceRepositoryIdentity
     note: FieldNoteIdentity
     note_byte_count: int
+    draft_evidence_sha256: str
+    draft_created_at: str
     save_as_of: str
     controller_state: Literal["saved"]
     read_back_verified: Literal[True]
@@ -162,9 +166,13 @@ class FieldNoteCreatorLiveA1CaptureCommitReceipt:
         authority: object,
         proof_attempt_id: str,
         run_id: str,
+        task_sha256: str,
+        actual_runtime_identity: CodexRuntimeIdentity,
         source_repository: FieldNoteSourceRepositoryIdentity,
         note: FieldNoteIdentity,
         note_byte_count: int,
+        draft_evidence_sha256: str,
+        draft_created_at: str,
         save_as_of: str,
     ) -> FieldNoteCreatorLiveA1CaptureCommitReceipt:
         if authority is not _A1_CAPTURE_COMMIT_AUTHORITY:
@@ -176,6 +184,16 @@ class FieldNoteCreatorLiveA1CaptureCommitReceipt:
             or not proof_attempt_id.strip()
             or not isinstance(run_id, str)
             or not run_id.strip()
+            or not isinstance(task_sha256, str)
+            or len(task_sha256) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in task_sha256
+            )
+            or not isinstance(
+                actual_runtime_identity,
+                CodexRuntimeIdentity,
+            )
             or not isinstance(
                 source_repository,
                 FieldNoteSourceRepositoryIdentity,
@@ -183,21 +201,41 @@ class FieldNoteCreatorLiveA1CaptureCommitReceipt:
             or not isinstance(note, FieldNoteIdentity)
             or type(note_byte_count) is not int
             or note_byte_count <= 0
+            or not isinstance(draft_evidence_sha256, str)
+            or len(draft_evidence_sha256) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in draft_evidence_sha256
+            )
         ):
             raise FieldNoteCreatorLiveValidationError(
                 "A1 capture commit identity is invalid."
             )
-        normalized_save_as_of, _ = _parse_time(
+        normalized_draft_created_at, draft_time = _parse_time(
+            draft_created_at,
+            "A1 draft creation time",
+        )
+        normalized_save_as_of, save_time = _parse_time(
             save_as_of,
             "A1 capture save As-of",
         )
+        if save_time < draft_time:
+            raise FieldNoteCreatorLiveValidationError(
+                "A1 capture save precedes draft creation."
+            )
         body = {
             "schema": A1_CAPTURE_COMMIT_SCHEMA,
             "proof_attempt_id": proof_attempt_id.strip(),
             "run_id": run_id.strip(),
+            "task_sha256": task_sha256,
+            "actual_runtime_identity": _runtime_as_dict(
+                actual_runtime_identity
+            ),
             "source_repository": source_repository.as_dict(),
             "note": note.as_dict(),
             "note_byte_count": note_byte_count,
+            "draft_evidence_sha256": draft_evidence_sha256,
+            "draft_created_at": normalized_draft_created_at,
             "save_as_of": normalized_save_as_of,
             "controller_state": "saved",
             "read_back_verified": True,
@@ -205,6 +243,7 @@ class FieldNoteCreatorLiveA1CaptureCommitReceipt:
         value = object.__new__(cls)
         for field, item in {
             **body,
+            "actual_runtime_identity": actual_runtime_identity,
             "source_repository": source_repository,
             "note": note,
             "receipt_sha256": _canonical_sha256(body),
@@ -217,9 +256,15 @@ class FieldNoteCreatorLiveA1CaptureCommitReceipt:
             "schema": self.schema,
             "proof_attempt_id": self.proof_attempt_id,
             "run_id": self.run_id,
+            "task_sha256": self.task_sha256,
+            "actual_runtime_identity": _runtime_as_dict(
+                self.actual_runtime_identity
+            ),
             "source_repository": self.source_repository.as_dict(),
             "note": self.note.as_dict(),
             "note_byte_count": self.note_byte_count,
+            "draft_evidence_sha256": self.draft_evidence_sha256,
+            "draft_created_at": self.draft_created_at,
             "save_as_of": self.save_as_of,
             "controller_state": self.controller_state,
             "read_back_verified": self.read_back_verified,
@@ -258,6 +303,24 @@ def _bounded_reason(value: Any) -> str:
             "Creator-live failure reason is outside its bounded schema."
         )
     return value.strip()
+
+
+def _a1_capture_chronology_is_valid(
+    *,
+    run_1_started_at: str,
+    draft_created_at: str,
+    save_as_of: str,
+    observed_at: str,
+    proof_as_of: str,
+) -> bool:
+    """Compare the five creator-live A1 instants in their required order."""
+
+    _, run_time = _parse_time(run_1_started_at, "Run 1 start")
+    _, draft_time = _parse_time(draft_created_at, "A1 draft creation time")
+    _, save_time = _parse_time(save_as_of, "A1 capture save As-of")
+    _, observed_time = _parse_time(observed_at, "A1 checkpoint observation")
+    _, proof_time = _parse_time(proof_as_of, "Proof As-of")
+    return run_time <= draft_time <= save_time <= observed_time <= proof_time
 
 
 def _runtime_from_dict(value: Any) -> CodexRuntimeIdentity:
@@ -702,9 +765,13 @@ def _a1_capture_commit_from_dict(
         "schema",
         "proof_attempt_id",
         "run_id",
+        "task_sha256",
+        "actual_runtime_identity",
         "source_repository",
         "note",
         "note_byte_count",
+        "draft_evidence_sha256",
+        "draft_created_at",
         "save_as_of",
         "controller_state",
         "read_back_verified",
@@ -720,11 +787,17 @@ def _a1_capture_commit_from_dict(
             authority=_A1_CAPTURE_COMMIT_AUTHORITY,
             proof_attempt_id=value["proof_attempt_id"],
             run_id=value["run_id"],
+            task_sha256=value["task_sha256"],
+            actual_runtime_identity=_runtime_from_dict(
+                value["actual_runtime_identity"]
+            ),
             source_repository=_repository_from_dict(
                 value["source_repository"]
             ),
             note=_note_from_dict(value["note"]),
             note_byte_count=value["note_byte_count"],
+            draft_evidence_sha256=value["draft_evidence_sha256"],
+            draft_created_at=value["draft_created_at"],
             save_as_of=value["save_as_of"],
         )
     except (TypeError, ValueError) as exc:
@@ -1198,6 +1271,7 @@ def _project_records(
                 if set(binding) != {
                     "evidence_type",
                     "evidence_sha256",
+                    "a1_draft_sha256",
                     "note",
                     "note_byte_count",
                     "capture_commit",
@@ -1223,6 +1297,10 @@ def _project_records(
                 if (
                     binding["capture_commit_sha256"]
                     != a1_capture_commit.receipt_sha256
+                    or binding["evidence_sha256"]
+                    != a1_capture_commit.receipt_sha256
+                    or binding["a1_draft_sha256"]
+                    != a1_capture_commit.draft_evidence_sha256
                     or a1_capture_commit.note != captured_note
                     or a1_capture_commit.note_byte_count != count
                     or a1_capture_commit.proof_attempt_id
@@ -1230,6 +1308,17 @@ def _project_records(
                     or a1_capture_commit.run_id != static.run_1.run_id
                     or a1_capture_commit.source_repository
                     != static.repository
+                    or a1_capture_commit.actual_runtime_identity
+                    != static.runtime
+                    or not _a1_capture_chronology_is_valid(
+                        run_1_started_at=static.run_1.started_at,
+                        draft_created_at=(
+                            a1_capture_commit.draft_created_at
+                        ),
+                        save_as_of=a1_capture_commit.save_as_of,
+                        observed_at=event.observed_at,
+                        proof_as_of=static.attempt.proof_as_of,
+                    )
                 ):
                     raise _JournalIntegrityError(
                         "CREATOR_LIVE_A1_CAPTURE_COMMIT_MISMATCH",
@@ -1781,6 +1870,7 @@ class FieldNoteCreatorLiveProofRuntime:
         *,
         evidence_sha256: str,
         binding: dict[str, Any],
+        observed_at: str | None = None,
     ) -> FieldNoteWholeFlowTraceEvent:
         readback = self._require_stage(stage)
         index = readback.trace_event_count
@@ -1795,7 +1885,9 @@ class FieldNoteCreatorLiveProofRuntime:
             sequence=index,
             stage=stage,
             run_id=run.run_id,
-            observed_at=_utc_now_rfc3339(),
+            observed_at=(
+                _utc_now_rfc3339() if observed_at is None else observed_at
+            ),
             evidence_sha256=evidence_sha256,
             previous_trace_sha256=readback.trace_chain_head_sha256,
             repair_action="NONE",
@@ -1888,6 +1980,9 @@ class FieldNoteCreatorLiveProofRuntime:
         draft: FieldNoteDraft,
         *,
         capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt,
+        expected_task_sha256: str,
+        actual_runtime_identity: CodexRuntimeIdentity,
+        observed_at: str | None = None,
     ) -> FieldNoteWholeFlowTraceEvent:
         self._require_stage("A1_CAPTURE")
         if not isinstance(draft, FieldNoteDraft):
@@ -1907,6 +2002,10 @@ class FieldNoteCreatorLiveProofRuntime:
             note_sha256=draft.sha256,
             origin_run_id=draft.source_run_id,
         )
+        draft_evidence_sha256 = _a1_evidence_sha256(draft)
+        checkpoint_observed_at = (
+            _utc_now_rfc3339() if observed_at is None else observed_at
+        )
         if (
             not isinstance(
                 capture_commit,
@@ -1915,9 +2014,16 @@ class FieldNoteCreatorLiveProofRuntime:
             or capture_commit.proof_attempt_id
             != self._static.attempt.proof_attempt_id
             or capture_commit.run_id != self._static.run_1.run_id
+            or capture_commit.task_sha256 != expected_task_sha256
+            or capture_commit.actual_runtime_identity
+            != actual_runtime_identity
+            or actual_runtime_identity != self._static.runtime
             or capture_commit.source_repository != self._static.repository
             or capture_commit.note != note
             or capture_commit.note_byte_count != len(draft.markdown)
+            or capture_commit.draft_evidence_sha256
+            != draft_evidence_sha256
+            or capture_commit.draft_created_at != draft.created_at
             or capture_commit.controller_state != "saved"
             or capture_commit.read_back_verified is not True
         ):
@@ -1925,15 +2031,29 @@ class FieldNoteCreatorLiveProofRuntime:
                 "A1_CAPTURE",
                 "A1_CAPTURE_COMMIT_MISMATCH",
             )
-        evidence_sha256 = _a1_evidence_sha256(draft)
+        if not _a1_capture_chronology_is_valid(
+            run_1_started_at=self._static.run_1.started_at,
+            draft_created_at=draft.created_at,
+            save_as_of=capture_commit.save_as_of,
+            observed_at=checkpoint_observed_at,
+            proof_as_of=self._static.attempt.proof_as_of,
+        ):
+            self._terminal_failure(
+                "A1_CAPTURE",
+                "A1_CAPTURE_CHRONOLOGY_INVALID",
+                repair_action="TIMESTAMP_CHANGE",
+            )
+        evidence_sha256 = capture_commit.receipt_sha256
         return self._emit(
             "A1_CAPTURE",
             evidence_sha256=evidence_sha256,
+            observed_at=checkpoint_observed_at,
             binding={
                 "evidence_type": (
                     "FieldNoteCreatorLiveA1CaptureCommitReceipt"
                 ),
                 "evidence_sha256": evidence_sha256,
+                "a1_draft_sha256": draft_evidence_sha256,
                 "note": note.as_dict(),
                 "note_byte_count": len(draft.markdown),
                 "capture_commit": capture_commit.as_dict(),

--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -78,6 +78,9 @@ CREATOR_LIVE_ANCHOR_SCHEMA = (
 )
 CREATOR_LIVE_JOURNAL_FILENAME = "creator-live-proof-v0.1.jsonl"
 CREATOR_LIVE_ANCHOR_FILENAME = "creator-live-proof-v0.1.anchor.jsonl"
+A1_CAPTURE_COMMIT_SCHEMA = (
+    "decision-os.field-note-creator-live-a1-capture-commit.v0.1"
+)
 JOURNAL_GENESIS_SHA256 = "0" * 64
 ANCHOR_GENESIS_SHA256 = "0" * 64
 
@@ -104,6 +107,7 @@ _STAGES: tuple[TraceStage, ...] = (
     "A6_REVIEW",
 )
 _READBACK_AUTHORITY = object()
+_A1_CAPTURE_COMMIT_AUTHORITY = object()
 
 
 class FieldNoteCreatorLiveError(RuntimeError):
@@ -127,6 +131,100 @@ class FieldNoteCreatorLiveDurabilityError(FieldNoteCreatorLiveError):
 
 class FieldNoteCreatorLiveAttemptExistsError(FieldNoteCreatorLiveError):
     """The one-attempt journal already exists and cannot be replaced."""
+
+
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveA1CaptureCommitReceipt:
+    """Identity-only proof that the controller saved and read back one Note."""
+
+    schema: Literal[
+        "decision-os.field-note-creator-live-a1-capture-commit.v0.1"
+    ]
+    proof_attempt_id: str
+    run_id: str
+    source_repository: FieldNoteSourceRepositoryIdentity
+    note: FieldNoteIdentity
+    note_byte_count: int
+    save_as_of: str
+    controller_state: Literal["saved"]
+    read_back_verified: Literal[True]
+    receipt_sha256: str
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise FieldNoteCreatorLiveValidationError(
+            "A1 capture commit receipts are issued only after exact read-back."
+        )
+
+    @classmethod
+    def _issue(
+        cls,
+        *,
+        authority: object,
+        proof_attempt_id: str,
+        run_id: str,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        note: FieldNoteIdentity,
+        note_byte_count: int,
+        save_as_of: str,
+    ) -> FieldNoteCreatorLiveA1CaptureCommitReceipt:
+        if authority is not _A1_CAPTURE_COMMIT_AUTHORITY:
+            raise FieldNoteCreatorLiveValidationError(
+                "A1 capture commit authority is invalid."
+            )
+        if (
+            not isinstance(proof_attempt_id, str)
+            or not proof_attempt_id.strip()
+            or not isinstance(run_id, str)
+            or not run_id.strip()
+            or not isinstance(
+                source_repository,
+                FieldNoteSourceRepositoryIdentity,
+            )
+            or not isinstance(note, FieldNoteIdentity)
+            or type(note_byte_count) is not int
+            or note_byte_count <= 0
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "A1 capture commit identity is invalid."
+            )
+        normalized_save_as_of, _ = _parse_time(
+            save_as_of,
+            "A1 capture save As-of",
+        )
+        body = {
+            "schema": A1_CAPTURE_COMMIT_SCHEMA,
+            "proof_attempt_id": proof_attempt_id.strip(),
+            "run_id": run_id.strip(),
+            "source_repository": source_repository.as_dict(),
+            "note": note.as_dict(),
+            "note_byte_count": note_byte_count,
+            "save_as_of": normalized_save_as_of,
+            "controller_state": "saved",
+            "read_back_verified": True,
+        }
+        value = object.__new__(cls)
+        for field, item in {
+            **body,
+            "source_repository": source_repository,
+            "note": note,
+            "receipt_sha256": _canonical_sha256(body),
+        }.items():
+            object.__setattr__(value, field, item)
+        return value
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proof_attempt_id": self.proof_attempt_id,
+            "run_id": self.run_id,
+            "source_repository": self.source_repository.as_dict(),
+            "note": self.note.as_dict(),
+            "note_byte_count": self.note_byte_count,
+            "save_as_of": self.save_as_of,
+            "controller_state": self.controller_state,
+            "read_back_verified": self.read_back_verified,
+            "receipt_sha256": self.receipt_sha256,
+        }
 
 
 class _JournalIntegrityError(ValueError):
@@ -597,6 +695,51 @@ def _note_from_dict(value: Any) -> FieldNoteIdentity:
         ) from exc
 
 
+def _a1_capture_commit_from_dict(
+    value: Any,
+) -> FieldNoteCreatorLiveA1CaptureCommitReceipt:
+    required = {
+        "schema",
+        "proof_attempt_id",
+        "run_id",
+        "source_repository",
+        "note",
+        "note_byte_count",
+        "save_as_of",
+        "controller_state",
+        "read_back_verified",
+        "receipt_sha256",
+    }
+    if not isinstance(value, dict) or set(value) != required:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_A1_CAPTURE_COMMIT_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        receipt = FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
+            authority=_A1_CAPTURE_COMMIT_AUTHORITY,
+            proof_attempt_id=value["proof_attempt_id"],
+            run_id=value["run_id"],
+            source_repository=_repository_from_dict(
+                value["source_repository"]
+            ),
+            note=_note_from_dict(value["note"]),
+            note_byte_count=value["note_byte_count"],
+            save_as_of=value["save_as_of"],
+        )
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_A1_CAPTURE_COMMIT_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+    if receipt.as_dict() != value:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_A1_CAPTURE_COMMIT_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    return receipt
+
+
 def _provenance_from_dict(
     value: Any,
     *,
@@ -702,6 +845,7 @@ class FieldNoteCreatorLiveTraceReadback:
     run_2: FieldNoteWholeFlowRunIdentity | None
     captured_note: FieldNoteIdentity | None
     captured_note_byte_count: int | None
+    a1_capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt | None
     a3_reuse_event_id: str | None
     current_stage: TraceStage | None
     trace_event_count: int
@@ -739,6 +883,9 @@ class FieldNoteCreatorLiveTraceReadback:
         run_2: FieldNoteWholeFlowRunIdentity | None,
         captured_note: FieldNoteIdentity | None,
         captured_note_byte_count: int | None,
+        a1_capture_commit: (
+            FieldNoteCreatorLiveA1CaptureCommitReceipt | None
+        ),
         a3_reuse_event_id: str | None,
         current_stage: TraceStage | None,
         events: tuple[FieldNoteWholeFlowTraceEvent, ...],
@@ -770,6 +917,7 @@ class FieldNoteCreatorLiveTraceReadback:
             "run_2": run_2,
             "captured_note": captured_note,
             "captured_note_byte_count": captured_note_byte_count,
+            "a1_capture_commit": a1_capture_commit,
             "a3_reuse_event_id": a3_reuse_event_id,
             "current_stage": current_stage,
             "trace_event_count": len(events),
@@ -816,6 +964,11 @@ class FieldNoteCreatorLiveTraceReadback:
                 self.captured_note.as_dict() if self.captured_note else None
             ),
             "captured_note_byte_count": self.captured_note_byte_count,
+            "a1_capture_commit": (
+                self.a1_capture_commit.as_dict()
+                if self.a1_capture_commit
+                else None
+            ),
             "a3_reuse_event_id": self.a3_reuse_event_id,
             "current_stage": self.current_stage,
             "trace_event_count": self.trace_event_count,
@@ -957,6 +1110,7 @@ def _project_records(
     events: list[FieldNoteWholeFlowTraceEvent] = []
     captured_note: FieldNoteIdentity | None = None
     captured_note_byte_count: int | None = None
+    a1_capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt | None = None
     a3_reuse_event_id: str | None = None
     state: CreatorLiveAttemptState = "OPEN"
     failure_boundary: WholeFlowBoundary | None = None
@@ -1046,7 +1200,11 @@ def _project_records(
                     "evidence_sha256",
                     "note",
                     "note_byte_count",
-                } or binding["evidence_type"] != "FieldNoteDraft":
+                    "capture_commit",
+                    "capture_commit_sha256",
+                } or binding["evidence_type"] != (
+                    "FieldNoteCreatorLiveA1CaptureCommitReceipt"
+                ):
                     raise _JournalIntegrityError(
                         "CREATOR_LIVE_A1_BINDING_INVALID",
                         repair_action="RECEIPT_REWRITE",
@@ -1059,6 +1217,24 @@ def _project_records(
                         repair_action="RECEIPT_REWRITE",
                     )
                 captured_note_byte_count = count
+                a1_capture_commit = _a1_capture_commit_from_dict(
+                    binding["capture_commit"]
+                )
+                if (
+                    binding["capture_commit_sha256"]
+                    != a1_capture_commit.receipt_sha256
+                    or a1_capture_commit.note != captured_note
+                    or a1_capture_commit.note_byte_count != count
+                    or a1_capture_commit.proof_attempt_id
+                    != static.attempt.proof_attempt_id
+                    or a1_capture_commit.run_id != static.run_1.run_id
+                    or a1_capture_commit.source_repository
+                    != static.repository
+                ):
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A1_CAPTURE_COMMIT_MISMATCH",
+                        repair_action="RECEIPT_REWRITE",
+                    )
             elif index == 2:
                 if set(binding) != {
                     "evidence_type",
@@ -1178,6 +1354,7 @@ def _project_records(
         run_2=run_2,
         captured_note=captured_note,
         captured_note_byte_count=captured_note_byte_count,
+        a1_capture_commit=a1_capture_commit,
         a3_reuse_event_id=a3_reuse_event_id,
         current_stage=current_stage,
         events=tuple(events),
@@ -1214,6 +1391,7 @@ def _failed_readback(
         run_2=None,
         captured_note=None,
         captured_note_byte_count=None,
+        a1_capture_commit=None,
         a3_reuse_event_id=None,
         current_stage=None,
         events=(),
@@ -1705,7 +1883,12 @@ class FieldNoteCreatorLiveProofRuntime:
             )
         return self._append("RUN_2_OPENED", {"run_2": run_2.as_dict()})
 
-    def record_a1_capture(self, draft: FieldNoteDraft) -> FieldNoteWholeFlowTraceEvent:
+    def record_a1_capture(
+        self,
+        draft: FieldNoteDraft,
+        *,
+        capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt,
+    ) -> FieldNoteWholeFlowTraceEvent:
         self._require_stage("A1_CAPTURE")
         if not isinstance(draft, FieldNoteDraft):
             self._terminal_failure("A1_CAPTURE", "A1_CAPTURE_INVALID")
@@ -1724,15 +1907,37 @@ class FieldNoteCreatorLiveProofRuntime:
             note_sha256=draft.sha256,
             origin_run_id=draft.source_run_id,
         )
+        if (
+            not isinstance(
+                capture_commit,
+                FieldNoteCreatorLiveA1CaptureCommitReceipt,
+            )
+            or capture_commit.proof_attempt_id
+            != self._static.attempt.proof_attempt_id
+            or capture_commit.run_id != self._static.run_1.run_id
+            or capture_commit.source_repository != self._static.repository
+            or capture_commit.note != note
+            or capture_commit.note_byte_count != len(draft.markdown)
+            or capture_commit.controller_state != "saved"
+            or capture_commit.read_back_verified is not True
+        ):
+            self._terminal_failure(
+                "A1_CAPTURE",
+                "A1_CAPTURE_COMMIT_MISMATCH",
+            )
         evidence_sha256 = _a1_evidence_sha256(draft)
         return self._emit(
             "A1_CAPTURE",
             evidence_sha256=evidence_sha256,
             binding={
-                "evidence_type": "FieldNoteDraft",
+                "evidence_type": (
+                    "FieldNoteCreatorLiveA1CaptureCommitReceipt"
+                ),
                 "evidence_sha256": evidence_sha256,
                 "note": note.as_dict(),
                 "note_byte_count": len(draft.markdown),
+                "capture_commit": capture_commit.as_dict(),
+                "capture_commit_sha256": capture_commit.receipt_sha256,
             },
         )
 

--- a/decision_os/companion/field_notes_creator_live_capture.py
+++ b/decision_os/companion/field_notes_creator_live_capture.py
@@ -15,6 +15,7 @@ from decision_os.acceleration.model import (
     git_output,
     repository_id,
 )
+from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
 from decision_os.companion.field_notes_controller import (
     FieldNoteError,
     FieldNotesCompanionController,
@@ -33,11 +34,20 @@ from decision_os.companion.field_notes_reuse import FieldNoteIdentity
 from decision_os.companion.field_notes_whole_flow import (
     FieldNoteSourceRepositoryIdentity,
     FieldNoteWholeFlowTraceEvent,
+    _a1_evidence_sha256,
 )
 
 
 class FieldNoteCreatorLiveA1CaptureBridgeError(RuntimeError):
     """The bounded A1 bridge failed and left the attempt terminal."""
+
+
+def _utc_now_rfc3339() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
 
 
 class FieldNoteCreatorLiveA1CaptureBridge:
@@ -53,6 +63,7 @@ class FieldNoteCreatorLiveA1CaptureBridge:
         timeout_seconds: float = 900.0,
         monotonic: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
+        utc_now: Callable[[], str] = _utc_now_rfc3339,
     ) -> None:
         if (
             not isinstance(runtime, FieldNoteCreatorLiveProofRuntime)
@@ -75,6 +86,7 @@ class FieldNoteCreatorLiveA1CaptureBridge:
         self.timeout_seconds = float(timeout_seconds)
         self.monotonic = monotonic
         self.sleep = sleep
+        self.utc_now = utc_now
         self._dispatched = False
 
     def _terminal(self, reason: str) -> None:
@@ -96,7 +108,7 @@ class FieldNoteCreatorLiveA1CaptureBridge:
         except (OSError, RepositoryIdentityError):
             return False
 
-    def _preflight(self) -> tuple[str, Path]:
+    def _preflight(self) -> tuple[str, Path, CodexRuntimeIdentity, str]:
         readback = self.runtime.read_back()
         if (
             not readback.durable_readback_verified
@@ -105,6 +117,7 @@ class FieldNoteCreatorLiveA1CaptureBridge:
             or readback.trace_event_count != 0
             or readback.run_2 is not None
             or readback.source_repository != self.source_repository
+            or readback.runtime != readback.run_1.runtime
         ):
             self._terminal("A1_ATTEMPT_NOT_OPEN")
         snapshot = self.controller.snapshot()
@@ -116,7 +129,12 @@ class FieldNoteCreatorLiveA1CaptureBridge:
             self._terminal("A1_REPOSITORY_IDENTITY_MISMATCH")
         if selected_root != root or not self._repository_identity_matches():
             self._terminal("A1_REPOSITORY_IDENTITY_MISMATCH")
-        return readback.run_1.run_id, root
+        return (
+            readback.run_1.run_id,
+            root,
+            readback.runtime,
+            readback.proof_attempt_id,
+        )
 
     def _wait_for_run(self) -> None:
         deadline = self.monotonic() + self.timeout_seconds
@@ -205,21 +223,32 @@ class FieldNoteCreatorLiveA1CaptureBridge:
 
         if self._dispatched:
             self._terminal("A1_RUN_ALREADY_DISPATCHED")
-        run_id, root = self._preflight()
+        run_id, root, expected_runtime, proof_attempt_id = self._preflight()
         self._dispatched = True
         try:
             self.controller.start_creator_live_a1_capture(
                 task,
                 run_id=run_id,
+                expected_runtime_identity=expected_runtime,
             )
             self._wait_for_run()
             draft = self.controller.creator_live_a1_capture_candidate()
+            completion = self.controller.creator_live_a1_run_completion()
             validate_compiled_markdown(draft.markdown)
+            task_sha256 = hashlib.sha256(
+                task.strip().encode("utf-8")
+            ).hexdigest()
             if (
                 draft.source_run_id != run_id
                 or hashlib.sha256(draft.markdown).hexdigest() != draft.sha256
             ):
                 self._terminal("A1_NOTE_IDENTITY_MISMATCH")
+            if completion.run_id != run_id:
+                self._terminal("A1_CAPTURE_IDENTITY_MISMATCH")
+            if completion.task_sha256 != task_sha256:
+                self._terminal("A1_TASK_IDENTITY_MISMATCH")
+            if completion.actual_runtime_identity != expected_runtime:
+                self._terminal("A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH")
             target = self._fixed_target(root, draft)
             self._require_unoccupied_target(target)
             if not self._repository_identity_matches():
@@ -265,22 +294,27 @@ class FieldNoteCreatorLiveA1CaptureBridge:
             )
             commit = FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
                 authority=_A1_CAPTURE_COMMIT_AUTHORITY,
-                proof_attempt_id=(
-                    self.runtime.read_back().proof_attempt_id
-                ),
+                proof_attempt_id=proof_attempt_id,
                 run_id=run_id,
+                task_sha256=task_sha256,
+                actual_runtime_identity=(
+                    completion.actual_runtime_identity
+                ),
                 source_repository=self.source_repository,
                 note=note,
                 note_byte_count=len(note_bytes),
-                save_as_of=(
-                    datetime.now(timezone.utc)
-                    .isoformat(timespec="microseconds")
-                    .replace("+00:00", "Z")
-                ),
+                draft_evidence_sha256=_a1_evidence_sha256(draft),
+                draft_created_at=draft.created_at,
+                save_as_of=self.utc_now(),
             )
             event = self.runtime.record_a1_capture(
                 draft,
                 capture_commit=commit,
+                expected_task_sha256=task_sha256,
+                actual_runtime_identity=(
+                    completion.actual_runtime_identity
+                ),
+                observed_at=self.utc_now(),
             )
             closed = self.runtime.read_back()
             if (

--- a/decision_os/companion/field_notes_creator_live_capture.py
+++ b/decision_os/companion/field_notes_creator_live_capture.py
@@ -1,0 +1,310 @@
+"""Bounded Run-1 bridge from the A1 proposal tool to durable A1 closure."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import stat
+import time
+from typing import Callable
+
+from decision_os.acceleration.model import (
+    RepositoryIdentityError,
+    git_output,
+    repository_id,
+)
+from decision_os.companion.field_notes_controller import (
+    FieldNoteError,
+    FieldNotesCompanionController,
+)
+from decision_os.companion.field_notes_creator_live import (
+    FieldNoteCreatorLiveA1CaptureCommitReceipt,
+    FieldNoteCreatorLiveProofRuntime,
+    FieldNoteCreatorLiveStageError,
+    _A1_CAPTURE_COMMIT_AUTHORITY,
+)
+from decision_os.companion.field_notes_model import (
+    FieldNoteDraft,
+    validate_compiled_markdown,
+)
+from decision_os.companion.field_notes_reuse import FieldNoteIdentity
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowTraceEvent,
+)
+
+
+class FieldNoteCreatorLiveA1CaptureBridgeError(RuntimeError):
+    """The bounded A1 bridge failed and left the attempt terminal."""
+
+
+class FieldNoteCreatorLiveA1CaptureBridge:
+    """Consume one already-open attempt and exactly one controller Run 1."""
+
+    def __init__(
+        self,
+        *,
+        runtime: FieldNoteCreatorLiveProofRuntime,
+        controller: FieldNotesCompanionController,
+        repository: Path,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        timeout_seconds: float = 900.0,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if (
+            not isinstance(runtime, FieldNoteCreatorLiveProofRuntime)
+            or not isinstance(controller, FieldNotesCompanionController)
+            or not isinstance(
+                source_repository,
+                FieldNoteSourceRepositoryIdentity,
+            )
+            or not isinstance(timeout_seconds, (int, float))
+            or isinstance(timeout_seconds, bool)
+            or timeout_seconds <= 0
+        ):
+            raise FieldNoteCreatorLiveA1CaptureBridgeError(
+                "Creator-live A1 bridge configuration is invalid."
+            )
+        self.runtime = runtime
+        self.controller = controller
+        self.repository = Path(repository)
+        self.source_repository = source_repository
+        self.timeout_seconds = float(timeout_seconds)
+        self.monotonic = monotonic
+        self.sleep = sleep
+        self._dispatched = False
+
+    def _terminal(self, reason: str) -> None:
+        bounded = reason if len(reason) <= 256 else reason[:256]
+        try:
+            self.runtime.record_stage_failure("A1_CAPTURE", bounded)
+        except FieldNoteCreatorLiveStageError as exc:
+            raise FieldNoteCreatorLiveA1CaptureBridgeError(bounded) from exc
+        raise FieldNoteCreatorLiveA1CaptureBridgeError(bounded)
+
+    def _repository_identity_matches(self) -> bool:
+        try:
+            root = self.repository.resolve(strict=True)
+            return (
+                repository_id(root) == self.source_repository.repository_id
+                and git_output(root, "rev-parse", "HEAD")
+                == self.source_repository.source_commit
+            )
+        except (OSError, RepositoryIdentityError):
+            return False
+
+    def _preflight(self) -> tuple[str, Path]:
+        readback = self.runtime.read_back()
+        if (
+            not readback.durable_readback_verified
+            or readback.state != "OPEN"
+            or readback.current_stage != "A1_CAPTURE"
+            or readback.trace_event_count != 0
+            or readback.run_2 is not None
+            or readback.source_repository != self.source_repository
+        ):
+            self._terminal("A1_ATTEMPT_NOT_OPEN")
+        snapshot = self.controller.snapshot()
+        selected = snapshot.get("repository")
+        try:
+            root = self.repository.resolve(strict=True)
+            selected_root = Path(selected["path"]).resolve(strict=True)
+        except (KeyError, OSError, TypeError):
+            self._terminal("A1_REPOSITORY_IDENTITY_MISMATCH")
+        if selected_root != root or not self._repository_identity_matches():
+            self._terminal("A1_REPOSITORY_IDENTITY_MISMATCH")
+        return readback.run_1.run_id, root
+
+    def _wait_for_run(self) -> None:
+        deadline = self.monotonic() + self.timeout_seconds
+        while True:
+            state = self.controller.snapshot()["run"]["state"]
+            if state != "running":
+                return
+            if self.monotonic() >= deadline:
+                self._terminal("A1_RUN_TIMEOUT")
+            self.sleep(0.05)
+
+    @staticmethod
+    def _fixed_target(root: Path, draft: FieldNoteDraft) -> Path:
+        parts = Path(draft.relative_path).parts
+        if (
+            len(parts) != 3
+            or parts[:2] != (".decision-os", "field-notes")
+        ):
+            raise FieldNoteCreatorLiveA1CaptureBridgeError(
+                "A1_TARGET_OUTSIDE_FIXED_ROOT"
+            )
+        return root.joinpath(*parts)
+
+    @staticmethod
+    def _require_unoccupied_target(target: Path) -> None:
+        for parent in (target.parent.parent, target.parent):
+            if parent.exists() or parent.is_symlink():
+                linked = parent.lstat()
+                if stat.S_ISLNK(linked.st_mode) or not stat.S_ISDIR(
+                    linked.st_mode
+                ):
+                    raise FieldNoteCreatorLiveA1CaptureBridgeError(
+                        "A1_TARGET_PARENT_UNSAFE"
+                    )
+        if target.exists() or target.is_symlink():
+            raise FieldNoteCreatorLiveA1CaptureBridgeError(
+                "A1_TARGET_PREEXISTING"
+            )
+        if target.parent.exists() and any(
+            child.name.casefold() == target.name.casefold()
+            for child in target.parent.iterdir()
+        ):
+            raise FieldNoteCreatorLiveA1CaptureBridgeError(
+                "A1_TARGET_COLLISION"
+            )
+
+    @staticmethod
+    def _exact_read_back(target: Path) -> bytes:
+        descriptor: int | None = None
+        try:
+            linked = target.lstat()
+            descriptor = os.open(
+                target,
+                os.O_RDONLY
+                | getattr(os, "O_NOFOLLOW", 0)
+                | getattr(os, "O_CLOEXEC", 0),
+            )
+            opened = os.fstat(descriptor)
+            if (
+                stat.S_ISLNK(linked.st_mode)
+                or not stat.S_ISREG(linked.st_mode)
+                or not stat.S_ISREG(opened.st_mode)
+                or (linked.st_dev, linked.st_ino)
+                != (opened.st_dev, opened.st_ino)
+            ):
+                raise OSError("A1 target identity changed.")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 65_536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b"".join(chunks)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+
+    def _capture_failure_reason(self, exc: Exception) -> str:
+        value = str(exc).strip()
+        if value.startswith("A1_"):
+            return value
+        return "A1_CAPTURE_FAILED"
+
+    def capture(self, task: str) -> FieldNoteWholeFlowTraceEvent:
+        """Dispatch one Run 1, save its exact proposal, then emit one A1."""
+
+        if self._dispatched:
+            self._terminal("A1_RUN_ALREADY_DISPATCHED")
+        run_id, root = self._preflight()
+        self._dispatched = True
+        try:
+            self.controller.start_creator_live_a1_capture(
+                task,
+                run_id=run_id,
+            )
+            self._wait_for_run()
+            draft = self.controller.creator_live_a1_capture_candidate()
+            validate_compiled_markdown(draft.markdown)
+            if (
+                draft.source_run_id != run_id
+                or hashlib.sha256(draft.markdown).hexdigest() != draft.sha256
+            ):
+                self._terminal("A1_NOTE_IDENTITY_MISMATCH")
+            target = self._fixed_target(root, draft)
+            self._require_unoccupied_target(target)
+            if not self._repository_identity_matches():
+                self._terminal("A1_REPOSITORY_IDENTITY_MISMATCH")
+
+            approval = self.controller.field_note_save()
+            surface = approval["run"]["field_note"]
+            request = surface["approval"]
+            if (
+                surface.get("state") != "approval"
+                or request.get("action") != "CREATE"
+                or request.get("path") != draft.relative_path
+                or request.get("content_sha256") != draft.sha256
+                or request.get("precondition") != "MUST_NOT_EXIST"
+                or request.get("approval_scope") != "THIS ONE FILE ONLY"
+            ):
+                self._terminal("A1_SAVE_APPROVAL_IDENTITY_MISMATCH")
+
+            saved = self.controller.field_note_approval("allow_once")
+            if saved["run"]["field_note"] != {
+                "state": "saved",
+                "path": draft.relative_path,
+            }:
+                self._terminal("A1_CONTROLLER_SAVE_NOT_CONFIRMED")
+            try:
+                note_bytes = self._exact_read_back(target)
+            except OSError:
+                self._terminal("A1_NOTE_READ_BACK_FAILED")
+            if (
+                note_bytes != draft.markdown
+                or len(note_bytes) != len(draft.markdown)
+                or hashlib.sha256(note_bytes).hexdigest() != draft.sha256
+            ):
+                self._terminal("A1_NOTE_READ_BACK_MISMATCH")
+            if not self._repository_identity_matches():
+                self._terminal("A1_REPOSITORY_IDENTITY_MISMATCH")
+
+            note = FieldNoteIdentity(
+                note_path=draft.relative_path,
+                field_note_id=draft.field_note_id,
+                note_sha256=draft.sha256,
+                origin_run_id=draft.source_run_id,
+            )
+            commit = FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
+                authority=_A1_CAPTURE_COMMIT_AUTHORITY,
+                proof_attempt_id=(
+                    self.runtime.read_back().proof_attempt_id
+                ),
+                run_id=run_id,
+                source_repository=self.source_repository,
+                note=note,
+                note_byte_count=len(note_bytes),
+                save_as_of=(
+                    datetime.now(timezone.utc)
+                    .isoformat(timespec="microseconds")
+                    .replace("+00:00", "Z")
+                ),
+            )
+            event = self.runtime.record_a1_capture(
+                draft,
+                capture_commit=commit,
+            )
+            closed = self.runtime.read_back()
+            if (
+                not closed.durable_readback_verified
+                or closed.state != "OPEN"
+                or closed.current_stage != "A2_RECONNECT"
+                or closed.trace_event_count != 1
+                or closed.captured_note != note
+                or closed.captured_note_byte_count != len(note_bytes)
+                or closed.a1_capture_commit != commit
+            ):
+                self._terminal("A1_DURABLE_CLOSURE_MISMATCH")
+            return event
+        except FieldNoteCreatorLiveA1CaptureBridgeError as exc:
+            if self.runtime.read_back().state == "OPEN":
+                self._terminal(self._capture_failure_reason(exc))
+            raise
+        except FieldNoteCreatorLiveStageError:
+            raise
+        except Exception as exc:
+            self._terminal(self._capture_failure_reason(exc))
+
+
+__all__ = [
+    "FieldNoteCreatorLiveA1CaptureBridge",
+    "FieldNoteCreatorLiveA1CaptureBridgeError",
+]

--- a/decision_os/companion/field_notes_whole_flow.py
+++ b/decision_os/companion/field_notes_whole_flow.py
@@ -664,6 +664,8 @@ class FieldNoteWholeFlowProofReceipt:
     reused_structure_sha256: str | None
     reused_structure_binding_sha256: str | None
     a1_evidence_sha256: str | None
+    a1_draft_sha256: str | None
+    a1_capture_commit_sha256: str | None
     a2_receipt_sha256: str | None
     a3_reuse_event_id: str | None
     a3_receipt_sha256: str | None
@@ -737,6 +739,11 @@ class FieldNoteWholeFlowProofReceipt:
                 "Reused structure binding identity",
             ),
             (self.a1_evidence_sha256, "A1 evidence identity"),
+            (self.a1_draft_sha256, "A1 draft identity"),
+            (
+                self.a1_capture_commit_sha256,
+                "A1 capture-commit identity",
+            ),
             (self.a2_receipt_sha256, "A2 receipt identity"),
             (self.a3_reuse_event_id, "A3 reuse event identity"),
             (self.a3_receipt_sha256, "A3 complete receipt identity"),
@@ -878,7 +885,11 @@ class FieldNoteWholeFlowProofReceipt:
                 any(value is None for value in required)
                 or (
                     self.proof_mode == "CREATOR_LIVE"
-                    and self.a3_receipt_sha256 is None
+                    and (
+                        self.a3_receipt_sha256 is None
+                        or self.a1_draft_sha256 is None
+                        or self.a1_capture_commit_sha256 is None
+                    )
                 )
                 or self.a4_event_count != 1
                 or self.a4_chain_head_sha256 != self.a4_event_sha256
@@ -954,6 +965,42 @@ class FieldNoteWholeFlowProofReceipt:
         ):
             raise FieldNoteWholeFlowValidationError(
                 "CREATOR_LIVE PASS durable runtime identity is invalid."
+            )
+        commit = readback.a1_capture_commit
+        if (
+            commit is None
+            or not self.proof_trace
+            or self.a1_evidence_sha256 != commit.receipt_sha256
+            or self.a1_capture_commit_sha256 != commit.receipt_sha256
+            or self.a1_draft_sha256 != commit.draft_evidence_sha256
+            or commit.proof_attempt_id != self.proof_attempt_id
+            or commit.run_id != self.run_1.run_id
+            or commit.actual_runtime_identity != self.source_runtime
+            or commit.source_repository != self.source_repository
+            or commit.note != self.note
+            or commit.note_byte_count != self.note_byte_count
+            or self.proof_trace[0].evidence_sha256
+            != commit.receipt_sha256
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "CREATOR_LIVE PASS A1 capture commit is invalid."
+            )
+        _, run_time = _parse_time(self.run_1.started_at, "Run 1 start")
+        _, draft_time = _parse_time(
+            commit.draft_created_at,
+            "A1 draft creation time",
+        )
+        _, save_time = _parse_time(commit.save_as_of, "A1 save As-of")
+        _, observed_time = _parse_time(
+            self.proof_trace[0].observed_at,
+            "A1 checkpoint observation",
+        )
+        _, proof_time = _parse_time(self.proof_as_of, "Proof As-of")
+        if not (
+            run_time <= draft_time <= save_time <= observed_time <= proof_time
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "CREATOR_LIVE PASS A1 chronology is invalid."
             )
 
     def _validate_proof_trace_identity(self) -> None:
@@ -1109,6 +1156,10 @@ class FieldNoteWholeFlowProofReceipt:
             "claim_boundary": self.claim_boundary.as_dict(),
         }
         if self.proof_mode == "CREATOR_LIVE":
+            body["a1_draft_sha256"] = self.a1_draft_sha256
+            body["a1_capture_commit_sha256"] = (
+                self.a1_capture_commit_sha256
+            )
             body["a3_receipt_sha256"] = self.a3_receipt_sha256
             body["creator_live_readback"] = (
                 self.creator_live_readback.as_dict()
@@ -1439,6 +1490,13 @@ def _receipt(
         a3 is not None and a3.use_evidence is not None
     ) else None
     first_event = a4.events[0] if a4 is not None and a4.events else None
+    a1_capture_commit = (
+        bundle.creator_live_readback.a1_capture_commit
+        if bundle.attempt.proof_mode == "CREATOR_LIVE"
+        and bundle.creator_live_readback is not None
+        else None
+    )
+    a1_draft_sha256 = _a1_evidence_sha256(a1) if a1 else None
     return FieldNoteWholeFlowProofReceipt(
         schema=WHOLE_FLOW_SCHEMA,
         proof_attempt_id=bundle.attempt.proof_attempt_id,
@@ -1456,7 +1514,25 @@ def _receipt(
         reused_structure_binding_sha256=(
             binding.binding_sha256 if binding else None
         ),
-        a1_evidence_sha256=_a1_evidence_sha256(a1) if a1 else None,
+        a1_evidence_sha256=(
+            a1_capture_commit.receipt_sha256
+            if a1_capture_commit is not None
+            else (
+                a1_draft_sha256
+                if bundle.attempt.proof_mode == "FIXTURE"
+                else None
+            )
+        ),
+        a1_draft_sha256=(
+            a1_draft_sha256
+            if bundle.attempt.proof_mode == "CREATOR_LIVE"
+            else None
+        ),
+        a1_capture_commit_sha256=(
+            a1_capture_commit.receipt_sha256
+            if a1_capture_commit is not None
+            else None
+        ),
         a2_receipt_sha256=_a2_receipt_sha256(a2) if a2 else None,
         a3_reuse_event_id=a3.reuse_event_id if a3 else None,
         a3_receipt_sha256=(
@@ -1660,6 +1736,45 @@ def verify_field_note_whole_flow(
         or _sha256_bytes(a1.markdown) != a1.sha256
     ):
         return _fail(bundle, "A1_CAPTURE", "A1_NOTE_IDENTITY_MISMATCH")
+    if bundle.attempt.proof_mode == "CREATOR_LIVE":
+        assert bundle.creator_live_readback is not None
+        commit = bundle.creator_live_readback.a1_capture_commit
+        if (
+            commit is None
+            or commit.proof_attempt_id != bundle.attempt.proof_attempt_id
+            or commit.run_id != bundle.run_1.run_id
+            or commit.actual_runtime_identity != bundle.run_1.runtime
+            or commit.source_repository != bundle.source_repository
+            or commit.note != bundle.note
+            or commit.note_byte_count != len(bundle.note_bytes)
+            or commit.draft_evidence_sha256 != _a1_evidence_sha256(a1)
+            or commit.draft_created_at != a1.created_at
+            or not bundle.proof_trace
+            or bundle.proof_trace[0].evidence_sha256
+            != commit.receipt_sha256
+        ):
+            return _fail(
+                bundle,
+                "A1_CAPTURE",
+                "A1_CAPTURE_COMMIT_MISMATCH",
+            )
+        _, save_time = _parse_time(commit.save_as_of, "A1 save As-of")
+        _, observed_time = _parse_time(
+            bundle.proof_trace[0].observed_at,
+            "A1 checkpoint observation",
+        )
+        _, proof_time = _parse_time(
+            bundle.attempt.proof_as_of,
+            "Proof As-of",
+        )
+        if not (
+            run_1_time <= a1_time <= save_time <= observed_time <= proof_time
+        ):
+            return _fail(
+                bundle,
+                "A1_CAPTURE",
+                "A1_CAPTURE_CHRONOLOGY_INVALID",
+            )
     if a1_time < run_1_time or a1_time >= run_2_time:
         return _fail(bundle, "A1_CAPTURE", "A1_NOT_NEW_FOR_PROOF_ATTEMPT")
 
@@ -1804,8 +1919,18 @@ def verify_field_note_whole_flow(
     if proof_time < review_time:
         return _fail(bundle, "PROOF_AS_OF", "PROOF_AS_OF_PRECEDES_A6_REVIEW")
 
+    creator_a1_commit = (
+        bundle.creator_live_readback.a1_capture_commit
+        if bundle.attempt.proof_mode == "CREATOR_LIVE"
+        and bundle.creator_live_readback is not None
+        else None
+    )
     expected_evidence = (
-        _a1_evidence_sha256(a1),
+        (
+            creator_a1_commit.receipt_sha256
+            if creator_a1_commit is not None
+            else _a1_evidence_sha256(a1)
+        ),
         _a2_receipt_sha256(a2),
         (
             _a3_receipt_sha256(a3)

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from decision_os.companion import field_notes_creator_live as creator_live
 from decision_os.companion import field_notes_whole_flow as whole_flow
 from decision_os.companion.field_notes_creator_live import (
+    FieldNoteCreatorLiveA1CaptureCommitReceipt,
     FieldNoteCreatorLiveAttemptExistsError,
     FieldNoteCreatorLiveDurabilityError,
     FieldNoteCreatorLiveProofRuntime,
@@ -82,12 +83,41 @@ class CreatorLiveTestCase(unittest.TestCase):
     ) -> None:
         evidence = bundle or self.bundle
         assert evidence.a1_capture is not None
+        capture_commit = self.capture_commit(
+            runtime_path,
+            evidence.a1_capture,
+        )
         with patch.object(
             creator_live,
             "_utc_now_rfc3339",
             return_value=observed_at,
         ):
-            runtime_path.record_a1_capture(evidence.a1_capture)
+            runtime_path.record_a1_capture(
+                evidence.a1_capture,
+                capture_commit=capture_commit,
+            )
+
+    @staticmethod
+    def capture_commit(
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        draft,
+    ) -> FieldNoteCreatorLiveA1CaptureCommitReceipt:
+        readback = runtime_path.read_back()
+        note = FieldNoteIdentity(
+            note_path=draft.relative_path,
+            field_note_id=draft.field_note_id,
+            note_sha256=draft.sha256,
+            origin_run_id=draft.source_run_id,
+        )
+        return FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
+            authority=creator_live._A1_CAPTURE_COMMIT_AUTHORITY,
+            proof_attempt_id=readback.proof_attempt_id,
+            run_id=readback.run_1.run_id,
+            source_repository=readback.source_repository,
+            note=note,
+            note_byte_count=len(draft.markdown),
+            save_as_of=draft.created_at,
+        )
 
     def open_run_2(
         self,
@@ -127,7 +157,13 @@ class CreatorLiveTestCase(unittest.TestCase):
             "_utc_now_rfc3339",
             side_effect=OBSERVED_AT,
         ):
-            runtime_path.record_a1_capture(evidence.a1_capture)
+            runtime_path.record_a1_capture(
+                evidence.a1_capture,
+                capture_commit=self.capture_commit(
+                    runtime_path,
+                    evidence.a1_capture,
+                ),
+            )
             runtime_path.open_run_2(evidence.run_2)
             runtime_path.record_a2_reconnect(
                 evidence.a2_reconnect,
@@ -200,6 +236,50 @@ class CreatorLiveProvenanceTests(CreatorLiveTestCase):
 
 
 class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
+    def test_draft_alone_cannot_emit_a1_checkpoint(self) -> None:
+        runtime_path = self.open_runtime()
+        assert self.bundle.a1_capture is not None
+        with self.assertRaises(TypeError):
+            runtime_path.record_a1_capture(  # type: ignore[call-arg]
+                self.bundle.a1_capture
+            )
+        readback = runtime_path.read_back()
+        self.assertEqual("OPEN", readback.state)
+        self.assertEqual(0, readback.trace_event_count)
+
+    def test_changed_capture_sha_or_byte_count_fails_terminal(self) -> None:
+        assert self.bundle.a1_capture is not None
+        for label, note_sha256, byte_delta in (
+            ("wrong-sha", "0" * 64, 0),
+            ("wrong-count", self.bundle.a1_capture.sha256, 1),
+        ):
+            with self.subTest(label=label):
+                runtime_path = self.open_runtime(label)
+                draft = self.bundle.a1_capture
+                commit = self.capture_commit(runtime_path, draft)
+                changed_note = replace(
+                    commit.note,
+                    note_sha256=note_sha256,
+                )
+                changed = FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
+                    authority=creator_live._A1_CAPTURE_COMMIT_AUTHORITY,
+                    proof_attempt_id=commit.proof_attempt_id,
+                    run_id=commit.run_id,
+                    source_repository=commit.source_repository,
+                    note=changed_note,
+                    note_byte_count=commit.note_byte_count + byte_delta,
+                    save_as_of=commit.save_as_of,
+                )
+                with self.assertRaises(FieldNoteCreatorLiveStageError):
+                    runtime_path.record_a1_capture(
+                        draft,
+                        capture_commit=changed,
+                    )
+                self.assertEqual(
+                    "A1_CAPTURE_COMMIT_MISMATCH",
+                    runtime_path.read_back().failure_reason,
+                )
+
     def test_attempt_opens_with_exact_repository_and_runtime(self) -> None:
         readback = self.open_runtime().read_back()
         self.assertEqual("OPEN", readback.state)
@@ -302,7 +382,13 @@ class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
         self.record_a1(runtime_path)
         assert self.bundle.a1_capture is not None
         with self.assertRaises(FieldNoteCreatorLiveStageError):
-            runtime_path.record_a1_capture(self.bundle.a1_capture)
+            runtime_path.record_a1_capture(
+                self.bundle.a1_capture,
+                capture_commit=self.capture_commit(
+                    runtime_path,
+                    self.bundle.a1_capture,
+                ),
+            )
         self.assertEqual("RETRY_REPLACEMENT", runtime_path.read_back().repair_action)
 
     def test_failed_stage_cannot_later_emit_success(self) -> None:

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -22,6 +22,7 @@ from decision_os.companion.field_notes_reuse import (
     FieldNoteIdentity,
     assess_field_note_reuse,
 )
+from decision_os.companion.field_notes_model import compile_draft
 from decision_os.companion.field_notes_whole_flow import (
     FieldNoteCreatorLiveRuntimeProvenance,
     FieldNoteWholeFlowTraceEvent,
@@ -33,6 +34,7 @@ from tests.test_field_notes_whole_flow import (
     ARTIFACT_SECRET,
     PRIVATE_NOTE_TEXT,
     build_bundle,
+    proposal,
     runtime,
     source_repository,
 )
@@ -46,6 +48,8 @@ OBSERVED_AT = (
     "2026-08-05T11:32:00Z",
     "2026-08-05T11:41:00Z",
 )
+RUN_1_TASK = "Complete the bounded creator-live Run 1 task."
+RUN_1_TASK_SHA256 = hashlib.sha256(RUN_1_TASK.encode("utf-8")).hexdigest()
 
 
 class CreatorLiveTestCase(unittest.TestCase):
@@ -83,6 +87,7 @@ class CreatorLiveTestCase(unittest.TestCase):
     ) -> None:
         evidence = bundle or self.bundle
         assert evidence.a1_capture is not None
+        readback = runtime_path.read_back()
         capture_commit = self.capture_commit(
             runtime_path,
             evidence.a1_capture,
@@ -95,6 +100,8 @@ class CreatorLiveTestCase(unittest.TestCase):
             runtime_path.record_a1_capture(
                 evidence.a1_capture,
                 capture_commit=capture_commit,
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=readback.runtime,
             )
 
     @staticmethod
@@ -113,10 +120,37 @@ class CreatorLiveTestCase(unittest.TestCase):
             authority=creator_live._A1_CAPTURE_COMMIT_AUTHORITY,
             proof_attempt_id=readback.proof_attempt_id,
             run_id=readback.run_1.run_id,
+            task_sha256=RUN_1_TASK_SHA256,
+            actual_runtime_identity=readback.runtime,
             source_repository=readback.source_repository,
             note=note,
             note_byte_count=len(draft.markdown),
+            draft_evidence_sha256=whole_flow._a1_evidence_sha256(draft),
+            draft_created_at=draft.created_at,
             save_as_of=draft.created_at,
+        )
+
+    @staticmethod
+    def reissue_capture_commit(
+        commit: FieldNoteCreatorLiveA1CaptureCommitReceipt,
+        **changes,
+    ) -> FieldNoteCreatorLiveA1CaptureCommitReceipt:
+        values = {
+            "proof_attempt_id": commit.proof_attempt_id,
+            "run_id": commit.run_id,
+            "task_sha256": commit.task_sha256,
+            "actual_runtime_identity": commit.actual_runtime_identity,
+            "source_repository": commit.source_repository,
+            "note": commit.note,
+            "note_byte_count": commit.note_byte_count,
+            "draft_evidence_sha256": commit.draft_evidence_sha256,
+            "draft_created_at": commit.draft_created_at,
+            "save_as_of": commit.save_as_of,
+        }
+        values.update(changes)
+        return FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
+            authority=creator_live._A1_CAPTURE_COMMIT_AUTHORITY,
+            **values,
         )
 
     def open_run_2(
@@ -163,6 +197,8 @@ class CreatorLiveTestCase(unittest.TestCase):
                     runtime_path,
                     evidence.a1_capture,
                 ),
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=runtime_path.read_back().runtime,
             )
             runtime_path.open_run_2(evidence.run_2)
             runtime_path.record_a2_reconnect(
@@ -196,6 +232,13 @@ class CreatorLiveProvenanceTests(CreatorLiveTestCase):
         self.assertEqual("PASS", receipt.state)
         self.assertEqual("FIXTURE", receipt.proof_mode)
         self.assertIsNone(receipt.creator_live_readback)
+        assert self.bundle.a1_capture is not None
+        self.assertEqual(
+            whole_flow._a1_evidence_sha256(self.bundle.a1_capture),
+            receipt.a1_evidence_sha256,
+        )
+        self.assertIsNone(receipt.a1_draft_sha256)
+        self.assertIsNone(receipt.a1_capture_commit_sha256)
 
     def test_hand_built_trace_cannot_satisfy_creator_live(self) -> None:
         live = replace(self.bundle, attempt=self.live_attempt)
@@ -265,20 +308,166 @@ class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
                     authority=creator_live._A1_CAPTURE_COMMIT_AUTHORITY,
                     proof_attempt_id=commit.proof_attempt_id,
                     run_id=commit.run_id,
+                    task_sha256=commit.task_sha256,
+                    actual_runtime_identity=(
+                        commit.actual_runtime_identity
+                    ),
                     source_repository=commit.source_repository,
                     note=changed_note,
                     note_byte_count=commit.note_byte_count + byte_delta,
+                    draft_evidence_sha256=(
+                        commit.draft_evidence_sha256
+                    ),
+                    draft_created_at=commit.draft_created_at,
                     save_as_of=commit.save_as_of,
                 )
                 with self.assertRaises(FieldNoteCreatorLiveStageError):
                     runtime_path.record_a1_capture(
                         draft,
                         capture_commit=changed,
+                        expected_task_sha256=RUN_1_TASK_SHA256,
+                        actual_runtime_identity=(
+                            runtime_path.read_back().runtime
+                        ),
                     )
                 self.assertEqual(
                     "A1_CAPTURE_COMMIT_MISMATCH",
                     runtime_path.read_back().failure_reason,
                 )
+
+    def test_changed_task_or_actual_runtime_in_commit_fails_terminal(self) -> None:
+        assert self.bundle.a1_capture is not None
+        for label, changes in (
+            ("task", {"task_sha256": "f" * 64}),
+            (
+                "runtime",
+                {
+                    "actual_runtime_identity": replace(
+                        self.bundle.run_1.runtime,
+                        model="other-model",
+                    )
+                },
+            ),
+        ):
+            with self.subTest(identity=label):
+                runtime_path = self.open_runtime(f"changed-{label}")
+                commit = self.capture_commit(
+                    runtime_path,
+                    self.bundle.a1_capture,
+                )
+                changed = self.reissue_capture_commit(commit, **changes)
+                with self.assertRaises(FieldNoteCreatorLiveStageError):
+                    runtime_path.record_a1_capture(
+                        self.bundle.a1_capture,
+                        capture_commit=changed,
+                        expected_task_sha256=RUN_1_TASK_SHA256,
+                        actual_runtime_identity=(
+                            runtime_path.read_back().runtime
+                        ),
+                        observed_at=OBSERVED_AT[0],
+                    )
+                self.assertEqual(
+                    "A1_CAPTURE_COMMIT_MISMATCH",
+                    runtime_path.read_back().failure_reason,
+                )
+
+    def test_draft_before_run_1_is_temporally_rejected(self) -> None:
+        runtime_path = self.open_runtime("draft-before-run")
+        draft = compile_draft(
+            proposal(),
+            source_run_id=self.bundle.run_1.run_id,
+            created_at="2026-08-05T09:59:00Z",
+            field_note_id="fn_a7_whole_flow_fixture_before_run",
+        )
+        commit = self.capture_commit(runtime_path, draft)
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a1_capture(
+                draft,
+                capture_commit=commit,
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=runtime_path.read_back().runtime,
+                observed_at=OBSERVED_AT[0],
+            )
+        readback = runtime_path.read_back()
+        self.assertEqual("A1_CAPTURE_CHRONOLOGY_INVALID", readback.failure_reason)
+        self.assertEqual("TIMESTAMP_CHANGE", readback.repair_action)
+
+    def test_save_before_draft_creation_is_rejected_by_typed_receipt(self) -> None:
+        assert self.bundle.a1_capture is not None
+        runtime_path = self.open_runtime("save-before-draft")
+        commit = self.capture_commit(runtime_path, self.bundle.a1_capture)
+        with self.assertRaises(FieldNoteCreatorLiveValidationError):
+            self.reissue_capture_commit(
+                commit,
+                save_as_of="2026-08-05T10:00:00Z",
+            )
+        self.assertEqual(0, runtime_path.read_back().trace_event_count)
+
+    def test_save_after_proof_as_of_is_temporally_rejected(self) -> None:
+        assert self.bundle.a1_capture is not None
+        runtime_path = self.open_runtime("save-after-proof")
+        commit = self.reissue_capture_commit(
+            self.capture_commit(runtime_path, self.bundle.a1_capture),
+            save_as_of="2026-08-05T12:01:00Z",
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a1_capture(
+                self.bundle.a1_capture,
+                capture_commit=commit,
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=runtime_path.read_back().runtime,
+                observed_at="2026-08-05T12:01:00Z",
+            )
+        self.assertEqual(
+            "A1_CAPTURE_CHRONOLOGY_INVALID",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_checkpoint_observation_before_save_is_temporally_rejected(self) -> None:
+        assert self.bundle.a1_capture is not None
+        runtime_path = self.open_runtime("observe-before-save")
+        commit = self.reissue_capture_commit(
+            self.capture_commit(runtime_path, self.bundle.a1_capture),
+            save_as_of="2026-08-05T10:03:00Z",
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_a1_capture(
+                self.bundle.a1_capture,
+                capture_commit=commit,
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=runtime_path.read_back().runtime,
+                observed_at=OBSERVED_AT[0],
+            )
+        self.assertEqual(
+            "A1_CAPTURE_CHRONOLOGY_INVALID",
+            runtime_path.read_back().failure_reason,
+        )
+
+    def test_capture_commit_identity_is_the_creator_live_trace_identity(self) -> None:
+        assert self.bundle.a1_capture is not None
+        events = []
+        commits = []
+        for label, save_as_of in (
+            ("first-commit", self.bundle.a1_capture.created_at),
+            ("second-commit", "2026-08-05T10:01:30Z"),
+        ):
+            runtime_path = self.open_runtime(label)
+            commit = self.reissue_capture_commit(
+                self.capture_commit(runtime_path, self.bundle.a1_capture),
+                save_as_of=save_as_of,
+            )
+            event = runtime_path.record_a1_capture(
+                self.bundle.a1_capture,
+                capture_commit=commit,
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=runtime_path.read_back().runtime,
+                observed_at=OBSERVED_AT[0],
+            )
+            events.append(event)
+            commits.append(commit)
+            self.assertEqual(commit.receipt_sha256, event.evidence_sha256)
+        self.assertNotEqual(commits[0].receipt_sha256, commits[1].receipt_sha256)
+        self.assertNotEqual(events[0].trace_sha256, events[1].trace_sha256)
 
     def test_attempt_opens_with_exact_repository_and_runtime(self) -> None:
         readback = self.open_runtime().read_back()
@@ -388,6 +577,8 @@ class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
                     runtime_path,
                     self.bundle.a1_capture,
                 ),
+                expected_task_sha256=RUN_1_TASK_SHA256,
+                actual_runtime_identity=runtime_path.read_back().runtime,
             )
         self.assertEqual("RETRY_REPLACEMENT", runtime_path.read_back().repair_action)
 
@@ -442,7 +633,7 @@ class CreatorLiveStageAcquisitionTests(CreatorLiveTestCase):
         assert evidence.a6_review is not None
         self.assertEqual(
             (
-                whole_flow._a1_evidence_sha256(evidence.a1_capture),
+                readback.a1_capture_commit.receipt_sha256,
                 whole_flow._a2_receipt_sha256(evidence.a2_reconnect),
                 whole_flow._a3_receipt_sha256(evidence.a3_assessment),
                 evidence.a4_snapshot.events[0].event_sha256,
@@ -1029,6 +1220,27 @@ class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):
         self.assertEqual(live.attempt, runtime_path.read_back().attempt)
         self.assertEqual(live.attempt, receipt.attempt)
         self.assertEqual("TYPED_TRACE_VERIFIED", receipt.human_repair_result)
+        commit = runtime_path.read_back().a1_capture_commit
+        assert commit is not None
+        self.assertEqual(commit.receipt_sha256, receipt.a1_evidence_sha256)
+        self.assertEqual(
+            commit.receipt_sha256,
+            receipt.a1_capture_commit_sha256,
+        )
+        self.assertEqual(
+            commit.draft_evidence_sha256,
+            receipt.a1_draft_sha256,
+        )
+
+    def test_direct_a7_receipt_cannot_cross_bind_a1_commit_identity(self) -> None:
+        runtime_path, _ = self.complete_runtime("direct-a7-commit")
+        live = self.live_bundle(runtime_path.read_back())
+        receipt = verify_field_note_whole_flow(live)
+        self.assertEqual("PASS", receipt.state)
+        for field in ("a1_capture_commit_sha256", "a1_draft_sha256"):
+            with self.subTest(field=field):
+                with self.assertRaises(FieldNoteWholeFlowValidationError):
+                    replace(receipt, **{field: "f" * 64})
         self.assertIsNotNone(receipt.creator_live_readback)
 
     def assert_attempt_substitution_fails(self, **changes) -> None:

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.acceleration.codex_adapter import (
+    CodexApproval,
+    CodexFileAction,
+    CodexReadEvidence,
+    CodexRuntimeIdentity,
+)
+from decision_os.acceleration.model import git_output, repository_id
+from decision_os.companion.field_notes_adapter import FieldNoteCodexRunResult
+from decision_os.companion.field_notes_controller import (
+    FieldNotesCompanionController,
+)
+from decision_os.companion.field_notes_creator_live import (
+    FieldNoteCreatorLiveA1CaptureCommitReceipt,
+    FieldNoteCreatorLiveProofRuntime,
+    FieldNoteCreatorLiveStageError,
+    FieldNoteCreatorLiveValidationError,
+)
+from decision_os.companion.field_notes_creator_live_capture import (
+    FieldNoteCreatorLiveA1CaptureBridge,
+    FieldNoteCreatorLiveA1CaptureBridgeError,
+)
+from decision_os.companion.field_notes_model import FieldNoteDraft, compile_draft
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowAttempt,
+    FieldNoteWholeFlowRunIdentity,
+)
+
+
+FAILED_LIVE_ATTEMPT = "proof_a7_creator_live_001_59a75977337edbec"
+
+
+def proposal() -> dict[str, object]:
+    return {
+        "title": "Creator Live A1 Capture Bridge",
+        "value_level": 1,
+        "source_model_class": "UNKNOWN",
+        "target_model_class": "UNKNOWN",
+        "trigger_terms": ["creator live", "capture bridge"],
+        "scope": {
+            "task_family": "creator-live-a1-capture",
+            "path_prefixes": ["decision_os/companion"],
+            "exclude_terms": ["direct write"],
+        },
+        "body": {
+            "trigger": "Use when Run 1 identifies a bounded reusable structure.",
+            "reusable_structure": "Route capture through one typed proposal.",
+            "scope": "One already-open creator-live attempt and one Run 1.",
+            "do_not_apply_when": "Any direct repository write was requested.",
+            "procedure": "Propose once, approve once, save, and read back.",
+            "acceptance": "The exact Note bytes and identities agree.",
+            "evidence": "A typed proposal and controller save confirmation.",
+            "remaining_unknowns": "No creator-live proof is executed by tests.",
+        },
+    }
+
+
+def create_repository(root: Path) -> Path:
+    repository = root / "repo"
+    repository.mkdir()
+    commands = (
+        ("git", "init", "-q", str(repository)),
+        ("git", "-C", str(repository), "add", "seed.txt"),
+        (
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=Field Notes Test",
+            "-c",
+            "user.email=field-notes@example.invalid",
+            "commit",
+            "-qm",
+            "seed",
+        ),
+    )
+    (repository / "seed.txt").write_text("seed\n", encoding="utf-8")
+    for command in commands:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(completed.stderr)
+    return repository
+
+
+class _CaptureAdapter:
+    def __init__(
+        self,
+        owner: "CreatorLiveCaptureBridgeTests",
+        approval_provider,
+    ) -> None:
+        self.owner = owner
+        self.approval_provider = approval_provider
+
+    async def run(self, task: str) -> FieldNoteCodexRunResult:
+        config = self.owner.controller._active_creator_live_a1_capture()
+        assert config is not None
+        self.owner.observed_task = task
+        draft = compile_draft(
+            proposal(),
+            source_run_id=(
+                "different-origin"
+                if self.owner.mode == "origin_mismatch"
+                else config.run_id
+            ),
+            created_at="2026-08-06T01:01:00Z",
+            field_note_id="fn_creator_live_capture_bridge_test",
+        )
+        if self.owner.mode == "outside_root":
+            draft = replace(draft, relative_path="field_notes/direct.md")
+        self.owner.last_draft = draft
+        if self.owner.mode.startswith("direct_"):
+            action = self.owner.mode.removeprefix("direct_")
+            decision = self.approval_provider(
+                CodexApproval(
+                    repository_name=self.owner.repository.name,
+                    action=action,
+                    normalized_scope="field_notes/direct.md",
+                    diff="bounded direct-write request",
+                    reason=None,
+                )
+            )
+            self.owner.direct_decision = decision
+            return self.owner.result(
+                config.run_id,
+                normal_terminal=False,
+                status="DENIED",
+                proposal=None,
+                failure="A1_DIRECT_WRITE_REQUESTED",
+                actions=(
+                    CodexFileAction(
+                        action=action,
+                        normalized_scope="field_notes/direct.md",
+                        access="denied",
+                        status="denied",
+                    ),
+                ),
+            )
+        if self.owner.mode in {"missing", "raw_markdown", "raw_json"}:
+            return self.owner.result(
+                config.run_id,
+                normal_terminal=False,
+                proposal=None,
+                failure="A1_PROPOSAL_MISSING",
+            )
+        if self.owner.mode == "duplicate":
+            return self.owner.result(
+                config.run_id,
+                normal_terminal=False,
+                proposal=None,
+                failure="A1_PROPOSAL_DUPLICATE",
+                attempts=2,
+            )
+        if self.owner.mode == "malformed":
+            return self.owner.result(
+                config.run_id,
+                normal_terminal=False,
+                proposal=None,
+                failure="A1_PROPOSAL_INVALID",
+            )
+        return self.owner.result(config.run_id, proposal=draft)
+
+
+class CreatorLiveCaptureBridgeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.repository = create_repository(self.root)
+        self.source_repository = FieldNoteSourceRepositoryIdentity(
+            repository_id=repository_id(self.repository),
+            source_commit=git_output(self.repository, "rev-parse", "HEAD"),
+        )
+        self.attempt = FieldNoteWholeFlowAttempt(
+            proof_attempt_id="proof_a7_capture_bridge_fixture_001",
+            proof_mode="CREATOR_LIVE",
+            creator_id="fixture-creator",
+            proof_as_of="2026-08-06T03:00:00Z",
+        )
+        self.run_1 = FieldNoteWholeFlowRunIdentity(
+            proof_attempt_id=self.attempt.proof_attempt_id,
+            run_id="run_creator_live_capture_fixture_001",
+            started_at="2026-08-06T01:00:00Z",
+            repository=self.source_repository,
+            runtime=CodexRuntimeIdentity(
+                model="gpt-5.6-sol",
+                reasoning_effort="ultra",
+                service_tier="priority",
+                codex_cli_version="0.146.0-alpha.3.1",
+                account_type="chatgpt",
+            ),
+        )
+        self.runtime = FieldNoteCreatorLiveProofRuntime.open_attempt(
+            self.root / "fixture-runtime",
+            attempt=self.attempt,
+            source_repository=self.source_repository,
+            run_1=self.run_1,
+        )
+        self.mode = "valid"
+        self.last_draft: FieldNoteDraft | None = None
+        self.observed_task: str | None = None
+        self.direct_decision: str | None = None
+        self.controller = FieldNotesCompanionController(
+            state_path=self.root / "state.json",
+            picker_script=self.root / "picker.scpt",
+            adapter_factory=lambda _engine, approval, _lifecycle: (
+                _CaptureAdapter(self, approval)
+            ),
+        )
+        self.controller.select_repository(self.repository)
+
+    @staticmethod
+    def result(
+        run_id: str,
+        *,
+        normal_terminal: bool = True,
+        status: str = "NORMAL_TERMINAL",
+        proposal: FieldNoteDraft | None,
+        failure: str | None = None,
+        attempts: int = 1,
+        actions: tuple[CodexFileAction, ...] = (),
+    ) -> FieldNoteCodexRunResult:
+        return FieldNoteCodexRunResult(
+            run_id=run_id,
+            normal_terminal=normal_terminal,
+            status=status,
+            error_type=None,
+            turn_status="completed",
+            runtime_identity=None,
+            checkpoint_outcomes=(),
+            final_message="Completed.",
+            file_actions=actions,
+            read_evidence=(
+                CodexReadEvidence(
+                    path="seed.txt",
+                    byte_count=5,
+                    sha256=hashlib.sha256(b"seed\n").hexdigest(),
+                    repository_identity=git_output(
+                        Path.cwd(), "rev-parse", "HEAD"
+                    )
+                    if (Path.cwd() / ".git").exists()
+                    else "fixture-head",
+                    status="succeeded",
+                ),
+            ),
+            field_note_proposal=proposal,
+            creator_live_a1_capture=True,
+            creator_live_a1_failure_reason=failure,
+            creator_live_a1_proposal_attempts=attempts,
+        )
+
+    def bridge(self) -> FieldNoteCreatorLiveA1CaptureBridge:
+        return FieldNoteCreatorLiveA1CaptureBridge(
+            runtime=self.runtime,
+            controller=self.controller,
+            repository=self.repository,
+            source_repository=self.source_repository,
+            timeout_seconds=5,
+        )
+
+    def test_exact_save_path_closes_one_durable_a1_checkpoint(self) -> None:
+        original_save = self.controller.field_note_save
+        original_approval = self.controller.field_note_approval
+        original_read = FieldNoteCreatorLiveA1CaptureBridge._exact_read_back
+
+        def checked_save():
+            self.assertEqual(0, self.runtime.read_back().trace_event_count)
+            return original_save()
+
+        def checked_approval(choice: str):
+            self.assertEqual("allow_once", choice)
+            self.assertEqual(0, self.runtime.read_back().trace_event_count)
+            return original_approval(choice)
+
+        def checked_read(target: Path):
+            self.assertEqual(0, self.runtime.read_back().trace_event_count)
+            return original_read(target)
+
+        with patch.object(
+            self.controller,
+            "field_note_save",
+            side_effect=checked_save,
+        ) as save, patch.object(
+            self.controller,
+            "field_note_approval",
+            side_effect=checked_approval,
+        ) as approval, patch.object(
+            FieldNoteCreatorLiveA1CaptureBridge,
+            "_exact_read_back",
+            side_effect=checked_read,
+        ):
+            event = self.bridge().capture(
+                "Perform the bounded reasoning task, propose once, and stop."
+            )
+
+        self.assertEqual("A1_CAPTURE", event.stage)
+        self.assertEqual(1, save.call_count)
+        self.assertEqual(1, approval.call_count)
+        self.assertEqual(
+            "Perform the bounded reasoning task, propose once, and stop.",
+            self.observed_task,
+        )
+        assert self.last_draft is not None
+        target = self.repository / self.last_draft.relative_path
+        self.assertEqual(self.last_draft.markdown, target.read_bytes())
+        self.assertEqual(
+            (".decision-os", "field-notes"),
+            Path(self.last_draft.relative_path).parts[:2],
+        )
+        readback = self.runtime.read_back()
+        self.assertEqual("OPEN", readback.state)
+        self.assertEqual("A2_RECONNECT", readback.current_stage)
+        self.assertEqual(1, readback.trace_event_count)
+        self.assertIsNotNone(readback.a1_capture_commit)
+
+    def test_full_note_body_is_absent_from_journal_and_anchor(self) -> None:
+        self.bridge().capture("Propose exactly once and stop.")
+        assert self.last_draft is not None
+        for path in (self.runtime.journal_path, self.runtime.anchor_path):
+            raw = path.read_bytes()
+            self.assertNotIn(self.last_draft.markdown, raw)
+            self.assertNotIn(
+                b"Route capture through one typed proposal.",
+                raw,
+            )
+
+    def test_missing_duplicate_malformed_and_raw_outputs_fail_closed(self) -> None:
+        for mode in (
+            "missing",
+            "duplicate",
+            "malformed",
+            "raw_markdown",
+            "raw_json",
+        ):
+            with self.subTest(mode=mode):
+                self.setUp()
+                self.mode = mode
+                with self.assertRaises(
+                    FieldNoteCreatorLiveA1CaptureBridgeError
+                ):
+                    self.bridge().capture("Propose exactly once and stop.")
+                readback = self.runtime.read_back()
+                self.assertEqual("FAILED", readback.state)
+                self.assertEqual("A1_CAPTURE", readback.failure_boundary)
+                self.assertEqual(0, readback.trace_event_count)
+
+    def test_direct_create_update_delete_are_denied_and_terminal(self) -> None:
+        for action in ("Create", "Update", "Delete"):
+            with self.subTest(action=action):
+                self.setUp()
+                self.mode = f"direct_{action}"
+                with self.assertRaises(
+                    FieldNoteCreatorLiveA1CaptureBridgeError
+                ):
+                    self.bridge().capture("Propose; do not write.")
+                self.assertEqual("3", self.direct_decision)
+                readback = self.runtime.read_back()
+                self.assertEqual("FAILED", readback.state)
+                self.assertTrue(
+                    readback.failure_reason.startswith(
+                        "A1_DIRECT_WRITE_REQUESTED:"
+                    )
+                )
+                self.assertFalse(
+                    (self.repository / "field_notes" / "direct.md").exists()
+                )
+                with self.assertRaises(FieldNoteCreatorLiveStageError):
+                    self.runtime.open_run_2(self.run_1)
+
+    def test_outside_root_origin_mismatch_and_existing_target_fail(self) -> None:
+        for mode in ("outside_root", "origin_mismatch", "preexisting"):
+            with self.subTest(mode=mode):
+                self.setUp()
+                self.mode = "valid" if mode == "preexisting" else mode
+                if mode == "preexisting":
+                    draft = compile_draft(
+                        proposal(),
+                        source_run_id=self.run_1.run_id,
+                        created_at="2026-08-06T01:01:00Z",
+                        field_note_id="fn_creator_live_capture_bridge_test",
+                    )
+                    target = self.repository / draft.relative_path
+                    target.parent.mkdir(parents=True)
+                    target.write_bytes(b"preexisting fixture\n")
+                with self.assertRaises(
+                    FieldNoteCreatorLiveA1CaptureBridgeError
+                ):
+                    self.bridge().capture("Propose exactly once and stop.")
+                self.assertEqual("FAILED", self.runtime.read_back().state)
+                self.assertEqual(0, self.runtime.read_back().trace_event_count)
+
+    def test_parent_symlink_and_case_collision_fail_closed(self) -> None:
+        for mode in ("symlink", "collision"):
+            with self.subTest(mode=mode):
+                self.setUp()
+                draft = compile_draft(
+                    proposal(),
+                    source_run_id=self.run_1.run_id,
+                    created_at="2026-08-06T01:01:00Z",
+                    field_note_id="fn_creator_live_capture_bridge_test",
+                )
+                if mode == "symlink":
+                    external = self.root / "external"
+                    external.mkdir()
+                    (self.repository / ".decision-os").symlink_to(
+                        external,
+                        target_is_directory=True,
+                    )
+                else:
+                    target = self.repository / draft.relative_path
+                    target.parent.mkdir(parents=True)
+                    (target.parent / target.name.upper()).write_bytes(
+                        b"collision fixture\n"
+                    )
+                with self.assertRaises(
+                    FieldNoteCreatorLiveA1CaptureBridgeError
+                ):
+                    self.bridge().capture("Propose exactly once and stop.")
+                self.assertEqual("FAILED", self.runtime.read_back().state)
+
+    def test_changed_readback_and_repository_identity_fail_closed(self) -> None:
+        for mode in ("bytes", "repository"):
+            with self.subTest(mode=mode):
+                self.setUp()
+                bridge = self.bridge()
+                if mode == "bytes":
+                    context = patch.object(
+                        bridge,
+                        "_exact_read_back",
+                        return_value=b"changed bytes",
+                    )
+                else:
+                    context = patch.object(
+                        bridge,
+                        "_repository_identity_matches",
+                        side_effect=(True, True, False),
+                    )
+                with context, self.assertRaises(
+                    FieldNoteCreatorLiveA1CaptureBridgeError
+                ):
+                    bridge.capture("Propose exactly once and stop.")
+                self.assertEqual("FAILED", self.runtime.read_back().state)
+                self.assertEqual(0, self.runtime.read_back().trace_event_count)
+
+    def test_capture_commit_cannot_be_caller_constructed(self) -> None:
+        with self.assertRaises(FieldNoteCreatorLiveValidationError):
+            FieldNoteCreatorLiveA1CaptureCommitReceipt()
+
+    def test_fixture_never_uses_closed_live_attempt_or_real_repository(self) -> None:
+        self.assertNotEqual(FAILED_LIVE_ATTEMPT, self.attempt.proof_attempt_id)
+        self.assertTrue(self.repository.is_relative_to(self.root))
+        self.assertTrue(self.runtime.journal_path.is_relative_to(self.root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -125,6 +125,10 @@ class _CaptureAdapter:
         self.owner.last_draft = draft
         if self.owner.mode.startswith("direct_"):
             action = self.owner.mode.removeprefix("direct_")
+            proposal_after_direct_request = None
+            if action.startswith("valid_"):
+                action = action.removeprefix("valid_")
+                proposal_after_direct_request = draft
             decision = self.approval_provider(
                 CodexApproval(
                     repository_name=self.owner.repository.name,
@@ -139,7 +143,7 @@ class _CaptureAdapter:
                 config.run_id,
                 normal_terminal=False,
                 status="DENIED",
-                proposal=None,
+                proposal=proposal_after_direct_request,
                 failure="A1_DIRECT_WRITE_REQUESTED",
                 actions=(
                     CodexFileAction(
@@ -214,6 +218,11 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         self.last_draft: FieldNoteDraft | None = None
         self.observed_task: str | None = None
         self.direct_decision: str | None = None
+        self.actual_runtime_identity: CodexRuntimeIdentity | None = (
+            self.run_1.runtime
+        )
+        self.read_evidence: tuple[CodexReadEvidence, ...] = ()
+        self.task_sha256_override: str | None = None
         self.controller = FieldNotesCompanionController(
             state_path=self.root / "state.json",
             picker_script=self.root / "picker.scpt",
@@ -223,8 +232,8 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         )
         self.controller.select_repository(self.repository)
 
-    @staticmethod
     def result(
+        self,
         run_id: str,
         *,
         normal_terminal: bool = True,
@@ -240,27 +249,20 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             status=status,
             error_type=None,
             turn_status="completed",
-            runtime_identity=None,
+            runtime_identity=self.actual_runtime_identity,
             checkpoint_outcomes=(),
             final_message="Completed.",
             file_actions=actions,
-            read_evidence=(
-                CodexReadEvidence(
-                    path="seed.txt",
-                    byte_count=5,
-                    sha256=hashlib.sha256(b"seed\n").hexdigest(),
-                    repository_identity=git_output(
-                        Path.cwd(), "rev-parse", "HEAD"
-                    )
-                    if (Path.cwd() / ".git").exists()
-                    else "fixture-head",
-                    status="succeeded",
-                ),
-            ),
+            read_evidence=self.read_evidence,
             field_note_proposal=proposal,
             creator_live_a1_capture=True,
             creator_live_a1_failure_reason=failure,
             creator_live_a1_proposal_attempts=attempts,
+            creator_live_a1_task_sha256=hashlib.sha256(
+                (self.observed_task or "").encode("utf-8")
+            ).hexdigest()
+            if self.task_sha256_override is None
+            else self.task_sha256_override,
         )
 
     def bridge(self) -> FieldNoteCreatorLiveA1CaptureBridge:
@@ -270,6 +272,7 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             repository=self.repository,
             source_repository=self.source_repository,
             timeout_seconds=5,
+            utc_now=lambda: "2026-08-06T01:02:00Z",
         )
 
     def test_exact_save_path_closes_one_durable_a1_checkpoint(self) -> None:
@@ -326,6 +329,134 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         self.assertEqual("A2_RECONNECT", readback.current_stage)
         self.assertEqual(1, readback.trace_event_count)
         self.assertIsNotNone(readback.a1_capture_commit)
+        completion = self.controller.creator_live_a1_run_completion()
+        self.assertEqual(self.run_1.runtime, completion.actual_runtime_identity)
+        self.assertEqual(0, completion.successful_read_count)
+        assert readback.a1_capture_commit is not None
+        self.assertEqual(
+            readback.a1_capture_commit.receipt_sha256,
+            event.evidence_sha256,
+        )
+        self.assertEqual(
+            hashlib.sha256(
+                self.observed_task.encode("utf-8")
+            ).hexdigest(),
+            readback.a1_capture_commit.task_sha256,
+        )
+
+    def test_one_exact_successful_read_is_optional_completion_evidence(self) -> None:
+        self.read_evidence = (
+            CodexReadEvidence(
+                path="seed.txt",
+                byte_count=5,
+                sha256=hashlib.sha256(b"seed\n").hexdigest(),
+                repository_identity=self.source_repository.repository_id,
+                status="succeeded",
+            ),
+        )
+        self.bridge().capture("Propose exactly once after one bounded read.")
+        completion = self.controller.creator_live_a1_run_completion()
+        self.assertEqual(1, completion.successful_read_count)
+
+    def test_failed_read_is_terminal_and_creates_no_note(self) -> None:
+        self.read_evidence = (
+            CodexReadEvidence(
+                path="missing.txt",
+                byte_count=None,
+                sha256=None,
+                repository_identity=self.source_repository.repository_id,
+                status="failed",
+                reason="read_path_not_found",
+            ),
+        )
+        with patch.object(self.controller, "field_note_save") as save:
+            with self.assertRaises(FieldNoteCreatorLiveA1CaptureBridgeError):
+                self.bridge().capture("Propose exactly once after a read.")
+        self.assertEqual(0, save.call_count)
+        readback = self.runtime.read_back()
+        self.assertEqual("A1_READ_EVIDENCE_FAILED", readback.failure_reason)
+        self.assertEqual(0, readback.trace_event_count)
+        assert self.last_draft is not None
+        self.assertFalse(
+            (self.repository / self.last_draft.relative_path).exists()
+        )
+
+    def test_successful_read_cannot_replace_missing_or_malformed_proposal(self) -> None:
+        for mode in ("missing", "malformed"):
+            with self.subTest(mode=mode):
+                self.setUp()
+                self.mode = mode
+                self.read_evidence = (
+                    CodexReadEvidence(
+                        path="seed.txt",
+                        byte_count=5,
+                        sha256=hashlib.sha256(b"seed\n").hexdigest(),
+                        repository_identity=(
+                            self.source_repository.repository_id
+                        ),
+                        status="succeeded",
+                    ),
+                )
+                with self.assertRaises(
+                    FieldNoteCreatorLiveA1CaptureBridgeError
+                ):
+                    self.bridge().capture("Propose exactly once and stop.")
+                self.assertEqual(0, self.runtime.read_back().trace_event_count)
+
+    def test_missing_and_each_changed_runtime_field_fail_before_save(self) -> None:
+        cases = {
+            "missing": None,
+            "model": replace(self.run_1.runtime, model="other-model"),
+            "reasoning_effort": replace(
+                self.run_1.runtime,
+                reasoning_effort="high",
+            ),
+            "service_tier": replace(
+                self.run_1.runtime,
+                service_tier="default",
+            ),
+            "codex_cli_version": replace(
+                self.run_1.runtime,
+                codex_cli_version="0.0.0",
+            ),
+            "account_type": replace(
+                self.run_1.runtime,
+                account_type="api",
+            ),
+        }
+        for label, actual in cases.items():
+            with self.subTest(field=label):
+                self.setUp()
+                self.actual_runtime_identity = actual
+                with patch.object(self.controller, "field_note_save") as save:
+                    with self.assertRaises(
+                        FieldNoteCreatorLiveA1CaptureBridgeError
+                    ):
+                        self.bridge().capture("Propose exactly once and stop.")
+                self.assertEqual(0, save.call_count)
+                readback = self.runtime.read_back()
+                self.assertEqual(
+                    "A1_ACTUAL_RUNTIME_IDENTITY_MISSING"
+                    if label == "missing"
+                    else "A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH",
+                    readback.failure_reason,
+                )
+                self.assertEqual(0, readback.trace_event_count)
+                assert self.last_draft is not None
+                self.assertFalse(
+                    (self.repository / self.last_draft.relative_path).exists()
+                )
+
+    def test_changed_task_identity_fails_before_save(self) -> None:
+        self.task_sha256_override = "f" * 64
+        with patch.object(self.controller, "field_note_save") as save:
+            with self.assertRaises(FieldNoteCreatorLiveA1CaptureBridgeError):
+                self.bridge().capture("Propose exactly once and stop.")
+        self.assertEqual(0, save.call_count)
+        self.assertEqual(
+            "A1_TASK_IDENTITY_MISMATCH",
+            self.runtime.read_back().failure_reason,
+        )
 
     def test_full_note_body_is_absent_from_journal_and_anchor(self) -> None:
         self.bridge().capture("Propose exactly once and stop.")
@@ -380,6 +511,16 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
                 )
                 with self.assertRaises(FieldNoteCreatorLiveStageError):
                     self.runtime.open_run_2(self.run_1)
+
+    def test_direct_write_request_fails_even_with_valid_proposal(self) -> None:
+        self.mode = "direct_valid_Create"
+        with self.assertRaises(FieldNoteCreatorLiveA1CaptureBridgeError):
+            self.bridge().capture("Propose once and do not write.")
+        readback = self.runtime.read_back()
+        self.assertTrue(
+            readback.failure_reason.startswith("A1_DIRECT_WRITE_REQUESTED:")
+        )
+        self.assertEqual(0, readback.trace_event_count)
 
     def test_outside_root_origin_mismatch_and_existing_target_fail(self) -> None:
         for mode in ("outside_root", "origin_mismatch", "preexisting"):

--- a/tests/test_field_notes_lite.py
+++ b/tests/test_field_notes_lite.py
@@ -20,6 +20,7 @@ from decision_os.acceleration.codex_adapter import (
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.companion.field_notes_adapter import (
+    FieldNoteCreatorLiveA1CaptureConfig,
     FieldNoteCodexRunResult,
     FieldNotesCodexAdapter,
 )
@@ -357,6 +358,191 @@ class FieldNotesModelTests(unittest.TestCase):
 
 
 class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def _creator_live_result(
+        self,
+        *,
+        calls: tuple[tuple[str, dict[str, object]], ...] = (),
+        final_message: str = "Completed.",
+    ) -> FieldNoteCodexRunResult:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        repository = create_repository(Path(temporary.name))
+        thread_id = "thread-creator-live-a1"
+        turn_id = "turn-creator-live-a1"
+        messages = handshake_messages(
+            repository,
+            thread_id=thread_id,
+            turn_id=turn_id,
+        )
+        for index, (call_id, arguments) in enumerate(calls):
+            messages.extend(
+                [
+                    started_proposal(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        call_id=call_id,
+                        arguments=arguments,
+                    ),
+                    proposal_request(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        call_id=call_id,
+                        request_id=f"proposal-request-{index}",
+                        arguments=arguments,
+                    ),
+                    {
+                        **completed_proposal(
+                            thread_id=thread_id,
+                            turn_id=turn_id,
+                            call_id=call_id,
+                            arguments=arguments,
+                        ),
+                        "params": {
+                            **completed_proposal(
+                                thread_id=thread_id,
+                                turn_id=turn_id,
+                                call_id=call_id,
+                                arguments=arguments,
+                            )["params"],
+                            "item": {
+                                **completed_proposal(
+                                    thread_id=thread_id,
+                                    turn_id=turn_id,
+                                    call_id=call_id,
+                                    arguments=arguments,
+                                )["params"]["item"],
+                                "status": (
+                                    "completed"
+                                    if index == 0 and arguments == proposal()
+                                    else "failed"
+                                ),
+                            },
+                        },
+                    },
+                ]
+            )
+        messages.extend(
+            [
+                completed_agent_message(
+                    thread_id=thread_id,
+                    turn_id=turn_id,
+                    text=final_message,
+                ),
+                completed_turn(thread_id=thread_id, turn_id=turn_id),
+            ]
+        )
+        factory = FakeTransportFactory([messages])
+        engine = AccelerationEngine(
+            repository,
+            adapter=ADAPTER_NAME,
+            adapter_version=CODEX_CLI_VERSION,
+        )
+        adapter = FieldNotesCodexAdapter(
+            engine,
+            input_func=lambda: None,
+            stdout=io.StringIO(),
+            transport_factory=factory,
+            trusted_source_model_class="stronger",
+            trusted_target_model_class="lower-cost",
+            creator_live_a1_capture_provider=lambda: (
+                FieldNoteCreatorLiveA1CaptureConfig("run-live-a1")
+            ),
+        )
+        result = await adapter.run(
+            "Reason, propose once, and make no mutation."
+        )
+        starts = [
+            message
+            for message in factory.transports[0].sent
+            if message.get("method") == "thread/start"
+        ]
+        self.assertEqual(1, len(starts))
+        self._creator_live_developer_instructions = starts[0]["params"][
+            "developerInstructions"
+        ]
+        return result
+
+    async def test_creator_live_mode_requires_one_valid_proposal(self) -> None:
+        result = await self._creator_live_result(
+            calls=(("proposal-call", proposal()),)
+        )
+        self.assertTrue(result.normal_terminal)
+        self.assertTrue(result.creator_live_a1_capture)
+        self.assertEqual("run-live-a1", result.run_id)
+        self.assertEqual(1, result.creator_live_a1_proposal_attempts)
+        self.assertIsNone(result.creator_live_a1_failure_reason)
+        self.assertIsNotNone(result.field_note_proposal)
+        self.assertIn(
+            "must call propose_field_note_candidate exactly once",
+            self._creator_live_developer_instructions,
+        )
+        self.assertIn(
+            "Do not create, update, modify, delete, patch",
+            self._creator_live_developer_instructions,
+        )
+        self.assertNotIn(
+            "Use the typed file-change tool for exactly one file mutation",
+            self._creator_live_developer_instructions,
+        )
+
+    async def test_creator_live_mode_rejects_missing_raw_output(self) -> None:
+        for raw in (
+            "# Raw Field Note\n\nNot a typed proposal.",
+            json.dumps(proposal(), sort_keys=True),
+        ):
+            with self.subTest(raw=raw[:1]):
+                result = await self._creator_live_result(final_message=raw)
+                self.assertFalse(result.normal_terminal)
+                self.assertEqual(
+                    "A1_PROPOSAL_MISSING",
+                    result.creator_live_a1_failure_reason,
+                )
+                self.assertIsNone(result.field_note_proposal)
+
+    async def test_creator_live_mode_rejects_duplicate_proposal(self) -> None:
+        result = await self._creator_live_result(
+            calls=(
+                ("proposal-call-1", proposal()),
+                ("proposal-call-2", proposal()),
+            )
+        )
+        self.assertFalse(result.normal_terminal)
+        self.assertEqual(
+            "A1_PROPOSAL_DUPLICATE",
+            result.creator_live_a1_failure_reason,
+        )
+        self.assertIsNone(result.field_note_proposal)
+
+    async def test_creator_live_mode_rejects_malformed_proposal(self) -> None:
+        malformed = proposal()
+        malformed["value_level"] = 99
+        result = await self._creator_live_result(
+            calls=(("proposal-call", malformed),)
+        )
+        self.assertFalse(result.normal_terminal)
+        self.assertEqual(
+            "A1_PROPOSAL_INVALID",
+            result.creator_live_a1_failure_reason,
+        )
+        self.assertIsNone(result.field_note_proposal)
+
+    async def test_creator_live_mode_rejects_inconsistent_replay(self) -> None:
+        changed = proposal()
+        changed["title"] = "Changed replay identity"
+        result = await self._creator_live_result(
+            calls=(
+                ("proposal-call", proposal()),
+                ("proposal-call", changed),
+            )
+        )
+        self.assertFalse(result.normal_terminal)
+        self.assertEqual(
+            "A1_PROPOSAL_INVALID",
+            result.creator_live_a1_failure_reason,
+        )
+        self.assertEqual(1, result.creator_live_a1_proposal_attempts)
+        self.assertIsNone(result.field_note_proposal)
+
     async def test_exact_proposal_request_replay_is_idempotent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             repository = create_repository(Path(temporary))

--- a/tests/test_field_notes_lite.py
+++ b/tests/test_field_notes_lite.py
@@ -15,8 +15,12 @@ from unittest.mock import patch
 from decision_os.acceleration.codex_adapter import (
     ADAPTER_NAME,
     CODEX_CLI_VERSION,
+    CODEX_MODEL,
+    CODEX_REASONING_EFFORT,
+    CODEX_SERVICE_TIER,
     CodexReadEvidence,
     CodexRunResult,
+    CodexRuntimeIdentity,
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.companion.field_notes_adapter import (
@@ -445,7 +449,16 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
             trusted_source_model_class="stronger",
             trusted_target_model_class="lower-cost",
             creator_live_a1_capture_provider=lambda: (
-                FieldNoteCreatorLiveA1CaptureConfig("run-live-a1")
+                FieldNoteCreatorLiveA1CaptureConfig(
+                    "run-live-a1",
+                    CodexRuntimeIdentity(
+                        model=CODEX_MODEL,
+                        reasoning_effort=CODEX_REASONING_EFFORT,
+                        service_tier=CODEX_SERVICE_TIER,
+                        codex_cli_version=CODEX_CLI_VERSION,
+                        account_type="chatgpt",
+                    ),
+                )
             ),
         )
         result = await adapter.run(


### PR DESCRIPTION
## Summary

- add an explicit read-only creator-live A1 capture mode with a predeclared Run-1 identity
- bind the observed `FieldNoteCodexRunResult.runtime_identity` to creator-live readback and Run 1 across model, reasoning effort, service tier, CLI version, and account type
- retain the exact task digest and observed runtime in a typed Run-1 completion projection consumed by the bridge
- use creator-live-specific completion eligibility: exactly one accepted proposal may close with zero reads, exact successful reads remain optional and bounded, and every failed read fails closed
- preserve ordinary non-live A1 eligibility unchanged
- make the durable capture-commit receipt the creator-live A1 checkpoint identity while retaining the draft digest separately
- bind the commit to proof attempt, Run 1, canonical task digest, actual runtime, source repository, exact Note identity and bytes, draft identity, saved/read-back state, and save As-of
- enforce and durably revalidate `Run 1 start <= draft creation <= save <= A1 observation <= Proof As-of`, including A7 admission

## Validation

- creator-live A1 bridge/runtime: 89 passed
- A1–A7 focused: 415 passed
- controller: 27 passed
- server: 35 passed
- controller/server total: 62 passed
- full default discovery: 1,112 passed
- full explicit discovery: 1,112 passed
- normalized suite identity: MATCH, 1,112 unique IDs in each mode (`92051528327a68b44fa7ea17e2741a2a14c6a822bc4380bf9943e5bc83bd337e`)
- Python compilation: PASS
- `git diff --check`: PASS
- protected creator Note and four validation artifacts: unchanged

## Boundaries

- starting main: `b28510a8e782eeb6cdd23d560bfe97d4a454ad8f`
- reviewed head before repair: `db44594aa81fb5498e8b18e2766efbc9fd626edc`
- repaired head: `02c58859015394c8d1993eaf3546d88afb71c91f`
- the failed attempt `proof_a7_creator_live_001_59a75977337edbec` remains permanently closed
- no real creator-live attempt, real Field Note, Run 2, live Companion task, runtime install/restart, Warehouse Import, automatic retry, PROMOTABLE, or Serving Policy behavior was added or performed
- this PR remains a bounded repository bridge and does not claim that a creator-live proof passed