### PR TITLE
Add Creator-Live A2 exact-lineage reconnect

### DIFF
--- a/decision_os/companion/field_notes_adapter.py
+++ b/decision_os/companion/field_notes_adapter.py
@@ -27,6 +27,11 @@ from decision_os.companion.field_notes_reconnect import (
     FieldNoteReconnectReceipt,
     prepare_field_note_reconnect,
 )
+from decision_os.companion.field_notes_creator_live_reconnect import (
+    FieldNoteCreatorLiveA2ReconnectError,
+    FieldNoteCreatorLiveA2ReconnectTarget,
+    prepare_creator_live_a2_reconnect,
+)
 
 
 _FIELD_NOTE_PROPOSAL_INSTRUCTIONS = (
@@ -313,6 +318,9 @@ class FieldNotesCodexAdapter(CodexAdapter):
         creator_live_a1_capture_provider: Callable[
             [], FieldNoteCreatorLiveA1CaptureConfig | None
         ] | None = None,
+        creator_live_a2_reconnect_provider: Callable[
+            [], FieldNoteCreatorLiveA2ReconnectTarget | None
+        ] | None = None,
         **kwargs: Any,
     ) -> None:
         self._reconnect_prompt: str | None = None
@@ -326,11 +334,15 @@ class FieldNotesCodexAdapter(CodexAdapter):
         self._creator_live_a1_capture_provider = (
             creator_live_a1_capture_provider or (lambda: None)
         )
+        self._creator_live_a2_reconnect_provider = (
+            creator_live_a2_reconnect_provider or (lambda: None)
+        )
         super().__init__(*args, **kwargs)
 
     def _reset_run(self) -> None:
         super()._reset_run()
         capture = self._creator_live_a1_capture_provider()
+        reconnect_target = self._creator_live_a2_reconnect_provider()
         if capture is not None and not isinstance(
             capture,
             FieldNoteCreatorLiveA1CaptureConfig,
@@ -338,9 +350,28 @@ class FieldNotesCodexAdapter(CodexAdapter):
             raise codex.CodexAdapterFailure(
                 "Creator-live A1 capture configuration is invalid."
             )
+        if reconnect_target is not None and not isinstance(
+            reconnect_target,
+            FieldNoteCreatorLiveA2ReconnectTarget,
+        ):
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+        if capture is not None and reconnect_target is not None:
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
         self._creator_live_a1_capture = capture
+        self._creator_live_a2_reconnect_target = reconnect_target
         if capture is not None:
             self._run_id = capture.run_id
+        elif reconnect_target is not None:
+            expected_runtime = CodexRuntimeIdentity(
+                model=self.expected_model,
+                reasoning_effort=self.expected_reasoning_effort,
+                service_tier=self.expected_service_tier,
+                codex_cli_version=self.expected_cli_version,
+                account_type="chatgpt",
+            )
+            if reconnect_target.expected_runtime_identity != expected_runtime:
+                raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+            self._run_id = reconnect_target.run_2_id
         self._field_note_gate = FieldNoteProposalGate(
             self._run_id,
             trusted_source_model_class=self.trusted_source_model_class,
@@ -366,10 +397,12 @@ class FieldNotesCodexAdapter(CodexAdapter):
         self._capture_response_identity_mismatch = False
         self._capture_inconsistent_replay = False
         prompt = self._reconnect_prompt
-        if (
-            isinstance(prompt, str)
-            and self._creator_live_a1_capture is None
-        ):
+        if reconnect_target is not None:
+            self._reconnect_plan = prepare_creator_live_a2_reconnect(
+                self.engine.store.repository,
+                reconnect_target,
+            ).plan
+        elif isinstance(prompt, str) and self._creator_live_a1_capture is None:
             self._reconnect_plan = prepare_field_note_reconnect(
                 self.engine.store.repository,
                 prompt,

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -43,6 +43,10 @@ from decision_os.companion.field_notes_model import (
 from decision_os.companion.field_notes_reconnect import (
     FieldNoteReconnectReceipt,
 )
+from decision_os.companion.field_notes_creator_live_reconnect import (
+    FieldNoteCreatorLiveA2ReconnectError,
+    FieldNoteCreatorLiveA2ReconnectTarget,
+)
 
 
 class FieldNoteError(CompanionError):
@@ -57,6 +61,7 @@ def _field_notes_adapter_factory(
     trusted_source_model_class: str = "UNKNOWN",
     trusted_target_model_class: str = "UNKNOWN",
     creator_live_a1_capture_provider: Any = None,
+    creator_live_a2_reconnect_provider: Any = None,
 ) -> FieldNotesCodexAdapter:
     return FieldNotesCodexAdapter(
         engine,
@@ -67,6 +72,9 @@ def _field_notes_adapter_factory(
         trusted_source_model_class=trusted_source_model_class,
         trusted_target_model_class=trusted_target_model_class,
         creator_live_a1_capture_provider=creator_live_a1_capture_provider,
+        creator_live_a2_reconnect_provider=(
+            creator_live_a2_reconnect_provider
+        ),
     )
 
 
@@ -109,6 +117,35 @@ class FieldNoteCreatorLiveA1RunCompletion:
             raise ValueError("Creator-live A1 Run completion is invalid.")
 
 
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveA2RunCompletion:
+    """Typed exact reconnect evidence observed from one completed Run 2."""
+
+    run_id: str
+    actual_runtime_identity: CodexRuntimeIdentity
+    reconnect_receipt: FieldNoteReconnectReceipt
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.run_id, str)
+            or not self.run_id.strip()
+            or not isinstance(
+                self.actual_runtime_identity,
+                CodexRuntimeIdentity,
+            )
+            or not isinstance(
+                self.reconnect_receipt,
+                FieldNoteReconnectReceipt,
+            )
+            or self.reconnect_receipt.run_id != self.run_id
+            or self.reconnect_receipt.state
+            not in {"INJECTED", "ACTIVATION_UNKNOWN"}
+            or self.reconnect_receipt.failure_reason is not None
+            or self.reconnect_receipt.full_notes_injected != 1
+        ):
+            raise ValueError("Creator-live A2 Run completion is invalid.")
+
+
 class FieldNotesCompanionController(CompanionController):
     """Companion controller extended only with Field Notes Lite Capture."""
 
@@ -127,6 +164,14 @@ class FieldNotesCompanionController(CompanionController):
         self._creator_live_a1_proposal_diagnostic: (
             FieldNoteA1ProposalDiagnostic | None
         ) = None
+        self._creator_live_a2_reconnect_target: (
+            FieldNoteCreatorLiveA2ReconnectTarget | None
+        ) = None
+        self._creator_live_a2_completed_run_id: str | None = None
+        self._creator_live_a2_run_completion: (
+            FieldNoteCreatorLiveA2RunCompletion | None
+        ) = None
+        self._creator_live_a2_failure_reason: str | None = None
         trusted_source_model_class = configured_model_class(
             kwargs.pop("trusted_source_model_class", "UNKNOWN")
         )
@@ -141,6 +186,9 @@ class FieldNotesCompanionController(CompanionController):
                 creator_live_a1_capture_provider=(
                     self._active_creator_live_a1_capture
                 ),
+                creator_live_a2_reconnect_provider=(
+                    self._active_creator_live_a2_reconnect
+                ),
             )
         super().__init__(**kwargs)
 
@@ -149,6 +197,12 @@ class FieldNotesCompanionController(CompanionController):
     ) -> FieldNoteCreatorLiveA1CaptureConfig | None:
         with self._condition:
             return self._creator_live_a1_capture_config
+
+    def _active_creator_live_a2_reconnect(
+        self,
+    ) -> FieldNoteCreatorLiveA2ReconnectTarget | None:
+        with self._condition:
+            return self._creator_live_a2_reconnect_target
 
     @staticmethod
     def _empty_run() -> dict[str, Any]:
@@ -162,10 +216,17 @@ class FieldNotesCompanionController(CompanionController):
         self._field_note_pending = None
         self._run["field_note"] = {"state": "none"}
 
+    def _clear_creator_live_a2_locked(self) -> None:
+        self._creator_live_a2_reconnect_target = None
+        self._creator_live_a2_completed_run_id = None
+        self._creator_live_a2_run_completion = None
+        self._creator_live_a2_failure_reason = None
+
     def start_run(self, task: str, *, task_mode: str = "manual") -> dict[str, Any]:
         with self._condition:
             self._require_no_active_run()
             self._clear_field_note_locked()
+            self._clear_creator_live_a2_locked()
         return super().start_run(task, task_mode=task_mode)
 
     def start_creator_live_a1_capture(
@@ -184,6 +245,9 @@ class FieldNotesCompanionController(CompanionController):
         with self._condition:
             self._require_no_active_run()
             self._clear_field_note_locked()
+            if self._creator_live_a2_reconnect_target is not None:
+                raise FieldNoteError("Creator-live A2 reconnect is active.")
+            self._clear_creator_live_a2_locked()
             self._creator_live_a1_capture_config = config
             self._creator_live_a1_completed_run_id = None
             self._creator_live_a1_run_completion = None
@@ -197,6 +261,32 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a1_capture_config = None
             raise
 
+    def start_creator_live_a2_reconnect(
+        self,
+        task: str,
+        *,
+        target: FieldNoteCreatorLiveA2ReconnectTarget,
+    ) -> dict[str, Any]:
+        """Start one Run 2 whose reconnect input is one durable exact target."""
+
+        if not isinstance(target, FieldNoteCreatorLiveA2ReconnectTarget):
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+        with self._condition:
+            self._require_no_active_run()
+            if self._creator_live_a1_capture_config is not None:
+                raise FieldNoteCreatorLiveA2ReconnectError(
+                    "A2_TARGET_INVALID"
+                )
+            self._clear_field_note_locked()
+            self._clear_creator_live_a2_locked()
+            self._creator_live_a2_reconnect_target = target
+        try:
+            return super().start_run(task, task_mode="manual")
+        except Exception:
+            with self._condition:
+                self._creator_live_a2_reconnect_target = None
+            raise
+
     def new_run(self) -> dict[str, Any]:
         with self._condition:
             self._clear_field_note_locked()
@@ -206,6 +296,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
             self._creator_live_a1_proposal_diagnostic = None
+            self._clear_creator_live_a2_locked()
         return super().new_run()
 
     def select_repository(self, candidate: str | Path) -> dict[str, Any]:
@@ -218,6 +309,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
             self._creator_live_a1_proposal_diagnostic = None
+            self._clear_creator_live_a2_locked()
             return self._snapshot_locked()
 
     @staticmethod
@@ -341,12 +433,15 @@ class FieldNotesCompanionController(CompanionController):
         result: CodexRunResult,
     ) -> None:
         capture = self._creator_live_a1_capture_config
+        reconnect_target = self._creator_live_a2_reconnect_target
         capture_failure = getattr(
             result,
             "creator_live_a1_failure_reason",
             None,
         )
         completion: FieldNoteCreatorLiveA1RunCompletion | None = None
+        reconnect_completion: FieldNoteCreatorLiveA2RunCompletion | None = None
+        reconnect_failure: str | None = None
         proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None
         if capture is not None:
             if (
@@ -448,6 +543,52 @@ class FieldNotesCompanionController(CompanionController):
                     ),
                     successful_read_count=len(result.read_evidence),
                 )
