### PR TITLE
Add runtime-issued terminal Proof As-of schema

### DIFF
--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -43,6 +43,7 @@ from decision_os.companion.field_notes_whole_flow import (
     TRACE_GENESIS_SHA256,
     WHOLE_FLOW_TRACE_SCHEMA,
     FieldNoteCreatorLiveRuntimeProvenance,
+    FieldNoteCreatorLiveAttempt,
     FieldNoteSourceRepositoryIdentity,
     FieldNoteWholeFlowAttempt,
     FieldNoteWholeFlowRunIdentity,
@@ -81,6 +82,20 @@ CREATOR_LIVE_ANCHOR_SCHEMA = (
 )
 CREATOR_LIVE_JOURNAL_FILENAME = "creator-live-proof-v0.1.jsonl"
 CREATOR_LIVE_ANCHOR_FILENAME = "creator-live-proof-v0.1.anchor.jsonl"
+CREATOR_LIVE_JOURNAL_SCHEMA_V2 = (
+    "decision-os.field-note-creator-live-proof-journal.v0.2"
+)
+CREATOR_LIVE_RECORD_SCHEMA_V2 = (
+    "decision-os.field-note-creator-live-proof-record.v0.2"
+)
+CREATOR_LIVE_READBACK_SCHEMA_V2 = (
+    "decision-os.field-note-creator-live-proof-readback.v0.2"
+)
+CREATOR_LIVE_ANCHOR_SCHEMA_V2 = (
+    "decision-os.field-note-creator-live-proof-anchor.v0.2"
+)
+CREATOR_LIVE_JOURNAL_FILENAME_V2 = "creator-live-proof-v0.2.jsonl"
+CREATOR_LIVE_ANCHOR_FILENAME_V2 = "creator-live-proof-v0.2.anchor.jsonl"
 A1_CAPTURE_COMMIT_SCHEMA = (
     "decision-os.field-note-creator-live-a1-capture-commit.v0.1"
 )
@@ -95,6 +110,7 @@ CreatorLiveAttemptState = Literal[
 ]
 JournalRecordKind = Literal[
     "ATTEMPT_OPENED",
+    "RUN_1_OPENED",
     "RUN_2_OPENED",
     "CHECKPOINT",
     "ATTEMPT_FAILED",
@@ -331,7 +347,7 @@ def _a1_capture_chronology_is_valid(
     draft_created_at: str,
     save_as_of: str,
     observed_at: str,
-    proof_as_of: str,
+    proof_as_of: str | None = None,
 ) -> bool:
     """Compare the five creator-live A1 instants in their required order."""
 
@@ -339,8 +355,11 @@ def _a1_capture_chronology_is_valid(
     _, draft_time = _parse_time(draft_created_at, "A1 draft creation time")
     _, save_time = _parse_time(save_as_of, "A1 capture save As-of")
     _, observed_time = _parse_time(observed_at, "A1 checkpoint observation")
+    chronology_valid = run_time <= draft_time <= save_time <= observed_time
+    if proof_as_of is None:
+        return chronology_valid
     _, proof_time = _parse_time(proof_as_of, "Proof As-of")
-    return run_time <= draft_time <= save_time <= observed_time <= proof_time
+    return chronology_valid and observed_time <= proof_time
 
 
 def _runtime_from_dict(value: Any) -> CodexRuntimeIdentity:
@@ -447,8 +466,29 @@ def _attempt_from_dict(value: Any) -> FieldNoteWholeFlowAttempt:
     return attempt
 
 
+def _attempt_v2_from_dict(value: Any) -> FieldNoteCreatorLiveAttempt:
+    if not isinstance(value, dict) or set(value) != {
+        "proof_attempt_id",
+        "proof_mode",
+        "creator_id",
+        "authorization_observed_at",
+    }:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        )
+    try:
+        return FieldNoteCreatorLiveAttempt(**value)
+    except (TypeError, ValueError) as exc:
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_ATTEMPT_IDENTITY_INVALID",
+            repair_action="RECEIPT_REWRITE",
+        ) from exc
+
+
 @dataclass(frozen=True)
 class _JournalRecord:
+    schema: str
     sequence: int
     kind: JournalRecordKind
     payload: dict[str, Any]
@@ -463,15 +503,17 @@ class _JournalRecord:
         kind: JournalRecordKind,
         payload: dict[str, Any],
         previous_record_sha256: str,
+        schema: str = CREATOR_LIVE_RECORD_SCHEMA,
     ) -> _JournalRecord:
         body = {
-            "schema": CREATOR_LIVE_RECORD_SCHEMA,
+            "schema": schema,
             "sequence": sequence,
             "kind": kind,
             "payload": payload,
             "previous_record_sha256": previous_record_sha256,
         }
         return cls(
+            schema=schema,
             sequence=sequence,
             kind=kind,
             payload=payload,
@@ -481,7 +523,7 @@ class _JournalRecord:
 
     def as_dict(self) -> dict[str, Any]:
         return {
-            "schema": CREATOR_LIVE_RECORD_SCHEMA,
+            "schema": self.schema,
             "sequence": self.sequence,
             "kind": self.kind,
             "payload": self.payload,
@@ -495,6 +537,7 @@ class _JournalRecord:
 
 @dataclass(frozen=True)
 class _AnchorRecord:
+    schema: str
     generation: int
     proof_attempt_id: str
     journal_record_count: int
@@ -513,9 +556,10 @@ class _AnchorRecord:
         journal_raw: bytes,
         journal_records: tuple[_JournalRecord, ...],
         previous_anchor_sha256: str,
+        schema: str = CREATOR_LIVE_ANCHOR_SCHEMA,
     ) -> _AnchorRecord:
         body = {
-            "schema": CREATOR_LIVE_ANCHOR_SCHEMA,
+            "schema": schema,
             "generation": generation,
             "proof_attempt_id": proof_attempt_id,
             "journal_record_count": len(journal_records),
@@ -527,6 +571,7 @@ class _AnchorRecord:
             "previous_anchor_sha256": previous_anchor_sha256,
         }
         return cls(
+            schema=schema,
             generation=generation,
             proof_attempt_id=proof_attempt_id,
             journal_record_count=len(journal_records),
@@ -541,7 +586,7 @@ class _AnchorRecord:
 
     def as_dict(self) -> dict[str, Any]:
         return {
-            "schema": CREATOR_LIVE_ANCHOR_SCHEMA,
+            "schema": self.schema,
             "generation": self.generation,
             "proof_attempt_id": self.proof_attempt_id,
             "journal_record_count": self.journal_record_count,
@@ -566,6 +611,7 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
         )
     records: list[_JournalRecord] = []
     previous = JOURNAL_GENESIS_SHA256
+    record_schema: str | None = None
     for index, line in enumerate(raw.splitlines()):
         try:
             text = line.decode("utf-8")
@@ -595,6 +641,7 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
         kind = value["kind"]
         if kind not in {
             "ATTEMPT_OPENED",
+            "RUN_1_OPENED",
             "RUN_2_OPENED",
             "CHECKPOINT",
             "ATTEMPT_FAILED",
@@ -612,8 +659,14 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
             "previous_record_sha256": value["previous_record_sha256"],
         }
         expected_sha = _canonical_sha256(body)
+        if record_schema is None:
+            record_schema = value["schema"]
         if (
-            value["schema"] != CREATOR_LIVE_RECORD_SCHEMA
+            value["schema"] not in {
+                CREATOR_LIVE_RECORD_SCHEMA,
+                CREATOR_LIVE_RECORD_SCHEMA_V2,
+            }
+            or value["schema"] != record_schema
             or value["sequence"] != index
             or value["previous_record_sha256"] != previous
             or value["record_sha256"] != expected_sha
@@ -631,6 +684,7 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
             )
             raise _JournalIntegrityError(reason, repair_action=action)
         record = _JournalRecord(
+            schema=value["schema"],
             sequence=index,
             kind=kind,
             payload=value["payload"],
@@ -650,6 +704,7 @@ def _parse_anchors(raw: bytes) -> tuple[_AnchorRecord, ...]:
         )
     anchors: list[_AnchorRecord] = []
     previous = ANCHOR_GENESIS_SHA256
+    anchor_schema: str | None = None
     for generation, line in enumerate(raw.splitlines()):
         try:
             text = line.decode("utf-8")
@@ -681,8 +736,14 @@ def _parse_anchors(raw: bytes) -> tuple[_AnchorRecord, ...]:
             )
         body = {key: value[key] for key in required - {"anchor_sha256"}}
         expected_sha = _canonical_sha256(body)
+        if anchor_schema is None:
+            anchor_schema = value["schema"]
         if (
-            value["schema"] != CREATOR_LIVE_ANCHOR_SCHEMA
+            value["schema"] not in {
+                CREATOR_LIVE_ANCHOR_SCHEMA,
+                CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+            }
+            or value["schema"] != anchor_schema
             or value["generation"] != generation
             or value["previous_anchor_sha256"] != previous
             or value["anchor_sha256"] != expected_sha
@@ -714,6 +775,7 @@ def _parse_anchors(raw: bytes) -> tuple[_AnchorRecord, ...]:
                     repair_action="EVENT_ID_CHANGE",
                 )
         anchor = _AnchorRecord(
+            schema=value["schema"],
             generation=generation,
             proof_attempt_id=value["proof_attempt_id"],
             journal_record_count=value["journal_record_count"],
@@ -836,7 +898,7 @@ def _a1_capture_commit_from_dict(
 def _provenance_from_dict(
     value: Any,
     *,
-    attempt: FieldNoteWholeFlowAttempt,
+    attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt,
     repository: FieldNoteSourceRepositoryIdentity,
     runtime: CodexRuntimeIdentity,
     run_1: FieldNoteWholeFlowRunIdentity,
@@ -859,7 +921,7 @@ def _provenance_from_dict(
 def _event_from_dict(
     value: Any,
     *,
-    attempt: FieldNoteWholeFlowAttempt,
+    attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt,
     repository: FieldNoteSourceRepositoryIdentity,
     runtime: CodexRuntimeIdentity,
     provenance: FieldNoteCreatorLiveRuntimeProvenance,
@@ -1100,7 +1162,7 @@ class FieldNoteCreatorLiveTraceReadback:
     def matches_admission(
         self,
         *,
-        attempt: FieldNoteWholeFlowAttempt,
+        attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt,
         source_repository: FieldNoteSourceRepositoryIdentity,
         runtime: CodexRuntimeIdentity,
         run_1: FieldNoteWholeFlowRunIdentity,
@@ -1122,7 +1184,9 @@ class FieldNoteCreatorLiveTraceReadback:
             and self.events == proof_trace
             and self.trace_event_count == len(_STAGES)
             and self.trace_chain_head_sha256 == proof_trace[-1].trace_sha256
-            and self.anchor_record_count == self.journal_record_count
+            and self.anchor_record_count
+            == self.journal_record_count
+            - (1 if self.schema == CREATOR_LIVE_READBACK_SCHEMA_V2 else 0)
             and self.journal_byte_length > 0
             and all(
                 event.runtime_provenance == self.runtime_provenance
@@ -1131,13 +1195,104 @@ class FieldNoteCreatorLiveTraceReadback:
         )
 
 
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveTraceReadbackV2(FieldNoteCreatorLiveTraceReadback):
+    """Forward-only readback with runtime-owned opening and terminal time."""
+
+    attempt: FieldNoteCreatorLiveAttempt
+    authorization_observed_at: str
+    attempt_opened_at: str
+    terminal_proof_as_of: str | None
+    last_admitted_observation: str | None
+
+    @classmethod
+    def _create_v2(
+        cls,
+        *,
+        authorization_observed_at: str,
+        attempt_opened_at: str,
+        terminal_proof_as_of: str | None,
+        **kwargs: Any,
+    ) -> FieldNoteCreatorLiveTraceReadbackV2:
+        attempt = kwargs.get("attempt")
+        if not isinstance(attempt, FieldNoteCreatorLiveAttempt):
+            raise FieldNoteCreatorLiveValidationError(
+                "v0.2 read-back attempt identity is invalid."
+            )
+        value = super()._create(**kwargs)
+        assert isinstance(value, cls)
+        events = value.events
+        object.__setattr__(value, "schema", CREATOR_LIVE_READBACK_SCHEMA_V2)
+        object.__setattr__(
+            value,
+            "authorization_observed_at",
+            authorization_observed_at,
+        )
+        object.__setattr__(value, "attempt_opened_at", attempt_opened_at)
+        object.__setattr__(value, "terminal_proof_as_of", terminal_proof_as_of)
+        object.__setattr__(
+            value,
+            "last_admitted_observation",
+            events[-1].observed_at if events else None,
+        )
+        return value
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            **super()._body(),
+            "authorization_observed_at": self.authorization_observed_at,
+            "attempt_opened_at": self.attempt_opened_at,
+            "terminal_proof_as_of": self.terminal_proof_as_of,
+            "last_admitted_observation": self.last_admitted_observation,
+        }
+
+    def matches_admission(
+        self,
+        *,
+        attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt,
+        source_repository: FieldNoteSourceRepositoryIdentity,
+        runtime: CodexRuntimeIdentity,
+        run_1: FieldNoteWholeFlowRunIdentity,
+        run_2: FieldNoteWholeFlowRunIdentity,
+        proof_trace: tuple[FieldNoteWholeFlowTraceEvent, ...],
+    ) -> bool:
+        if self.terminal_proof_as_of is None or not proof_trace:
+            return False
+        _, terminal_time = _parse_time(
+            self.terminal_proof_as_of,
+            "Terminal Proof As-of",
+        )
+        _, last_time = _parse_time(
+            proof_trace[-1].observed_at,
+            "Last admitted observation",
+        )
+        return (
+            super().matches_admission(
+                attempt=attempt,
+                source_repository=source_repository,
+                runtime=runtime,
+                run_1=run_1,
+                run_2=run_2,
+                proof_trace=proof_trace,
+            )
+            and self.authorization_observed_at
+            == self.attempt.authorization_observed_at
+            and self.last_admitted_observation == proof_trace[-1].observed_at
+            and last_time <= terminal_time
+        )
+
+
 @dataclass(frozen=True)
 class _StaticIdentity:
-    attempt: FieldNoteWholeFlowAttempt
+    attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt
     repository: FieldNoteSourceRepositoryIdentity
     runtime: CodexRuntimeIdentity
     run_1: FieldNoteWholeFlowRunIdentity
     provenance: FieldNoteCreatorLiveRuntimeProvenance
+    journal_schema: str
+    record_schema: str
+    anchor_schema: str
+    attempt_opened_at: str | None
 
 
 def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
@@ -1147,6 +1302,84 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
             repair_action="EVIDENCE_DELETION",
         )
     payload = records[0].payload
+    if records[0].schema == CREATOR_LIVE_RECORD_SCHEMA_V2:
+        if set(payload) != {
+            "journal_schema",
+            "attempt",
+            "attempt_opened_at",
+            "source_repository",
+            "runtime",
+            "run_1_id",
+            "one_attempt_no_retry",
+        } or payload["journal_schema"] != CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_ATTEMPT_RECORD_INVALID",
+                repair_action="RECEIPT_REWRITE",
+            )
+        if payload["one_attempt_no_retry"] is not True:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_RETRY_BOUNDARY_INVALID",
+                repair_action="RETRY_REPLACEMENT",
+            )
+        if len(records) < 2 or records[1].kind != "RUN_1_OPENED":
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_RUN_1_RECORD_MISSING",
+                repair_action="EVIDENCE_DELETION",
+            )
+        run_payload = records[1].payload
+        if set(run_payload) != {"run_1", "runtime_provenance"}:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_RUN_1_RECORD_INVALID",
+                repair_action="RECEIPT_REWRITE",
+            )
+        attempt = _attempt_v2_from_dict(payload["attempt"])
+        repository = _repository_from_dict(payload["source_repository"])
+        runtime = _runtime_from_dict(payload["runtime"])
+        run_1 = _run_from_dict(
+            run_payload["run_1"],
+            repository=repository,
+            runtime=runtime,
+        )
+        if (
+            run_1.proof_attempt_id != attempt.proof_attempt_id
+            or run_1.run_id != payload["run_1_id"]
+        ):
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_RUN_ATTEMPT_MISMATCH",
+                repair_action="RECEIPT_REWRITE",
+            )
+        opened_at, opened_time = _parse_time(
+            payload["attempt_opened_at"],
+            "Attempt opening time",
+        )
+        _, authorization_time = _parse_time(
+            attempt.authorization_observed_at,
+            "Authorization observation",
+        )
+        _, run_time = _parse_time(run_1.started_at, "Run 1 start")
+        if authorization_time > opened_time or opened_time >= run_time:
+            raise _JournalIntegrityError(
+                "CREATOR_LIVE_OPENING_CHRONOLOGY_INVALID",
+                repair_action="TIMESTAMP_CHANGE",
+            )
+        provenance = _provenance_from_dict(
+            run_payload["runtime_provenance"],
+            attempt=attempt,
+            repository=repository,
+            runtime=runtime,
+            run_1=run_1,
+        )
+        return _StaticIdentity(
+            attempt=attempt,
+            repository=repository,
+            runtime=runtime,
+            run_1=run_1,
+            provenance=provenance,
+            journal_schema=CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+            record_schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
+            anchor_schema=CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+            attempt_opened_at=opened_at,
+        )
     if set(payload) != {
         "journal_schema",
         "attempt",
@@ -1191,6 +1424,10 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
         runtime=runtime,
         run_1=run_1,
         provenance=provenance,
+        journal_schema=CREATOR_LIVE_JOURNAL_SCHEMA,
+        record_schema=CREATOR_LIVE_RECORD_SCHEMA,
+        anchor_schema=CREATOR_LIVE_ANCHOR_SCHEMA,
+        attempt_opened_at=None,
     )
 
 
