### PR TITLE
Repair A1 malformed-vs-missing taxonomy

### DIFF
--- a/decision_os/companion/field_notes_adapter.py
+++ b/decision_os/companion/field_notes_adapter.py
@@ -690,6 +690,8 @@ class FieldNotesCodexAdapter(CodexAdapter):
             return "A1_DIRECT_WRITE_REQUESTED"
         attempts = len(self._capture_proposal_call_ids)
         if attempts == 0:
+            if self._capture_request_shape_valid is False:
+                return "A1_PROPOSAL_REQUEST_SHAPE_INVALID"
             return "A1_PROPOSAL_MISSING"
         if attempts != 1:
             return "A1_PROPOSAL_DUPLICATE"

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -180,6 +180,14 @@ class _CaptureAdapter:
                 failure="A1_PROPOSAL_DUPLICATE",
                 attempts=2,
             )
+        if self.owner.mode == "request_shape_invalid":
+            return self.owner.result(
+                config.run_id,
+                normal_terminal=False,
+                proposal=None,
+                failure="A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+                attempts=0,
+            )
         if self.owner.mode == "malformed":
             return self.owner.result(
                 config.run_id,
@@ -238,6 +246,9 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         self.read_evidence: tuple[CodexReadEvidence, ...] = ()
         self.task_sha256_override: str | None = None
         self.omit_proposal_diagnostic = False
+        self.proposal_diagnostic_override: (
+            FieldNoteA1ProposalDiagnostic | None
+        ) = None
         self.diagnostic_final_subcause_override: str | None = None
         self.result_run_id_override: str | None = None
         self.controller = FieldNotesCompanionController(
@@ -328,6 +339,8 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
                 else proposal_failure
             ),
         )
+        if self.proposal_diagnostic_override is not None:
+            diagnostic = self.proposal_diagnostic_override
         return FieldNoteCodexRunResult(
             run_id=run_id,
             normal_terminal=normal_terminal,
@@ -535,6 +548,71 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             "A1_PROPOSAL_SCHEMA_REJECTED",
             readback.a1_proposal_diagnostic.final_subcause,
         )
+
+    def test_zero_identity_shape_failure_is_durable_and_cannot_continue(
+        self,
+    ) -> None:
+        self.mode = "request_shape_invalid"
+        self.proposal_diagnostic_override = FieldNoteA1ProposalDiagnostic(
+            proposal_call_count=0,
+            call_identity_sha256=None,
+            request_identity_sha256="2" * 64,
+            arguments_identity_sha256="3" * 64,
+            request_shape_valid=False,
+            malformed_observed=True,
+            gate_invoked=False,
+            gate_response_code=None,
+            gate_response_success=None,
+            accepted_proposal_present=False,
+            item_start_observed=True,
+            item_completion_observed=False,
+            item_observed_status=None,
+            item_expected_status=None,
+            all_proposals_completed=False,
+            request_identity_mismatch=False,
+            response_identity_mismatch=False,
+            inconsistent_replay=False,
+            protocol_identity_failure=True,
+            protocol_failure_phase="dynamic_tool_call",
+            direct_write_identity=None,
+            final_subcause="A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+        )
+        with patch.object(self.controller, "field_note_save") as save:
+            with self.assertRaises(FieldNoteCreatorLiveA1CaptureBridgeError):
+                self.bridge().capture("Propose exactly once and stop.")
+        self.assertEqual(0, save.call_count)
+        readback = self.runtime.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("A1_CAPTURE", readback.failure_boundary)
+        self.assertEqual(
+            "A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+            readback.failure_reason,
+        )
+        self.assertEqual(
+            self.proposal_diagnostic_override,
+            readback.a1_proposal_diagnostic,
+        )
+        self.assertTrue(readback.durable_readback_verified)
+        self.assertEqual(
+            readback.journal_record_count,
+            readback.anchor_record_count,
+        )
+        journal = self.runtime.journal_path.read_text(encoding="utf-8")
+        anchor = self.runtime.anchor_path.read_text(encoding="utf-8")
+        assert self.proposal_diagnostic_override is not None
+        self.assertIn(
+            self.proposal_diagnostic_override.diagnostic_sha256,
+            journal,
+        )
+        self.assertIn("A1_PROPOSAL_REQUEST_SHAPE_INVALID", journal)
+        self.assertIn(readback.journal_sha256, anchor)
+        self.assertEqual(0, readback.trace_event_count)
+        self.assertIsNone(readback.run_2)
+        self.assertFalse(
+            (self.repository / ".decision-os" / "field-notes").exists()
+        )
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            self.runtime.open_run_2(self.run_1)
 
     def test_non_proposal_failures_precede_valid_diagnostic_subcause(
         self,

--- a/tests/test_field_notes_lite.py
+++ b/tests/test_field_notes_lite.py
@@ -372,6 +372,8 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
         include_completion: bool = True,
         observed_status: str | None = None,
         request_extra: dict[str, object] | None = None,
+        omit_request_call_id: bool = False,
+        request_id_override: str | int | bool | None = None,
         completion_thread_id: str | None = None,
         mismatched_completion_content: bool = False,
     ) -> FieldNoteCodexRunResult:
@@ -390,11 +392,17 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
                 thread_id=thread_id,
                 turn_id=turn_id,
                 call_id=call_id,
-                request_id=f"proposal-request-{index}",
+                request_id=(
+                    f"proposal-request-{index}"
+                    if request_id_override is None
+                    else request_id_override
+                ),
                 arguments=arguments,
             )
             if request_extra:
                 request["params"].update(request_extra)  # type: ignore[union-attr]