+        elif reconnect_target is not None:
+            draft = None
+            reconnect_receipt = getattr(result, "reconnect_receipt", None)
+            if result.run_id != reconnect_target.run_2_id:
+                reconnect_failure = "A2_TARGET_RUN_2_MISMATCH"
+            elif result.runtime_identity != (
+                reconnect_target.expected_runtime_identity
+            ):
+                reconnect_failure = "A2_TARGET_INVALID"
+            elif not isinstance(
+                reconnect_receipt,
+                FieldNoteReconnectReceipt,
+            ):
+                reconnect_failure = "A2_TARGET_INVALID"
+            elif reconnect_receipt.run_id != reconnect_target.run_2_id:
+                reconnect_failure = "A2_TARGET_RUN_2_MISMATCH"
+            elif reconnect_receipt.selected_field_note_path != (
+                reconnect_target.note_relative_path
+            ):
+                reconnect_failure = "A2_TARGET_PATH_INVALID"
+            elif reconnect_receipt.selected_field_note_id != (
+                reconnect_target.field_note_id
+            ):
+                reconnect_failure = "A2_TARGET_NOTE_ID_MISMATCH"
+            elif reconnect_receipt.selected_full_note_sha256 != (
+                reconnect_target.note_sha256
+            ):
+                reconnect_failure = "A2_TARGET_SHA256_MISMATCH"
+            elif reconnect_receipt.full_note_bytes_read != (
+                reconnect_target.note_byte_count
+            ):
+                reconnect_failure = "A2_TARGET_BYTE_COUNT_MISMATCH"
+            elif (
+                reconnect_receipt.state
+                not in {"INJECTED", "ACTIVATION_UNKNOWN"}
+                or reconnect_receipt.full_notes_injected != 1
+                or reconnect_receipt.failure_reason is not None
+            ):
+                reconnect_failure = "A2_TARGET_INVALID"
+            else:
+                assert result.runtime_identity is not None
+                reconnect_completion = FieldNoteCreatorLiveA2RunCompletion(
+                    run_id=result.run_id,
+                    actual_runtime_identity=result.runtime_identity,
+                    reconnect_receipt=reconnect_receipt,
+                )
         else:
             draft = self._eligible_draft(result)
         reconnect_receipt = getattr(result, "reconnect_receipt", None)
@@ -462,6 +603,13 @@ class FieldNotesCompanionController(CompanionController):
             if capture is not None:
                 self._creator_live_a1_completed_run_id = capture.run_id
                 self._creator_live_a1_capture_config = None
+            if reconnect_target is not None:
+                self._creator_live_a2_completed_run_id = (
+                    reconnect_target.run_2_id
+                )
+                self._creator_live_a2_reconnect_target = None
+                self._creator_live_a2_run_completion = reconnect_completion
+                self._creator_live_a2_failure_reason = reconnect_failure
             self._creator_live_a1_run_completion = completion
             self._creator_live_a1_failure_reason = capture_failure
             self._creator_live_a1_proposal_diagnostic = proposal_diagnostic
@@ -579,6 +727,48 @@ class FieldNotesCompanionController(CompanionController):
                 raise FieldNoteError("Creator-live A1 capture is still running.")
             return self._creator_live_a1_failure_reason
 