@@ -1207,6 +1444,11 @@ def _project_records(
         anchors,
         proof_attempt_id=static.attempt.proof_attempt_id,
     )
+    if any(anchor.schema != static.anchor_schema for anchor in anchors):
+        raise _JournalIntegrityError(
+            "CREATOR_LIVE_DURABLE_SCHEMA_MISMATCH",
+            repair_action="RECEIPT_REWRITE",
+        )
     run_2: FieldNoteWholeFlowRunIdentity | None = None
     events: list[FieldNoteWholeFlowTraceEvent] = []
     captured_note: FieldNoteIdentity | None = None
@@ -1218,9 +1460,15 @@ def _project_records(
     failure_boundary: WholeFlowBoundary | None = None
     failure_reason: str | None = None
     repair_action: RepairAction = "NONE"
+    terminal_proof_as_of: str | None = None
     previous_trace = TRACE_GENESIS_SHA256
 
-    for record in records[1:]:
+    start_index = (
+        2
+        if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2
+        else 1
+    )
+    for record in records[start_index:]:
         if state in {"FAILED", "TRACE_COMPLETE"}:
             raise _JournalIntegrityError(
                 "CREATOR_LIVE_TERMINAL_STATE_EXTENDED",
@@ -1346,7 +1594,14 @@ def _project_records(
                         ),
                         save_as_of=a1_capture_commit.save_as_of,
                         observed_at=event.observed_at,
-                        proof_as_of=static.attempt.proof_as_of,
+                        proof_as_of=(
+                            static.attempt.proof_as_of
+                            if isinstance(
+                                static.attempt,
+                                FieldNoteWholeFlowAttempt,
+                            )
+                            else None
+                        ),
                     )
                 ):
                     raise _JournalIntegrityError(
@@ -1397,6 +1652,9 @@ def _project_records(
                 "proposal_diagnostic",
                 "proposal_diagnostic_sha256",
             }
+            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+                legacy_fields = legacy_fields | {"proof_as_of"}
+                diagnostic_fields = diagnostic_fields | {"proof_as_of"}
             if set(payload) not in {
                 frozenset(legacy_fields),
                 frozenset(diagnostic_fields),
@@ -1439,6 +1697,26 @@ def _project_records(
             failure_boundary = boundary
             failure_reason = _bounded_reason(payload["failure_reason"])
             repair_action = action
+            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+                terminal_proof_as_of, terminal_time = _parse_time(
+                    payload["proof_as_of"],
+                    "Terminal Proof As-of",
+                )
+                lower_bound = (
+                    events[-1].observed_at
+                    if events
+                    else static.attempt_opened_at
+                )
+                assert lower_bound is not None
+                _, lower_time = _parse_time(
+                    lower_bound,
+                    "Last admitted observation",
+                )
+                if terminal_time < lower_time:
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_TERMINAL_CUTOFF_INVALID",
+                        repair_action="TIMESTAMP_CHANGE",
+                    )
             if set(payload) == diagnostic_fields:
                 if (
                     boundary != "A1_CAPTURE"
@@ -1474,12 +1752,15 @@ def _project_records(
                 a1_proposal_diagnostic = diagnostic
             continue
         if record.kind == "TRACE_COMPLETED":
-            if set(payload) != {
+            completion_fields = {
                 "trace_event_count",
                 "trace_chain_head_sha256",
                 "runtime_provenance_id",
                 "no_repair_verified",
-            } or (
+            }
+            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+                completion_fields.add("proof_as_of")
+            if set(payload) != completion_fields or (
                 len(events) != len(_STAGES)
                 or run_2 is None
                 or a3_reuse_event_id is None
@@ -1493,6 +1774,20 @@ def _project_records(
                     "CREATOR_LIVE_COMPLETION_RECORD_INVALID",
                     repair_action="RECEIPT_REWRITE",
                 )
+            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+                terminal_proof_as_of, terminal_time = _parse_time(
+                    payload["proof_as_of"],
+                    "Terminal Proof As-of",
+                )
+                _, last_time = _parse_time(
+                    events[-1].observed_at,
+                    "Last admitted observation",
+                )
+                if terminal_time < last_time:
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_TERMINAL_CUTOFF_INVALID",
+                        repair_action="TIMESTAMP_CHANGE",
+                    )
             state = "TRACE_COMPLETE"
             continue
         raise _JournalIntegrityError(
@@ -1505,7 +1800,7 @@ def _project_records(
         if state == "OPEN" and len(events) < len(_STAGES)
         else None
     )
-    return FieldNoteCreatorLiveTraceReadback._create(
+    readback_fields = dict(
         authority=_READBACK_AUTHORITY,
         attempt=static.attempt,
         source_repository=static.repository,
@@ -1533,6 +1828,18 @@ def _project_records(
         anchor_sha256=hashlib.sha256(anchor_raw).hexdigest(),
         durable_readback_verified=True,
     )
+    if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+        assert isinstance(static.attempt, FieldNoteCreatorLiveAttempt)
+        assert static.attempt_opened_at is not None
+        return FieldNoteCreatorLiveTraceReadbackV2._create_v2(
+            authorization_observed_at=(
+                static.attempt.authorization_observed_at
+            ),
+            attempt_opened_at=static.attempt_opened_at,
+            terminal_proof_as_of=terminal_proof_as_of,
+            **readback_fields,
+        )
+    return FieldNoteCreatorLiveTraceReadback._create(**readback_fields)
 
 
 def _failed_readback(
@@ -1543,7 +1850,7 @@ def _failed_readback(
     reason: str,
     repair_action: RepairAction,
 ) -> FieldNoteCreatorLiveTraceReadback:
-    return FieldNoteCreatorLiveTraceReadback._create(
+    fields = dict(
         authority=_READBACK_AUTHORITY,
         attempt=static.attempt,
         source_repository=static.repository,
@@ -1571,6 +1878,18 @@ def _failed_readback(
         anchor_sha256=hashlib.sha256(anchor_raw).hexdigest(),
         durable_readback_verified=False,
     )
+    if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+        assert isinstance(static.attempt, FieldNoteCreatorLiveAttempt)
+        assert static.attempt_opened_at is not None
+        return FieldNoteCreatorLiveTraceReadbackV2._create_v2(
+            authorization_observed_at=(
+                static.attempt.authorization_observed_at
+            ),
+            attempt_opened_at=static.attempt_opened_at,
+            terminal_proof_as_of=None,
+            **fields,
+        )
+    return FieldNoteCreatorLiveTraceReadback._create(**fields)
 
 
 class FieldNoteCreatorLiveProofRuntime:
@@ -1588,8 +1907,17 @@ class FieldNoteCreatorLiveProofRuntime:
         static: _StaticIdentity,
     ) -> None:
         self._storage_root = storage_root
-        self._journal_path = storage_root / CREATOR_LIVE_JOURNAL_FILENAME
-        self._anchor_path = storage_root / CREATOR_LIVE_ANCHOR_FILENAME
+        is_v2 = static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2
+        self._journal_path = storage_root / (
+            CREATOR_LIVE_JOURNAL_FILENAME_V2
+            if is_v2
+            else CREATOR_LIVE_JOURNAL_FILENAME
+        )
+        self._anchor_path = storage_root / (
+            CREATOR_LIVE_ANCHOR_FILENAME_V2
+            if is_v2
+            else CREATOR_LIVE_ANCHOR_FILENAME
+        )
         self._static = static
         self._lock = threading.Lock()
 
@@ -1606,30 +1934,32 @@ class FieldNoteCreatorLiveProofRuntime:
         cls,
         storage_root: Path,
         *,
-        attempt: FieldNoteWholeFlowAttempt,
+        attempt: FieldNoteCreatorLiveAttempt,
         source_repository: FieldNoteSourceRepositoryIdentity,
-        run_1: FieldNoteWholeFlowRunIdentity,
+        run_1_id: str,
+        runtime: CodexRuntimeIdentity,
     ) -> FieldNoteCreatorLiveProofRuntime:
-        if not isinstance(attempt, FieldNoteWholeFlowAttempt) or (
-            attempt.proof_mode != "CREATOR_LIVE"
-        ):
+        if not isinstance(attempt, FieldNoteCreatorLiveAttempt):
             raise FieldNoteCreatorLiveValidationError(
-                "Creator-live runtime requires a CREATOR_LIVE attempt."
+                "Creator-live runtime requires a forward-only attempt."
             )
         if not isinstance(
             source_repository,
             FieldNoteSourceRepositoryIdentity,
-        ) or not isinstance(run_1, FieldNoteWholeFlowRunIdentity):
+        ) or not isinstance(runtime, CodexRuntimeIdentity):
             raise FieldNoteCreatorLiveValidationError(
                 "Creator-live runtime identity is not typed."
             )
         if (
-            run_1.proof_attempt_id != attempt.proof_attempt_id
-            or run_1.repository != source_repository
+            not isinstance(run_1_id, str)
+            or not run_1_id.strip()
+            or len(run_1_id) > 256
+            or "\x00" in run_1_id
         ):
             raise FieldNoteCreatorLiveValidationError(
-                "Run 1 is cross-bound to the creator-live attempt."
+                "Creator-live Run 1 ID is invalid."
             )
+        run_1_id = run_1_id.strip()
         root = Path(storage_root)
         if not root.is_absolute():
             raise FieldNoteCreatorLiveValidationError(
@@ -1640,27 +1970,70 @@ class FieldNoteCreatorLiveProofRuntime:
                 "Creator-live storage root cannot be a symlink."
             )
         root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if any(
+            (root / filename).exists()
+            for filename in (
+                CREATOR_LIVE_JOURNAL_FILENAME,
+                CREATOR_LIVE_ANCHOR_FILENAME,
+                CREATOR_LIVE_JOURNAL_FILENAME_V2,
+                CREATOR_LIVE_ANCHOR_FILENAME_V2,
+            )
+        ):
+            raise FieldNoteCreatorLiveAttemptExistsError(
+                "Creator-live one-attempt storage already exists."
+            )
+        attempt_opened_at, opened_time = _parse_time(
+            _utc_now_rfc3339(),
+            "Attempt opening time",
+        )
+        _, authorization_time = _parse_time(
+            attempt.authorization_observed_at,
+            "Authorization observation",
+        )
+        if authorization_time > opened_time:
+            raise FieldNoteCreatorLiveValidationError(
+                "Authorization observation follows attempt opening."
+            )
+        run_1_started_at, run_time = _parse_time(
+            _utc_now_rfc3339(),
+            "Run 1 start",
+        )
+        if opened_time >= run_time:
+            raise FieldNoteCreatorLiveValidationError(
+                "Attempt opening must precede Run 1."
+            )
+        run_1 = FieldNoteWholeFlowRunIdentity(
+            proof_attempt_id=attempt.proof_attempt_id,
+            run_id=run_1_id,
+            started_at=run_1_started_at,
+            repository=source_repository,
+            runtime=runtime,
+        )
         provenance = FieldNoteCreatorLiveRuntimeProvenance._issue(
             authority=_RUNTIME_PROVENANCE_AUTHORITY,
             proof_attempt_id=attempt.proof_attempt_id,
             source_repository=source_repository,
-            runtime=run_1.runtime,
+            runtime=runtime,
             issued_for_run_1_id=run_1.run_id,
         )
         static = _StaticIdentity(
             attempt=attempt,
             repository=source_repository,
-            runtime=run_1.runtime,
+            runtime=runtime,
             run_1=run_1,
             provenance=provenance,
+            journal_schema=CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+            record_schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
+            anchor_schema=CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+            attempt_opened_at=attempt_opened_at,
         )
         payload = {
-            "journal_schema": CREATOR_LIVE_JOURNAL_SCHEMA,
+            "journal_schema": CREATOR_LIVE_JOURNAL_SCHEMA_V2,
             "attempt": attempt.as_dict(),
+            "attempt_opened_at": attempt_opened_at,
             "source_repository": source_repository.as_dict(),
-            "runtime": _runtime_as_dict(run_1.runtime),
-            "run_1": run_1.as_dict(),
-            "runtime_provenance": provenance.as_dict(),
+            "runtime": _runtime_as_dict(runtime),
+            "run_1_id": run_1_id,
             "one_attempt_no_retry": True,
         }
         record = _JournalRecord.create(
@@ -1668,8 +2041,19 @@ class FieldNoteCreatorLiveProofRuntime:
             kind="ATTEMPT_OPENED",
             payload=payload,
             previous_record_sha256=JOURNAL_GENESIS_SHA256,
+            schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
         )
-        path = root / CREATOR_LIVE_JOURNAL_FILENAME
+        run_record = _JournalRecord.create(
+            sequence=1,
+            kind="RUN_1_OPENED",
+            payload={
+                "run_1": run_1.as_dict(),
+                "runtime_provenance": provenance.as_dict(),
+            },
+            previous_record_sha256=record.record_sha256,
+            schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
+        )
+        path = root / CREATOR_LIVE_JOURNAL_FILENAME_V2
         try:
             descriptor = os.open(
                 path,
@@ -1681,9 +2065,9 @@ class FieldNoteCreatorLiveProofRuntime:
                 "Creator-live one-attempt journal already exists."
             ) from exc
         try:
-            line = record.serialize_line()
-            written = os.write(descriptor, line)
-            if written != len(line):
+            journal_raw = record.serialize_line() + run_record.serialize_line()
+            written = os.write(descriptor, journal_raw)
+            if written != len(journal_raw):
                 raise FieldNoteCreatorLiveDurabilityError(
                     "Creator-live attempt record write was incomplete."
                 )
@@ -1693,11 +2077,12 @@ class FieldNoteCreatorLiveProofRuntime:
         anchor = _AnchorRecord.create(
             generation=0,
             proof_attempt_id=attempt.proof_attempt_id,
-            journal_raw=line,
-            journal_records=(record,),
+            journal_raw=journal_raw,
+            journal_records=(record, run_record),
             previous_anchor_sha256=ANCHOR_GENESIS_SHA256,
+            schema=CREATOR_LIVE_ANCHOR_SCHEMA_V2,
         )
-        anchor_path = root / CREATOR_LIVE_ANCHOR_FILENAME
+        anchor_path = root / CREATOR_LIVE_ANCHOR_FILENAME_V2
         try:
             anchor_descriptor = os.open(
                 anchor_path,
@@ -1736,8 +2121,14 @@ class FieldNoteCreatorLiveProofRuntime:
         storage_root: Path,
     ) -> FieldNoteCreatorLiveProofRuntime:
         root = Path(storage_root)
-        path = root / CREATOR_LIVE_JOURNAL_FILENAME
-        anchor_path = root / CREATOR_LIVE_ANCHOR_FILENAME
+        v2_path = root / CREATOR_LIVE_JOURNAL_FILENAME_V2
+        v2_anchor = root / CREATOR_LIVE_ANCHOR_FILENAME_V2
+        v1_path = root / CREATOR_LIVE_JOURNAL_FILENAME
+        v1_anchor = root / CREATOR_LIVE_ANCHOR_FILENAME
+        if v2_path.exists() or v2_anchor.exists():
+            path, anchor_path = v2_path, v2_anchor
+        else:
+            path, anchor_path = v1_path, v1_anchor
         journal_raw = path.read_bytes()
         anchor_raw = anchor_path.read_bytes()
         records = _parse_records(journal_raw)
@@ -1815,6 +2206,10 @@ class FieldNoteCreatorLiveProofRuntime:
         kind: JournalRecordKind,
         payload: dict[str, Any],
     ) -> FieldNoteCreatorLiveTraceReadback:
+        if self._static.journal_schema != CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            raise FieldNoteCreatorLiveStageError(
+                "Historical v0.1 creator-live attempts are read-only."
+            )
         with self._lock:
             journal_descriptor: int | None = None
             try:
@@ -1865,6 +2260,7 @@ class FieldNoteCreatorLiveProofRuntime:
                     kind=kind,
                     payload=payload,
                     previous_record_sha256=records[-1].record_sha256,
+                    schema=self._static.record_schema,
                 )
                 line = record.serialize_line()
                 written = os.write(journal_descriptor, line)
@@ -1881,6 +2277,7 @@ class FieldNoteCreatorLiveProofRuntime:
                     journal_raw=next_journal_raw,
                     journal_records=next_records,
                     previous_anchor_sha256=anchors[-1].anchor_sha256,
+                    schema=self._static.anchor_schema,
                 )
                 anchor_line = anchor.serialize_line()
                 anchor_written = os.write(anchor_descriptor, anchor_line)
@@ -1934,6 +2331,10 @@ class FieldNoteCreatorLiveProofRuntime:
             "failure_reason": bounded,
             "repair_action": repair_action,
         }
+        if self._static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            payload["proof_as_of"] = self._runtime_terminal_proof_as_of(
+                readback
+            )
         if proposal_diagnostic is not None:
             payload.update(
                 {
@@ -1949,6 +2350,33 @@ class FieldNoteCreatorLiveProofRuntime:
             )
         self._append("ATTEMPT_FAILED", payload)
         raise FieldNoteCreatorLiveStageError(bounded)
+
+    def _runtime_terminal_proof_as_of(
+        self,
+        readback: FieldNoteCreatorLiveTraceReadback,
+    ) -> str:
+        proof_as_of, proof_time = _parse_time(
+            _utc_now_rfc3339(),
+            "Terminal Proof As-of",
+        )
+        lower_bound = (
+            readback.events[-1].observed_at
+            if readback.events
+            else self._static.attempt_opened_at
+        )
+        if lower_bound is None:
+            raise FieldNoteCreatorLiveValidationError(
+                "Terminal Proof As-of lacks an opening lower bound."
+            )
+        _, lower_time = _parse_time(
+            lower_bound,
+            "Last admitted observation",
+        )
+        if proof_time < lower_time:
+            raise FieldNoteCreatorLiveValidationError(
+                "Terminal Proof As-of precedes admitted evidence."
+            )
+        return proof_as_of
 
     def _require_stage(self, stage: TraceStage) -> FieldNoteCreatorLiveTraceReadback:
         readback = self.read_back()
@@ -2007,18 +2435,23 @@ class FieldNoteCreatorLiveProofRuntime:
         )
         if stage == "A6_REVIEW":
             completed = self.read_back()
+            completion_payload = {
+                "trace_event_count": len(_STAGES),
+                "trace_chain_head_sha256": (
+                    completed.trace_chain_head_sha256
+                ),
+                "runtime_provenance_id": (
+                    self._static.provenance.runtime_provenance_id
+                ),
+                "no_repair_verified": True,
+            }
+            if self._static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+                completion_payload["proof_as_of"] = (
+                    self._runtime_terminal_proof_as_of(completed)
+                )
             self._append(
                 "TRACE_COMPLETED",
-                {
-                    "trace_event_count": len(_STAGES),
-                    "trace_chain_head_sha256": (
-                        completed.trace_chain_head_sha256
-                    ),
-                    "runtime_provenance_id": (
-                        self._static.provenance.runtime_provenance_id
-                    ),
-                    "no_repair_verified": True,
-                },
+                completion_payload,
             )
         return event
 
@@ -2141,7 +2574,14 @@ class FieldNoteCreatorLiveProofRuntime:
             draft_created_at=draft.created_at,
             save_as_of=capture_commit.save_as_of,
             observed_at=checkpoint_observed_at,
-            proof_as_of=self._static.attempt.proof_as_of,
+            proof_as_of=(
+                self._static.attempt.proof_as_of
+                if isinstance(
+                    self._static.attempt,
+                    FieldNoteWholeFlowAttempt,
+                )
+                else None
+            ),
         ):
             self._terminal_failure(
                 "A1_CAPTURE",

--- a/decision_os/companion/field_notes_creator_live_capture.py
+++ b/decision_os/companion/field_notes_creator_live_capture.py
@@ -27,6 +27,7 @@ from decision_os.companion.field_notes_creator_live import (
     FieldNoteCreatorLiveA1CaptureCommitReceipt,
     FieldNoteCreatorLiveProofRuntime,
     FieldNoteCreatorLiveStageError,
+    FieldNoteCreatorLiveTraceReadbackV2,
     _A1_CAPTURE_COMMIT_AUTHORITY,
 )
 from decision_os.companion.field_notes_model import (
@@ -123,7 +124,9 @@ class FieldNoteCreatorLiveA1CaptureBridge:
         readback = self.runtime.read_back()
         if (
             not readback.durable_readback_verified
+            or not isinstance(readback, FieldNoteCreatorLiveTraceReadbackV2)
             or readback.state != "OPEN"
+            or readback.terminal_proof_as_of is not None
             or readback.current_stage != "A1_CAPTURE"
             or readback.trace_event_count != 0
             or readback.run_2 is not None

--- a/decision_os/companion/field_notes_whole_flow.py
+++ b/decision_os/companion/field_notes_whole_flow.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
 
 WHOLE_FLOW_SCHEMA = "decision-os.field-note-whole-flow-proof.v0.1"
+WHOLE_FLOW_SCHEMA_V2 = "decision-os.field-note-whole-flow-proof.v0.2"
 WHOLE_FLOW_TRACE_SCHEMA = "decision-os.field-note-whole-flow-trace-event.v0.1"
 WAREHOUSE_MANIFEST_SCHEMA = (
     "decision-os.portable-candidate-warehouse-manifest.v0.1"
@@ -207,7 +208,7 @@ class FieldNoteSourceRepositoryIdentity:
 
 @dataclass(frozen=True)
 class FieldNoteWholeFlowAttempt:
-    """Caller-supplied identity and explicit As-of for one bounded proof."""
+    """Historical v0.1 or fixture identity with an explicit proof cutoff."""
 
     proof_attempt_id: str
     proof_mode: WholeFlowMode
@@ -238,6 +239,49 @@ class FieldNoteWholeFlowAttempt:
             "proof_mode": self.proof_mode,
             "creator_id": self.creator_id,
             "proof_as_of": self.proof_as_of,
+        }
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveAttempt:
+    """Forward-only creator-live identity carrying authorization evidence."""
+
+    proof_attempt_id: str
+    proof_mode: Literal["CREATOR_LIVE"]
+    creator_id: str
+    authorization_observed_at: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "proof_attempt_id",
+            _bounded_text(self.proof_attempt_id, "Proof attempt ID"),
+        )
+        object.__setattr__(
+            self,
+            "creator_id",
+            _bounded_text(self.creator_id, "Creator identity"),
+        )
+        if self.proof_mode != "CREATOR_LIVE":
+            raise FieldNoteWholeFlowValidationError(
+                "Creator-live attempt mode is invalid."
+            )
+        normalized, _ = _parse_time(
+            self.authorization_observed_at,
+            "Authorization observation",
+        )
+        object.__setattr__(
+            self,
+            "authorization_observed_at",
+            normalized,
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "proof_attempt_id": self.proof_attempt_id,
+            "proof_mode": self.proof_mode,
+            "creator_id": self.creator_id,
+            "authorization_observed_at": self.authorization_observed_at,
         }
 
 
@@ -499,7 +543,7 @@ class FieldNoteWholeFlowTraceEvent:
 class FieldNoteWholeFlowEvidenceBundle:
     """Existing A1-A6 values plus the smallest typed no-repair trace."""
 
-    attempt: FieldNoteWholeFlowAttempt
+    attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt
     source_repository: FieldNoteSourceRepositoryIdentity
     run_1: FieldNoteWholeFlowRunIdentity
     run_2: FieldNoteWholeFlowRunIdentity
@@ -515,8 +559,14 @@ class FieldNoteWholeFlowEvidenceBundle:
     creator_live_readback: FieldNoteCreatorLiveTraceReadback | None = None
 
     def __post_init__(self) -> None:
+        if not isinstance(
+            self.attempt,
+            (FieldNoteWholeFlowAttempt, FieldNoteCreatorLiveAttempt),
+        ):
+            raise FieldNoteWholeFlowValidationError(
+                "Whole-Flow bundle lacks a typed proof attempt."
+            )
         required = (
-            (self.attempt, FieldNoteWholeFlowAttempt, "proof attempt"),
             (
                 self.source_repository,
                 FieldNoteSourceRepositoryIdentity,
@@ -649,7 +699,10 @@ class FieldNoteWholeFlowClaimBoundary:
 class FieldNoteWholeFlowProofReceipt:
     """Deterministic bounded result of verifying one exact A1-A6 lineage."""
 
-    schema: Literal["decision-os.field-note-whole-flow-proof.v0.1"]
+    schema: Literal[
+        "decision-os.field-note-whole-flow-proof.v0.1",
+        "decision-os.field-note-whole-flow-proof.v0.2",
+    ]
     proof_attempt_id: str
     proof_mode: WholeFlowMode
     proof_as_of: str
@@ -698,7 +751,7 @@ class FieldNoteWholeFlowProofReceipt:
     claim_boundary: FieldNoteWholeFlowClaimBoundary
 
     def __post_init__(self) -> None:
-        if self.schema != WHOLE_FLOW_SCHEMA:
+        if self.schema not in {WHOLE_FLOW_SCHEMA, WHOLE_FLOW_SCHEMA_V2}:
             raise FieldNoteWholeFlowValidationError(
                 "Whole-Flow receipt schema is unsupported."
             )
@@ -810,6 +863,7 @@ class FieldNoteWholeFlowProofReceipt:
         if self.creator_live_readback is not None:
             from decision_os.companion.field_notes_creator_live import (
                 FieldNoteCreatorLiveTraceReadback,
+                FieldNoteCreatorLiveTraceReadbackV2,
             )
 
             if not isinstance(
@@ -818,6 +872,27 @@ class FieldNoteWholeFlowProofReceipt:
             ):
                 raise FieldNoteWholeFlowValidationError(
                     "Receipt creator-live durable read-back is not typed."
+                )
+            if self.schema == WHOLE_FLOW_SCHEMA_V2:
+                if (
+                    not isinstance(
+                        self.creator_live_readback,
+                        FieldNoteCreatorLiveTraceReadbackV2,
+                    )
+                    or self.creator_live_readback.state
+                    not in {"FAILED", "TRACE_COMPLETE"}
+                    or self.creator_live_readback.terminal_proof_as_of
+                    != self.proof_as_of
+                ):
+                    raise FieldNoteWholeFlowValidationError(
+                        "v0.2 receipt terminal cutoff is not runtime-bound."
+                    )
+            elif isinstance(
+                self.creator_live_readback,
+                FieldNoteCreatorLiveTraceReadbackV2,
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "v0.1 receipt cannot reinterpret v0.2 read-back."
                 )
         if (
             self.proof_mode == "FIXTURE"
@@ -1087,9 +1162,19 @@ class FieldNoteWholeFlowProofReceipt:
             previous_time = event_time
 
     @property
-    def attempt(self) -> FieldNoteWholeFlowAttempt:
+    def attempt(self) -> FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt:
         """Return the exact typed attempt identity preserved by this receipt."""
 
+        if self.schema == WHOLE_FLOW_SCHEMA_V2:
+            readback = self.creator_live_readback
+            if readback is None or not isinstance(
+                readback.attempt,
+                FieldNoteCreatorLiveAttempt,
+            ):
+                raise FieldNoteWholeFlowValidationError(
+                    "v0.2 receipt lacks its creator-live attempt identity."
+                )
+            return readback.attempt
         return FieldNoteWholeFlowAttempt(
             proof_attempt_id=self.proof_attempt_id,
             proof_mode=self.proof_mode,
@@ -1181,7 +1266,11 @@ class FieldNoteWholeFlowProofReceipt:
     def render_text(self) -> str:
         return "\n".join(
             (
-                "Field Note Whole-Flow Proof Receipt v0.1",
+                (
+                    "Field Note Whole-Flow Proof Receipt v0.2"
+                    if self.schema == WHOLE_FLOW_SCHEMA_V2
+                    else "Field Note Whole-Flow Proof Receipt v0.1"
+                ),
                 f"State: {self.state}",
                 f"Proof mode: {self.proof_mode}",
                 f"Proof As-of: {self.proof_as_of}",
@@ -1472,6 +1561,22 @@ def _outcome_summary(packet: FieldNoteMaturityReviewPacket) -> FieldNoteOutcomeS
     )
 
 
+def _bundle_proof_as_of(bundle: FieldNoteWholeFlowEvidenceBundle) -> str:
+    if isinstance(bundle.attempt, FieldNoteCreatorLiveAttempt):
+        readback = bundle.creator_live_readback
+        terminal = (
+            getattr(readback, "terminal_proof_as_of", None)
+            if readback is not None
+            else None
+        )
+        if terminal is None:
+            raise FieldNoteWholeFlowValidationError(
+                "Forward-only creator-live proof is not terminal."
+            )
+        return _parse_time(terminal, "Terminal Proof As-of")[0]
+    return bundle.attempt.proof_as_of
+
+
 def _receipt(
     bundle: FieldNoteWholeFlowEvidenceBundle,
     *,
@@ -1498,10 +1603,14 @@ def _receipt(
     )
     a1_draft_sha256 = _a1_evidence_sha256(a1) if a1 else None
     return FieldNoteWholeFlowProofReceipt(
-        schema=WHOLE_FLOW_SCHEMA,
+        schema=(
+            WHOLE_FLOW_SCHEMA_V2
+            if isinstance(bundle.attempt, FieldNoteCreatorLiveAttempt)
+            else WHOLE_FLOW_SCHEMA
+        ),
         proof_attempt_id=bundle.attempt.proof_attempt_id,
         proof_mode=bundle.attempt.proof_mode,
-        proof_as_of=bundle.attempt.proof_as_of,
+        proof_as_of=_bundle_proof_as_of(bundle),
         creator_id=bundle.attempt.creator_id,
         source_repository=bundle.source_repository,
         source_runtime=bundle.run_1.runtime,
@@ -1764,7 +1873,7 @@ def verify_field_note_whole_flow(
             "A1 checkpoint observation",
         )
         _, proof_time = _parse_time(
-            bundle.attempt.proof_as_of,
+            _bundle_proof_as_of(bundle),
             "Proof As-of",
         )
         if not (
@@ -1915,7 +2024,7 @@ def verify_field_note_whole_flow(
     _, review_time = _parse_time(a6.review_as_of, "A6 Review As-of")
     if review_time < max(recorded_time, use_time, outcome_time):
         return _fail(bundle, "A6_REVIEW", "A6_FUTURE_DATED_EVIDENCE")
-    _, proof_time = _parse_time(bundle.attempt.proof_as_of, "Proof As-of")
+    _, proof_time = _parse_time(_bundle_proof_as_of(bundle), "Proof As-of")
     if proof_time < review_time:
         return _fail(bundle, "PROOF_AS_OF", "PROOF_AS_OF_PRECEDES_A6_REVIEW")
 

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -92,10 +92,19 @@ class CreatorLiveTestCase(unittest.TestCase):
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
         self.bundle, self.ledger = build_bundle(self.root / "evidence")
-        self.live_attempt = replace(
-            self.bundle.attempt,
+        self.live_attempt = whole_flow.FieldNoteCreatorLiveAttempt(
+            proof_attempt_id=self.bundle.attempt.proof_attempt_id,
             proof_mode="CREATOR_LIVE",
+            creator_id=self.bundle.attempt.creator_id,
+            authorization_observed_at="2026-08-05T09:58:00Z",
         )
+        terminal_clock = patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value="2026-08-05T12:00:00Z",
+        )
+        terminal_clock.start()
+        self.addCleanup(terminal_clock.stop)
 
     def open_runtime(
         self,
@@ -104,13 +113,24 @@ class CreatorLiveTestCase(unittest.TestCase):
         bundle=None,
     ) -> FieldNoteCreatorLiveProofRuntime:
         evidence = bundle or self.bundle
-        attempt = replace(evidence.attempt, proof_mode="CREATOR_LIVE")
-        return FieldNoteCreatorLiveProofRuntime.open_attempt(
-            self.root / label,
-            attempt=attempt,
-            source_repository=evidence.source_repository,
-            run_1=evidence.run_1,
+        attempt = whole_flow.FieldNoteCreatorLiveAttempt(
+            proof_attempt_id=evidence.attempt.proof_attempt_id,
+            proof_mode="CREATOR_LIVE",
+            creator_id=evidence.attempt.creator_id,
+            authorization_observed_at="2026-08-05T09:58:00Z",
         )
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=("2026-08-05T09:59:00Z", evidence.run_1.started_at),
+        ):
+            return FieldNoteCreatorLiveProofRuntime.open_attempt(
+                self.root / label,
+                attempt=attempt,
+                source_repository=evidence.source_repository,
+                run_1_id=evidence.run_1.run_id,
+                runtime=evidence.run_1.runtime,
+            )
 
     def record_a1(
         self,
@@ -223,7 +243,7 @@ class CreatorLiveTestCase(unittest.TestCase):
         with patch.object(
             creator_live,
             "_utc_now_rfc3339",
-            side_effect=OBSERVED_AT,
+            side_effect=(*OBSERVED_AT, "2026-08-05T12:00:00Z"),
         ):
             runtime_path.record_a1_capture(
                 evidence.a1_capture,
@@ -254,7 +274,8 @@ class CreatorLiveTestCase(unittest.TestCase):
         evidence = bundle or self.bundle
         return replace(
             evidence,
-            attempt=replace(evidence.attempt, proof_mode="CREATOR_LIVE"),
+            attempt=readback.attempt,
+            run_1=readback.run_1,
             proof_trace=readback.events,
             creator_live_readback=readback,
         )
@@ -275,7 +296,10 @@ class CreatorLiveProvenanceTests(CreatorLiveTestCase):
         self.assertIsNone(receipt.a1_capture_commit_sha256)
 
     def test_hand_built_trace_cannot_satisfy_creator_live(self) -> None:
-        live = replace(self.bundle, attempt=self.live_attempt)
+        live = replace(
+            self.bundle,
+            attempt=replace(self.bundle.attempt, proof_mode="CREATOR_LIVE"),
+        )
         receipt = verify_field_note_whole_flow(live)
         self.assertEqual("NOT_READY", receipt.state)
         self.assertEqual(
@@ -313,6 +337,188 @@ class CreatorLiveProvenanceTests(CreatorLiveTestCase):
 
 
 class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
+    def test_runtime_issued_terminal_cutoff_allows_delayed_run_1(self) -> None:
+        authorization_observed_at = "2026-08-05T08:00:00Z"
+        attempt_opened_at = "2026-08-05T09:59:00Z"
+        run_1_started_at = "2026-08-05T10:00:00Z"
+        terminal_proof_as_of = "2026-08-05T10:03:00Z"
+        attempt = whole_flow.FieldNoteCreatorLiveAttempt(
+            proof_attempt_id=self.bundle.attempt.proof_attempt_id,
+            proof_mode="CREATOR_LIVE",
+            creator_id=self.bundle.attempt.creator_id,
+            authorization_observed_at=authorization_observed_at,
+        )
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=(attempt_opened_at, run_1_started_at),
+        ):
+            runtime_path = FieldNoteCreatorLiveProofRuntime.open_attempt(
+                self.root / "delayed-run-1",
+                attempt=attempt,
+                source_repository=self.bundle.source_repository,
+                run_1_id=self.bundle.run_1.run_id,
+                runtime=self.bundle.run_1.runtime,
+            )
+
+        assert self.bundle.a1_capture is not None
+        runtime_path.record_a1_capture(
+            self.bundle.a1_capture,
+            capture_commit=self.capture_commit(
+                runtime_path,
+                self.bundle.a1_capture,
+            ),
+            expected_task_sha256=RUN_1_TASK_SHA256,
+            actual_runtime_identity=self.bundle.run_1.runtime,
+            observed_at=OBSERVED_AT[0],
+        )
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value=terminal_proof_as_of,
+        ):
+            with self.assertRaises(FieldNoteCreatorLiveStageError):
+                runtime_path.record_stage_failure(
+                    "A2_RECONNECT",
+                    "DELAYED_RUN_1_TEST_TERMINAL",
+                )
+
+        readback = runtime_path.read_back()
+        self.assertEqual(authorization_observed_at, readback.authorization_observed_at)
+        self.assertEqual(attempt_opened_at, readback.attempt_opened_at)
+        self.assertEqual(run_1_started_at, readback.run_1.started_at)
+        self.assertEqual(OBSERVED_AT[0], readback.last_admitted_observation)
+        self.assertEqual(terminal_proof_as_of, readback.terminal_proof_as_of)
+        self.assertEqual("FAILED", readback.state)
+        self.assertLess(
+            readback.authorization_observed_at,
+            readback.attempt_opened_at,
+        )
+        self.assertLess(readback.attempt_opened_at, readback.run_1.started_at)
+        self.assertLess(readback.run_1.started_at, self.bundle.a1_capture.created_at)
+        self.assertLessEqual(
+            self.bundle.a1_capture.created_at,
+            readback.a1_capture_commit.save_as_of,
+        )
+        self.assertLessEqual(
+            readback.a1_capture_commit.save_as_of,
+            readback.last_admitted_observation,
+        )
+        self.assertLessEqual(
+            readback.last_admitted_observation,
+            readback.terminal_proof_as_of,
+        )
+
+    def test_open_readback_has_no_guessed_terminal_cutoff(self) -> None:
+        runtime_path = self.open_runtime("open-time-authorities")
+        readback = runtime_path.read_back()
+        self.assertEqual(creator_live.CREATOR_LIVE_READBACK_SCHEMA_V2, readback.schema)
+        self.assertEqual(
+            readback.attempt.authorization_observed_at,
+            readback.authorization_observed_at,
+        )
+        self.assertLessEqual(
+            readback.authorization_observed_at,
+            readback.attempt_opened_at,
+        )
+        self.assertLess(readback.attempt_opened_at, readback.run_1.started_at)
+        self.assertIsNone(readback.terminal_proof_as_of)
+        self.assertIsNone(readback.last_admitted_observation)
+        self.assertEqual(
+            creator_live.CREATOR_LIVE_JOURNAL_FILENAME_V2,
+            runtime_path.journal_path.name,
+        )
+        self.assertNotIn(
+            b'"proof_as_of"',
+            runtime_path.journal_path.read_bytes(),
+        )
+
+    def test_authorization_after_attempt_opening_is_rejected(self) -> None:
+        attempt = whole_flow.FieldNoteCreatorLiveAttempt(
+            proof_attempt_id=self.bundle.attempt.proof_attempt_id,
+            proof_mode="CREATOR_LIVE",
+            creator_id=self.bundle.attempt.creator_id,
+            authorization_observed_at="2026-08-05T10:00:00Z",
+        )
+        root = self.root / "authorization-after-opening"
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=("2026-08-05T09:59:00Z", "2026-08-05T10:01:00Z"),
+        ):
+            with self.assertRaises(FieldNoteCreatorLiveValidationError):
+                FieldNoteCreatorLiveProofRuntime.open_attempt(
+                    root,
+                    attempt=attempt,
+                    source_repository=self.bundle.source_repository,
+                    run_1_id=self.bundle.run_1.run_id,
+                    runtime=self.bundle.run_1.runtime,
+                )
+        self.assertFalse((root / creator_live.CREATOR_LIVE_JOURNAL_FILENAME_V2).exists())
+
+    def test_attempt_opening_not_before_run_1_is_rejected(self) -> None:
+        root = self.root / "opening-after-run"
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=("2026-08-05T10:00:00Z", "2026-08-05T10:00:00Z"),
+        ):
+            with self.assertRaises(FieldNoteCreatorLiveValidationError):
+                FieldNoteCreatorLiveProofRuntime.open_attempt(
+                    root,
+                    attempt=self.live_attempt,
+                    source_repository=self.bundle.source_repository,
+                    run_1_id=self.bundle.run_1.run_id,
+                    runtime=self.bundle.run_1.runtime,
+                )
+        self.assertFalse((root / creator_live.CREATOR_LIVE_JOURNAL_FILENAME_V2).exists())
+
+    def test_failure_before_first_checkpoint_gets_terminal_cutoff(self) -> None:
+        runtime_path = self.open_runtime("failure-before-checkpoint")
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value="2026-08-05T10:00:00Z",
+        ):
+            with self.assertRaises(FieldNoteCreatorLiveStageError):
+                runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        readback = runtime_path.read_back()
+        self.assertEqual("2026-08-05T10:00:00Z", readback.terminal_proof_as_of)
+        self.assertIsNone(readback.last_admitted_observation)
+        self.assertLessEqual(
+            readback.attempt_opened_at,
+            readback.terminal_proof_as_of,
+        )
+
+    def test_terminal_cutoff_is_immutable_across_load_and_append(self) -> None:
+        runtime_path = self.open_runtime("immutable-terminal")
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        before = runtime_path.journal_path.read_bytes()
+        first = runtime_path.read_back()
+        loaded = FieldNoteCreatorLiveProofRuntime.load_attempt(
+            runtime_path.journal_path.parent
+        )
+        second = loaded.read_back()
+        self.assertEqual(first.terminal_proof_as_of, second.terminal_proof_as_of)
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            loaded.record_stage_failure("A1_CAPTURE", "OTHER_FAILURE")
+        self.assertEqual(before, runtime_path.journal_path.read_bytes())
+
+    def test_terminal_cutoff_byte_change_fails_durable_readback(self) -> None:
+        runtime_path = self.open_runtime("changed-terminal-cutoff")
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        raw = runtime_path.journal_path.read_bytes()
+        original = b'"proof_as_of":"2026-08-05T12:00:00Z"'
+        changed = b'"proof_as_of":"2026-08-05T12:00:01Z"'
+        self.assertIn(original, raw)
+        runtime_path.journal_path.write_bytes(raw.replace(original, changed, 1))
+        readback = runtime_path.read_back()
+        self.assertEqual("FAILED", readback.state)
+        self.assertFalse(readback.durable_readback_verified)
+        self.assertIsNone(readback.terminal_proof_as_of)
+
     def test_draft_alone_cannot_emit_a1_checkpoint(self) -> None:
         runtime_path = self.open_runtime()
         assert self.bundle.a1_capture is not None
@@ -437,25 +643,31 @@ class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
             )
         self.assertEqual(0, runtime_path.read_back().trace_event_count)
 
-    def test_save_after_proof_as_of_is_temporally_rejected(self) -> None:
+    def test_terminal_cutoff_before_a1_observation_is_rejected(self) -> None:
         assert self.bundle.a1_capture is not None
         runtime_path = self.open_runtime("save-after-proof")
         commit = self.reissue_capture_commit(
             self.capture_commit(runtime_path, self.bundle.a1_capture),
             save_as_of="2026-08-05T12:01:00Z",
         )
-        with self.assertRaises(FieldNoteCreatorLiveStageError):
-            runtime_path.record_a1_capture(
-                self.bundle.a1_capture,
-                capture_commit=commit,
-                expected_task_sha256=RUN_1_TASK_SHA256,
-                actual_runtime_identity=runtime_path.read_back().runtime,
-                observed_at="2026-08-05T12:01:00Z",
-            )
-        self.assertEqual(
-            "A1_CAPTURE_CHRONOLOGY_INVALID",
-            runtime_path.read_back().failure_reason,
+        runtime_path.record_a1_capture(
+            self.bundle.a1_capture,
+            capture_commit=commit,
+            expected_task_sha256=RUN_1_TASK_SHA256,
+            actual_runtime_identity=runtime_path.read_back().runtime,
+            observed_at="2026-08-05T12:01:00Z",
         )
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value="2026-08-05T12:00:00Z",
+        ):
+            with self.assertRaises(FieldNoteCreatorLiveValidationError):
+                runtime_path.record_stage_failure(
+                    "A2_RECONNECT",
+                    "TERMINAL_CUTOFF_TEST",
+                )
+        self.assertEqual("OPEN", runtime_path.read_back().state)
 
     def test_checkpoint_observation_before_save_is_temporally_rejected(self) -> None:
         assert self.bundle.a1_capture is not None
@@ -678,7 +890,8 @@ class CreatorLiveAttemptStateTests(CreatorLiveTestCase):
                 runtime_path.journal_path.parent,
                 attempt=self.live_attempt,
                 source_repository=self.bundle.source_repository,
-                run_1=self.bundle.run_1,
+                run_1_id=self.bundle.run_1.run_id,
+                runtime=self.bundle.run_1.runtime,
             )
         self.assertEqual("OPEN", runtime_path.read_back().state)
 
@@ -969,6 +1182,83 @@ class CreatorLiveStageAcquisitionTests(CreatorLiveTestCase):
 
 
 class CreatorLiveDurabilityTests(CreatorLiveTestCase):
+    def test_historical_v0_1_artifacts_remain_byte_exact_and_read_only(self) -> None:
+        root = self.root / "historical-v0-1"
+        root.mkdir()
+        attempt = whole_flow.FieldNoteWholeFlowAttempt(
+            proof_attempt_id=self.bundle.attempt.proof_attempt_id,
+            proof_mode="CREATOR_LIVE",
+            creator_id=self.bundle.attempt.creator_id,
+            proof_as_of="2026-08-05T12:00:00Z",
+        )
+        provenance = whole_flow.FieldNoteCreatorLiveRuntimeProvenance._issue(
+            authority=whole_flow._RUNTIME_PROVENANCE_AUTHORITY,
+            proof_attempt_id=attempt.proof_attempt_id,
+            source_repository=self.bundle.source_repository,
+            runtime=self.bundle.run_1.runtime,
+            issued_for_run_1_id=self.bundle.run_1.run_id,
+        )
+        record = creator_live._JournalRecord.create(
+            sequence=0,
+            kind="ATTEMPT_OPENED",
+            payload={
+                "journal_schema": creator_live.CREATOR_LIVE_JOURNAL_SCHEMA,
+                "attempt": attempt.as_dict(),
+                "source_repository": self.bundle.source_repository.as_dict(),
+                "runtime": whole_flow._runtime_as_dict(self.bundle.run_1.runtime),
+                "run_1": self.bundle.run_1.as_dict(),
+                "runtime_provenance": provenance.as_dict(),
+                "one_attempt_no_retry": True,
+            },
+            previous_record_sha256=creator_live.JOURNAL_GENESIS_SHA256,
+        )
+        journal_raw = record.serialize_line()
+        anchor = creator_live._AnchorRecord.create(
+            generation=0,
+            proof_attempt_id=attempt.proof_attempt_id,
+            journal_raw=journal_raw,
+            journal_records=(record,),
+            previous_anchor_sha256=creator_live.ANCHOR_GENESIS_SHA256,
+        )
+        anchor_raw = anchor.serialize_line()
+        journal_path = root / creator_live.CREATOR_LIVE_JOURNAL_FILENAME
+        anchor_path = root / creator_live.CREATOR_LIVE_ANCHOR_FILENAME
+        journal_path.write_bytes(journal_raw)
+        anchor_path.write_bytes(anchor_raw)
+
+        self.assertEqual(
+            "6c154a8df21c4eb25245919e9b672b66d75c893f32b9937191f51881c73d0451",
+            hashlib.sha256(journal_raw).hexdigest(),
+        )
+        self.assertEqual(
+            "d4033bee02d008dd269395663c3e13f04e24cb98c5c62413048aec384db82695",
+            hashlib.sha256(anchor_raw).hexdigest(),
+        )
+        runtime_path = FieldNoteCreatorLiveProofRuntime.load_attempt(root)
+        readback = runtime_path.read_back()
+        self.assertEqual(creator_live.CREATOR_LIVE_READBACK_SCHEMA, readback.schema)
+        self.assertEqual(
+            "e04be488d568651afb7d89f7cc19ec0f5cc558a13460fc1d1e84d2fe9dc5450a",
+            readback.readback_sha256,
+        )
+        self.assertEqual(attempt, readback.attempt)
+        self.assertFalse(hasattr(readback, "terminal_proof_as_of"))
+        receipt = verify_field_note_whole_flow(
+            replace(
+                self.bundle,
+                attempt=attempt,
+                creator_live_readback=readback,
+                proof_trace=(),
+            )
+        )
+        self.assertEqual("NOT_READY", receipt.state)
+        self.assertEqual(whole_flow.WHOLE_FLOW_SCHEMA, receipt.schema)
+        self.assertEqual(attempt.proof_as_of, receipt.proof_as_of)
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A1_CAPTURE", "A1_FAILED")
+        self.assertEqual(journal_raw, journal_path.read_bytes())
+        self.assertEqual(anchor_raw, anchor_path.read_bytes())
+
     def runtime_through_a2(
         self,
         label: str,
@@ -1050,8 +1340,8 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
         self.assertTrue(readback.durable_readback_verified)
         self.assertEqual(diagnostic, readback.a1_proposal_diagnostic)
         self.assertEqual(
-            readback.journal_record_count,
             readback.anchor_record_count,
+            readback.journal_record_count - 1,
         )
         journal = runtime_path.journal_path.read_text(encoding="utf-8")
         anchor = runtime_path.anchor_path.read_text(encoding="utf-8")
@@ -1185,7 +1475,10 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
         self.assertEqual("TRACE_COMPLETE", readback.state)
         self.assertTrue(readback.durable_readback_verified)
         self.assertEqual(6, readback.trace_event_count)
-        self.assertEqual(readback.journal_record_count, readback.anchor_record_count)
+        self.assertEqual(
+            readback.journal_record_count - 1,
+            readback.anchor_record_count,
+        )
         self.assertEqual(
             len(runtime_path.journal_path.read_bytes()),
             readback.journal_byte_length,
@@ -1202,6 +1495,14 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
             readback.events[-1].trace_sha256,
             readback.trace_chain_head_sha256,
         )
+
+    def test_trace_completion_cannot_be_extended(self) -> None:
+        runtime_path, _ = self.complete_runtime("completion-terminal")
+        readback = runtime_path.read_back()
+        before = runtime_path.journal_path.read_bytes()
+        with self.assertRaises(FieldNoteCreatorLiveStageError):
+            runtime_path.record_stage_failure("A6_REVIEW", "LATE_FAILURE")
+        self.assertEqual(before, runtime_path.journal_path.read_bytes())
         loaded = FieldNoteCreatorLiveProofRuntime.load_attempt(
             runtime_path.journal_path.parent
         )
@@ -1263,8 +1564,8 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
             proof_trace=readback.events,
             creator_live_readback=None,
         )
-        receipt = verify_field_note_whole_flow(live)
-        self.assertEqual("NOT_READY", receipt.state)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            verify_field_note_whole_flow(live)
 
     def test_repair_marker_causes_fail(self) -> None:
         runtime_path = self.open_runtime()
@@ -1315,12 +1616,13 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
 
 
 class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):
-    def test_open_attempt_is_not_ready_not_fail(self) -> None:
+    def test_open_attempt_cannot_produce_a_receipt(self) -> None:
         runtime_path = self.open_runtime()
         live = self.live_bundle(runtime_path.read_back())
-        receipt = verify_field_note_whole_flow(live)
-        self.assertEqual("NOT_READY", receipt.state)
-        self.assertEqual("CREATOR_LIVE_TRACE_INCOMPLETE", receipt.failure_reason)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            verify_field_note_whole_flow(live)
+        with self.assertRaises(FieldNoteWholeFlowValidationError):
+            build_portable_candidate_warehouse_manifest(live)
 
     def test_failed_attempt_enters_a7_as_fail(self) -> None:
         runtime_path = self.open_runtime()
@@ -1330,12 +1632,21 @@ class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):
         receipt = verify_field_note_whole_flow(live)
         self.assertEqual("FAIL", receipt.state)
         self.assertEqual("A1_FAILED", receipt.failure_reason)
+        self.assertEqual(
+            runtime_path.read_back().terminal_proof_as_of,
+            receipt.proof_as_of,
+        )
 
     def test_trace_complete_creator_live_evidence_can_enter_a7(self) -> None:
         runtime_path, _ = self.complete_runtime()
         live = self.live_bundle(runtime_path.read_back())
         receipt = verify_field_note_whole_flow(live)
         self.assertEqual("PASS", receipt.state)
+        self.assertEqual(whole_flow.WHOLE_FLOW_SCHEMA_V2, receipt.schema)
+        self.assertEqual(
+            runtime_path.read_back().terminal_proof_as_of,
+            receipt.proof_as_of,
+        )
         self.assertEqual("CREATOR_LIVE", receipt.proof_mode)
         self.assertEqual(live.attempt, runtime_path.read_back().attempt)
         self.assertEqual(live.attempt, receipt.attempt)
@@ -1380,10 +1691,12 @@ class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):
     def test_changed_creator_identity_cannot_enter_a7(self) -> None:
         self.assert_attempt_substitution_fails(creator_id="Other Creator")
 
-    def test_changed_proof_as_of_cannot_enter_a7(self) -> None:
-        self.assert_attempt_substitution_fails(
-            proof_as_of="2026-08-05T12:01:00Z"
-        )
+    def test_caller_cannot_supply_terminal_proof_as_of(self) -> None:
+        with self.assertRaises(TypeError):
+            replace(
+                self.live_attempt,
+                proof_as_of="2026-08-05T12:01:00Z",
+            )
 
     def test_changed_attempt_id_cannot_enter_a7(self) -> None:
         self.assert_attempt_substitution_fails(proof_attempt_id="other_attempt")

--- a/tests/test_field_notes_creator_live_capture.py
+++ b/tests/test_field_notes_creator_live_capture.py
@@ -16,6 +16,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexRuntimeIdentity,
 )
 from decision_os.acceleration.model import git_output, repository_id
+from decision_os.companion import field_notes_creator_live as creator_live
 from decision_os.companion.field_notes_adapter import (
     FieldNoteA1ProposalDiagnostic,
     FieldNoteCodexRunResult,
@@ -36,9 +37,8 @@ from decision_os.companion.field_notes_creator_live_capture import (
 )
 from decision_os.companion.field_notes_model import FieldNoteDraft, compile_draft
 from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteCreatorLiveAttempt,
     FieldNoteSourceRepositoryIdentity,
-    FieldNoteWholeFlowAttempt,
-    FieldNoteWholeFlowRunIdentity,
 )
 
 
@@ -221,31 +221,42 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
             repository_id=repository_id(self.repository),
             source_commit=git_output(self.repository, "rev-parse", "HEAD"),
         )
-        self.attempt = FieldNoteWholeFlowAttempt(
+        self.attempt = FieldNoteCreatorLiveAttempt(
             proof_attempt_id="proof_a7_capture_bridge_fixture_001",
             proof_mode="CREATOR_LIVE",
             creator_id="fixture-creator",
-            proof_as_of="2026-08-06T03:00:00Z",
+            authorization_observed_at="2026-08-06T00:58:00Z",
         )
-        self.run_1 = FieldNoteWholeFlowRunIdentity(
-            proof_attempt_id=self.attempt.proof_attempt_id,
-            run_id="run_creator_live_capture_fixture_001",
-            started_at="2026-08-06T01:00:00Z",
-            repository=self.source_repository,
-            runtime=CodexRuntimeIdentity(
-                model="gpt-5.6-sol",
-                reasoning_effort="ultra",
-                service_tier="priority",
-                codex_cli_version="0.146.0-alpha.3.1",
-                account_type="chatgpt",
+        exact_runtime = CodexRuntimeIdentity(
+            model="gpt-5.6-sol",
+            reasoning_effort="ultra",
+            service_tier="priority",
+            codex_cli_version="0.146.0-alpha.3.1",
+            account_type="chatgpt",
+        )
+        terminal_clock = patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value="2026-08-06T03:00:00Z",
+        )
+        terminal_clock.start()
+        self.addCleanup(terminal_clock.stop)
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=(
+                "2026-08-06T00:59:00Z",
+                "2026-08-06T01:00:00Z",
             ),
-        )
-        self.runtime = FieldNoteCreatorLiveProofRuntime.open_attempt(
-            self.root / "fixture-runtime",
-            attempt=self.attempt,
-            source_repository=self.source_repository,
-            run_1=self.run_1,
-        )
+        ):
+            self.runtime = FieldNoteCreatorLiveProofRuntime.open_attempt(
+                self.root / "fixture-runtime",
+                attempt=self.attempt,
+                source_repository=self.source_repository,
+                run_1_id="run_creator_live_capture_fixture_001",
+                runtime=exact_runtime,
+            )
+        self.run_1 = self.runtime.read_back().run_1
         self.mode = "valid"
         self.last_draft: FieldNoteDraft | None = None
         self.observed_task: str | None = None
@@ -634,7 +645,7 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
                 )
                 self.assertTrue(readback.durable_readback_verified)
                 self.assertEqual(
-                    readback.journal_record_count,
+                    readback.journal_record_count - 1,
                     readback.anchor_record_count,
                 )
                 journal = self.runtime.journal_path.read_text(encoding="utf-8")
@@ -703,7 +714,7 @@ class CreatorLiveCaptureBridgeTests(unittest.TestCase):
         )
         self.assertTrue(readback.durable_readback_verified)
         self.assertEqual(
-            readback.journal_record_count,
+            readback.journal_record_count - 1,
             readback.anchor_record_count,
         )
         journal = self.runtime.journal_path.read_text(encoding="utf-8")

--- a/tests/test_field_notes_creator_live_reconnect.py
+++ b/tests/test_field_notes_creator_live_reconnect.py
@@ -42,8 +42,8 @@ from decision_os.companion.field_notes_creator_live_reconnect import (
 from decision_os.companion.field_notes_model import compile_draft
 from decision_os.companion.field_notes_reuse import FieldNoteIdentity
 from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteCreatorLiveAttempt,
     FieldNoteSourceRepositoryIdentity,
-    FieldNoteWholeFlowAttempt,
     FieldNoteWholeFlowRunIdentity,
 )
 from tests.test_acceleration_codex_adapter import (
@@ -182,19 +182,36 @@ class CreatorLiveExactReconnectTests(unittest.TestCase):
             repository_id=repository_id(self.repository),
             source_commit=git_output(self.repository, "rev-parse", "HEAD"),
         )
-        self.attempt = FieldNoteWholeFlowAttempt(
+        self.attempt = FieldNoteCreatorLiveAttempt(
             proof_attempt_id="proof_a7_exact_reconnect_fixture_001",
             proof_mode="CREATOR_LIVE",
             creator_id="fixture-creator",
-            proof_as_of="2026-08-06T12:00:00Z",
+            authorization_observed_at="2026-08-06T09:58:00Z",
         )
-        self.run_1 = FieldNoteWholeFlowRunIdentity(
-            proof_attempt_id=self.attempt.proof_attempt_id,
-            run_id="run_exact_reconnect_fixture_1",
-            started_at="2026-08-06T10:00:00Z",
-            repository=self.source_repository,
-            runtime=_runtime_identity(),
+        exact_runtime = _runtime_identity()
+        terminal_clock = patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            return_value="2026-08-06T12:00:00Z",
         )
+        terminal_clock.start()
+        self.addCleanup(terminal_clock.stop)
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=(
+                "2026-08-06T09:59:00Z",
+                "2026-08-06T10:00:00Z",
+            ),
+        ):
+            self.runtime = FieldNoteCreatorLiveProofRuntime.open_attempt(
+                self.root / "runtime",
+                attempt=self.attempt,
+                source_repository=self.source_repository,
+                run_1_id="run_exact_reconnect_fixture_1",
+                runtime=exact_runtime,
+            )
+        self.run_1 = self.runtime.read_back().run_1
         self.run_2 = FieldNoteWholeFlowRunIdentity(
             proof_attempt_id=self.attempt.proof_attempt_id,
             run_id="run_exact_reconnect_fixture_2",
@@ -211,12 +228,6 @@ class CreatorLiveExactReconnectTests(unittest.TestCase):
         self.note_path = self.repository / self.draft.relative_path
         self.note_path.parent.mkdir(parents=True)
         self.note_path.write_bytes(self.draft.markdown)
-        self.runtime = FieldNoteCreatorLiveProofRuntime.open_attempt(
-            self.root / "runtime",
-            attempt=self.attempt,
-            source_repository=self.source_repository,
-            run_1=self.run_1,
-        )
         note = FieldNoteIdentity(
             note_path=self.draft.relative_path,
             field_note_id=self.draft.field_note_id,


### PR DESCRIPTION
## Scope

Diagnosis remains **B — DURABLE PROOF-AS-OF SCHEMA GAP**.

This forward-only v0.2 schema separates three time authorities:

- `authorization_observed_at`: caller-supplied authorization observation bound to the attempt identity.
- `attempt_opened_at`: issued by the runtime while opening the attempt, before Run 1.
- `proof_as_of`: issued by the runtime only on `ATTEMPT_FAILED` or `TRACE_COMPLETED`, at or after the last admitted observation (or attempt opening when none exists).

The implementation does not accept a caller-supplied Proof As-of value and does not fabricate or guess a future terminal timestamp. The runtime binds `attempt_opened_at` beside the caller attempt identity, and terminal receipts use the durable terminal cutoff.

Historical v0.1 journals, anchors, typed readback, and receipts remain readable with pinned byte/semantic compatibility. They are not migrated or reinterpreted. Historical v0.1 append remains closed.

Cycle 004 remains permanently **FAILED / A1_CAPTURE / A1_CAPTURE_CHRONOLOGY_INVALID**. Nothing in this PR reopens, retries, replaces, or reinterprets that cycle.

## Changed surface

- Creator-live journal, anchor, projection, and typed readback v0.2
- Whole-flow receipt and verifier terminal-cutoff binding
- Capture preflight enforcement
- Focused deterministic model-free regression tests

## Validation

- Creator Live + capture + reconnect + Whole Flow: **193 passed**
- Focused A1–A7 + controller/server: **524 passed**
- Full default discovery: **1175 passed, 5 skipped**
- Full explicit discovery: **1175 passed, 5 skipped**
- Normalized suite identity: **1175 / 1175**, zero one-sided IDs
- Python compilation: **PASS**
- `git diff --check`: **PASS**
- Protected Proof 002/003 and Cycle 003/004 artifact identities: **PASS**

The required test-first vertical test failed before production implementation and passed afterward.

## Gates

- Live proof: **BLOCK**
- Install/restart: **BLOCK**
- Product/runtime model invocation: **none**
- Proof attempt, Run, or Note creation: **none**
- Merge: requires independent schema review