### PR TITLE
Retain bounded A1 proposal failure diagnostics

### DIFF
--- a/decision_os/companion/field_notes_adapter.py
+++ b/decision_os/companion/field_notes_adapter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 import hashlib
 import json
 from typing import Any, Callable, Mapping
@@ -19,6 +19,7 @@ from decision_os.companion.field_notes_model import (
     FIELD_NOTE_TOOL_SPEC,
     FieldNoteDraft,
     FieldNoteProposalGate,
+    canonical_json,
     configured_model_class,
 )
 from decision_os.companion.field_notes_reconnect import (
@@ -65,6 +66,201 @@ _DIRECT_MUTATION_REASONS = frozenset(
     }
 )
 
+_A1_PROPOSAL_DIAGNOSTIC_SCHEMA = (
+    "decision-os.field-note-a1-proposal-diagnostic.v0.1"
+)
+_A1_PROPOSAL_SUBCAUSES = frozenset(
+    {
+        "A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+        "A1_PROPOSAL_SCHEMA_REJECTED",
+        "A1_PROPOSAL_GATE_REJECTED",
+        "A1_PROPOSAL_ITEM_NOT_COMPLETED",
+        "A1_PROPOSAL_ITEM_STATUS_MISMATCH",
+        "A1_PROPOSAL_RESPONSE_IDENTITY_MISMATCH",
+        "A1_PROPOSAL_INCONSISTENT_REPLAY",
+        "A1_PROPOSAL_PROTOCOL_IDENTITY_FAILURE",
+        "A1_PROPOSAL_ACCEPTED_STATE_MISSING",
+        "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE",
+        "A1_PROPOSAL_MISSING",
+        "A1_PROPOSAL_DUPLICATE",
+        "A1_DIRECT_WRITE_REQUESTED",
+    }
+)
+
+
+def _optional_sha256(value: str | None, label: str) -> None:
+    if value is not None and (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"{label} is invalid.")
+
+
+@dataclass(frozen=True)
+class FieldNoteA1ProposalDiagnostic:
+    """Payload-free lifecycle facts for one future creator-live A1 proposal."""
+
+    proposal_call_count: int
+    call_identity_sha256: str | None
+    request_identity_sha256: str | None
+    arguments_identity_sha256: str | None
+    request_shape_valid: bool | None
+    malformed_observed: bool
+    gate_invoked: bool
+    gate_response_code: str | None
+    gate_response_success: bool | None
+    accepted_proposal_present: bool
+    item_start_observed: bool
+    item_completion_observed: bool
+    item_observed_status: str | None
+    item_expected_status: str | None
+    all_proposals_completed: bool
+    request_identity_mismatch: bool
+    response_identity_mismatch: bool
+    inconsistent_replay: bool
+    protocol_identity_failure: bool
+    protocol_failure_phase: str | None
+    direct_write_identity: str | None
+    final_subcause: str | None
+    schema: str = field(
+        default=_A1_PROPOSAL_DIAGNOSTIC_SCHEMA,
+        init=False,
+    )
+    diagnostic_sha256: str = field(default="", init=False)
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.proposal_call_count) is not int
+            or self.proposal_call_count < 0
+            or self.schema != _A1_PROPOSAL_DIAGNOSTIC_SCHEMA
+            or (
+                self.request_shape_valid is not None
+                and type(self.request_shape_valid) is not bool
+            )
+            or (
+                self.gate_response_success is not None
+                and type(self.gate_response_success) is not bool
+            )
+            or any(
+                type(value) is not bool
+                for value in (
+                    self.malformed_observed,
+                    self.gate_invoked,
+                    self.accepted_proposal_present,
+                    self.item_start_observed,
+                    self.item_completion_observed,
+                    self.all_proposals_completed,
+                    self.request_identity_mismatch,
+                    self.response_identity_mismatch,
+                    self.inconsistent_replay,
+                    self.protocol_identity_failure,
+                )
+            )
+            or any(
+                value is not None
+                and (
+                    not isinstance(value, str)
+                    or not value
+                    or len(value) > 128
+                )
+                for value in (
+                    self.gate_response_code,
+                    self.item_observed_status,
+                    self.item_expected_status,
+                    self.protocol_failure_phase,
+                )
+            )
+            or self.final_subcause not in _A1_PROPOSAL_SUBCAUSES | {None}
+            or (
+                self.protocol_identity_failure
+                != (self.protocol_failure_phase is not None)
+            )
+            or (not self.gate_invoked and self.gate_response_code is not None)
+            or (not self.gate_invoked and self.gate_response_success is not None)
+        ):
+            raise ValueError("A1 proposal diagnostic is invalid.")
+        _optional_sha256(self.call_identity_sha256, "Proposal call identity")
+        _optional_sha256(
+            self.request_identity_sha256,
+            "Proposal request identity",
+        )
+        _optional_sha256(
+            self.arguments_identity_sha256,
+            "Proposal arguments identity",
+        )
+        _optional_sha256(
+            self.direct_write_identity,
+            "Direct-write identity",
+        )
+        object.__setattr__(
+            self,
+            "diagnostic_sha256",
+            hashlib.sha256(
+                canonical_json(self._body()).encode("utf-8")
+            ).hexdigest(),
+        )
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proposal_call_count": self.proposal_call_count,
+            "call_identity_sha256": self.call_identity_sha256,
+            "request_identity_sha256": self.request_identity_sha256,
+            "arguments_identity_sha256": self.arguments_identity_sha256,
+            "request_shape_valid": self.request_shape_valid,
+            "malformed_observed": self.malformed_observed,
+            "gate_invoked": self.gate_invoked,
+            "gate_response_code": self.gate_response_code,
+            "gate_response_success": self.gate_response_success,
+            "accepted_proposal_present": self.accepted_proposal_present,
+            "item_start_observed": self.item_start_observed,
+            "item_completion_observed": self.item_completion_observed,
+            "item_observed_status": self.item_observed_status,
+            "item_expected_status": self.item_expected_status,
+            "all_proposals_completed": self.all_proposals_completed,
+            "request_identity_mismatch": self.request_identity_mismatch,
+            "response_identity_mismatch": self.response_identity_mismatch,
+            "inconsistent_replay": self.inconsistent_replay,
+            "protocol_identity_failure": self.protocol_identity_failure,
+            "protocol_failure_phase": self.protocol_failure_phase,
+            "direct_write_identity": self.direct_write_identity,
+            "final_subcause": self.final_subcause,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._body(), "diagnostic_sha256": self.diagnostic_sha256}
+
+    @classmethod
+    def from_dict(cls, value: Any) -> FieldNoteA1ProposalDiagnostic:
+        if not isinstance(value, dict):
+            raise ValueError("A1 proposal diagnostic must be an object.")
+        expected = set(cls.__dataclass_fields__)  # type: ignore[attr-defined]
+        if set(value) != expected:
+            raise ValueError("A1 proposal diagnostic fields are invalid.")
+        digest = value.get("diagnostic_sha256")
+        try:
+            diagnostic = cls(
+                **{
+                    key: item
+                    for key, item in value.items()
+                    if key not in {"schema", "diagnostic_sha256"}
+                }
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("A1 proposal diagnostic is invalid.") from exc
+        if value.get("schema") != diagnostic.schema or (
+            digest != diagnostic.diagnostic_sha256
+        ):
+            raise ValueError("A1 proposal diagnostic digest is invalid.")
+        return diagnostic
+
+    def with_direct_write_identity(
+        self,
+        identity: str,
+    ) -> FieldNoteA1ProposalDiagnostic:
+        return replace(self, direct_write_identity=identity)
+
 
 @dataclass(frozen=True)
 class FieldNoteCreatorLiveA1CaptureConfig:
@@ -101,6 +297,9 @@ class FieldNoteCodexRunResult(CodexRunResult):
     creator_live_a1_failure_reason: str | None = None
     creator_live_a1_proposal_attempts: int = 0
     creator_live_a1_task_sha256: str | None = None
+    creator_live_a1_proposal_diagnostic: (
+        FieldNoteA1ProposalDiagnostic | None
+    ) = None
 
 
 class FieldNotesCodexAdapter(CodexAdapter):
@@ -152,7 +351,20 @@ class FieldNotesCodexAdapter(CodexAdapter):
         self._resolved_proposal_requests: set[str | int] = set()
         self._completed_proposal_items: set[str] = set()
         self._capture_proposal_call_ids: set[str] = set()
+        self._capture_request_identities: set[str] = set()
+        self._capture_argument_identities: set[str] = set()
         self._capture_proposal_malformed = False
+        self._capture_request_shape_valid: bool | None = None
+        self._capture_gate_invoked = False
+        self._capture_gate_response_code: str | None = None
+        self._capture_gate_response_success: bool | None = None
+        self._capture_item_start_observed = False
+        self._capture_item_completion_observed = False
+        self._capture_item_observed_status: str | None = None
+        self._capture_item_expected_status: str | None = None
+        self._capture_request_identity_mismatch = False
+        self._capture_response_identity_mismatch = False
+        self._capture_inconsistent_replay = False
         prompt = self._reconnect_prompt
         if (
             isinstance(prompt, str)
@@ -332,6 +544,12 @@ class FieldNotesCodexAdapter(CodexAdapter):
 
     def _respond_field_note_tool_call(self, message: dict[str, Any]) -> None:
         request_id = message.get("id")
+        if (
+            self._creator_live_a1_capture is not None
+            and not isinstance(message.get("params"), dict)
+        ):
+            self._capture_proposal_malformed = True
+            self._capture_request_shape_valid = False
         params = self._require_object(
             message.get("params"),
             "Field Note proposal parameters",
@@ -342,8 +560,22 @@ class FieldNotesCodexAdapter(CodexAdapter):
             not isinstance(request_id, (str, int))
             or isinstance(request_id, bool)
         ):
+            if self._creator_live_a1_capture is not None:
+                self._capture_proposal_malformed = True
+                self._capture_request_shape_valid = False
             self._mark_identity_failure()
             return
+        if self._creator_live_a1_capture is not None:
+            self._capture_request_identities.add(
+                hashlib.sha256(
+                    canonical_json(
+                        {
+                            "type": type(request_id).__name__,
+                            "value": request_id,
+                        }
+                    ).encode("utf-8")
+                ).hexdigest()
+            )
         safe_call_id = call_id if isinstance(call_id, str) else "invalid-proposal"
         safe_arguments = arguments if isinstance(arguments, dict) else {}
         if self._creator_live_a1_capture is not None:
@@ -353,6 +585,8 @@ class FieldNotesCodexAdapter(CodexAdapter):
                 self._capture_proposal_malformed = True
         if request_id in self._proposal_request_ids:
             if self._proposal_request_ids[request_id] != call_id:
+                if self._creator_live_a1_capture is not None:
+                    self._capture_request_identity_mismatch = True
                 self._failed_proposal_response(
                     request_id=request_id,
                     call_id=safe_call_id,
@@ -387,6 +621,7 @@ class FieldNotesCodexAdapter(CodexAdapter):
         if not valid_shape:
             if self._creator_live_a1_capture is not None:
                 self._capture_proposal_malformed = True
+                self._capture_request_shape_valid = False
             self._failed_proposal_response(
                 request_id=request_id,
                 call_id=safe_call_id,
@@ -398,9 +633,15 @@ class FieldNotesCodexAdapter(CodexAdapter):
         assert isinstance(call_id, str)
         assert isinstance(arguments, dict)
         arguments_identity = self._arguments_identity(arguments)
+        if self._creator_live_a1_capture is not None:
+            if self._capture_request_shape_valid is None:
+                self._capture_request_shape_valid = True
+            self._capture_argument_identities.add(arguments_identity)
         existing = self._proposal_responses.get(call_id)
         if existing is not None:
             if existing.arguments_identity != arguments_identity:
+                if self._creator_live_a1_capture is not None:
+                    self._capture_inconsistent_replay = True
                 self._failed_proposal_response(
                     request_id=request_id,
                     call_id=call_id,
@@ -411,7 +652,12 @@ class FieldNotesCodexAdapter(CodexAdapter):
                 return
             self._send_proposal_response(request_id, existing)
             return
+        if self._creator_live_a1_capture is not None:
+            self._capture_gate_invoked = True
         accepted, code = self._field_note_gate.propose(arguments)
+        if self._creator_live_a1_capture is not None:
+            self._capture_gate_response_code = code
+            self._capture_gate_response_success = accepted
         response = _ProposalResponse(
             call_id=safe_call_id,
             arguments_identity=arguments_identity,
@@ -426,6 +672,135 @@ class FieldNotesCodexAdapter(CodexAdapter):
         self._proposal_responses[safe_call_id] = response
         self._send_proposal_response(request_id, response)
 
+    @staticmethod
+    def _identity_set_sha256(values: set[str]) -> str | None:
+        if not values:
+            return None
+        return hashlib.sha256(
+            canonical_json(sorted(values)).encode("utf-8")
+        ).hexdigest()
+
+    def _proposal_final_subcause(
+        self,
+        result: CodexRunResult,
+        *,
+        all_proposals_completed: bool,
+    ) -> str | None:
+        if result.file_actions or result.unsupported_reason in _DIRECT_MUTATION_REASONS:
+            return "A1_DIRECT_WRITE_REQUESTED"
+        attempts = len(self._capture_proposal_call_ids)
+        if attempts == 0:
+            return "A1_PROPOSAL_MISSING"
+        if attempts != 1:
+            return "A1_PROPOSAL_DUPLICATE"
+        if self._capture_inconsistent_replay:
+            return "A1_PROPOSAL_INCONSISTENT_REPLAY"
+        if self._capture_request_shape_valid is False:
+            return "A1_PROPOSAL_REQUEST_SHAPE_INVALID"
+        if (
+            self._capture_item_completion_observed
+            and self._capture_item_observed_status is not None
+            and self._capture_item_expected_status is not None
+            and (
+                self._capture_item_observed_status
+                != self._capture_item_expected_status
+            )
+        ):
+            return "A1_PROPOSAL_ITEM_STATUS_MISMATCH"
+        if (
+            self._capture_request_identity_mismatch
+            or self._capture_response_identity_mismatch
+        ):
+            return "A1_PROPOSAL_RESPONSE_IDENTITY_MISMATCH"
+        if (
+            self._capture_gate_invoked
+            and self._capture_gate_response_code == "proposal_schema_invalid"
+        ):
+            return "A1_PROPOSAL_SCHEMA_REJECTED"
+        if (
+            self._capture_gate_invoked
+            and self._capture_gate_response_success is False
+        ):
+            return "A1_PROPOSAL_GATE_REJECTED"
+        if (
+            self._capture_gate_response_success is True
+            and self._field_note_gate.accepted is None
+        ):
+            return "A1_PROPOSAL_ACCEPTED_STATE_MISSING"
+        if not all_proposals_completed:
+            if not self._capture_item_completion_observed:
+                return "A1_PROPOSAL_ITEM_NOT_COMPLETED"
+            if (
+                self._identity_failure
+                and self._failure_phase == "dynamic_tool_call"
+            ):
+                return "A1_PROPOSAL_PROTOCOL_IDENTITY_FAILURE"
+            return "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+        if (
+            self._identity_failure
+            and self._failure_phase == "dynamic_tool_call"
+        ):
+            return "A1_PROPOSAL_PROTOCOL_IDENTITY_FAILURE"
+        if self._capture_proposal_malformed:
+            return "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+        if self._field_note_gate.accepted is None:
+            return "A1_PROPOSAL_ACCEPTED_STATE_MISSING"
+        return None
+
+    def _creator_live_a1_proposal_diagnostic(
+        self,
+        result: CodexRunResult,
+        *,
+        all_proposals_completed: bool,
+    ) -> FieldNoteA1ProposalDiagnostic | None:
+        if self._creator_live_a1_capture is None:
+            return None
+        subcause = self._proposal_final_subcause(
+            result,
+            all_proposals_completed=all_proposals_completed,
+        )
+        return FieldNoteA1ProposalDiagnostic(
+            proposal_call_count=len(self._capture_proposal_call_ids),
+            call_identity_sha256=self._identity_set_sha256(
+                {
+                    hashlib.sha256(value.encode("utf-8")).hexdigest()
+                    for value in self._capture_proposal_call_ids
+                }
+            ),
+            request_identity_sha256=self._identity_set_sha256(
+                self._capture_request_identities
+            ),
+            arguments_identity_sha256=self._identity_set_sha256(
+                self._capture_argument_identities
+            ),
+            request_shape_valid=self._capture_request_shape_valid,
+            malformed_observed=self._capture_proposal_malformed,
+            gate_invoked=self._capture_gate_invoked,
+            gate_response_code=self._capture_gate_response_code,
+            gate_response_success=self._capture_gate_response_success,
+            accepted_proposal_present=self._field_note_gate.accepted is not None,
+            item_start_observed=self._capture_item_start_observed,
+            item_completion_observed=(
+                self._capture_item_completion_observed
+            ),
+            item_observed_status=self._capture_item_observed_status,
+            item_expected_status=self._capture_item_expected_status,
+            all_proposals_completed=all_proposals_completed,
+            request_identity_mismatch=(
+                self._capture_request_identity_mismatch
+            ),
+            response_identity_mismatch=(
+                self._capture_response_identity_mismatch
+            ),
+            inconsistent_replay=self._capture_inconsistent_replay,
+            protocol_identity_failure=self._identity_failure,
+            protocol_failure_phase=(
+                self._failure_phase if self._identity_failure else None
+            ),
+            direct_write_identity=None,
+            final_subcause=subcause,
+        )
+
     def _creator_live_a1_failure(
         self,
         result: CodexRunResult,
@@ -434,19 +809,12 @@ class FieldNotesCodexAdapter(CodexAdapter):
     ) -> str | None:
         if self._creator_live_a1_capture is None:
             return None
-        if result.file_actions or result.unsupported_reason in _DIRECT_MUTATION_REASONS:
-            return "A1_DIRECT_WRITE_REQUESTED"
-        attempts = len(self._capture_proposal_call_ids)
-        if attempts == 0:
-            return "A1_PROPOSAL_MISSING"
-        if attempts != 1:
-            return "A1_PROPOSAL_DUPLICATE"
-        if (
-            self._capture_proposal_malformed
-            or self._field_note_gate.accepted is None
-            or not all_proposals_completed
-        ):
-            return "A1_PROPOSAL_INVALID"
+        proposal_failure = self._proposal_final_subcause(
+            result,
+            all_proposals_completed=all_proposals_completed,
+        )
+        if proposal_failure is not None:
+            return proposal_failure
         if any(
             evidence.status != "succeeded"
             for evidence in result.read_evidence
@@ -470,6 +838,8 @@ class FieldNotesCodexAdapter(CodexAdapter):
             and item.get("type") == "dynamicToolCall"
             and item.get("tool") == FIELD_NOTE_TOOL_NAME
         ):
+            if self._creator_live_a1_capture is not None:
+                self._capture_item_start_observed = True
             if not self._ids_match(params):
                 self._mark_identity_failure()
                 return
@@ -482,11 +852,23 @@ class FieldNotesCodexAdapter(CodexAdapter):
                 or item.get("status") != "inProgress"
                 or not isinstance(arguments, dict)
             ):
+                if self._creator_live_a1_capture is not None:
+                    self._capture_proposal_malformed = True
                 self._mark_identity_failure()
                 return
             if item_id in self._items and self._items[item_id] != item:
+                if self._creator_live_a1_capture is not None:
+                    existing = self._items[item_id]
+                    if existing.get("arguments") != arguments:
+                        self._capture_inconsistent_replay = True
+                    else:
+                        self._capture_response_identity_mismatch = True
                 self._mark_identity_failure()
                 return
+            if self._creator_live_a1_capture is not None:
+                self._capture_argument_identities.add(
+                    self._arguments_identity(arguments)
+                )
             self._items[item_id] = item
             return
         super()._cache_item(params)
@@ -498,6 +880,12 @@ class FieldNotesCodexAdapter(CodexAdapter):
             and item.get("type") == "dynamicToolCall"
             and item.get("tool") == FIELD_NOTE_TOOL_NAME
         ):
+            if self._creator_live_a1_capture is not None:
+                self._capture_item_completion_observed = True
+                status = item.get("status")
+                self._capture_item_observed_status = (
+                    status if isinstance(status, str) and status else None
+                )
             if not self._ids_match(params):
                 self._mark_identity_failure()
                 return
@@ -518,6 +906,8 @@ class FieldNotesCodexAdapter(CodexAdapter):
             expected_status = (
                 "completed" if response is not None and response.success else "failed"
             )
+            if self._creator_live_a1_capture is not None:
+                self._capture_item_expected_status = expected_status
             if (
                 response is None
                 or started is None
@@ -537,6 +927,10 @@ class FieldNotesCodexAdapter(CodexAdapter):
                 )
                 or not resolved
             ):
+                if self._creator_live_a1_capture is not None and (
+                    item.get("status") == expected_status
+                ):
+                    self._capture_response_identity_mismatch = True
                 self._mark_identity_failure()
                 return
             self._completed_proposal_items.add(item_id)
@@ -563,6 +957,10 @@ class FieldNotesCodexAdapter(CodexAdapter):
             self._reconnect_prompt = None
         all_proposals_completed = set(self._proposal_responses).issubset(
             self._completed_proposal_items
+        )
+        proposal_diagnostic = self._creator_live_a1_proposal_diagnostic(
+            result,
+            all_proposals_completed=all_proposals_completed,
         )
         capture_failure = self._creator_live_a1_failure(
             result,
@@ -631,4 +1029,5 @@ class FieldNotesCodexAdapter(CodexAdapter):
                 if self._creator_live_a1_capture is not None
                 else None
             ),
+            creator_live_a1_proposal_diagnostic=proposal_diagnostic,
         )

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 import hashlib
 import io
@@ -28,6 +28,7 @@ from decision_os.companion.controller import (
     CompanionError,
 )
 from decision_os.companion.field_notes_adapter import (
+    FieldNoteA1ProposalDiagnostic,
     FieldNoteCreatorLiveA1CaptureConfig,
     FieldNoteCodexRunResult,
     FieldNotesCodexAdapter,
@@ -123,6 +124,9 @@ class FieldNotesCompanionController(CompanionController):
         ) = None
         self._creator_live_a1_failure_reason: str | None = None
         self._creator_live_a1_direct_write_identity: str | None = None
+        self._creator_live_a1_proposal_diagnostic: (
+            FieldNoteA1ProposalDiagnostic | None
+        ) = None
         trusted_source_model_class = configured_model_class(
             kwargs.pop("trusted_source_model_class", "UNKNOWN")
         )
@@ -185,6 +189,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_run_completion = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
+            self._creator_live_a1_proposal_diagnostic = None
         try:
             return super().start_run(task, task_mode="manual")
         except Exception:
@@ -200,6 +205,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_run_completion = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
+            self._creator_live_a1_proposal_diagnostic = None
         return super().new_run()
 
     def select_repository(self, candidate: str | Path) -> dict[str, Any]:
@@ -211,6 +217,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_run_completion = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
+            self._creator_live_a1_proposal_diagnostic = None
             return self._snapshot_locked()
 
     @staticmethod
@@ -340,7 +347,35 @@ class FieldNotesCompanionController(CompanionController):
             None,
         )
         completion: FieldNoteCreatorLiveA1RunCompletion | None = None