+            if omit_request_call_id:
+                request["params"].pop("callId")  # type: ignore[union-attr]
             messages.extend(
                 [
                     started_proposal(
@@ -469,6 +477,7 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
             if message.get("method") == "thread/start"
         ]
         self.assertEqual(1, len(starts))
+        self._creator_live_repository = repository
         self._creator_live_developer_instructions = starts[0]["params"][
             "developerInstructions"
         ]
@@ -561,6 +570,61 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
                     result.creator_live_a1_failure_reason,
                 )
                 self.assertIsNone(result.field_note_proposal)
+                diagnostic = result.creator_live_a1_proposal_diagnostic
+                assert diagnostic is not None
+                self.assertEqual(0, diagnostic.proposal_call_count)
+                self.assertIsNone(diagnostic.request_shape_valid)
+                self.assertFalse(diagnostic.malformed_observed)
+                self.assertEqual(
+                    "A1_PROPOSAL_MISSING",
+                    diagnostic.final_subcause,
+                )
+
+    async def test_creator_live_zero_identity_malformed_request_is_shape_invalid(
+        self,
+    ) -> None:
+        cases = (
+            ("missing", None, True, None),
+            ("empty", {"callId": ""}, False, None),
+            ("non-string", {"callId": 7}, False, None),
+            ("invalid-request-id", None, False, True),
+        )
+        for label, request_extra, omit_call_id, request_id in cases:
+            with self.subTest(case=label):
+                result = await self._creator_live_result(
+                    calls=(("proposal-call", proposal()),),
+                    request_extra=request_extra,
+                    omit_request_call_id=omit_call_id,
+                    request_id_override=request_id,
+                )
+                diagnostic = result.creator_live_a1_proposal_diagnostic
+                assert diagnostic is not None
+                self.assertFalse(result.normal_terminal)
+                self.assertEqual(
+                    "A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+                    result.creator_live_a1_failure_reason,
+                )
+                self.assertEqual(0, diagnostic.proposal_call_count)
+                self.assertIsNone(diagnostic.call_identity_sha256)
+                self.assertFalse(diagnostic.request_shape_valid)
+                self.assertTrue(diagnostic.malformed_observed)
+                self.assertTrue(diagnostic.protocol_identity_failure)
+                self.assertEqual(
+                    "dynamic_tool_call",
+                    diagnostic.protocol_failure_phase,
+                )
+                self.assertEqual(
+                    "A1_PROPOSAL_REQUEST_SHAPE_INVALID",
+                    diagnostic.final_subcause,
+                )
+                self.assertIsNone(result.field_note_proposal)
+                self.assertFalse(
+                    (
+                        self._creator_live_repository
+                        / ".decision-os"
+                        / "field-notes"
+                    ).exists()
+                )
 
     async def test_creator_live_mode_rejects_duplicate_proposal(self) -> None:
         result = await self._creator_live_result(
@@ -573,6 +637,13 @@ class FieldNotesAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             "A1_PROPOSAL_DUPLICATE",
             result.creator_live_a1_failure_reason,
+        )
+        diagnostic = result.creator_live_a1_proposal_diagnostic
+        assert diagnostic is not None
+        self.assertEqual(2, diagnostic.proposal_call_count)
+        self.assertEqual(
+            "A1_PROPOSAL_DUPLICATE",
+            diagnostic.final_subcause,
         )
         self.assertIsNone(result.field_note_proposal)
 


### PR DESCRIPTION
## What

- repairs the bounded current A1 malformed-vs-missing taxonomy defect diagnosed in merged PR #84
- keeps `A1_PROPOSAL_MISSING` for runs with no recognizable Field Note proposal request
- returns `A1_PROPOSAL_REQUEST_SHAPE_INVALID` when a recognizable request is malformed before any valid non-empty call identity is counted
- preserves direct-write precedence, distinct-valid-call duplicate classification, every established proposal subcause, and non-proposal precedence
- adds deterministic adapter coverage plus durable capture/journal/anchor/readback coverage

## Root cause and implementation

`_proposal_final_subcause()` checked zero valid call IDs before consulting the already-retained request-shape fact. The repair refines only the zero-count branch: when `request_shape_valid is False`, it selects request-shape-invalid; otherwise it remains missing.

Production changes are limited to two lines in `decision_os/companion/field_notes_adapter.py`. No diagnostic, journal, anchor, readback, controller, bridge, shared-writer, A2-A6, or A7 schema/logic changed.

## Proved behavior

- no proposal request remains `A1_PROPOSAL_MISSING`
- missing, empty, and non-string `callId` become `A1_PROPOSAL_REQUEST_SHAPE_INVALID`
- invalid outer request identity becomes `A1_PROPOSAL_REQUEST_SHAPE_INVALID`
- unexpected params key remains request-shape-invalid
- two distinct valid call IDs remain duplicate
- schema rejection, inconsistent replay, item status mismatch, response identity mismatch, protocol identity failure, direct-write, and non-proposal precedence remain exact
- corrected terminal reason and diagnostic are journaled, anchor-sealed, and recovered by typed durable readback
- corrected failure creates no Note, records zero trace events, and cannot open Run 2

## Validation

- focused repair/precedence matrix: 12/12 PASS
- all A1 proposal and creator-live capture tests: 59/59 PASS
- A1-A7 focused Field Note tests: 375/375 PASS
- controller/server tests: 62/62 PASS in localhost/browser-capable environment
- full default discovery: 1,131/1,131 PASS
- full explicit discovery: 1,131/1,131 PASS
- normalized suite identity: exact equality, 1,131 unique IDs each, SHA-256 `3a46ec5c595d6b1a424efc4fc77f5573812dd24d169a36d208f08f86fc3039ad`
- Python compilation: PASS
- `git diff --check`: PASS

## Protected boundary

Base is exact diagnosis merge commit `b2502090363191fc71e9397fac1e1ab684ee1e9f`.

Proof 002 remains Outcome B and was not modified.

- journal SHA-256 unchanged: `8d346c5f57f28c105ec84c640e21649c1d6b31274614bc8d2fc56737f8aec99c`
- anchor SHA-256 unchanged: `3ccbd87e9ff4b8871f7009bf925e5acfe9111378509bd38d8764d23a9fc5344c`

No live attempt, model invocation, Note, Run 2, proof-artifact mutation, shared terminal-writer repair, release, or publication occurred. Third live attempt remains **BLOCK / NOT AUTHORIZED**.