+    def creator_live_a2_run_completion(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> FieldNoteCreatorLiveA2RunCompletion:
+        """Return exact injected reconnect evidence for one completed Run 2."""
+
+        with self._condition:
+            if (
+                not isinstance(expected_run_id, str)
+                or not expected_run_id
+                or self._creator_live_a2_completed_run_id != expected_run_id
+            ):
+                raise FieldNoteError("A2_TARGET_RUN_2_MISMATCH")
+            if self._run.get("state") == "running":
+                raise FieldNoteError("Creator-live A2 reconnect is still running.")
+            completion = self._creator_live_a2_run_completion
+            if completion is None:
+                raise FieldNoteError(
+                    self._creator_live_a2_failure_reason
+                    or "A2_TARGET_INVALID"
+                )
+            return completion
+
+    def creator_live_a2_failure_reason(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> str | None:
+        """Return the exact fail-closed preparation reason for one Run 2."""
+
+        with self._condition:
+            if (
+                not isinstance(expected_run_id, str)
+                or not expected_run_id
+                or self._creator_live_a2_completed_run_id != expected_run_id
+            ):
+                raise FieldNoteError("A2_TARGET_RUN_2_MISMATCH")
+            if self._run.get("state") == "running":
+                raise FieldNoteError("Creator-live A2 reconnect is still running.")
+            return self._creator_live_a2_failure_reason
+
     def _fail_run(self, repository: Path, exc: Exception) -> None:
         with self._condition:
             super()._fail_run(repository, exc)
@@ -590,6 +780,20 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a1_failure_reason = "A1_RUN_FAILED"
                 self._creator_live_a1_run_completion = None
                 self._creator_live_a1_proposal_diagnostic = None
+            if self._creator_live_a2_reconnect_target is not None:
+                self._creator_live_a2_completed_run_id = (
+                    self._creator_live_a2_reconnect_target.run_2_id
+                )
+                self._creator_live_a2_reconnect_target = None
+                self._creator_live_a2_failure_reason = (
+                    exc.code
+                    if isinstance(
+                        exc,
+                        FieldNoteCreatorLiveA2ReconnectError,
+                    )
+                    else "A2_TARGET_INVALID"
+                )
+                self._creator_live_a2_run_completion = None
             self._clear_field_note_locked()
             self._condition.notify_all()
 

--- a/decision_os/companion/field_notes_creator_live_reconnect.py
+++ b/decision_os/companion/field_notes_creator_live_reconnect.py
@@ -1,0 +1,498 @@
+"""Exact-lineage creator-live A2 reconnect preparation and bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import time
+from typing import Any, Callable
+
+from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.acceleration.model import (
+    RepositoryIdentityError,
+    git_output,
+    repository_id,
+)
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteExactReadError,
+    FieldNoteReconnectPlan,
+    FieldNoteReconnectReceipt,
+    read_exact_field_note,
+)
+from decision_os.companion.field_notes_reuse import FieldNoteIdentity
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowTraceEvent,
+)
+
+
+A2_TARGET_FAILURE_CODES = frozenset(
+    {
+        "A2_TARGET_MISSING",
+        "A2_TARGET_INVALID",
+        "A2_TARGET_PROOF_MISMATCH",
+        "A2_TARGET_RUN_1_MISMATCH",
+        "A2_TARGET_RUN_2_MISMATCH",
+        "A2_TARGET_NOTE_ID_MISMATCH",
+        "A2_TARGET_SOURCE_RUN_MISMATCH",
+        "A2_TARGET_PATH_INVALID",
+        "A2_TARGET_NOTE_MISSING",
+        "A2_TARGET_NOTE_INVALID",
+        "A2_TARGET_SHA256_MISMATCH",
+        "A2_TARGET_BYTE_COUNT_MISMATCH",
+        "A2_TARGET_REPOSITORY_MISMATCH",
+        "A2_TARGET_COMMIT_MISMATCH",
+        "A2_TARGET_CHANGED_DURING_READ",
+    }
+)
+_A2_TARGET_AUTHORITY = object()
+
+
+class FieldNoteCreatorLiveA2ReconnectError(RuntimeError):
+    """An exact A2 target failed closed with a bounded diagnostic code."""
+
+    def __init__(self, code: str) -> None:
+        if code not in A2_TARGET_FAILURE_CODES:
+            raise ValueError("Creator-live A2 failure code is invalid.")
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveA2ReconnectTarget:
+    """Immutable exact target issued only from verified durable read-back."""
+
+    proof_attempt_id: str
+    run_1_id: str
+    run_2_id: str
+    field_note_id: str
+    note_relative_path: str
+    note_sha256: str
+    note_byte_count: int
+    source_repository_id: str
+    source_commit: str
+    expected_runtime_identity: CodexRuntimeIdentity
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+
+    @classmethod
+    def _issue(
+        cls,
+        *,
+        authority: object,
+        proof_attempt_id: str,
+        run_1_id: str,
+        run_2_id: str,
+        field_note_id: str,
+        note_relative_path: str,
+        note_sha256: str,
+        note_byte_count: int,
+        source_repository_id: str,
+        source_commit: str,
+        expected_runtime_identity: CodexRuntimeIdentity,
+    ) -> FieldNoteCreatorLiveA2ReconnectTarget:
+        if authority is not _A2_TARGET_AUTHORITY:
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+        bounded = (
+            proof_attempt_id,
+            run_1_id,
+            run_2_id,
+            field_note_id,
+            note_relative_path,
+            source_repository_id,
+            source_commit,
+        )
+        if (
+            any(
+                not isinstance(value, str)
+                or not value.strip()
+                or len(value) > 1024
+                or "\x00" in value
+                for value in bounded
+            )
+            or not isinstance(note_sha256, str)
+            or len(note_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in note_sha256)
+            or type(note_byte_count) is not int
+            or note_byte_count <= 0
+            or not isinstance(expected_runtime_identity, CodexRuntimeIdentity)
+        ):
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+        value = object.__new__(cls)
+        fields = {
+            "proof_attempt_id": proof_attempt_id,
+            "run_1_id": run_1_id,
+            "run_2_id": run_2_id,
+            "field_note_id": field_note_id,
+            "note_relative_path": note_relative_path,
+            "note_sha256": note_sha256,
+            "note_byte_count": note_byte_count,
+            "source_repository_id": source_repository_id,
+            "source_commit": source_commit,
+            "expected_runtime_identity": expected_runtime_identity,
+        }
+        for name, item in fields.items():
+            object.__setattr__(value, name, item)
+        return value
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveA2Preparation:
+    """Exact safe-read bytes and the existing reconnect plan projection."""
+
+    target: FieldNoteCreatorLiveA2ReconnectTarget
+    plan: FieldNoteReconnectPlan
+    note_bytes: bytes
+
+
+def creator_live_a2_target_from_readback(
+    readback: Any,
+) -> FieldNoteCreatorLiveA2ReconnectTarget:
+    """Issue one target from the exact verified post-open_run_2 read-back."""
+
+    from decision_os.companion.field_notes_creator_live import (
+        FieldNoteCreatorLiveA1CaptureCommitReceipt,
+        FieldNoteCreatorLiveTraceReadback,
+    )
+
+    if not isinstance(readback, FieldNoteCreatorLiveTraceReadback):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    if (
+        readback.durable_readback_verified is not True
+        or readback.state != "OPEN"
+        or readback.current_stage != "A2_RECONNECT"
+        or readback.trace_event_count != 1
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    note = readback.captured_note
+    commit = readback.a1_capture_commit
+    run_2 = readback.run_2
+    if note is None or commit is None or run_2 is None:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_MISSING")
+    if not isinstance(note, FieldNoteIdentity) or not isinstance(
+        commit,
+        FieldNoteCreatorLiveA1CaptureCommitReceipt,
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    if (
+        readback.proof_attempt_id != readback.run_1.proof_attempt_id
+        or readback.proof_attempt_id != run_2.proof_attempt_id
+        or commit.proof_attempt_id != readback.proof_attempt_id
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_PROOF_MISMATCH")
+    if commit.run_id != readback.run_1.run_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_RUN_1_MISMATCH")
+    if run_2.run_id == readback.run_1.run_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_RUN_2_MISMATCH")
+    if commit.note.field_note_id != note.field_note_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_NOTE_ID_MISMATCH")
+    if (
+        note.origin_run_id != readback.run_1.run_id
+        or commit.note.origin_run_id != readback.run_1.run_id
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_SOURCE_RUN_MISMATCH")
+    if commit.note != note:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    if (
+        readback.captured_note_byte_count != commit.note_byte_count
+        or type(readback.captured_note_byte_count) is not int
+        or readback.captured_note_byte_count <= 0
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    if (
+        commit.source_repository != readback.source_repository
+        or readback.run_1.repository != readback.source_repository
+        or run_2.repository != readback.source_repository
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_REPOSITORY_MISMATCH"
+        )
+    if (
+        commit.actual_runtime_identity != readback.runtime
+        or readback.run_1.runtime != readback.runtime
+        or run_2.runtime != readback.runtime
+    ):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    return FieldNoteCreatorLiveA2ReconnectTarget._issue(
+        authority=_A2_TARGET_AUTHORITY,
+        proof_attempt_id=readback.proof_attempt_id,
+        run_1_id=readback.run_1.run_id,
+        run_2_id=run_2.run_id,
+        field_note_id=note.field_note_id,
+        note_relative_path=note.note_path,
+        note_sha256=note.note_sha256,
+        note_byte_count=readback.captured_note_byte_count,
+        source_repository_id=readback.source_repository.repository_id,
+        source_commit=readback.source_repository.source_commit,
+        expected_runtime_identity=readback.runtime,
+    )
+
+
+def _require_target_readback_binding(target: Any, readback: Any) -> None:
+    note = readback.captured_note
+    run_2 = readback.run_2
+    if not isinstance(target, FieldNoteCreatorLiveA2ReconnectTarget):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    if note is None or run_2 is None:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_MISSING")
+    if target.proof_attempt_id != readback.proof_attempt_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_PROOF_MISMATCH")
+    if target.run_1_id != readback.run_1.run_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_RUN_1_MISMATCH")
+    if target.run_2_id != run_2.run_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_RUN_2_MISMATCH")
+    if target.field_note_id != note.field_note_id:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_NOTE_ID_MISMATCH")
+    if target.note_relative_path != note.note_path:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_PATH_INVALID")
+    if target.run_1_id != note.origin_run_id:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_SOURCE_RUN_MISMATCH"
+        )
+    if target.note_sha256 != note.note_sha256:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_SHA256_MISMATCH"
+        )
+    if target.note_byte_count != readback.captured_note_byte_count:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_BYTE_COUNT_MISMATCH"
+        )
+    if target.source_repository_id != readback.source_repository.repository_id:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_REPOSITORY_MISMATCH"
+        )
+    if target.source_commit != readback.source_repository.source_commit:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_COMMIT_MISMATCH")
+    if target.expected_runtime_identity != readback.runtime:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+
+
+def _repository_identity(root: Path) -> tuple[str, str]:
+    try:
+        return repository_id(root), git_output(root, "rev-parse", "HEAD")
+    except (OSError, RepositoryIdentityError) as exc:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_REPOSITORY_MISMATCH"
+        ) from exc
+
+
+def _map_exact_read_failure(reason: str) -> str:
+    if reason == "exact_note_missing":
+        return "A2_TARGET_NOTE_MISSING"
+    if reason == "exact_changed_during_read":
+        return "A2_TARGET_CHANGED_DURING_READ"
+    if reason in {
+        "exact_path_invalid",
+        "exact_entry_unsafe",
+        "repository_root_unsafe",
+        "decision_directory_unsafe",
+        "field_notes_directory_unsafe",
+    }:
+        return "A2_TARGET_PATH_INVALID"
+    return "A2_TARGET_NOTE_INVALID"
+
+
+def prepare_creator_live_a2_reconnect(
+    repository: Path,
+    target: FieldNoteCreatorLiveA2ReconnectTarget | None,
+) -> FieldNoteCreatorLiveA2Preparation:
+    """Prepare only the durable target path; never scan, score, or fall back."""
+
+    if target is None:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_MISSING")
+    if not isinstance(target, FieldNoteCreatorLiveA2ReconnectTarget):
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+    root = Path(repository)
+    observed_repository, observed_commit = _repository_identity(root)
+    if observed_repository != target.source_repository_id:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_REPOSITORY_MISMATCH"
+        )
+    if observed_commit != target.source_commit:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_COMMIT_MISMATCH")
+    try:
+        exact = read_exact_field_note(root, target.note_relative_path)
+    except FieldNoteExactReadError as exc:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            _map_exact_read_failure(exc.reason)
+        ) from exc
+    repository_after, commit_after = _repository_identity(root)
+    if repository_after != target.source_repository_id:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_REPOSITORY_MISMATCH"
+        )
+    if commit_after != target.source_commit:
+        raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_COMMIT_MISMATCH")
+    if exact.field_note_id != target.field_note_id:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_NOTE_ID_MISMATCH"
+        )
+    if exact.source_run_id != target.run_1_id:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_SOURCE_RUN_MISMATCH"
+        )
+    if exact.note_sha256 != target.note_sha256:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_SHA256_MISMATCH"
+        )
+    if len(exact.note_bytes) != target.note_byte_count:
+        raise FieldNoteCreatorLiveA2ReconnectError(
+            "A2_TARGET_BYTE_COUNT_MISMATCH"
+        )
+    receipt = FieldNoteReconnectReceipt(
+        run_id=target.run_2_id,
+        state="SELECTED",
+        failure_reason=None,
+        metadata_entries_seen=1,
+        metadata_candidate_files_seen=1,
+        metadata_files_valid=1,
+        metadata_bytes_read=exact.metadata_byte_count,
+        selected_field_note_path=exact.relative_path,
+        selected_field_note_id=exact.field_note_id,
+        selected_metadata_sha256=exact.metadata_sha256,
+        selected_full_note_sha256=exact.note_sha256,
+        full_note_bytes_read=len(exact.note_bytes),
+        full_notes_injected=0,
+        ordinary_distinct_paths_consumed=0,
+    )
+    return FieldNoteCreatorLiveA2Preparation(
+        target=target,
+        plan=FieldNoteReconnectPlan(receipt=receipt, envelope=exact.envelope),
+        note_bytes=exact.note_bytes,
+    )
+
+
+class FieldNoteCreatorLiveA2ReconnectBridge:
+    """Dispatch Run 2 through exact preparation and emit the existing A2."""
+
+    def __init__(
+        self,
+        *,
+        runtime: Any,
+        controller: Any,
+        repository: Path,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        timeout_seconds: float = 900.0,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        from decision_os.companion.field_notes_controller import (
+            FieldNotesCompanionController,
+        )
+        from decision_os.companion.field_notes_creator_live import (
+            FieldNoteCreatorLiveProofRuntime,
+        )
+
+        if (
+            not isinstance(runtime, FieldNoteCreatorLiveProofRuntime)
+            or not isinstance(controller, FieldNotesCompanionController)
+            or not isinstance(source_repository, FieldNoteSourceRepositoryIdentity)
+            or not isinstance(timeout_seconds, (int, float))
+            or isinstance(timeout_seconds, bool)
+            or timeout_seconds <= 0
+        ):
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+        self.runtime = runtime
+        self.controller = controller
+        self.repository = Path(repository)
+        self.source_repository = source_repository
+        self.timeout_seconds = float(timeout_seconds)
+        self.monotonic = monotonic
+        self.sleep = sleep
+        self._dispatched = False
+
+    def _terminal(self, code: str) -> None:
+        from decision_os.companion.field_notes_creator_live import (
+            FieldNoteCreatorLiveStageError,
+        )
+
+        if code not in A2_TARGET_FAILURE_CODES:
+            code = "A2_TARGET_INVALID"
+        try:
+            self.runtime.record_stage_failure("A2_RECONNECT", code)
+        except FieldNoteCreatorLiveStageError as exc:
+            raise FieldNoteCreatorLiveA2ReconnectError(code) from exc
+        raise FieldNoteCreatorLiveA2ReconnectError(code)
+
+    def _wait_for_run(self) -> None:
+        deadline = self.monotonic() + self.timeout_seconds
+        while self.controller.snapshot()["run"]["state"] == "running":
+            if self.monotonic() >= deadline:
+                self._terminal("A2_TARGET_INVALID")
+            self.sleep(0.05)
+
+    def reconnect(self, task: str) -> FieldNoteWholeFlowTraceEvent:
+        """Execute exactly one already-open Run 2 and durably close A2."""
+
+        if self._dispatched:
+            self._terminal("A2_TARGET_INVALID")
+        try:
+            readback = self.runtime.read_back()
+            target = creator_live_a2_target_from_readback(readback)
+            _require_target_readback_binding(target, readback)
+            if readback.source_repository != self.source_repository:
+                self._terminal("A2_TARGET_REPOSITORY_MISMATCH")
+            snapshot = self.controller.snapshot()
+            selected = snapshot.get("repository")
+            try:
+                root = self.repository.resolve(strict=True)
+                selected_root = Path(selected["path"]).resolve(strict=True)
+            except (KeyError, OSError, TypeError):
+                self._terminal("A2_TARGET_REPOSITORY_MISMATCH")
+            if selected_root != root:
+                self._terminal("A2_TARGET_REPOSITORY_MISMATCH")
+            self._dispatched = True
+            self.controller.start_creator_live_a2_reconnect(task, target=target)
+            self._wait_for_run()
+            failure = self.controller.creator_live_a2_failure_reason(
+                expected_run_id=target.run_2_id
+            )
+            if failure is not None:
+                self._terminal(failure)
+            completion = self.controller.creator_live_a2_run_completion(
+                expected_run_id=target.run_2_id
+            )
+            if completion.actual_runtime_identity != target.expected_runtime_identity:
+                self._terminal("A2_TARGET_INVALID")
+            prepared = prepare_creator_live_a2_reconnect(root, target)
+            note = FieldNoteIdentity(
+                note_path=target.note_relative_path,
+                field_note_id=target.field_note_id,
+                note_sha256=target.note_sha256,
+                origin_run_id=target.run_1_id,
+            )
+            event = self.runtime.record_a2_reconnect(
+                completion.reconnect_receipt,
+                note=note,
+                note_bytes=prepared.note_bytes,
+            )
+            closed = self.runtime.read_back()
+            if (
+                not closed.durable_readback_verified
+                or closed.state != "OPEN"
+                or closed.current_stage != "A3_REUSE"
+                or closed.trace_event_count != 2
+                or closed.events[-1] != event
+            ):
+                self._terminal("A2_TARGET_INVALID")
+            return event
+        except FieldNoteCreatorLiveA2ReconnectError as exc:
+            if self.runtime.read_back().state == "OPEN":
+                self._terminal(exc.code)
+            raise
+        except Exception:
+            if self.runtime.read_back().state == "OPEN":
+                self._terminal("A2_TARGET_INVALID")
+            raise
+
+
+__all__ = [
+    "A2_TARGET_FAILURE_CODES",
+    "FieldNoteCreatorLiveA2Preparation",
+    "FieldNoteCreatorLiveA2ReconnectBridge",
+    "FieldNoteCreatorLiveA2ReconnectError",
+    "FieldNoteCreatorLiveA2ReconnectTarget",
+    "creator_live_a2_target_from_readback",
+    "prepare_creator_live_a2_reconnect",
+]

--- a/decision_os/companion/field_notes_reconnect.py
+++ b/decision_os/companion/field_notes_reconnect.py
@@ -211,6 +211,28 @@ class FieldNoteReconnectPlan:
 
 
 @dataclass(frozen=True)
+class FieldNoteExactRead:
+    """One exact-path Note read with no relevance scan or selection."""
+
+    relative_path: str
+    field_note_id: str
+    source_run_id: str
+    metadata_sha256: str
+    metadata_byte_count: int
+    note_sha256: str
+    note_bytes: bytes
+    envelope: str
+
+
+class FieldNoteExactReadError(RuntimeError):
+    """An exact-path Note could not be read through the safe local lane."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
 class _FileIdentity:
     device: int
     inode: int
@@ -861,6 +883,171 @@ def _empty_receipt(
         full_notes_injected=0,
         ordinary_distinct_paths_consumed=0,
     )
+
+
+def read_exact_field_note(
+    repository: Path,
+    relative_path: str,
+) -> FieldNoteExactRead:
+    """Read exactly one named Note without scanning or relevance scoring."""
+
+    repository_fd: int | None = None
+    decision_fd: int | None = None
+    notes_fd: int | None = None
+    try:
+        try:
+            segments = _path_segments(
+                relative_path,
+                allow_trailing_slash=False,
+            )
+        except (TypeError, ValueError) as exc:
+            raise FieldNoteExactReadError("exact_path_invalid") from exc
+        raw_segments = relative_path.split("/")
+        if (
+            segments[:2] != (".decision-os", "field-notes")
+            or len(segments) != 3
+            or len(raw_segments) != 3
+            or raw_segments[:2] != [".decision-os", "field-notes"]
+            or not raw_segments[2].endswith(".md")
+        ):
+            raise FieldNoteExactReadError("exact_path_invalid")
+        filename = raw_segments[2]
+
+        repository_fd = _open_directory(
+            repository,
+            dir_fd=None,
+            missing_ok=False,
+            reason="repository_root_unsafe",
+        )
+        assert repository_fd is not None
+        repository_identity = _identity(os.fstat(repository_fd))
+        decision_fd = _open_directory(
+            ".decision-os",
+            dir_fd=repository_fd,
+            missing_ok=True,
+            reason="decision_directory_unsafe",
+        )
+        if decision_fd is None:
+            raise FieldNoteExactReadError("exact_note_missing")
+        decision_identity = _identity(os.fstat(decision_fd))
+        notes_fd = _open_directory(
+            "field-notes",
+            dir_fd=decision_fd,
+            missing_ok=True,
+            reason="field_notes_directory_unsafe",
+        )
+        if notes_fd is None:
+            raise FieldNoteExactReadError("exact_note_missing")
+        notes_identity = _identity(os.fstat(notes_fd))
+
+        try:
+            entry_stat = os.stat(
+                filename,
+                dir_fd=notes_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            raise FieldNoteExactReadError("exact_note_missing") from None
+        except OSError:
+            raise FieldNoteExactReadError("exact_entry_unsafe") from None
+        if not stat.S_ISREG(entry_stat.st_mode):
+            raise FieldNoteExactReadError("exact_entry_unsafe")
+        expected = _identity(entry_stat)
+        try:
+            metadata_bytes, consumed, metadata_error = _read_metadata(
+                notes_fd,
+                filename,
+                expected,
+                MAX_METADATA_BYTES,
+            )
+        except _ScanStop as exc:
+            raise FieldNoteExactReadError(
+                "exact_changed_during_read"
+                if exc.reason == "candidate_entry_unsafe"
+                else "exact_note_invalid"
+            ) from exc
+        if metadata_error is not None or metadata_bytes is None:
+            raise FieldNoteExactReadError("exact_note_invalid")
+        try:
+            metadata = _validated_metadata(metadata_bytes, filename)
+        except (TypeError, ValueError) as exc:
+            raise FieldNoteExactReadError("exact_note_invalid") from exc
+        scope = metadata["scope"]
+        candidate = _MetadataCandidate(
+            relative_path=relative_path,
+            filename=filename,
+            identity=expected,
+            metadata_bytes=metadata_bytes,
+            metadata_sha256=hashlib.sha256(metadata_bytes).hexdigest(),
+            field_note_id=metadata["field_note_id"],
+            schema_version=metadata["schema_version"],
+            value_level=metadata["value_level"],
+            status=metadata["status"],
+            created_at=_parse_time(metadata["created_at"]),
+            trigger_terms=tuple(metadata["trigger_terms"]),
+            task_family=scope["task_family"],
+            path_prefixes=tuple(
+                _path_segments(value, allow_trailing_slash=True)
+                for value in scope["path_prefixes"]
+            ),
+            exclude_terms=tuple(scope["exclude_terms"]),
+        )
+        note, full_bytes, full_error = _read_full_note(notes_fd, candidate)
+        if full_error is not None or note is None:
+            if full_error in {
+                "selected_entry_changed",
+                "selected_full_read_failed",
+                "selected_identity_changed",
+                "selected_metadata_changed",
+            }:
+                raise FieldNoteExactReadError("exact_changed_during_read")
+            raise FieldNoteExactReadError("exact_note_invalid")
+        if full_bytes != len(note):
+            raise FieldNoteExactReadError("exact_changed_during_read")
+        if not (
+            _verify_directory_entry(
+                repository,
+                dir_fd=None,
+                descriptor=repository_fd,
+                expected=repository_identity,
+            )
+            and _verify_directory_entry(
+                ".decision-os",
+                dir_fd=repository_fd,
+                descriptor=decision_fd,
+                expected=decision_identity,
+            )
+            and _verify_directory_entry(
+                "field-notes",
+                dir_fd=decision_fd,
+                descriptor=notes_fd,
+                expected=notes_identity,
+            )
+        ):
+            raise FieldNoteExactReadError("exact_changed_during_read")
+        return FieldNoteExactRead(
+            relative_path=relative_path,
+            field_note_id=candidate.field_note_id,
+            source_run_id=metadata["source_run_id"],
+            metadata_sha256=candidate.metadata_sha256,
+            metadata_byte_count=consumed,
+            note_sha256=hashlib.sha256(note).hexdigest(),
+            note_bytes=note,
+            envelope=_envelope(candidate, note),
+        )
+    except FieldNoteExactReadError:
+        raise
+    except _ScanStop as exc:
+        raise FieldNoteExactReadError(exc.reason) from exc
+    except Exception as exc:
+        raise FieldNoteExactReadError("scan_failure") from exc
+    finally:
+        for descriptor in (notes_fd, decision_fd, repository_fd):
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
 
 
 def prepare_field_note_reconnect(

--- a/tests/test_field_notes_creator_live_reconnect.py
+++ b/tests/test_field_notes_creator_live_reconnect.py
@@ -1,0 +1,660 @@
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.acceleration import codex_adapter as codex
+from decision_os.acceleration.codex_adapter import (
+    ADAPTER_NAME,
+    CODEX_CLI_VERSION,
+    CodexRuntimeIdentity,
+)
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import git_output, repository_id
+from decision_os.companion import field_notes_creator_live as creator_live
+from decision_os.companion import field_notes_creator_live_reconnect as exact_a2
+from decision_os.companion import field_notes_reconnect as reconnect
+from decision_os.companion import field_notes_whole_flow as whole_flow
+from decision_os.companion.field_notes_adapter import (
+    FieldNoteCodexRunResult,
+    FieldNoteCreatorLiveA1CaptureConfig,
+    FieldNotesCodexAdapter,
+)
+from decision_os.companion.field_notes_controller import (
+    FieldNotesCompanionController,
+)
+from decision_os.companion.field_notes_creator_live import (
+    FieldNoteCreatorLiveA1CaptureCommitReceipt,
+    FieldNoteCreatorLiveProofRuntime,
+)
+from decision_os.companion.field_notes_creator_live_reconnect import (
+    FieldNoteCreatorLiveA2ReconnectBridge,
+    FieldNoteCreatorLiveA2ReconnectError,
+    FieldNoteCreatorLiveA2ReconnectTarget,
+    creator_live_a2_target_from_readback,
+    prepare_creator_live_a2_reconnect,
+)
+from decision_os.companion.field_notes_model import compile_draft
+from decision_os.companion.field_notes_reuse import FieldNoteIdentity
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowAttempt,
+    FieldNoteWholeFlowRunIdentity,
+)
+from tests.test_acceleration_codex_adapter import (
+    FakeTransportFactory,
+    completed_agent_message,
+    completed_turn,
+    handshake_messages,
+)
+
+
+RUN_1_TASK = "Create one bounded fixture candidate."
+RUN_1_TASK_SHA256 = hashlib.sha256(RUN_1_TASK.encode("utf-8")).hexdigest()
+
+
+def _proposal(*, title: str = "Exact lineage reconnect") -> dict[str, object]:
+    return {
+        "title": title,
+        "value_level": 1,
+        "source_model_class": "UNKNOWN",
+        "target_model_class": "UNKNOWN",
+        "trigger_terms": ["never matching", "fixture only"],
+        "scope": {
+            "task_family": "creator-live-a2-exact-reconnect",
+            "path_prefixes": ["decision_os/companion"],
+            "exclude_terms": [],
+        },
+        "body": {
+            "trigger": "Use only for the exact durable lineage.",
+            "reusable_structure": "Keep the captured Note identity exact.",
+            "scope": "One proof attempt and its distinct Run 2.",
+            "do_not_apply_when": "Any target field differs.",
+            "procedure": "Validate and inject exactly one Note envelope.",
+            "acceptance": "The existing A2 admission accepts the receipt.",
+            "evidence": "Deterministic model-free fixture evidence.",
+            "remaining_unknowns": "No live proof claim is made.",
+        },
+    }
+
+
+def _create_repository(root: Path) -> Path:
+    repository = root / "repo"
+    repository.mkdir()
+    (repository / "seed.txt").write_text("seed\n", encoding="utf-8")
+    commands = (
+        ("git", "init", "-q", str(repository)),
+        ("git", "-C", str(repository), "add", "seed.txt"),
+        (
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=Field Notes Test",
+            "-c",
+            "user.email=field-notes@example.invalid",
+            "commit",
+            "-qm",
+            "seed",
+        ),
+    )
+    for command in commands:
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise AssertionError(result.stderr)
+    return repository
+
+
+def _runtime_identity() -> CodexRuntimeIdentity:
+    return CodexRuntimeIdentity(
+        model=codex.CODEX_MODEL,
+        reasoning_effort=codex.CODEX_REASONING_EFFORT,
+        service_tier=codex.CODEX_SERVICE_TIER,
+        codex_cli_version=codex.CODEX_CLI_VERSION,
+        account_type="chatgpt",
+    )
+
+
+def _reissue(
+    target: FieldNoteCreatorLiveA2ReconnectTarget,
+    **changes: object,
+) -> FieldNoteCreatorLiveA2ReconnectTarget:
+    values = {
+        "proof_attempt_id": target.proof_attempt_id,
+        "run_1_id": target.run_1_id,
+        "run_2_id": target.run_2_id,
+        "field_note_id": target.field_note_id,
+        "note_relative_path": target.note_relative_path,
+        "note_sha256": target.note_sha256,
+        "note_byte_count": target.note_byte_count,
+        "source_repository_id": target.source_repository_id,
+        "source_commit": target.source_commit,
+        "expected_runtime_identity": target.expected_runtime_identity,
+    }
+    values.update(changes)
+    return FieldNoteCreatorLiveA2ReconnectTarget._issue(
+        authority=exact_a2._A2_TARGET_AUTHORITY,
+        **values,
+    )
+
+
+class _BridgeAdapter:
+    def __init__(self, owner: "CreatorLiveExactReconnectTests") -> None:
+        self.owner = owner
+
+    async def run(self, task: str) -> FieldNoteCodexRunResult:
+        self.owner.adapter_invocations += 1
+        target = self.owner.controller._active_creator_live_a2_reconnect()
+        assert target is not None
+        prepared = prepare_creator_live_a2_reconnect(
+            self.owner.repository,
+            target,
+        )
+        plan = prepared.plan.injected().finalized(
+            normal_terminal=True,
+            ordinary_paths=0,
+        )
+        return FieldNoteCodexRunResult(
+            run_id=target.run_2_id,
+            normal_terminal=True,
+            status="NORMAL_TERMINAL",
+            error_type=None,
+            turn_status="completed",
+            runtime_identity=target.expected_runtime_identity,
+            checkpoint_outcomes=(),
+            final_message="bounded model-free fixture",
+            reconnect_receipt=plan.receipt,
+        )
+
+
+class CreatorLiveExactReconnectTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.repository = _create_repository(self.root)
+        self.source_repository = FieldNoteSourceRepositoryIdentity(
+            repository_id=repository_id(self.repository),
+            source_commit=git_output(self.repository, "rev-parse", "HEAD"),
+        )
+        self.attempt = FieldNoteWholeFlowAttempt(
+            proof_attempt_id="proof_a7_exact_reconnect_fixture_001",
+            proof_mode="CREATOR_LIVE",
+            creator_id="fixture-creator",
+            proof_as_of="2026-08-06T12:00:00Z",
+        )
+        self.run_1 = FieldNoteWholeFlowRunIdentity(
+            proof_attempt_id=self.attempt.proof_attempt_id,
+            run_id="run_exact_reconnect_fixture_1",
+            started_at="2026-08-06T10:00:00Z",
+            repository=self.source_repository,
+            runtime=_runtime_identity(),
+        )
+        self.run_2 = FieldNoteWholeFlowRunIdentity(
+            proof_attempt_id=self.attempt.proof_attempt_id,
+            run_id="run_exact_reconnect_fixture_2",
+            started_at="2026-08-06T11:00:00Z",
+            repository=self.source_repository,
+            runtime=self.run_1.runtime,
+        )
+        self.draft = compile_draft(
+            _proposal(),
+            source_run_id=self.run_1.run_id,
+            created_at="2026-08-06T10:01:00Z",
+            field_note_id="fn_exact_reconnect_fixture_001",
+        )
+        self.note_path = self.repository / self.draft.relative_path
+        self.note_path.parent.mkdir(parents=True)
+        self.note_path.write_bytes(self.draft.markdown)
+        self.runtime = FieldNoteCreatorLiveProofRuntime.open_attempt(
+            self.root / "runtime",
+            attempt=self.attempt,
+            source_repository=self.source_repository,
+            run_1=self.run_1,
+        )
+        note = FieldNoteIdentity(
+            note_path=self.draft.relative_path,
+            field_note_id=self.draft.field_note_id,
+            note_sha256=self.draft.sha256,
+            origin_run_id=self.draft.source_run_id,
+        )
+        commit = FieldNoteCreatorLiveA1CaptureCommitReceipt._issue(
+            authority=creator_live._A1_CAPTURE_COMMIT_AUTHORITY,
+            proof_attempt_id=self.attempt.proof_attempt_id,
+            run_id=self.run_1.run_id,
+            task_sha256=RUN_1_TASK_SHA256,
+            actual_runtime_identity=self.run_1.runtime,
+            source_repository=self.source_repository,
+            note=note,
+            note_byte_count=len(self.draft.markdown),
+            draft_evidence_sha256=whole_flow._a1_evidence_sha256(self.draft),
+            draft_created_at=self.draft.created_at,
+            save_as_of="2026-08-06T10:02:00Z",
+        )
+        self.runtime.record_a1_capture(
+            self.draft,
+            capture_commit=commit,
+            expected_task_sha256=RUN_1_TASK_SHA256,
+            actual_runtime_identity=self.run_1.runtime,
+            observed_at="2026-08-06T10:03:00Z",
+        )
+        self.runtime.open_run_2(self.run_2)
+        self.target = creator_live_a2_target_from_readback(
+            self.runtime.read_back()
+        )
+        self.adapter_invocations = 0
+        self.controller = FieldNotesCompanionController(
+            state_path=self.root / "state.json",
+            picker_script=self.root / "picker.scpt",
+            adapter_factory=lambda _engine, _approval, _lifecycle: (
+                _BridgeAdapter(self)
+            ),
+        )
+        self.controller.select_repository(self.repository)
+
+    def _bridge(self) -> FieldNoteCreatorLiveA2ReconnectBridge:
+        return FieldNoteCreatorLiveA2ReconnectBridge(
+            runtime=self.runtime,
+            controller=self.controller,
+            repository=self.repository,
+            source_repository=self.source_repository,
+            timeout_seconds=5,
+        )
+
+    @staticmethod
+    def _terminal_messages(repository: Path) -> list[dict[str, object]]:
+        messages = handshake_messages(
+            repository,
+            thread_id="thread-exact-a2",
+            turn_id="turn-exact-a2",
+        )
+        messages.extend(
+            [
+                completed_agent_message(
+                    thread_id="thread-exact-a2",
+                    turn_id="turn-exact-a2",
+                    text="Completed.",
+                ),
+                completed_turn(
+                    thread_id="thread-exact-a2",
+                    turn_id="turn-exact-a2",
+                ),
+            ]
+        )
+        return messages
+
+    def _adapter(
+        self,
+        target: FieldNoteCreatorLiveA2ReconnectTarget,
+        factory: object,
+        *,
+        a1: bool = False,
+    ) -> FieldNotesCodexAdapter:
+        engine = AccelerationEngine(
+            self.repository,
+            adapter=ADAPTER_NAME,
+            adapter_version=CODEX_CLI_VERSION,
+        )
+        return FieldNotesCodexAdapter(
+            engine,
+            input_func=lambda: None,
+            stdout=io.StringIO(),
+            transport_factory=factory,
+            creator_live_a1_capture_provider=(
+                lambda: FieldNoteCreatorLiveA1CaptureConfig(
+                    run_id=self.run_1.run_id,
+                    expected_runtime_identity=self.run_1.runtime,
+                )
+                if a1
+                else None
+            ),
+            creator_live_a2_reconnect_provider=lambda: target,
+        )
+
+    def test_target_is_issued_only_from_verified_post_run_2_readback(self) -> None:
+        with self.assertRaisesRegex(
+            FieldNoteCreatorLiveA2ReconnectError,
+            "A2_TARGET_INVALID",
+        ):
+            FieldNoteCreatorLiveA2ReconnectTarget()
+        self.assertEqual(self.attempt.proof_attempt_id, self.target.proof_attempt_id)
+        self.assertEqual(self.run_1.run_id, self.target.run_1_id)
+        self.assertEqual(self.run_2.run_id, self.target.run_2_id)
+        self.assertEqual(self.draft.relative_path, self.target.note_relative_path)
+
+    def test_exact_preparation_is_score_free_and_never_selects_alternate(self) -> None:
+        alternate = compile_draft(
+            _proposal(title="Higher scoring alternate"),
+            source_run_id=self.run_1.run_id,
+            created_at="2026-08-06T10:01:30Z",
+            field_note_id="fn_exact_reconnect_alternate_001",
+        )
+        (self.repository / alternate.relative_path).write_bytes(alternate.markdown)
+        ordinary = reconnect.prepare_field_note_reconnect(
+            self.repository,
+            "completely unrelated score zero task",
+            self.run_2.run_id,
+        )
+        self.assertEqual("NO_MATCH", ordinary.receipt.state)
+        with patch.object(reconnect, "_score", side_effect=AssertionError("score")):
+            prepared = prepare_creator_live_a2_reconnect(
+                self.repository,
+                self.target,
+            )
+        self.assertEqual("SELECTED", prepared.plan.receipt.state)
+        self.assertEqual(
+            self.draft.field_note_id,
+            prepared.plan.receipt.selected_field_note_id,
+        )
+        self.assertNotEqual(
+            alternate.field_note_id,
+            prepared.plan.receipt.selected_field_note_id,
+        )
+
+    def test_exact_selected_receipt_contains_all_existing_identity_fields(self) -> None:
+        prepared = prepare_creator_live_a2_reconnect(
+            self.repository,
+            self.target,
+        )
+        receipt = prepared.plan.receipt
+        self.assertEqual("SELECTED", receipt.state)
+        self.assertEqual(self.run_2.run_id, receipt.run_id)
+        self.assertEqual(self.draft.relative_path, receipt.selected_field_note_path)
+        self.assertEqual(self.draft.field_note_id, receipt.selected_field_note_id)
+        self.assertEqual(self.draft.sha256, receipt.selected_full_note_sha256)
+        self.assertEqual(len(self.draft.markdown), receipt.full_note_bytes_read)
+        self.assertEqual(0, receipt.full_notes_injected)
+        self.assertEqual(self.draft.markdown, prepared.note_bytes)
+
+    def test_exact_identity_mismatch_matrix_fails_closed(self) -> None:
+        cases = {
+            "note_id": (
+                {"field_note_id": "fn_different"},
+                "A2_TARGET_NOTE_ID_MISMATCH",
+            ),
+            "traversal": (
+                {"note_relative_path": "../alternate.md"},
+                "A2_TARGET_PATH_INVALID",
+            ),
+            "source_run": (
+                {"run_1_id": "run_different"},
+                "A2_TARGET_SOURCE_RUN_MISMATCH",
+            ),
+            "repository": (
+                {"source_repository_id": "repo:v1:" + "0" * 64},
+                "A2_TARGET_REPOSITORY_MISMATCH",
+            ),
+            "commit": (
+                {"source_commit": "0" * 40},
+                "A2_TARGET_COMMIT_MISMATCH",
+            ),
+            "sha": (
+                {"note_sha256": "0" * 64},
+                "A2_TARGET_SHA256_MISMATCH",
+            ),
+            "bytes": (
+                {"note_byte_count": self.target.note_byte_count + 1},
+                "A2_TARGET_BYTE_COUNT_MISMATCH",
+            ),
+        }
+        for label, (changes, code) in cases.items():
+            with self.subTest(label=label):
+                target = _reissue(self.target, **changes)
+                with self.assertRaisesRegex(
+                    FieldNoteCreatorLiveA2ReconnectError,
+                    code,
+                ):
+                    prepare_creator_live_a2_reconnect(self.repository, target)
+
+    def test_missing_symlink_changed_and_invalid_notes_fail_closed(self) -> None:
+        original = self.note_path.read_bytes()
+        cases = (
+            "missing",
+            "symlink",
+            "replaced",
+            "changed",
+            "invalid_metadata",
+            "invalid_full",
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                if self.note_path.exists() or self.note_path.is_symlink():
+                    self.note_path.unlink()
+                self.note_path.write_bytes(original)
+                if case == "missing":
+                    self.note_path.unlink()
+                elif case == "symlink":
+                    alternate = self.root / "outside.md"
+                    alternate.write_bytes(original)
+                    self.note_path.unlink()
+                    self.note_path.symlink_to(alternate)
+                elif case == "replaced":
+                    replacement = compile_draft(
+                        _proposal(title="Replacement note"),
+                        source_run_id=self.run_1.run_id,
+                        created_at="2026-08-06T10:01:30Z",
+                        field_note_id="fn_replacement_note_001",
+                    )
+                    self.note_path.write_bytes(replacement.markdown)
+                elif case == "invalid_metadata":
+                    self.note_path.write_bytes(
+                        original.replace(
+                            b'"status":"CANDIDATE"',
+                            b'"status":"BROKEN"',
+                        )
+                    )
+                elif case == "invalid_full":
+                    self.note_path.write_bytes(original + b"\x00")
+                if case == "changed":
+                    with patch.object(
+                        reconnect,
+                        "_read_full_note",
+                        return_value=(
+                            None,
+                            10,
+                            "selected_identity_changed",
+                        ),
+                    ):
+                        with self.assertRaisesRegex(
+                            FieldNoteCreatorLiveA2ReconnectError,
+                            "A2_TARGET_CHANGED_DURING_READ",
+                        ):
+                            prepare_creator_live_a2_reconnect(
+                                self.repository,
+                                self.target,
+                            )
+                else:
+                    with self.assertRaises(FieldNoteCreatorLiveA2ReconnectError):
+                        prepare_creator_live_a2_reconnect(
+                            self.repository,
+                            self.target,
+                        )
+
+    async def _run_exact_adapter(self) -> tuple[object, FakeTransportFactory]:
+        factory = FakeTransportFactory(
+            [self._terminal_messages(self.repository)]
+        )
+        adapter = self._adapter(self.target, factory)
+        result = await adapter.run("completely unrelated score zero task")
+        return result, factory
+
+    def test_successful_bridge_admits_existing_receipt_and_opens_a3(self) -> None:
+        event = self._bridge().reconnect("fixed Run 2 task")
+        readback = self.runtime.read_back()
+        self.assertEqual("A2_RECONNECT", event.stage)
+        self.assertEqual("OPEN", readback.state)
+        self.assertEqual("A3_REUSE", readback.current_stage)
+        self.assertEqual(2, readback.trace_event_count)
+        self.assertEqual(1, self.adapter_invocations)
+        completion = self.controller.creator_live_a2_run_completion(
+            expected_run_id=self.run_2.run_id
+        )
+        self.assertIn(
+            completion.reconnect_receipt.state,
+            {"INJECTED", "ACTIVATION_UNKNOWN"},
+        )
+        self.assertEqual(1, completion.reconnect_receipt.full_notes_injected)
+
+    def _assert_cross_bound_terminal(
+        self,
+        target: FieldNoteCreatorLiveA2ReconnectTarget,
+        code: str,
+    ) -> None:
+        with patch.object(
+            exact_a2,
+            "creator_live_a2_target_from_readback",
+            return_value=target,
+        ):
+            with self.assertRaisesRegex(
+                FieldNoteCreatorLiveA2ReconnectError,
+                code,
+            ):
+                self._bridge().reconnect("fixed Run 2 task")
+        readback = self.runtime.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("A2_RECONNECT", readback.failure_boundary)
+        self.assertEqual(code, readback.failure_reason)
+        self.assertEqual(1, readback.trace_event_count)
+        self.assertEqual(0, self.adapter_invocations)
+
+    def test_cross_bound_proof_fails_before_adapter_and_terminalizes(self) -> None:
+        self._assert_cross_bound_terminal(
+            _reissue(self.target, proof_attempt_id="proof_different"),
+            "A2_TARGET_PROOF_MISMATCH",
+        )
+
+    def test_cross_bound_run_2_fails_before_adapter_and_terminalizes(self) -> None:
+        self._assert_cross_bound_terminal(
+            _reissue(self.target, run_2_id="run_different"),
+            "A2_TARGET_RUN_2_MISMATCH",
+        )
+
+    def test_pre_thread_failure_constructs_no_transport(self) -> None:
+        calls = 0
+
+        def factory(_executable: Path):
+            nonlocal calls
+            calls += 1
+            raise AssertionError("transport must not be constructed")
+
+        adapter = self._adapter(
+            _reissue(self.target, note_sha256="0" * 64),
+            factory,
+        )
+
+        async def invoke() -> None:
+            await adapter.run("fixed Run 2 task")
+
+        with self.assertRaisesRegex(
+            FieldNoteCreatorLiveA2ReconnectError,
+            "A2_TARGET_SHA256_MISMATCH",
+        ):
+            import asyncio
+
+            asyncio.run(invoke())
+        self.assertEqual(0, calls)
+
+    def test_bridge_file_failure_is_durable_with_zero_transport(
+        self,
+    ) -> None:
+        calls = 0
+        holder: dict[str, FieldNotesCompanionController] = {}
+
+        def transport_factory(_executable: Path):
+            nonlocal calls
+            calls += 1
+            raise AssertionError("transport must not be constructed")
+
+        def adapter_factory(engine, approval, lifecycle):
+            return FieldNotesCodexAdapter(
+                engine,
+                input_func=lambda: None,
+                stdout=io.StringIO(),
+                approval_provider=approval,
+                lifecycle_sink=lifecycle,
+                transport_factory=transport_factory,
+                creator_live_a2_reconnect_provider=(
+                    holder["controller"]._active_creator_live_a2_reconnect
+                ),
+            )
+
+        controller = FieldNotesCompanionController(
+            state_path=self.root / "failure-state.json",
+            picker_script=self.root / "failure-picker.scpt",
+            adapter_factory=adapter_factory,
+        )
+        holder["controller"] = controller
+        controller.select_repository(self.repository)
+        self.note_path.unlink()
+        bridge = FieldNoteCreatorLiveA2ReconnectBridge(
+            runtime=self.runtime,
+            controller=controller,
+            repository=self.repository,
+            source_repository=self.source_repository,
+            timeout_seconds=5,
+        )
+        with self.assertRaisesRegex(
+            FieldNoteCreatorLiveA2ReconnectError,
+            "A2_TARGET_NOTE_MISSING",
+        ):
+            bridge.reconnect("fixed Run 2 task")
+        readback = self.runtime.read_back()
+        self.assertEqual(0, calls)
+        self.assertEqual("FAILED", readback.state)
+        self.assertEqual("A2_RECONNECT", readback.failure_boundary)
+        self.assertEqual("A2_TARGET_NOTE_MISSING", readback.failure_reason)
+        self.assertEqual(1, readback.trace_event_count)
+
+    def test_a1_and_a2_modes_are_mutually_exclusive_before_transport(self) -> None:
+        calls = 0
+
+        def factory(_executable: Path):
+            nonlocal calls
+            calls += 1
+            raise AssertionError("transport must not be constructed")
+
+        adapter = self._adapter(self.target, factory, a1=True)
+
+        async def invoke() -> None:
+            await adapter.run("fixed Run task")
+
+        with self.assertRaisesRegex(
+            FieldNoteCreatorLiveA2ReconnectError,
+            "A2_TARGET_INVALID",
+        ):
+            import asyncio
+
+            asyncio.run(invoke())
+        self.assertEqual(0, calls)
+
+
+class CreatorLiveExactReconnectAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_successful_thread_injects_exact_envelope_once(self) -> None:
+        case = CreatorLiveExactReconnectTests("runTest")
+        case.setUp()
+        self.addCleanup(case.doCleanups)
+        result, factory = await case._run_exact_adapter()
+        self.assertEqual("ACTIVATION_UNKNOWN", result.reconnect_receipt.state)
+        self.assertEqual(1, result.reconnect_receipt.full_notes_injected)
+        request = next(
+            item
+            for item in factory.transports[0].sent
+            if item.get("method") == "thread/start"
+        )
+        instructions = request["params"]["developerInstructions"]
+        self.assertEqual(1, instructions.count(case.draft.markdown.decode("utf-8")))
+        self.assertEqual(
+            1,
+            instructions.count(
+                "=== DECISION OS FIELD NOTE / ADVISORY MEMORY / BEGIN ==="
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Classification

Classification A — EXACT-LINEAGE PINNING GAP ESTABLISHED.

## What changed

- Adds an immutable Creator-Live A2 target issued only from verified durable readback after Run 2 is opened.
- Adds a separate exact-path preparation lane that validates the durable A1 Note identity, repository, commit, full bytes, and Run lineage without scanning, scoring, or fallback.
- Wires that target through the adapter and controller before `thread/start`, then uses the existing `FieldNoteReconnectReceipt` and existing `record_a2_reconnect()` admission.
- Adds deterministic model-free coverage for exact success, every bounded mismatch family, race/symlink/invalid Note handling, durable A2 failure, mutual exclusion, and receipt admission.

## Boundaries

- Ordinary reconnect is unchanged: it remains relevance-based and may return `NO_MATCH`.
- The bypass is exact mode only; it never calls ordinary scoring and never selects an alternate Note.
- Any exact-target preparation failure occurs before thread creation, so model invocation count is zero.
- No journal, anchor, typed-readback, receipt, or A7 schema changed.
- A1 and A3–A7 behavior is unchanged.
- Cycle 003 remains permanently `FAILED / A2_RECONNECT / A2_NOT_INJECTED`; it was not retried, continued, reopened, or reinterpreted.
- Live gate remains `BLOCK`.

## Validation

- Exact reconnect tests: PASS.
- Adapter/controller/Creator-Live focused set: 220 passed, one declared local-artifact skip.
- A2–A7 focused qualification: 351 passed, two declared skips.
- Full default discovery, authorized local integration environment: 1,166 passed, five declared skips.
- Full explicit discovery, authorized local integration environment: 1,166 passed, five declared skips.
- Normalized default/explicit test-ID sets: exact match, SHA-256 `e6a23ab7415ffef057a7858c4c3e921cc74b7cde09187bc7dfb7c9cad6038992`.
- Python compilation: PASS.
- `git diff --check`: PASS.
- Cycle 003 protected Note, journal, anchor, and typed-readback identities: exact.

No product/runtime model was invoked. No live proof activity, proof identity, Run, Note, journal, anchor, installation, or restart was performed.