+        proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None
         if capture is not None:
+            raw_diagnostic = getattr(
+                result,
+                "creator_live_a1_proposal_diagnostic",
+                None,
+            )
+            if isinstance(raw_diagnostic, FieldNoteA1ProposalDiagnostic):
+                try:
+                    proposal_diagnostic = (
+                        FieldNoteA1ProposalDiagnostic.from_dict(
+                            raw_diagnostic.as_dict()
+                        )
+                    )
+                except ValueError:
+                    proposal_diagnostic = None
+            if proposal_diagnostic is None:
+                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+            elif (
+                proposal_diagnostic.final_subcause is not None
+                and capture_failure != proposal_diagnostic.final_subcause
+            ):
+                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+            elif (
+                proposal_diagnostic.final_subcause is None
+                and isinstance(capture_failure, str)
+                and capture_failure.startswith("A1_PROPOSAL_")
+            ):
+                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
             if (
                 getattr(result, "creator_live_a1_capture", False) is not True
                 or result.run_id != capture.run_id
@@ -358,6 +393,24 @@ class FieldNotesCompanionController(CompanionController):
                 for evidence in result.read_evidence
             ):
                 capture_failure = "A1_READ_EVIDENCE_FAILED"
+            if (
+                proposal_diagnostic is not None
+                and proposal_diagnostic.final_subcause
+                == "A1_DIRECT_WRITE_REQUESTED"
+                and self._creator_live_a1_direct_write_identity is not None
+            ):
+                proposal_diagnostic = (
+                    proposal_diagnostic.with_direct_write_identity(
+                        self._creator_live_a1_direct_write_identity
+                    )
+                )
+                if isinstance(result, FieldNoteCodexRunResult):
+                    result = replace(
+                        result,
+                        creator_live_a1_proposal_diagnostic=(
+                            proposal_diagnostic
+                        ),
+                    )
             draft = (
                 self._eligible_creator_live_draft(
                     result,
@@ -399,6 +452,7 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a1_capture_config = None
             self._creator_live_a1_run_completion = completion
             self._creator_live_a1_failure_reason = capture_failure
+            self._creator_live_a1_proposal_diagnostic = proposal_diagnostic
             self._run["field_note_reconnect"] = reconnect_projection
             if draft is None:
                 self._clear_field_note_locked()
@@ -469,6 +523,32 @@ class FieldNotesCompanionController(CompanionController):
                 )
             return completion
 
+    def creator_live_a1_proposal_diagnostic(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> FieldNoteA1ProposalDiagnostic:
+        """Return the digest-verified diagnostic for the exact completed Run."""
+
+        with self._condition:
+            if (
+                not isinstance(expected_run_id, str)
+                or not expected_run_id
+                or self._creator_live_a1_completed_run_id != expected_run_id
+            ):
+                raise FieldNoteError("A1_CAPTURE_IDENTITY_MISMATCH")
+            diagnostic = self._creator_live_a1_proposal_diagnostic
+            if diagnostic is None:
+                raise FieldNoteError("A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE")
+            try:
+                return FieldNoteA1ProposalDiagnostic.from_dict(
+                    diagnostic.as_dict()
+                )
+            except ValueError as exc:
+                raise FieldNoteError(
+                    "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+                ) from exc
+
     def _fail_run(self, repository: Path, exc: Exception) -> None:
         super()._fail_run(repository, exc)
         with self._condition:
@@ -479,6 +559,7 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a1_capture_config = None
                 self._creator_live_a1_failure_reason = "A1_RUN_FAILED"
                 self._creator_live_a1_run_completion = None
+                self._creator_live_a1_proposal_diagnostic = None
             self._clear_field_note_locked()
             self._condition.notify_all()
 

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -382,20 +382,28 @@ class FieldNotesCompanionController(CompanionController):
                     proposal_diagnostic = None
             proposal_failure = bool(
                 isinstance(capture_failure, str)
-                and (
-                    capture_failure.startswith("A1_PROPOSAL_")
-                    or capture_failure == "A1_DIRECT_WRITE_REQUESTED"
-                )
+                and capture_failure.startswith("A1_PROPOSAL_")
+            )
+            direct_write_failure = (
+                capture_failure == "A1_DIRECT_WRITE_REQUESTED"
             )
             if proposal_diagnostic is None:
-                if capture_failure is None or proposal_failure:
+                if (
+                    capture_failure is None
+                    or proposal_failure
+                    or direct_write_failure
+                ):
                     capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
             elif proposal_diagnostic.final_subcause is not None:
-                if capture_failure is None or not proposal_failure:
+                if capture_failure is None or proposal_failure:
                     capture_failure = proposal_diagnostic.final_subcause
-                elif capture_failure != proposal_diagnostic.final_subcause:
+                elif (
+                    direct_write_failure
+                    and proposal_diagnostic.final_subcause
+                    != "A1_DIRECT_WRITE_REQUESTED"
+                ):
                     capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
-            elif proposal_failure:
+            elif proposal_failure or direct_write_failure:
                 capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
             if (
                 proposal_diagnostic is not None

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -349,33 +349,6 @@ class FieldNotesCompanionController(CompanionController):
         completion: FieldNoteCreatorLiveA1RunCompletion | None = None
         proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None
         if capture is not None:
-            raw_diagnostic = getattr(
-                result,
-                "creator_live_a1_proposal_diagnostic",
-                None,
-            )
-            if isinstance(raw_diagnostic, FieldNoteA1ProposalDiagnostic):
-                try:
-                    proposal_diagnostic = (
-                        FieldNoteA1ProposalDiagnostic.from_dict(
-                            raw_diagnostic.as_dict()
-                        )
-                    )
-                except ValueError:
-                    proposal_diagnostic = None
-            if proposal_diagnostic is None:
-                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
-            elif (
-                proposal_diagnostic.final_subcause is not None
-                and capture_failure != proposal_diagnostic.final_subcause
-            ):
-                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
-            elif (
-                proposal_diagnostic.final_subcause is None
-                and isinstance(capture_failure, str)
-                and capture_failure.startswith("A1_PROPOSAL_")
-            ):
-                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
             if (
                 getattr(result, "creator_live_a1_capture", False) is not True
                 or result.run_id != capture.run_id
@@ -393,6 +366,37 @@ class FieldNotesCompanionController(CompanionController):
                 for evidence in result.read_evidence
             ):
                 capture_failure = "A1_READ_EVIDENCE_FAILED"
+            raw_diagnostic = getattr(
+                result,
+                "creator_live_a1_proposal_diagnostic",
+                None,
+            )
+            if isinstance(raw_diagnostic, FieldNoteA1ProposalDiagnostic):
+                try:
+                    proposal_diagnostic = (
+                        FieldNoteA1ProposalDiagnostic.from_dict(
+                            raw_diagnostic.as_dict()
+                        )
+                    )
+                except ValueError:
+                    proposal_diagnostic = None
+            proposal_failure = bool(
+                isinstance(capture_failure, str)
+                and (
+                    capture_failure.startswith("A1_PROPOSAL_")
+                    or capture_failure == "A1_DIRECT_WRITE_REQUESTED"
+                )
+            )
+            if proposal_diagnostic is None:
+                if capture_failure is None or proposal_failure:
+                    capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+            elif proposal_diagnostic.final_subcause is not None:
+                if capture_failure is None or not proposal_failure:
+                    capture_failure = proposal_diagnostic.final_subcause
+                elif capture_failure != proposal_diagnostic.final_subcause:
+                    capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
+            elif proposal_failure:
+                capture_failure = "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
             if (
                 proposal_diagnostic is not None
                 and proposal_diagnostic.final_subcause
@@ -549,9 +553,27 @@ class FieldNotesCompanionController(CompanionController):
                     "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE"
                 ) from exc
 
-    def _fail_run(self, repository: Path, exc: Exception) -> None:
-        super()._fail_run(repository, exc)
+    def creator_live_a1_failure_reason(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> str | None:
+        """Return the exact established failure family for one completed Run."""
+
         with self._condition:
+            if (
+                not isinstance(expected_run_id, str)
+                or not expected_run_id
+                or self._creator_live_a1_completed_run_id != expected_run_id
+            ):
+                raise FieldNoteError("A1_CAPTURE_IDENTITY_MISMATCH")
+            if self._run.get("state") == "running":
+                raise FieldNoteError("Creator-live A1 capture is still running.")
+            return self._creator_live_a1_failure_reason
+
+    def _fail_run(self, repository: Path, exc: Exception) -> None:
+        with self._condition:
+            super()._fail_run(repository, exc)
             if self._creator_live_a1_capture_config is not None:
                 self._creator_live_a1_completed_run_id = (
                     self._creator_live_a1_capture_config.run_id

--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -13,6 +13,9 @@ import threading
 from typing import Any, Literal
 
 from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.companion.field_notes_adapter import (
+    FieldNoteA1ProposalDiagnostic,
+)
 from decision_os.companion.field_notes_maturity_commit import (
     FieldNoteMaturityCommitResult,
 )
@@ -131,6 +134,23 @@ class FieldNoteCreatorLiveDurabilityError(FieldNoteCreatorLiveError):
 
 class FieldNoteCreatorLiveAttemptExistsError(FieldNoteCreatorLiveError):
     """The one-attempt journal already exists and cannot be replaced."""
+
+
+def _proposal_diagnostic_reason_matches(
+    diagnostic: FieldNoteA1ProposalDiagnostic,
+    reason: str,
+) -> bool:
+    subcause = diagnostic.final_subcause
+    if subcause is None:
+        return False
+    if subcause == "A1_DIRECT_WRITE_REQUESTED":
+        suffix = (
+            f":{diagnostic.direct_write_identity}"
+            if diagnostic.direct_write_identity is not None
+            else ""
+        )
+        return reason == f"{subcause}{suffix}"
+    return reason == subcause
 
 
 @dataclass(frozen=True, init=False)
@@ -919,6 +939,7 @@ class FieldNoteCreatorLiveTraceReadback:
     captured_note: FieldNoteIdentity | None
     captured_note_byte_count: int | None
     a1_capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt | None
+    a1_proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None
     a3_reuse_event_id: str | None
     current_stage: TraceStage | None
     trace_event_count: int
@@ -959,6 +980,7 @@ class FieldNoteCreatorLiveTraceReadback:
         a1_capture_commit: (
             FieldNoteCreatorLiveA1CaptureCommitReceipt | None
         ),
+        a1_proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None,
         a3_reuse_event_id: str | None,
         current_stage: TraceStage | None,
         events: tuple[FieldNoteWholeFlowTraceEvent, ...],
@@ -991,6 +1013,7 @@ class FieldNoteCreatorLiveTraceReadback:
             "captured_note": captured_note,
             "captured_note_byte_count": captured_note_byte_count,
             "a1_capture_commit": a1_capture_commit,
+            "a1_proposal_diagnostic": a1_proposal_diagnostic,
             "a3_reuse_event_id": a3_reuse_event_id,
             "current_stage": current_stage,
             "trace_event_count": len(events),
@@ -1040,6 +1063,11 @@ class FieldNoteCreatorLiveTraceReadback:
             "a1_capture_commit": (
                 self.a1_capture_commit.as_dict()
                 if self.a1_capture_commit
+                else None
+            ),
+            "a1_proposal_diagnostic": (
+                self.a1_proposal_diagnostic.as_dict()
+                if self.a1_proposal_diagnostic
                 else None
             ),
             "a3_reuse_event_id": self.a3_reuse_event_id,
@@ -1184,6 +1212,7 @@ def _project_records(
     captured_note: FieldNoteIdentity | None = None
     captured_note_byte_count: int | None = None
     a1_capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt | None = None
+    a1_proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None
     a3_reuse_event_id: str | None = None
     state: CreatorLiveAttemptState = "OPEN"
     failure_boundary: WholeFlowBoundary | None = None
@@ -1357,10 +1386,20 @@ def _project_records(
             previous_trace = event.trace_sha256
             continue
         if record.kind == "ATTEMPT_FAILED":
-            if set(payload) != {
+            legacy_fields = {
                 "failure_boundary",
                 "failure_reason",
                 "repair_action",
+            }
+            diagnostic_fields = legacy_fields | {
+                "proof_attempt_id",
+                "run_id",
+                "proposal_diagnostic",
+                "proposal_diagnostic_sha256",
+            }
+            if set(payload) not in {
+                frozenset(legacy_fields),
+                frozenset(diagnostic_fields),
             }:
                 raise _JournalIntegrityError(
                     "CREATOR_LIVE_FAILURE_RECORD_INVALID",
@@ -1400,6 +1439,39 @@ def _project_records(
             failure_boundary = boundary
             failure_reason = _bounded_reason(payload["failure_reason"])
             repair_action = action
+            if set(payload) == diagnostic_fields:
+                if (
+                    boundary != "A1_CAPTURE"
+                    or payload["proof_attempt_id"]
+                    != static.attempt.proof_attempt_id
+                    or payload["run_id"] != static.run_1.run_id
+                ):
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A1_DIAGNOSTIC_BINDING_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    )
+                try:
+                    diagnostic = FieldNoteA1ProposalDiagnostic.from_dict(
+                        payload["proposal_diagnostic"]
+                    )
+                except ValueError as exc:
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A1_DIAGNOSTIC_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    ) from exc
+                if (
+                    payload["proposal_diagnostic_sha256"]
+                    != diagnostic.diagnostic_sha256
+                    or not _proposal_diagnostic_reason_matches(
+                        diagnostic,
+                        failure_reason,
+                    )
+                ):
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A1_DIAGNOSTIC_IDENTITY_INVALID",
+                        repair_action="RECEIPT_REWRITE",
+                    )
+                a1_proposal_diagnostic = diagnostic
             continue
         if record.kind == "TRACE_COMPLETED":
             if set(payload) != {
@@ -1444,6 +1516,7 @@ def _project_records(
         captured_note=captured_note,
         captured_note_byte_count=captured_note_byte_count,
         a1_capture_commit=a1_capture_commit,
+        a1_proposal_diagnostic=a1_proposal_diagnostic,
         a3_reuse_event_id=a3_reuse_event_id,
         current_stage=current_stage,
         events=tuple(events),
@@ -1481,6 +1554,7 @@ def _failed_readback(
         captured_note=None,
         captured_note_byte_count=None,
         a1_capture_commit=None,
+        a1_proposal_diagnostic=None,
         a3_reuse_event_id=None,
         current_stage=None,
         events=(),
@@ -1828,21 +1902,52 @@ class FieldNoteCreatorLiveProofRuntime:
         reason: str,
         *,
         repair_action: RepairAction = "NONE",
+        proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None,
     ) -> None:
         bounded = _bounded_reason(reason)
+        if proposal_diagnostic is not None:
+            try:
+                proposal_diagnostic = FieldNoteA1ProposalDiagnostic.from_dict(
+                    proposal_diagnostic.as_dict()
+                )
+            except ValueError as exc:
+                raise FieldNoteCreatorLiveValidationError(
+                    "Creator-live A1 proposal diagnostic is invalid."
+                ) from exc
+            if (
+                boundary != "A1_CAPTURE"
+                or not _proposal_diagnostic_reason_matches(
+                    proposal_diagnostic,
+                    bounded,
+                )
+            ):
+                raise FieldNoteCreatorLiveValidationError(
+                    "Creator-live A1 proposal diagnostic is cross-bound."
+                )
         readback = self.read_back()
         if readback.state in {"FAILED", "TRACE_COMPLETE"}:
             raise FieldNoteCreatorLiveStageError(
                 "Creator-live attempt is terminal and cannot be reset."
             )
-        self._append(
-            "ATTEMPT_FAILED",
-            {
-                "failure_boundary": boundary,
-                "failure_reason": bounded,
-                "repair_action": repair_action,
-            },
-        )
+        payload: dict[str, Any] = {
+            "failure_boundary": boundary,
+            "failure_reason": bounded,
+            "repair_action": repair_action,
+        }
+        if proposal_diagnostic is not None:
+            payload.update(
+                {
+                    "proof_attempt_id": (
+                        self._static.attempt.proof_attempt_id
+                    ),
+                    "run_id": self._static.run_1.run_id,
+                    "proposal_diagnostic": proposal_diagnostic.as_dict(),
+                    "proposal_diagnostic_sha256": (
+                        proposal_diagnostic.diagnostic_sha256
+                    ),
+                }
+            )
+        self._append("ATTEMPT_FAILED", payload)
         raise FieldNoteCreatorLiveStageError(bounded)
 
     def _require_stage(self, stage: TraceStage) -> FieldNoteCreatorLiveTraceReadback:
@@ -2301,8 +2406,14 @@ class FieldNoteCreatorLiveProofRuntime:
         self,
         boundary: WholeFlowBoundary,
         reason: str,
+        *,
+        proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None,
     ) -> None:
-        self._terminal_failure(boundary, reason)
+        self._terminal_failure(
+            boundary,
+            reason,
+            proposal_diagnostic=proposal_diagnostic,
+        )
 
     def record_repair(
         self,

--- a/decision_os/companion/field_notes_creator_live_capture.py
+++ b/decision_os/companion/field_notes_creator_live_capture.py
@@ -261,6 +261,11 @@ class FieldNoteCreatorLiveA1CaptureBridge:
                 )
             except FieldNoteError as exc:
                 self._terminal(self._capture_failure_reason(exc))
+            if (
+                failure_reason is not None
+                and not self._is_proposal_failure(failure_reason)
+            ):
+                self._terminal(failure_reason)
             try:
                 proposal_diagnostic = (
                     self.controller.creator_live_a1_proposal_diagnostic(
@@ -268,11 +273,6 @@ class FieldNoteCreatorLiveA1CaptureBridge:
                     )
                 )
             except FieldNoteError as exc:
-                if (
-                    failure_reason is not None
-                    and not self._is_proposal_failure(failure_reason)
-                ):
-                    self._terminal(failure_reason)
                 self._terminal(self._capture_failure_reason(exc))
             proposal_diagnostic = FieldNoteA1ProposalDiagnostic.from_dict(
                 proposal_diagnostic.as_dict()

--- a/decision_os/companion/field_notes_creator_live_capture.py
+++ b/decision_os/companion/field_notes_creator_live_capture.py
@@ -229,6 +229,16 @@ class FieldNoteCreatorLiveA1CaptureBridge:
             return value
         return "A1_CAPTURE_FAILED"
 
+    @staticmethod
+    def _is_proposal_failure(reason: str | None) -> bool:
+        return bool(
+            isinstance(reason, str)
+            and (
+                reason.startswith("A1_PROPOSAL_")
+                or reason == "A1_DIRECT_WRITE_REQUESTED"
+            )
+        )
+
     def capture(self, task: str) -> FieldNoteWholeFlowTraceEvent:
         """Dispatch one Run 1, save its exact proposal, then emit one A1."""
 
@@ -244,12 +254,25 @@ class FieldNoteCreatorLiveA1CaptureBridge:
             )
             self._wait_for_run()
             try:
+                failure_reason = (
+                    self.controller.creator_live_a1_failure_reason(
+                        expected_run_id=run_id
+                    )
+                )
+            except FieldNoteError as exc:
+                self._terminal(self._capture_failure_reason(exc))
+            try:
                 proposal_diagnostic = (
                     self.controller.creator_live_a1_proposal_diagnostic(
                         expected_run_id=run_id
                     )
                 )
             except FieldNoteError as exc:
+                if (
+                    failure_reason is not None
+                    and not self._is_proposal_failure(failure_reason)
+                ):
+                    self._terminal(failure_reason)
                 self._terminal(self._capture_failure_reason(exc))
             proposal_diagnostic = FieldNoteA1ProposalDiagnostic.from_dict(
                 proposal_diagnostic.as_dict()
@@ -265,6 +288,8 @@ class FieldNoteCreatorLiveA1CaptureBridge:
                         f"{proposal_diagnostic.direct_write_identity}"
                     )
                 self._terminal(reason, proposal_diagnostic)
+            if failure_reason is not None:
+                self._terminal(failure_reason)
             draft = self.controller.creator_live_a1_capture_candidate()
             completion = self.controller.creator_live_a1_run_completion()
             validate_compiled_markdown(draft.markdown)

--- a/decision_os/companion/field_notes_creator_live_capture.py
+++ b/decision_os/companion/field_notes_creator_live_capture.py
@@ -16,6 +16,9 @@ from decision_os.acceleration.model import (
     repository_id,
 )
 from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.companion.field_notes_adapter import (
+    FieldNoteA1ProposalDiagnostic,
+)
 from decision_os.companion.field_notes_controller import (
     FieldNoteError,
     FieldNotesCompanionController,
@@ -89,10 +92,18 @@ class FieldNoteCreatorLiveA1CaptureBridge:
         self.utc_now = utc_now
         self._dispatched = False
 
-    def _terminal(self, reason: str) -> None:
+    def _terminal(
+        self,
+        reason: str,
+        proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None,
+    ) -> None:
         bounded = reason if len(reason) <= 256 else reason[:256]
         try:
-            self.runtime.record_stage_failure("A1_CAPTURE", bounded)
+            self.runtime.record_stage_failure(
+                "A1_CAPTURE",
+                bounded,
+                proposal_diagnostic=proposal_diagnostic,
+            )
         except FieldNoteCreatorLiveStageError as exc:
             raise FieldNoteCreatorLiveA1CaptureBridgeError(bounded) from exc
         raise FieldNoteCreatorLiveA1CaptureBridgeError(bounded)
@@ -232,6 +243,28 @@ class FieldNoteCreatorLiveA1CaptureBridge:
                 expected_runtime_identity=expected_runtime,
             )
             self._wait_for_run()
+            try:
+                proposal_diagnostic = (
+                    self.controller.creator_live_a1_proposal_diagnostic(
+                        expected_run_id=run_id
+                    )
+                )
+            except FieldNoteError as exc:
+                self._terminal(self._capture_failure_reason(exc))
+            proposal_diagnostic = FieldNoteA1ProposalDiagnostic.from_dict(
+                proposal_diagnostic.as_dict()
+            )
+            if proposal_diagnostic.final_subcause is not None:
+                reason = proposal_diagnostic.final_subcause
+                if (
+                    reason == "A1_DIRECT_WRITE_REQUESTED"
+                    and proposal_diagnostic.direct_write_identity is not None
+                ):
+                    reason = (
+                        f"{reason}:"
+                        f"{proposal_diagnostic.direct_write_identity}"
+                    )
+                self._terminal(reason, proposal_diagnostic)
             draft = self.controller.creator_live_a1_capture_candidate()
             completion = self.controller.creator_live_a1_run_completion()
             validate_compiled_markdown(draft.markdown)

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -9,6 +9,9 @@ from unittest.mock import patch
 
 from decision_os.companion import field_notes_creator_live as creator_live
 from decision_os.companion import field_notes_whole_flow as whole_flow
+from decision_os.companion.field_notes_adapter import (
+    FieldNoteA1ProposalDiagnostic,
+)
 from decision_os.companion.field_notes_creator_live import (
     FieldNoteCreatorLiveA1CaptureCommitReceipt,
     FieldNoteCreatorLiveAttemptExistsError,
@@ -50,6 +53,37 @@ OBSERVED_AT = (
 )
 RUN_1_TASK = "Complete the bounded creator-live Run 1 task."
 RUN_1_TASK_SHA256 = hashlib.sha256(RUN_1_TASK.encode("utf-8")).hexdigest()
+
+
+def proposal_diagnostic(
+    **changes,
+) -> FieldNoteA1ProposalDiagnostic:
+    values = {
+        "proposal_call_count": 1,
+        "call_identity_sha256": "1" * 64,
+        "request_identity_sha256": "2" * 64,
+        "arguments_identity_sha256": "3" * 64,
+        "request_shape_valid": True,
+        "malformed_observed": True,
+        "gate_invoked": True,
+        "gate_response_code": "proposal_schema_invalid",
+        "gate_response_success": False,
+        "accepted_proposal_present": False,
+        "item_start_observed": True,
+        "item_completion_observed": True,
+        "item_observed_status": "failed",
+        "item_expected_status": "failed",
+        "all_proposals_completed": True,
+        "request_identity_mismatch": False,
+        "response_identity_mismatch": False,
+        "inconsistent_replay": False,
+        "protocol_identity_failure": False,
+        "protocol_failure_phase": None,
+        "direct_write_identity": None,
+        "final_subcause": "A1_PROPOSAL_SCHEMA_REJECTED",
+    }
+    values.update(changes)
+    return FieldNoteA1ProposalDiagnostic(**values)
 
 
 class CreatorLiveTestCase(unittest.TestCase):
@@ -609,6 +643,34 @@ class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
         with self.assertRaises(FieldNoteCreatorLiveStageError):
             self.record_a1(loaded)
 
+    def test_legacy_terminal_record_projects_diagnostic_unavailable(self) -> None:
+        runtime_path = self.open_runtime("legacy-failure")
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure(
+                "A1_CAPTURE",
+                "A1_PROPOSAL_INVALID",
+            )
+        loaded = FieldNoteCreatorLiveProofRuntime.load_attempt(
+            runtime_path.journal_path.parent
+        )
+        readback = loaded.read_back()
+        self.assertTrue(readback.durable_readback_verified)
+        self.assertEqual("A1_PROPOSAL_INVALID", readback.failure_reason)
+        self.assertIsNone(readback.a1_proposal_diagnostic)
+
+    def test_typed_proposal_failure_cannot_open_run_2(self) -> None:
+        runtime_path = self.open_runtime("diagnostic-terminal")
+        diagnostic = proposal_diagnostic()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure(
+                "A1_CAPTURE",
+                diagnostic.final_subcause,
+                proposal_diagnostic=diagnostic,
+            )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.open_run_2(self.bundle.run_2)
+        self.assertEqual(0, runtime_path.read_back().trace_event_count)
+
     def test_second_attempt_is_not_started_automatically(self) -> None:
         runtime_path = self.open_runtime()
         with self.assertRaises(FieldNoteCreatorLiveAttemptExistsError):
@@ -970,6 +1032,64 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
         runtime_path = self.open_runtime("drop-failure")
         with self.assertRaises(FieldNoteCreatorLiveStageError):
             runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        self.remove_journal_tail(runtime_path)
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+
+    def test_proposal_diagnostic_is_journaled_anchor_sealed_and_read_back(self) -> None:
+        runtime_path = self.open_runtime("diagnostic-sealed")
+        diagnostic = proposal_diagnostic()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure(
+                "A1_CAPTURE",
+                diagnostic.final_subcause,
+                proposal_diagnostic=diagnostic,
+            )
+        readback = runtime_path.read_back()
+        self.assertTrue(readback.durable_readback_verified)
+        self.assertEqual(diagnostic, readback.a1_proposal_diagnostic)
+        self.assertEqual(
+            readback.journal_record_count,
+            readback.anchor_record_count,
+        )
+        journal = runtime_path.journal_path.read_text(encoding="utf-8")
+        anchor = runtime_path.anchor_path.read_text(encoding="utf-8")
+        self.assertIn(diagnostic.diagnostic_sha256, journal)
+        self.assertIn(readback.journal_sha256, anchor)
+        self.assertNotIn("reusable_structure", journal)
+        self.assertNotIn("proposal Markdown", journal)
+        self.assertNotIn("raw model output", journal)
+
+    def test_proposal_diagnostic_record_mutation_fails_closed(self) -> None:
+        runtime_path = self.open_runtime("diagnostic-mutation")
+        diagnostic = proposal_diagnostic()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure(
+                "A1_CAPTURE",
+                diagnostic.final_subcause,
+                proposal_diagnostic=diagnostic,
+            )
+        raw = runtime_path.journal_path.read_bytes()
+        marker = diagnostic.diagnostic_sha256.encode("ascii")
+        offset = raw.index(marker)
+        replacement = b"f" if marker[:1] != b"f" else b"e"
+        runtime_path.journal_path.write_bytes(
+            raw[:offset] + replacement + raw[offset + 1 :]
+        )
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+
+    def test_proposal_diagnostic_tail_deletion_fails_closed(self) -> None:
+        runtime_path = self.open_runtime("diagnostic-tail")
+        diagnostic = proposal_diagnostic()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure(
+                "A1_CAPTURE",
+                diagnostic.final_subcause,
+                proposal_diagnostic=diagnostic,
+            )
         self.remove_journal_tail(runtime_path)
         readback = runtime_path.read_back()
         self.assertEqual("FAILED", readback.state)

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -187,7 +187,10 @@ class _CaptureAdapter:
                 proposal=None,
                 failure="A1_PROPOSAL_SCHEMA_REJECTED",
             )
-        return self.owner.result(config.run_id, proposal=draft)
+        return self.owner.result(
+            self.owner.result_run_id_override or config.run_id,
+            proposal=draft,
+        )
 
 
 class CreatorLiveCaptureBridgeTests(unittest.TestCase):
@@ -235,6 +238,8 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         self.read_evidence: tuple[CodexReadEvidence, ...] = ()
         self.task_sha256_override: str | None = None
         self.omit_proposal_diagnostic = False
+        self.diagnostic_final_subcause_override: str | None = None
+        self.result_run_id_override: str | None = None
         self.controller = FieldNotesCompanionController(
             state_path=self.root / "state.json",
             picker_script=self.root / "picker.scpt",
@@ -317,7 +322,11 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             protocol_identity_failure=False,
             protocol_failure_phase=None,
             direct_write_identity=None,
-            final_subcause=proposal_failure,
+            final_subcause=(
+                self.diagnostic_final_subcause_override
+                if self.diagnostic_final_subcause_override is not None
+                else proposal_failure
+            ),
         )
         return FieldNoteCodexRunResult(
             run_id=run_id,
@@ -526,6 +535,85 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             "A1_PROPOSAL_SCHEMA_REJECTED",
             readback.a1_proposal_diagnostic.final_subcause,
         )
+
+    def test_non_proposal_failures_precede_valid_diagnostic_subcause(
+        self,
+    ) -> None:
+        cases = (
+            "A1_READ_EVIDENCE_FAILED",
+            "A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH",
+            "A1_CAPTURE_IDENTITY_MISMATCH",
+        )
+        for expected_reason in cases:
+            with self.subTest(expected_reason=expected_reason):
+                self.setUp()
+                self.diagnostic_final_subcause_override = (
+                    "A1_PROPOSAL_SCHEMA_REJECTED"
+                )
+                if expected_reason == "A1_READ_EVIDENCE_FAILED":
+                    self.read_evidence = (
+                        CodexReadEvidence(
+                            path="missing.txt",
+                            byte_count=None,
+                            sha256=None,
+                            repository_identity=(
+                                self.source_repository.repository_id
+                            ),
+                            status="failed",
+                            reason="read_path_not_found",
+                        ),
+                    )
+                elif expected_reason == (
+                    "A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH"
+                ):
+                    self.actual_runtime_identity = replace(
+                        self.run_1.runtime,
+                        model="different-runtime-model",
+                    )
+                else:
+                    self.result_run_id_override = "different-run-id"
+
+                with patch.object(
+                    self.controller,
+                    "field_note_save",
+                ) as save:
+                    with self.assertRaises(
+                        FieldNoteCreatorLiveA1CaptureBridgeError
+                    ):
+                        self.bridge().capture(
+                            "Propose once after the bounded mutation."
+                        )
+
+                self.assertEqual(0, save.call_count)
+                self.assertEqual(
+                    expected_reason,
+                    self.controller.creator_live_a1_failure_reason(
+                        expected_run_id=self.run_1.run_id
+                    ),
+                )
+                diagnostic = (
+                    self.controller.creator_live_a1_proposal_diagnostic(
+                        expected_run_id=self.run_1.run_id
+                    )
+                )
+                self.assertEqual(
+                    "A1_PROPOSAL_SCHEMA_REJECTED",
+                    diagnostic.final_subcause,
+                )
+                readback = self.runtime.read_back()
+                self.assertEqual("FAILED", readback.state)
+                self.assertEqual("A1_CAPTURE", readback.failure_boundary)
+                self.assertEqual(expected_reason, readback.failure_reason)
+                self.assertIsNone(readback.a1_proposal_diagnostic)
+                self.assertEqual(0, readback.trace_event_count)
+                assert self.last_draft is not None
+                self.assertFalse(
+                    (
+                        self.repository / self.last_draft.relative_path
+                    ).exists()
+                )
+                with self.assertRaises(FieldNoteCreatorLiveStageError):
+                    self.runtime.open_run_2(self.run_1)
 
     def test_successful_read_cannot_replace_missing_or_malformed_proposal(self) -> None:
         for mode in ("missing", "malformed"):

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -15,7 +15,10 @@ from decision_os.acceleration.codex_adapter import (
     CodexRuntimeIdentity,
 )
 from decision_os.acceleration.model import git_output, repository_id
-from decision_os.companion.field_notes_adapter import FieldNoteCodexRunResult
+from decision_os.companion.field_notes_adapter import (
+    FieldNoteA1ProposalDiagnostic,
+    FieldNoteCodexRunResult,
+)
 from decision_os.companion.field_notes_controller import (
     FieldNotesCompanionController,
 )
@@ -174,7 +177,7 @@ class _CaptureAdapter:
                 config.run_id,
                 normal_terminal=False,
                 proposal=None,
-                failure="A1_PROPOSAL_INVALID",
+                failure="A1_PROPOSAL_SCHEMA_REJECTED",
             )
         return self.owner.result(config.run_id, proposal=draft)
 
@@ -243,6 +246,70 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         attempts: int = 1,
         actions: tuple[CodexFileAction, ...] = (),
     ) -> FieldNoteCodexRunResult:
+        proposal_failure = failure if failure in {
+            "A1_PROPOSAL_MISSING",
+            "A1_PROPOSAL_DUPLICATE",
+            "A1_PROPOSAL_SCHEMA_REJECTED",
+            "A1_DIRECT_WRITE_REQUESTED",
+        } else None
+        has_proposal = proposal is not None
+        gate_invoked = has_proposal or failure == "A1_PROPOSAL_SCHEMA_REJECTED"
+        diagnostic = FieldNoteA1ProposalDiagnostic(
+            proposal_call_count=(
+                0 if failure == "A1_PROPOSAL_MISSING" else attempts
+            ),
+            call_identity_sha256=(
+                None if failure == "A1_PROPOSAL_MISSING" else "1" * 64
+            ),
+            request_identity_sha256=(
+                None if failure == "A1_PROPOSAL_MISSING" else "2" * 64
+            ),
+            arguments_identity_sha256=(
+                None if failure == "A1_PROPOSAL_MISSING" else "3" * 64
+            ),
+            request_shape_valid=(
+                None if failure == "A1_PROPOSAL_MISSING" else True
+            ),
+            malformed_observed=(
+                failure == "A1_PROPOSAL_SCHEMA_REJECTED"
+            ),
+            gate_invoked=gate_invoked,
+            gate_response_code=(
+                "proposal_schema_invalid"
+                if failure == "A1_PROPOSAL_SCHEMA_REJECTED"
+                else "proposal_accepted" if gate_invoked else None
+            ),
+            gate_response_success=(
+                False
+                if failure == "A1_PROPOSAL_SCHEMA_REJECTED"
+                else True if gate_invoked else None
+            ),
+            accepted_proposal_present=has_proposal,
+            item_start_observed=(failure != "A1_PROPOSAL_MISSING"),
+            item_completion_observed=(failure != "A1_PROPOSAL_MISSING"),
+            item_observed_status=(
+                None
+                if failure == "A1_PROPOSAL_MISSING"
+                else "failed"
+                if failure == "A1_PROPOSAL_SCHEMA_REJECTED"
+                else "completed"
+            ),
+            item_expected_status=(
+                None
+                if failure == "A1_PROPOSAL_MISSING"
+                else "failed"
+                if failure == "A1_PROPOSAL_SCHEMA_REJECTED"
+                else "completed"
+            ),
+            all_proposals_completed=True,
+            request_identity_mismatch=False,
+            response_identity_mismatch=False,
+            inconsistent_replay=False,
+            protocol_identity_failure=False,
+            protocol_failure_phase=None,
+            direct_write_identity=None,
+            final_subcause=proposal_failure,
+        )
         return FieldNoteCodexRunResult(
             run_id=run_id,
             normal_terminal=normal_terminal,
@@ -263,6 +330,7 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             ).hexdigest()
             if self.task_sha256_override is None
             else self.task_sha256_override,
+            creator_live_a1_proposal_diagnostic=diagnostic,
         )
 
     def bridge(self) -> FieldNoteCreatorLiveA1CaptureBridge:
@@ -488,6 +556,18 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
                 self.assertEqual("FAILED", readback.state)
                 self.assertEqual("A1_CAPTURE", readback.failure_boundary)
                 self.assertEqual(0, readback.trace_event_count)
+                self.assertIsNotNone(readback.a1_proposal_diagnostic)
+                assert readback.a1_proposal_diagnostic is not None
+                self.assertEqual(
+                    readback.failure_reason,
+                    readback.a1_proposal_diagnostic.final_subcause,
+                )
+                assert self.last_draft is not None
+                self.assertFalse(
+                    (
+                        self.repository / self.last_draft.relative_path
+                    ).exists()
+                )
 
     def test_direct_create_update_delete_are_denied_and_terminal(self) -> None:
         for action in ("Create", "Update", "Delete"):
@@ -505,6 +585,12 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
                     readback.failure_reason.startswith(
                         "A1_DIRECT_WRITE_REQUESTED:"
                     )
+                )
+                self.assertIsNotNone(readback.a1_proposal_diagnostic)
+                assert readback.a1_proposal_diagnostic is not None
+                self.assertEqual(
+                    readback.a1_proposal_diagnostic.direct_write_identity,
+                    readback.failure_reason.rsplit(":", 1)[-1],
                 )
                 self.assertFalse(
                     (self.repository / "field_notes" / "direct.md").exists()

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from decision_os.acceleration.codex_adapter import (
     CodexApproval,
+    CodexAdapterFailure,
     CodexFileAction,
     CodexReadEvidence,
     CodexRuntimeIdentity,
@@ -20,6 +21,7 @@ from decision_os.companion.field_notes_adapter import (
     FieldNoteCodexRunResult,
 )
 from decision_os.companion.field_notes_controller import (
+    FieldNoteError,
     FieldNotesCompanionController,
 )
 from decision_os.companion.field_notes_creator_live import (
@@ -113,6 +115,12 @@ class _CaptureAdapter:
         config = self.owner.controller._active_creator_live_a1_capture()
         assert config is not None
         self.owner.observed_task = task
+        if self.owner.mode == "adapter_exception":
+            raise RuntimeError("adapter failed before a Run result existed")
+        if self.owner.mode == "transport_start_failure":
+            raise CodexAdapterFailure(
+                "transport failed before the proposal lifecycle"
+            )
         draft = compile_draft(
             proposal(),
             source_run_id=(
@@ -226,6 +234,7 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         )
         self.read_evidence: tuple[CodexReadEvidence, ...] = ()
         self.task_sha256_override: str | None = None
+        self.omit_proposal_diagnostic = False
         self.controller = FieldNotesCompanionController(
             state_path=self.root / "state.json",
             picker_script=self.root / "picker.scpt",
@@ -330,7 +339,9 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             ).hexdigest()
             if self.task_sha256_override is None
             else self.task_sha256_override,
-            creator_live_a1_proposal_diagnostic=diagnostic,
+            creator_live_a1_proposal_diagnostic=(
+                None if self.omit_proposal_diagnostic else diagnostic
+            ),
         )
 
     def bridge(self) -> FieldNoteCreatorLiveA1CaptureBridge:
@@ -447,6 +458,73 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         assert self.last_draft is not None
         self.assertFalse(
             (self.repository / self.last_draft.relative_path).exists()
+        )
+
+    def test_pre_result_failures_preserve_exact_run_failure_family(self) -> None:
+        for mode in ("adapter_exception", "transport_start_failure"):
+            with self.subTest(mode=mode):
+                self.setUp()
+                self.mode = mode
+                with patch.object(self.controller, "field_note_save") as save:
+                    with self.assertRaises(
+                        FieldNoteCreatorLiveA1CaptureBridgeError
+                    ):
+                        self.bridge().capture(
+                            "Propose exactly once if the Run starts."
+                        )
+                self.assertEqual(0, save.call_count)
+                self.assertEqual(
+                    "A1_RUN_FAILED",
+                    self.controller.creator_live_a1_failure_reason(
+                        expected_run_id=self.run_1.run_id
+                    ),
+                )
+                with self.assertRaises(FieldNoteError):
+                    self.controller.creator_live_a1_proposal_diagnostic(
+                        expected_run_id=self.run_1.run_id
+                    )
+                readback = self.runtime.read_back()
+                self.assertEqual("FAILED", readback.state)
+                self.assertEqual("A1_CAPTURE", readback.failure_boundary)
+                self.assertEqual("A1_RUN_FAILED", readback.failure_reason)
+                self.assertIsNone(readback.a1_proposal_diagnostic)
+                self.assertEqual(0, readback.trace_event_count)
+                self.assertFalse(
+                    (self.repository / ".decision-os" / "field-notes").exists()
+                )
+                with self.assertRaises(FieldNoteCreatorLiveStageError):
+                    self.runtime.open_run_2(self.run_1)
+
+    def test_missing_diagnostic_is_limited_to_proposal_failure(self) -> None:
+        self.mode = "malformed"
+        self.omit_proposal_diagnostic = True
+        with patch.object(self.controller, "field_note_save") as save:
+            with self.assertRaises(FieldNoteCreatorLiveA1CaptureBridgeError):
+                self.bridge().capture("Propose exactly once and stop.")
+        self.assertEqual(0, save.call_count)
+        readback = self.runtime.read_back()
+        self.assertEqual(
+            "A1_PROPOSAL_DIAGNOSTIC_UNAVAILABLE",
+            readback.failure_reason,
+        )
+        self.assertIsNone(readback.a1_proposal_diagnostic)
+
+    def test_valid_proposal_diagnostic_retains_exact_subcause(self) -> None:
+        self.mode = "malformed"
+        with patch.object(self.controller, "field_note_save") as save:
+            with self.assertRaises(FieldNoteCreatorLiveA1CaptureBridgeError):
+                self.bridge().capture("Propose exactly once and stop.")
+        self.assertEqual(0, save.call_count)
+        readback = self.runtime.read_back()
+        self.assertEqual(
+            "A1_PROPOSAL_SCHEMA_REJECTED",
+            readback.failure_reason,
+        )
+        self.assertIsNotNone(readback.a1_proposal_diagnostic)
+        assert readback.a1_proposal_diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_SCHEMA_REJECTED",
+            readback.a1_proposal_diagnostic.final_subcause,
         )
 
     def test_successful_read_cannot_replace_missing_or_malformed_proposal(self) -> None:

--- a/tests/test_field_notes_lite.py
+++ b/tests/test_field_notes_lite.py
@@ -24,6 +24,7 @@ from decision_os.acceleration.codex_adapter import (
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.companion.field_notes_adapter import (
+    FieldNoteA1ProposalDiagnostic,
     FieldNoteCreatorLiveA1CaptureConfig,
     FieldNoteCodexRunResult,
     FieldNotesCodexAdapter,
@@ -367,6 +368,11 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
         *,
         calls: tuple[tuple[str, dict[str, object]], ...] = (),
         final_message: str = "Completed.",
+        include_completion: bool = True,
+        observed_status: str | None = None,
+        request_extra: dict[str, object] | None = None,
+        completion_thread_id: str | None = None,
+        mismatched_completion_content: bool = False,
     ) -> FieldNoteCodexRunResult:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -379,6 +385,15 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
             turn_id=turn_id,
         )
         for index, (call_id, arguments) in enumerate(calls):
+            request = proposal_request(
+                thread_id=thread_id,
+                turn_id=turn_id,
+                call_id=call_id,
+                request_id=f"proposal-request-{index}",
+                arguments=arguments,
+            )
+            if request_extra:
+                request["params"].update(request_extra)  # type: ignore[union-attr]
             messages.extend(
                 [
                     started_proposal(
@@ -387,44 +402,27 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
                         call_id=call_id,
                         arguments=arguments,
                     ),
-                    proposal_request(
-                        thread_id=thread_id,
-                        turn_id=turn_id,
-                        call_id=call_id,
-                        request_id=f"proposal-request-{index}",
-                        arguments=arguments,
-                    ),
-                    {
-                        **completed_proposal(
-                            thread_id=thread_id,
-                            turn_id=turn_id,
-                            call_id=call_id,
-                            arguments=arguments,
-                        ),
-                        "params": {
-                            **completed_proposal(
-                                thread_id=thread_id,
-                                turn_id=turn_id,
-                                call_id=call_id,
-                                arguments=arguments,
-                            )["params"],
-                            "item": {
-                                **completed_proposal(
-                                    thread_id=thread_id,
-                                    turn_id=turn_id,
-                                    call_id=call_id,
-                                    arguments=arguments,
-                                )["params"]["item"],
-                                "status": (
-                                    "completed"
-                                    if index == 0 and arguments == proposal()
-                                    else "failed"
-                                ),
-                            },
-                        },
-                    },
+                    request,
                 ]
             )
+            if include_completion:
+                completion = completed_proposal(
+                    thread_id=completion_thread_id or thread_id,
+                    turn_id=turn_id,
+                    call_id=call_id,
+                    arguments=arguments,
+                )
+                completion_item = completion["params"]["item"]  # type: ignore[index]
+                completion_item["status"] = (  # type: ignore[index]
+                    observed_status
+                    if observed_status is not None
+                    else "completed"
+                    if index == 0 and arguments == proposal()
+                    else "failed"
+                )
+                if mismatched_completion_content:
+                    completion_item["contentItems"] = []  # type: ignore[index]
+                messages.append(completion)
         messages.extend(
             [
                 completed_agent_message(
@@ -485,6 +483,16 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, result.creator_live_a1_proposal_attempts)
         self.assertIsNone(result.creator_live_a1_failure_reason)
         self.assertIsNotNone(result.field_note_proposal)
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        self.assertIsInstance(diagnostic, FieldNoteA1ProposalDiagnostic)
+        assert diagnostic is not None
+        self.assertIsNone(diagnostic.final_subcause)
+        self.assertTrue(diagnostic.all_proposals_completed)
+        self.assertEqual("proposal_accepted", diagnostic.gate_response_code)
+        self.assertEqual(
+            diagnostic,
+            FieldNoteA1ProposalDiagnostic.from_dict(diagnostic.as_dict()),
+        )
         self.assertIn(
             "must call propose_field_note_candidate exactly once",
             self._creator_live_developer_instructions,
@@ -534,7 +542,7 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(result.normal_terminal)
         self.assertEqual(
-            "A1_PROPOSAL_INVALID",
+            "A1_PROPOSAL_SCHEMA_REJECTED",
             result.creator_live_a1_failure_reason,
         )
         self.assertIsNone(result.field_note_proposal)
@@ -550,11 +558,137 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(result.normal_terminal)
         self.assertEqual(
-            "A1_PROPOSAL_INVALID",
+            "A1_PROPOSAL_INCONSISTENT_REPLAY",
             result.creator_live_a1_failure_reason,
         )
         self.assertEqual(1, result.creator_live_a1_proposal_attempts)
         self.assertIsNone(result.field_note_proposal)
+
+    async def test_creator_live_request_shape_failure_is_retained(self) -> None:
+        result = await self._creator_live_result(
+            calls=(("proposal-call", proposal()),),
+            request_extra={"unexpected": "value"},
+        )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+            result.creator_live_a1_failure_reason,
+        )
+        self.assertFalse(diagnostic.request_shape_valid)
+        self.assertTrue(diagnostic.malformed_observed)
+
+    async def test_creator_live_gate_rejection_is_retained(self) -> None:
+        with patch.object(
+            FieldNoteProposalGate,
+            "propose",
+            return_value=(False, "proposal_policy_rejected"),
+        ):
+            result = await self._creator_live_result(
+                calls=(("proposal-call", proposal()),),
+                observed_status="failed",
+            )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_GATE_REJECTED",
+            diagnostic.final_subcause,
+        )
+        self.assertEqual(
+            "proposal_policy_rejected",
+            diagnostic.gate_response_code,
+        )
+
+    async def test_creator_live_accepted_item_not_completed_is_retained(self) -> None:
+        result = await self._creator_live_result(
+            calls=(("proposal-call", proposal()),),
+            include_completion=False,
+        )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_ITEM_NOT_COMPLETED",
+            diagnostic.final_subcause,
+        )
+        self.assertFalse(diagnostic.item_completion_observed)
+        self.assertFalse(diagnostic.all_proposals_completed)
+
+    async def test_creator_live_item_status_mismatch_is_retained(self) -> None:
+        result = await self._creator_live_result(
+            calls=(("proposal-call", proposal()),),
+            observed_status="failed",
+        )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_ITEM_STATUS_MISMATCH",
+            diagnostic.final_subcause,
+        )
+        self.assertEqual("failed", diagnostic.item_observed_status)
+        self.assertEqual("completed", diagnostic.item_expected_status)
+
+    async def test_creator_live_response_identity_mismatch_is_retained(self) -> None:
+        result = await self._creator_live_result(
+            calls=(("proposal-call", proposal()),),
+            mismatched_completion_content=True,
+        )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_RESPONSE_IDENTITY_MISMATCH",
+            diagnostic.final_subcause,
+        )
+        self.assertTrue(diagnostic.response_identity_mismatch)
+
+    async def test_creator_live_protocol_failure_retains_exact_phase(self) -> None:
+        result = await self._creator_live_result(
+            calls=(("proposal-call", proposal()),),
+            completion_thread_id="different-thread",
+        )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(
+            "A1_PROPOSAL_PROTOCOL_IDENTITY_FAILURE",
+            diagnostic.final_subcause,
+        )
+        self.assertTrue(diagnostic.protocol_identity_failure)
+        self.assertEqual("dynamic_tool_call", diagnostic.protocol_failure_phase)
+
+    def test_proposal_diagnostic_digest_and_payload_non_retention(self) -> None:
+        diagnostic = FieldNoteA1ProposalDiagnostic(
+            proposal_call_count=1,
+            call_identity_sha256="1" * 64,
+            request_identity_sha256="2" * 64,
+            arguments_identity_sha256="3" * 64,
+            request_shape_valid=True,
+            malformed_observed=False,
+            gate_invoked=True,
+            gate_response_code="proposal_schema_invalid",
+            gate_response_success=False,
+            accepted_proposal_present=False,
+            item_start_observed=True,
+            item_completion_observed=True,
+            item_observed_status="failed",
+            item_expected_status="failed",
+            all_proposals_completed=True,
+            request_identity_mismatch=False,
+            response_identity_mismatch=False,
+            inconsistent_replay=False,
+            protocol_identity_failure=False,
+            protocol_failure_phase=None,
+            direct_write_identity=None,
+            final_subcause="A1_PROPOSAL_SCHEMA_REJECTED",
+        )
+        changed = replace(diagnostic, malformed_observed=True)
+        self.assertNotEqual(
+            diagnostic.diagnostic_sha256,
+            changed.diagnostic_sha256,
+        )
+        encoded = json.dumps(diagnostic.as_dict(), sort_keys=True)
+        self.assertNotIn("Approval byte binding", encoded)
+        self.assertNotIn("reusable_structure", encoded)
+        self.assertNotIn("Completed.", encoded)
+        self.assertNotIn("arguments", diagnostic.as_dict())
 
     async def test_exact_proposal_request_replay_is_idempotent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_field_notes_lite.py
+++ b/tests/test_field_notes_lite.py
@@ -18,6 +18,7 @@ from decision_os.acceleration.codex_adapter import (
     CODEX_MODEL,
     CODEX_REASONING_EFFORT,
     CODEX_SERVICE_TIER,
+    CodexAdapterFailure,
     CodexReadEvidence,
     CodexRunResult,
     CodexRuntimeIdentity,
@@ -505,6 +506,47 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
             "Use the typed file-change tool for exactly one file mutation",
             self._creator_live_developer_instructions,
         )
+
+    async def test_creator_live_transport_start_failure_has_no_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = create_repository(Path(temporary))
+            engine = AccelerationEngine(
+                repository,
+                adapter=ADAPTER_NAME,
+                adapter_version=CODEX_CLI_VERSION,
+            )
+
+            def fail_transport_start(_executable: str):
+                raise CodexAdapterFailure(
+                    "transport failed before proposal lifecycle"
+                )
+
+            adapter = FieldNotesCodexAdapter(
+                engine,
+                input_func=lambda: None,
+                stdout=io.StringIO(),
+                transport_factory=fail_transport_start,
+                trusted_source_model_class="stronger",
+                trusted_target_model_class="lower-cost",
+                creator_live_a1_capture_provider=lambda: (
+                    FieldNoteCreatorLiveA1CaptureConfig(
+                        "run-live-a1-transport-failure",
+                        CodexRuntimeIdentity(
+                            model=CODEX_MODEL,
+                            reasoning_effort=CODEX_REASONING_EFFORT,
+                            service_tier=CODEX_SERVICE_TIER,
+                            codex_cli_version=CODEX_CLI_VERSION,
+                            account_type="chatgpt",
+                        ),
+                    )
+                ),
+            )
+
+            with self.assertRaises(CodexAdapterFailure):
+                await adapter.run("Fail before the proposal lifecycle.")
+
+            self.assertEqual(set(), adapter._capture_proposal_call_ids)
+            self.assertIsNone(adapter._field_note_gate.accepted)
 
     async def test_creator_live_mode_rejects_missing_raw_output(self) -> None:
         for raw in (


### PR DESCRIPTION
## What
- adds immutable payload-free A1 proposal lifecycle diagnostics with canonical SHA-256 identity
- propagates diagnostics through the adapter, controller, capture bridge, terminal journal, anchor, and typed readback
- preserves legacy terminal journals as readable with an unavailable diagnostic projection
- preserves exact established non-proposal Run failure families ahead of diagnostic presence, absence, validity, or content

## Why
The terminal A1_PROPOSAL_INVALID umbrella did not retain enough lifecycle facts to establish a narrower cause after process teardown. Follow-up review found that valid diagnostic content could still replace an already established non-proposal failure in the controller and bridge.

## Failure-family closure
- reads the authoritative completed creator-live Run failure before proposal-diagnostic interpretation
- terminalizes established non-proposal failures exactly before reading or validating diagnostic content
- allows validated diagnostic subcauses to narrow only proposal-class failures
- still requires a valid failure-free diagnostic for eligible proposal admission
- retains existing direct-write precedence
- proves A1_READ_EVIDENCE_FAILED, A1_ACTUAL_RUNTIME_IDENTITY_MISMATCH, and A1_CAPTURE_IDENTITY_MISMATCH survive a conflicting valid proposal subcause
- saves no Note and cannot open Run 2 on any repaired failure path

## Impact
Bounded diagnostics and failure-family precedence only. Proposal admission, one-attempt behavior, A1 boundary, ordinary A1 behavior, legacy readback, direct-write handling, and FIXTURE behavior are unchanged. No retry, live attempt, model invocation, Note creation, install, runtime restart, Run 2, or merge occurred.

## Identity
- prior reviewed head: 0eedf9d65f30bf372a199b041a1ad3603cfce14a
- current repaired head: 3abc61ca4de9473246395ccbb4642ef0f18c6355
- precedence repair boundary: decision_os/companion/field_notes_controller.py; decision_os/companion/field_notes_creator_live_capture.py; tests/test_field_notes_creator_live_capture.py

## Checks
- affected proposal/capture/runtime: 136/136 PASS
- A1–A7 focused: 432/432 PASS
- controller: 27/27 PASS
- server: 35/35 PASS
- full default discovery: 1129/1129 PASS
- full explicit discovery: 1129/1129 PASS
- normalized suite identity: MATCH, SHA-256 699d1823955f2f03d07e66a48feaa718024896715af14158850adecadf91d2fd
- Python compilation: PASS
- git diff --check: PASS
- protected creator Note, four validation artifacts, and Live Proof 002 journal/anchor: UNCHANGED