### PR TITLE
Add Cycle 005 creator-live entrypoint

### DIFF
--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -9,7 +9,7 @@ import io
 import os
 from pathlib import Path
 import stat
-from typing import Any
+from typing import Any, Callable
 
 from decision_os.acceleration.codex_adapter import (
     ADAPTER_NAME,
@@ -124,6 +124,8 @@ class FieldNoteCreatorLiveA2RunCompletion:
     run_id: str
     actual_runtime_identity: CodexRuntimeIdentity
     reconnect_receipt: FieldNoteReconnectReceipt
+    final_output_bytes: bytes
+    final_output_sha256: str
 
     def __post_init__(self) -> None:
         if (
@@ -142,6 +144,11 @@ class FieldNoteCreatorLiveA2RunCompletion:
             not in {"INJECTED", "ACTIVATION_UNKNOWN"}
             or self.reconnect_receipt.failure_reason is not None
             or self.reconnect_receipt.full_notes_injected != 1
+            or not isinstance(self.final_output_bytes, bytes)
+            or not self.final_output_bytes
+            or len(self.final_output_bytes) > 65_536
+            or hashlib.sha256(self.final_output_bytes).hexdigest()
+            != self.final_output_sha256
         ):
             raise ValueError("Creator-live A2 Run completion is invalid.")
 
@@ -150,6 +157,10 @@ class FieldNotesCompanionController(CompanionController):
     """Companion controller extended only with Field Notes Lite Capture."""
 
     def __init__(self, **kwargs: Any) -> None:
+        creator_live_entrypoint_factory: Callable[[Any], Any] | None = kwargs.pop(
+            "creator_live_entrypoint_factory",
+            None,
+        )
         self._field_note_draft: FieldNoteDraft | None = None
         self._field_note_pending: _PendingSave | None = None
         self._creator_live_a1_capture_config: (
@@ -159,6 +170,7 @@ class FieldNotesCompanionController(CompanionController):
         self._creator_live_a1_run_completion: (
             FieldNoteCreatorLiveA1RunCompletion | None
         ) = None
+        self._creator_live_a1_completed_draft: FieldNoteDraft | None = None
         self._creator_live_a1_failure_reason: str | None = None
         self._creator_live_a1_direct_write_identity: str | None = None
         self._creator_live_a1_proposal_diagnostic: (
@@ -191,6 +203,13 @@ class FieldNotesCompanionController(CompanionController):
                 ),
             )
         super().__init__(**kwargs)
+        if creator_live_entrypoint_factory is None:
+            from decision_os.companion.field_notes_creator_live_entrypoint import (
+                CreatorLiveCycle005Entrypoint,
+            )
+
+            creator_live_entrypoint_factory = CreatorLiveCycle005Entrypoint
+        self._creator_live_cycle_005 = creator_live_entrypoint_factory(self)
 
     def _active_creator_live_a1_capture(
         self,
@@ -224,6 +243,8 @@ class FieldNotesCompanionController(CompanionController):
 
     def start_run(self, task: str, *, task_mode: str = "manual") -> dict[str, Any]:
         with self._condition:
+            if self.creator_live_cycle_005_mutation_blocked():
+                raise FieldNoteError("CREATOR_LIVE_CYCLE_005_ACTIVE")
             self._require_no_active_run()
             self._clear_field_note_locked()
             self._clear_creator_live_a2_locked()
@@ -251,6 +272,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_capture_config = config
             self._creator_live_a1_completed_run_id = None
             self._creator_live_a1_run_completion = None
+            self._creator_live_a1_completed_draft = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
             self._creator_live_a1_proposal_diagnostic = None
@@ -293,6 +315,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_capture_config = None
             self._creator_live_a1_completed_run_id = None
             self._creator_live_a1_run_completion = None
+            self._creator_live_a1_completed_draft = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
             self._creator_live_a1_proposal_diagnostic = None
@@ -306,6 +329,7 @@ class FieldNotesCompanionController(CompanionController):
             self._creator_live_a1_capture_config = None
             self._creator_live_a1_completed_run_id = None
             self._creator_live_a1_run_completion = None
+            self._creator_live_a1_completed_draft = None
             self._creator_live_a1_failure_reason = None
             self._creator_live_a1_direct_write_identity = None
             self._creator_live_a1_proposal_diagnostic = None
@@ -584,10 +608,39 @@ class FieldNotesCompanionController(CompanionController):
                 reconnect_failure = "A2_TARGET_INVALID"
             else:
                 assert result.runtime_identity is not None
+                try:
+                    final_output_bytes = result.final_message.encode("utf-8")
+                except UnicodeEncodeError:
+                    reconnect_failure = "A2_OUTPUT_INVALID"
+                    final_output_bytes = b""
+                if (
+                    reconnect_failure is None
+                    and (
+                        not result.normal_terminal
+                        or result.turn_status != "completed"
+                        or result.status != "NORMAL_TERMINAL"
+                        or result.failure_diagnostic is not None
+                        or getattr(result, "field_note_proposal", None)
+                        is not None
+                        or result.file_actions
+                        or result.checkpoint_outcomes
+                        or not final_output_bytes
+                        or len(final_output_bytes) > 65_536
+                    )
+                ):
+                    reconnect_failure = "A2_OUTPUT_INVALID"
+                if reconnect_failure is not None:
+                    final_output_bytes = b""
+            if reconnect_failure is None:
+                assert result.runtime_identity is not None
                 reconnect_completion = FieldNoteCreatorLiveA2RunCompletion(
                     run_id=result.run_id,
                     actual_runtime_identity=result.runtime_identity,
                     reconnect_receipt=reconnect_receipt,
+                    final_output_bytes=final_output_bytes,
+                    final_output_sha256=hashlib.sha256(
+                        final_output_bytes
+                    ).hexdigest(),
                 )
         else:
             draft = self._eligible_draft(result)
@@ -611,6 +664,8 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a2_run_completion = reconnect_completion
                 self._creator_live_a2_failure_reason = reconnect_failure
             self._creator_live_a1_run_completion = completion
+            if capture is not None:
+                self._creator_live_a1_completed_draft = draft
             self._creator_live_a1_failure_reason = capture_failure
             self._creator_live_a1_proposal_diagnostic = proposal_diagnostic
             self._run["field_note_reconnect"] = reconnect_projection
@@ -682,6 +737,24 @@ class FieldNotesCompanionController(CompanionController):
                     "Creator-live A1 Run completion is unavailable."
                 )
             return completion
+
+    def creator_live_a1_completed_draft(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> FieldNoteDraft:
+        """Return the private typed A1 draft retained for A7 construction."""
+
+        with self._condition:
+            draft = self._creator_live_a1_completed_draft
+            if (
+                not isinstance(expected_run_id, str)
+                or not expected_run_id
+                or draft is None
+                or draft.source_run_id != expected_run_id
+            ):
+                raise FieldNoteError("A1_CAPTURE_IDENTITY_MISMATCH")
+            return draft
 
     def creator_live_a1_proposal_diagnostic(
         self,
@@ -779,6 +852,7 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a1_capture_config = None
                 self._creator_live_a1_failure_reason = "A1_RUN_FAILED"
                 self._creator_live_a1_run_completion = None
+                self._creator_live_a1_completed_draft = None
                 self._creator_live_a1_proposal_diagnostic = None
             if self._creator_live_a2_reconnect_target is not None:
                 self._creator_live_a2_completed_run_id = (
@@ -1428,3 +1502,69 @@ class FieldNotesCompanionController(CompanionController):
             self._field_note_draft = None
             self._run["field_note"] = {"state": "saved", "path": path}
             return self._snapshot_locked()
+
+    def creator_live_cycle_005_start(
+        self,
+        launch_binding_sha256: str,
+    ) -> dict[str, Any]:
+        """Start only the dedicated Cycle 005 production entrypoint."""
+
+        self._creator_live_cycle_005.start(launch_binding_sha256)
+        return self.snapshot()
+
+    def creator_live_cycle_005_mutation_blocked(self) -> bool:
+        entrypoint = getattr(self, "_creator_live_cycle_005", None)
+        return bool(entrypoint is not None and entrypoint.mutation_blocked)
+
+    @staticmethod
+    def creator_live_cycle_005_public_projection(
+        snapshot: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Redact private coordinator Runs from every HTTP projection."""
+
+        cycle = snapshot.get("creator_live_cycle_005")
+        if not isinstance(cycle, dict) or cycle.get("state") in {
+            "READY",
+            "NOT_READY",
+            "UNAVAILABLE",
+        }:
+            return snapshot
+        state = cycle.get("state")
+        public_state = (
+            "running"
+            if state == "RUNNING"
+            else "completed"
+            if state == "PASS"
+            else "needs_attention"
+        )
+        snapshot["run"] = {
+            "run_type": "creator_live_cycle_005",
+            "task_mode": None,
+            "state": public_state,
+            "progress": [cycle.get("stage") or "P0"],
+            "result": "",
+            "file_actions": [],
+            "read_evidence": [],
+            "outcomes": None,
+            "runtime": None,
+            "receipt_delta": None,
+            "approval": None,
+            "error": cycle.get("failure_code"),
+            "failure": None,
+        }
+        return snapshot
+
+    def _snapshot_locked(self) -> dict[str, Any]:
+        snapshot = super()._snapshot_locked()
+        entrypoint = getattr(self, "_creator_live_cycle_005", None)
+        snapshot["creator_live_cycle_005"] = (
+            entrypoint.snapshot(snapshot)
+            if entrypoint is not None
+            else {
+                "cycle_key": "cycle-005",
+                "state": "UNAVAILABLE",
+                "p0": {"ready": False, "failure_code": "ENTRYPOINT_UNAVAILABLE"},
+                "launch_binding_sha256": None,
+            }
+        )
+        return snapshot

--- a/decision_os/companion/field_notes_creator_live_entrypoint.py
+++ b/decision_os/companion/field_notes_creator_live_entrypoint.py
@@ -1,0 +1,1217 @@
+"""Authenticated production entrypoint for the fixed Creator-Live Cycle 005."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import threading
+from typing import Any, Callable, Mapping, Protocol
+
+from decision_os.acceleration.codex_adapter import CodexRuntimeIdentity
+from decision_os.acceleration.model import git_output, repository_id
+from decision_os.companion.field_notes_creator_live import (
+    CREATOR_LIVE_ANCHOR_FILENAME,
+    CREATOR_LIVE_ANCHOR_FILENAME_V2,
+    CREATOR_LIVE_JOURNAL_FILENAME,
+    CREATOR_LIVE_JOURNAL_FILENAME_V2,
+    FieldNoteCreatorLiveAttemptExistsError,
+    FieldNoteCreatorLiveProofRuntime,
+)
+from decision_os.companion.field_notes_creator_live_capture import (
+    FieldNoteCreatorLiveA1CaptureBridge,
+)
+from decision_os.companion.field_notes_creator_live_reconnect import (
+    FieldNoteCreatorLiveA2ReconnectBridge,
+    creator_live_a2_target_from_readback,
+    prepare_creator_live_a2_reconnect,
+)
+from decision_os.companion.field_notes_maturity_commit import (
+    FieldNoteMaturityCommitRequest,
+    commit_field_note_maturity,
+)
+from decision_os.companion.field_notes_maturity_ledger import (
+    FieldNoteMaturityLedger,
+)
+from decision_os.companion.field_notes_maturity_review import (
+    review_field_note_maturity,
+)
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.guided_intake import _quoted_payload_boundary
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteOutcomeEvaluation,
+    FieldNoteReuseClaim,
+    FieldNoteReuseDisposition,
+    FieldNoteUseEvidence,
+    assess_field_note_reuse,
+    bind_field_note_structure,
+)
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteCreatorLiveAttempt,
+    FieldNoteSourceRepositoryIdentity,
+    FieldNoteWholeFlowEvidenceBundle,
+    FieldNoteWholeFlowRunIdentity,
+    build_portable_candidate_warehouse_manifest,
+    verify_field_note_whole_flow,
+)
+
+
+CYCLE_KEY = "cycle-005"
+CYCLE_AUTHORIZATION_OBSERVED_AT = "2026-08-05T06:22:00Z"
+IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT = "2026-08-05T08:47:00Z"
+EXPECTED_REPOSITORY = Path(
+    "/Users/sn/Documents/v13/decision-os-v13-loopkit"
+)
+EXPECTED_REMOTE = "https://github.com/shin4141/decision-os-v13-loopkit.git"
+EXPECTED_CONTRACT_PROFILE = "ORDINARY_USER_PATH_CONTRACT_APPROVED_CANDIDATE_V0_1"
+EXPECTED_CONTRACT_TITLE = "Ordinary User Path Contract v0.1 — APPROVED CANDIDATE"
+EXPECTED_CONTRACT_BYTES = 11_039
+EXPECTED_CONTRACT_SHA256 = (
+    "519bd39305af1a3a7cc35e61e1b9cfc742c5723d0cc64d0d970b070d0e65068e"
+)
+EXPECTED_WRAPPER_SHA256 = (
+    "c3de6236a450666d8a8ef59a8f8db303bf4654cc9cb20d6ab816f3066177b11e"
+)
+EXPECTED_INTERPRETATION_SHA256 = (
+    "7503f4b01c7c05c9ec3aed8855c9fd538c66b9b3b38840f423ec41c2101f4dd7"
+)
+EXPECTED_EXECUTION_AUTHORITY = "INTERPRETATION_ONLY"
+EXPECTED_FREEZE_AUTHORITY = "IMMUTABLE_INTERPRETATION_ONLY"
+EXPECTED_GATE = "CLEAR ENOUGH TO FREEZE"
+
+EXPECTED_RUNTIME = CodexRuntimeIdentity(
+    model="gpt-5.6-sol",
+    reasoning_effort="ultra",
+    service_tier="priority",
+    codex_cli_version="0.146.0-alpha.3.1",
+    account_type="chatgpt",
+)
+
+RUN_1_TASK = """Read only
+validation/a7_creator_live_whole_flow_reentry_charter_v0_1.md.
+
+Identify one reusable execution-identity rule that distinguishes:
+
+- an implementation or product-code baseline; and
+- the repository HEAD containing a merged execution Charter.
+
+Propose exactly one new Field Note through the authorized Field Note proposal
+path.
+
+The proposed Note must preserve these bounded points:
+
+- implementation baseline and execution repository HEAD are separate identities;
+- documentation-only Charter bytes need not be packaged into the runtime build;
+- execution must bind both identities explicitly;
+- a later repository commit requires bounded requalification or a Charter delta.
+
+Do not write or modify repository files.
+Do not request direct write.
+Do not make more than one Field Note proposal.
+After the one proposal, stop."""
+
+RUN_2_TASK = """Use the exact reconnected Field Note from Run 1 to evaluate this proposed
+execution decision:
+
+“A documentation-only execution Charter was merged after product code baseline
+X. The installed runtime matches code baseline X. Repository main later moved
+to commit Y after the Charter merge. Because the runtime code did not change,
+execution may proceed without recording Y or requalifying the repository.”
+
+Return a bounded verdict.
+
+Demonstrate use of one exact structure from the reconnected Note through
+RULE_TRACE or OUTPUT_ARTIFACT.
+
+The evidence must identify the exact Note, exact bounded structure, exact Run 2,
+and how that structure affected the verdict.
+
+Generic similarity, correct task output, or an unsupported statement that the
+Note was useful is insufficient.
+
+Do not propose another Field Note.
+Do not write or modify repository files."""
+
+RUN_1_TASK_SHA256 = (
+    "e377fb2f9e003f3f04e8d1b10d2aef96347416d86f78305102d4671519ed3417"
+)
+RUN_2_TASK_SHA256 = (
+    "688203fd91c880cb4c9e32619219e9e660160b31fded0ae630ae2a401ea6cdcf"
+)
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_PROOF_FILENAMES = (
+    CREATOR_LIVE_JOURNAL_FILENAME,
+    CREATOR_LIVE_ANCHOR_FILENAME,
+    CREATOR_LIVE_JOURNAL_FILENAME_V2,
+    CREATOR_LIVE_ANCHOR_FILENAME_V2,
+)
+
+PROTECTED_HISTORY: tuple[tuple[str, str], ...] = (
+    (
+        ".decision-os/field-notes/2026-08-03-topmost-canonical-state-restart-guard-lcmwhjvkpf.md",
+        "3c2e45460f21a2346a8d100ebfefc6ed079994e687a70911e5f4a8954cf2d05d",
+    ),
+    (
+        ".decision-os/field-notes/2026-08-04-bind-product-code-baseline-and-ws4unkvwfe.md",
+        "dab6f42bd2c8e6a1e3f31f6f2fb8f260c380a11151bea92cfab868f8e85d2446",
+    ),
+    (
+        ".decision-os/field-notes/2026-08-05-bind-governed-execution-to-both-nnyn57esbq.md",
+        "e3f49d578dd525c0a8c8ffdf90374c50ab00167e684fbdae991d7d2d24ff9cdd",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_002_1d4c714b11c3f614/creator-live-proof-v0.1.jsonl",
+        "8d346c5f57f28c105ec84c640e21649c1d6b31274614bc8d2fc56737f8aec99c",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_002_1d4c714b11c3f614/creator-live-proof-v0.1.anchor.jsonl",
+        "3ccbd87e9ff4b8871f7009bf925e5acfe9111378509bd38d8764d23a9fc5344c",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_003_94a0d625f4d155f5/creator-live-proof-v0.1.jsonl",
+        "d310a5a7131f78dab8a999e97a941748b7713f102adb44c54cb9e5be8dd0efd1",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_003_94a0d625f4d155f5/creator-live-proof-v0.1.anchor.jsonl",
+        "0ba29aadef6267e902182a918bb0e9bc9b73eef3dd2fb60ec9c429c9fbaa44dc",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_004_862c2f5cfdf7b134/creator-live-proof-v0.1.jsonl",
+        "af0906977646897fa6bb279f512372998404974a5b581070fe5e1e94f9fd4c4a",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_004_862c2f5cfdf7b134/creator-live-proof-v0.1.anchor.jsonl",
+        "349b3298379f88cd2ea62f454c486ac857bc71e16614b7e8de4906e802b80331",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_005_1f0c0263566af0a8/creator-live-proof-v0.1.jsonl",
+        "5e329626cc9b23fa800ddf53fc2a5ff637a38da58442d1e1c01d7eee00a27f6b",
+    ),
+    (
+        ".decision-os/field-notes/proofs/proof_a7_creator_live_005_1f0c0263566af0a8/creator-live-proof-v0.1.anchor.jsonl",
+        "c434ff5e4e38b45bd8f8d497fb51d11bcc5ad050d8e29ed2025b514e0bb9a4d0",
+    ),
+)
+
+
+class _Controller(Protocol):
+    def creator_live_a1_completed_draft(self, *, expected_run_id: str) -> Any: ...
+    def creator_live_a2_run_completion(self, *, expected_run_id: str) -> Any: ...
+
+
+class CreatorLiveEntrypointError(RuntimeError):
+    """One bounded public start request failed closed."""
+
+    def __init__(self, code: str, *, http_status: int = 409) -> None:
+        super().__init__(code)
+        self.code = code
+        self.http_status = http_status
+
+
+@dataclass(frozen=True)
+class CreatorLiveCycle005Spec:
+    repository: Path = EXPECTED_REPOSITORY
+    remote: str = EXPECTED_REMOTE
+    cycle_key: str = CYCLE_KEY
+    cycle_authorization_observed_at: str = CYCLE_AUTHORIZATION_OBSERVED_AT
+    implementation_authorization_observed_at: str = (
+        IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT
+    )
+    runtime: CodexRuntimeIdentity = EXPECTED_RUNTIME
+    run_1_task: str = RUN_1_TASK
+    run_2_task: str = RUN_2_TASK
+    protected_history: tuple[tuple[str, str], ...] = PROTECTED_HISTORY
+
+    @property
+    def storage_root(self) -> Path:
+        return self.repository / ".decision-os/field-notes/proofs/cycle-005"
+
+
+@dataclass(frozen=True)
+class CreatorLiveP0Result:
+    ready: bool
+    failure_code: str | None
+    binding: dict[str, Any] | None
+    launch_binding_sha256: str | None
+
+
+def _utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _strict_object(raw: bytes, label: str) -> dict[str, Any]:
+    def pairs(value: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in value:
+            if key in result:
+                raise ValueError(f"{label} contains a duplicate field.")
+            result[key] = item
+        return result
+
+    try:
+        value = json.loads(raw, object_pairs_hook=pairs)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} is not strict JSON.") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} is not an object.")
+    return value
+
+
+def _run_git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ("git", *arguments),
+        cwd=repository,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode != 0:
+        raise ValueError("P0_GIT_IDENTITY_UNAVAILABLE")
+    return completed.stdout.strip()
+
+
+def _git_diff_clean(repository: Path, *, cached: bool) -> bool:
+    arguments = ["git", "diff", "--quiet"]
+    if cached:
+        arguments.append("--cached")
+    completed = subprocess.run(
+        arguments,
+        cwd=repository,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    if completed.returncode not in {0, 1}:
+        raise ValueError("P0_GIT_IDENTITY_UNAVAILABLE")
+    return completed.returncode == 0
+
+
+def product_tree_sha256(runtime_root: Path) -> str:
+    """Hash one exact Decision OS product tree without following symlinks."""
+
+    package = runtime_root / "decision_os"
+    if not package.is_dir() or package.is_symlink():
+        raise ValueError("P0_PRODUCT_TREE_UNAVAILABLE")
+    files: list[Path] = []
+    for path in package.rglob("*"):
+        relative = path.relative_to(runtime_root)
+        if "__pycache__" in relative.parts or path.suffix == ".pyc":
+            continue
+        if path.is_symlink():
+            raise ValueError("P0_PRODUCT_TREE_SYMLINK")
+        if path.is_file():
+            files.append(path)
+    rows = []
+    for path in sorted(
+        files,
+        key=lambda item: item.relative_to(runtime_root).as_posix().encode("utf-8"),
+    ):
+        relative = path.relative_to(runtime_root).as_posix()
+        rows.append(f"{_sha256_bytes(path.read_bytes())}  {relative}\n")
+    return _sha256_bytes("".join(rows).encode("utf-8"))
+
+
+def _runtime_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _task_identities(spec: CreatorLiveCycle005Spec) -> dict[str, Any]:
+    run_1 = spec.run_1_task.encode("utf-8")
+    run_2 = spec.run_2_task.encode("utf-8")
+    if (
+        len(run_1) != 832
+        or _sha256_bytes(run_1) != RUN_1_TASK_SHA256
+        or len(run_2) != 856
+        or _sha256_bytes(run_2) != RUN_2_TASK_SHA256
+        or spec.run_1_task != spec.run_1_task.strip()
+        or spec.run_2_task != spec.run_2_task.strip()
+    ):
+        raise ValueError("P0_TASK_IDENTITY_MISMATCH")
+    return {
+        "run_1": {
+            "byte_count": len(run_1),
+            "sha256": RUN_1_TASK_SHA256,
+            "lane": "A1_ONLY",
+        },
+        "run_2": {
+            "byte_count": len(run_2),
+            "sha256": RUN_2_TASK_SHA256,
+            "lane": "EXACT_A2_ONLY",
+        },
+    }
+
+
+def _proof_artifacts_exist(root: Path) -> bool:
+    return any(os.path.lexists(root / filename) for filename in _PROOF_FILENAMES)
+
+
+def _proof_storage_occupied(root: Path) -> bool:
+    if _proof_artifacts_exist(root):
+        return True
+    if not os.path.lexists(root):
+        return False
+    if root.is_symlink() or not root.is_dir():
+        return True
+    try:
+        return next(root.iterdir(), None) is not None
+    except OSError:
+        return True
+
+
+def compile_run_2_output_artifact(
+    *,
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+    run_2_id: str,
+    final_output_bytes: bytes,
+    final_output_sha256: str,
+    observed_at: str,
+) -> FieldNoteReuseClaim:
+    """Compile only a unique, exact, non-whole UTF-8 output-artifact claim."""
+
+    if (
+        not isinstance(note_bytes, bytes)
+        or _sha256_bytes(note_bytes) != note.note_sha256
+        or not isinstance(final_output_bytes, bytes)
+        or not final_output_bytes
+        or _sha256_bytes(final_output_bytes) != final_output_sha256
+        or note_bytes in final_output_bytes
+    ):
+        raise ValueError("A3_OUTPUT_ARTIFACT_IDENTITY_INVALID")
+    try:
+        note_bytes.decode("utf-8")
+        final_output_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("A3_OUTPUT_ARTIFACT_UTF8_INVALID") from exc
+    for identity in (
+        note.note_path,
+        note.field_note_id,
+        note.note_sha256,
+    ):
+        if identity.encode("utf-8") not in final_output_bytes:
+            raise ValueError("A3_OUTPUT_ARTIFACT_LINEAGE_MISSING")
+    candidates: list[tuple[int, int, bytes, int]] = []
+    for match in re.finditer(rb"[^\r\n]+", note_bytes):
+        structure = match.group(0)
+        if (
+            len(structure.strip()) < 32
+            or (match.start() == 0 and match.end() == len(note_bytes))
+            or note_bytes.count(structure) != 1
+            or final_output_bytes.count(structure) != 1
+        ):
+            continue
+        candidates.append(
+            (
+                match.start(),
+                match.end(),
+                structure,
+                final_output_bytes.index(structure),
+            )
+        )
+    if not candidates:
+        raise ValueError("A3_EXACT_STRUCTURE_MISSING")
+    longest = max(len(item[2]) for item in candidates)
+    winners = tuple(item for item in candidates if len(item[2]) == longest)
+    if len(winners) != 1:
+        raise ValueError("A3_EXACT_STRUCTURE_AMBIGUOUS")
+    start, end, structure, output_start = winners[0]
+    binding = bind_field_note_structure(
+        note,
+        note_bytes,
+        structure_id=f"exact-utf8-line:{start}:{end}",
+        start_byte=start,
+        end_byte=end,
+    )
+    evidence = FieldNoteUseEvidence(
+        evidence_class="OUTPUT_ARTIFACT",
+        evidence_origin="IMMEDIATE_COMPLETION_RECORD",
+        reusing_run_id=run_2_id,
+        structure_binding=binding,
+        evidence_ref=(
+            f"run:{run_2_id}:final-output:bytes:"
+            f"{output_start}:{output_start + len(structure)}"
+        ),
+        evidence_sha256=final_output_sha256,
+        observer_id=run_2_id,
+        observer_relation="REUSING_RUN_SELF",
+        as_of=observed_at,
+    )
+    return FieldNoteReuseClaim(
+        claimed_note=note,
+        reusing_run_id=run_2_id,
+        use_evidence=evidence,
+        outcome_evaluation=FieldNoteOutcomeEvaluation(
+            outcome="UNKNOWN",
+            scope="Cycle 005 Run 2 bounded verdict output.",
+            observer_id=run_2_id,
+            observer_relation="REUSING_RUN_SELF",
+            as_of=observed_at,
+            causal_evidence_ref=f"run:{run_2_id}:final-output",
+            causal_evidence_sha256=final_output_sha256,
+            contribution_separated=False,
+        ),
+        human_intervention="NONE",
+        disposition=FieldNoteReuseDisposition(
+            action="HOLD",
+            reevaluation_condition=(
+                "Independent evidence may later confirm the exact structure's "
+                "bounded contribution."
+            ),
+        ),
+    )
+
+
+class CreatorLiveCycle005Entrypoint:
+    """Own P0, one durable attempt, and the content-free Cycle projection."""
+
+    def __init__(
+        self,
+        controller: _Controller,
+        *,
+        spec: CreatorLiveCycle005Spec | None = None,
+        now: Callable[[], str] = _utc_now,
+        runtime_opener: Callable[..., FieldNoteCreatorLiveProofRuntime] = (
+            FieldNoteCreatorLiveProofRuntime.open_attempt
+        ),
+        worker_factory: Callable[..., Any] = threading.Thread,
+    ) -> None:
+        self.controller = controller
+        self.spec = spec or CreatorLiveCycle005Spec()
+        self.now = now
+        self.runtime_opener = runtime_opener
+        self.worker_factory = worker_factory
+        self._lock = threading.RLock()
+        self._runtime: FieldNoteCreatorLiveProofRuntime | None = None
+        self._worker: threading.Thread | None = None
+        self._starting = False
+        self._active = False
+        self._stage = "P0"
+        self._terminal_state: str | None = None
+        self._terminal_failure_code: str | None = None
+        self._receipt_sha256: str | None = None
+        self._manifest_sha256: str | None = None
+
+    @property
+    def mutation_blocked(self) -> bool:
+        with self._lock:
+            return self._starting or self._active
+
+    def _git_common_dir(self, repository: Path) -> Path:
+        value = _run_git(repository, "rev-parse", "--git-common-dir")
+        path = Path(value)
+        return (repository / path).resolve() if not path.is_absolute() else path
+
+    def _p0(self, base_snapshot: Mapping[str, Any]) -> CreatorLiveP0Result:
+        try:
+            repository = self.spec.repository.resolve(strict=True)
+            selected = base_snapshot.get("repository")
+            if not isinstance(selected, Mapping) or Path(
+                str(selected.get("path", ""))
+            ).resolve(strict=True) != repository:
+                raise ValueError("P0_REPOSITORY_PATH_MISMATCH")
+            head = _run_git(repository, "rev-parse", "HEAD")
+            local_main = _run_git(repository, "rev-parse", "main")
+            origin_main = _run_git(repository, "rev-parse", "origin/main")
+            branch = _run_git(repository, "branch", "--show-current")
+            remote = _run_git(repository, "remote", "get-url", "origin")
+            if remote != self.spec.remote:
+                raise ValueError("P0_REMOTE_MISMATCH")
+            if branch != "main":
+                raise ValueError("P0_BRANCH_MISMATCH")
+            if head != local_main or head != origin_main:
+                raise ValueError("P0_REVISION_MISMATCH")
+            if (
+                _run_git(
+                    repository,
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=no",
+                )
+                or not _git_diff_clean(repository, cached=False)
+            ):
+                raise ValueError("P0_TRACKED_WORKTREE_DIRTY")
+            if not _git_diff_clean(repository, cached=True):
+                raise ValueError("P0_INDEX_DIRTY")
+            common = self._git_common_dir(repository)
+            operation_paths = (
+                common / "MERGE_HEAD",
+                common / "CHERRY_PICK_HEAD",
+                common / "REVERT_HEAD",
+                common / "REBASE_HEAD",
+                common / "rebase-apply",
+                common / "rebase-merge",
+            )
+            if any(path.exists() for path in operation_paths):
+                raise ValueError("P0_GIT_OPERATION_ACTIVE")
+            observed_repository_id = repository_id(repository)
+
+            ordinary = base_snapshot.get("ordinary_contract")
+            if not isinstance(ordinary, Mapping) or ordinary.get("state") != "FIXED":
+                raise ValueError("P0_CONTRACT_NOT_FIXED")
+            if ordinary.get("repository_identity") != head:
+                raise ValueError("P0_CONTRACT_REPOSITORY_MISMATCH")
+            if ordinary.get("execution_authority") != EXPECTED_EXECUTION_AUTHORITY:
+                raise ValueError("P0_EXECUTION_AUTHORITY_MISMATCH")
+            source = ordinary.get("source_identity")
+            if not isinstance(source, Mapping) or (
+                source.get("byte_size") != EXPECTED_CONTRACT_BYTES
+                or source.get("sha256") != EXPECTED_CONTRACT_SHA256
+                or source.get("profile") != EXPECTED_CONTRACT_PROFILE
+                or source.get("title") != EXPECTED_CONTRACT_TITLE
+            ):
+                raise ValueError("P0_CONTRACT_SOURCE_MISMATCH")
+            technical = ordinary.get("technical_details")
+            if not isinstance(technical, Mapping) or (
+                technical.get("wrapper_sha256") != EXPECTED_WRAPPER_SHA256
+                or technical.get("interpretation_sha256")
+                != EXPECTED_INTERPRETATION_SHA256
+                or technical.get("gate") != EXPECTED_GATE
+            ):
+                raise ValueError("P0_CONTRACT_LINEAGE_MISMATCH")
+            freeze = technical.get("freeze")
+            if not isinstance(freeze, Mapping) or freeze.get("current") is not True:
+                raise ValueError("P0_FREEZE_NOT_CURRENT")
+            freeze_receipt = freeze.get("receipt")
+            if not isinstance(freeze_receipt, Mapping) or (
+                freeze_receipt.get("authority_state") != EXPECTED_FREEZE_AUTHORITY
+                or freeze_receipt.get("product_commit") != head
+                or freeze_receipt.get("current_gate") != EXPECTED_GATE
+            ):
+                raise ValueError("P0_FREEZE_AUTHORITY_MISMATCH")
+            freeze_receipt_sha = freeze.get("receipt_sha256")
+            preparation_receipt_sha = technical.get("preparation_receipt_sha256")
+            if not isinstance(freeze_receipt_sha, str) or not _SHA256.fullmatch(
+                freeze_receipt_sha
+            ):
+                raise ValueError("P0_FREEZE_RECEIPT_IDENTITY_INVALID")
+            if not isinstance(preparation_receipt_sha, str) or not _SHA256.fullmatch(
+                preparation_receipt_sha
+            ):
+                raise ValueError("P0_PREPARATION_RECEIPT_IDENTITY_INVALID")
+
+            guided_root = common / "decision-os/guided-intake-v0.1"
+            guided_state = _strict_object(
+                (guided_root / "state.json").read_bytes(),
+                "Guided Intake state",
+            )
+            guided_record = guided_state.get("record")
+            if not isinstance(guided_record, Mapping):
+                raise ValueError("P0_GUIDED_STATE_INVALID")
+            current_chain_head = guided_record.get("event_chain_head")
+            if not isinstance(current_chain_head, str) or not _SHA256.fullmatch(
+                current_chain_head
+            ):
+                raise ValueError("P0_CURRENT_CHAIN_HEAD_INVALID")
+            events = (guided_root / "events.ndjson").read_bytes().splitlines()
+            if len(events) < 2:
+                raise ValueError("P0_EVENT_CHAIN_INCOMPLETE")
+            previous_event = _strict_object(events[-2], "Previous Guided event")
+            current_event = _strict_object(events[-1], "Current Guided event")
+            predecessor_head = freeze_receipt.get("event_chain_head")
+            if (
+                current_event.get("event_hash") != current_chain_head
+                or current_event.get("kind") != "INTAKE_FROZEN"
+                or current_event.get("previous_event_hash") != predecessor_head
+                or previous_event.get("event_hash") != predecessor_head
+            ):
+                raise ValueError("P0_EVENT_CHAIN_RELATIONSHIP_INVALID")
+            freeze_receipt_path = guided_root / "receipts" / f"{freeze_receipt_sha}.json"
+            freeze_receipt_bytes = freeze_receipt_path.read_bytes()
+            if (
+                _sha256_bytes(freeze_receipt_bytes) != freeze_receipt_sha
+                or _strict_object(freeze_receipt_bytes, "Freeze receipt")
+                != dict(freeze_receipt)
+            ):
+                raise ValueError("P0_FREEZE_RECEIPT_MISMATCH")
+            ordinary_root = common / "decision-os/ordinary-user-path-v0.1"
+            preparation_path = (
+                ordinary_root
+                / "preparation-receipts"
+                / f"{preparation_receipt_sha}.json"
+            )
+            preparation_bytes = preparation_path.read_bytes()
+            preparation = _strict_object(preparation_bytes, "Preparation receipt")
+            if (
+                _sha256_bytes(preparation_bytes) != preparation_receipt_sha
+                or preparation.get("event_chain_head") != predecessor_head
+                or preparation.get("implementation_authority_state") != "NONE"
+                or preparation.get("repository_identity") != head
+            ):
+                raise ValueError("P0_PREPARATION_RECEIPT_MISMATCH")
+            wrapper_identity = preparation.get("wrapper_identity")
+            source_identity = preparation.get("source_identity")
+            if (
+                not isinstance(wrapper_identity, Mapping)
+                or not isinstance(source_identity, Mapping)
+                or wrapper_identity.get("sha256") != EXPECTED_WRAPPER_SHA256
+                or wrapper_identity.get("byte_size") != 11_946
+                or source_identity.get("sha256") != EXPECTED_CONTRACT_SHA256
+                or source_identity.get("byte_size") != EXPECTED_CONTRACT_BYTES
+            ):
+                raise ValueError("P0_CONTRACT_BYTE_IDENTITY_MISMATCH")
+            wrapper_path = (
+                guided_root
+                / "original-requests"
+                / f"{EXPECTED_WRAPPER_SHA256}.utf8"
+            )
+            wrapper_bytes = wrapper_path.read_bytes()
+            if (
+                len(wrapper_bytes) != 11_946
+                or _sha256_bytes(wrapper_bytes) != EXPECTED_WRAPPER_SHA256
+            ):
+                raise ValueError("P0_CONTRACT_WRAPPER_MISMATCH")
+            boundary = _quoted_payload_boundary(wrapper_bytes.decode("utf-8"))
+            if boundary is None:
+                raise ValueError("P0_CONTRACT_SOURCE_BOUNDARY_MISSING")
+            source_bytes = wrapper_bytes[
+                boundary.payload_byte_start : boundary.payload_byte_end
+            ]
+            if (
+                len(source_bytes) != EXPECTED_CONTRACT_BYTES
+                or _sha256_bytes(source_bytes) != EXPECTED_CONTRACT_SHA256
+                or boundary.byte_size != EXPECTED_CONTRACT_BYTES
+                or boundary.sha256 != EXPECTED_CONTRACT_SHA256
+            ):
+                raise ValueError("P0_CONTRACT_SOURCE_BYTES_MISMATCH")
+            draft_identity = preparation.get("draft_identity")
+            if not isinstance(draft_identity, Mapping):
+                raise ValueError("P0_CONTRACT_DRAFT_IDENTITY_INVALID")
+            draft_sha = draft_identity.get("sha256")
+            if not isinstance(draft_sha, str) or not _SHA256.fullmatch(draft_sha):
+                raise ValueError("P0_CONTRACT_DRAFT_IDENTITY_INVALID")
+            draft_bytes = (guided_root / "drafts" / f"{draft_sha}.json").read_bytes()
+            if _sha256_bytes(draft_bytes) != draft_sha:
+                raise ValueError("P0_CONTRACT_DRAFT_MISMATCH")
+            frozen_sha = freeze.get("frozen_intake_sha256")
+            if not isinstance(frozen_sha, str) or not _SHA256.fullmatch(frozen_sha):
+                raise ValueError("P0_FROZEN_INTAKE_IDENTITY_INVALID")
+            frozen_bytes = (guided_root / "freezes" / f"{frozen_sha}.json").read_bytes()
+            if _sha256_bytes(frozen_bytes) != frozen_sha:
+                raise ValueError("P0_FROZEN_INTAKE_MISMATCH")
+
+            protected: list[dict[str, str]] = []
+            for relative, expected_sha in self.spec.protected_history:
+                target = repository / relative
+                if (
+                    not target.is_file()
+                    or target.is_symlink()
+                    or _sha256_bytes(target.read_bytes()) != expected_sha
+                ):
+                    raise ValueError("P0_PROTECTED_HISTORY_MISMATCH")
+                protected.append({"path": relative, "sha256": expected_sha})
+
+            source_product_tree = product_tree_sha256(repository)
+            installed_product_tree = product_tree_sha256(_runtime_root())
+            if source_product_tree != installed_product_tree:
+                raise ValueError("P0_SOURCE_INSTALLED_PRODUCT_TREE_MISMATCH")
+            tasks = _task_identities(self.spec)
+            charter: list[dict[str, str]] = []
+            for target in sorted(
+                (repository / "validation").glob(
+                    "a7_creator_live_whole_flow_reentry_charter*.md"
+                ),
+                key=lambda item: item.name.encode("utf-8"),
+            ):
+                charter.append(
+                    {
+                        "path": target.relative_to(repository).as_posix(),
+                        "sha256": _sha256_bytes(target.read_bytes()),
+                    }
+                )
+            if not charter:
+                raise ValueError("P0_CHARTER_LINEAGE_MISSING")
+            binding = {
+                "schema": "decision-os.creator-live-cycle-005-launch-binding.v0.1",
+                "cycle_key": self.spec.cycle_key,
+                "repository": {
+                    "path": str(repository),
+                    "repository_id": observed_repository_id,
+                    "head": head,
+                    "local_main": local_main,
+                    "origin_main": origin_main,
+                    "branch": branch,
+                    "remote": remote,
+                    "tracked_worktree_clean": True,
+                    "index_clean": True,
+                    "git_operation_active": False,
+                },
+                "contract": {
+                    "profile": EXPECTED_CONTRACT_PROFILE,
+                    "source_byte_count": EXPECTED_CONTRACT_BYTES,
+                    "source_sha256": EXPECTED_CONTRACT_SHA256,
+                    "wrapper_sha256": EXPECTED_WRAPPER_SHA256,
+                    "interpretation_sha256": EXPECTED_INTERPRETATION_SHA256,
+                    "preparation_id": ordinary.get("preparation_id"),
+                    "preparation_receipt_sha256": preparation_receipt_sha,
+                    "request_id": technical.get("request_id"),
+                    "draft_id": technical.get("draft_id"),
+                    "freeze_id": freeze.get("freeze_id"),
+                    "frozen_intake_sha256": freeze.get("frozen_intake_sha256"),
+                    "freeze_receipt_sha256": freeze_receipt_sha,
+                    "guided_intake_current_event_chain_head": current_chain_head,
+                    "contract_preparation_receipt_event_chain_head": preparation.get(
+                        "event_chain_head"
+                    ),
+                    "contract_freeze_receipt_event_chain_head": predecessor_head,
+                    "ordinary_contract_execution_authority": (
+                        EXPECTED_EXECUTION_AUTHORITY
+                    ),
+                    "guided_intake_freeze_authority_state": (
+                        EXPECTED_FREEZE_AUTHORITY
+                    ),
+                    "gate": EXPECTED_GATE,
+                },
+                "authorizations": {
+                    "cycle_observed_at": self.spec.cycle_authorization_observed_at,
+                    "implementation_observed_at": (
+                        self.spec.implementation_authorization_observed_at
+                    ),
+                },
+                "runtime": {
+                    "provider": "openai",
+                    "account_type": self.spec.runtime.account_type,
+                    "model": self.spec.runtime.model,
+                    "reasoning_effort": self.spec.runtime.reasoning_effort,
+                    "service_tier": self.spec.runtime.service_tier,
+                    "codex_cli_version": self.spec.runtime.codex_cli_version,
+                    "fresh_ephemeral_thread_per_run": True,
+                    "provider_transport_required": True,
+                    "model_sandbox_network_access": False,
+                    "model_capabilities": {
+                        "web": False,
+                        "browser": False,
+                        "general_url_access": False,
+                        "mcp": False,
+                        "plugins": False,
+                        "apps": False,
+                        "hooks": False,
+                        "remote_plugins": False,
+                        "multi_agent": False,
+                        "shell_or_command_execution": False,
+                        "dependency_installation": False,
+                        "arbitrary_file_mutation": False,
+                    },
+                },
+                "tasks": tasks,
+                "attempt_policy": {
+                    "one_attempt_no_retry": True,
+                    "replacement_permitted": False,
+                },
+                "charter_lineage": charter,
+                "protected_history": protected,
+                "product": {
+                    "source_tree_sha256": source_product_tree,
+                    "installed_tree_sha256": installed_product_tree,
+                },
+                "historical_boundary": (
+                    "Cycle 004 remains FAILED/A1_CAPTURE/"
+                    "A1_CAPTURE_CHRONOLOGY_INVALID; earlier proofs remain terminal."
+                ),
+            }
+            digest = _sha256_bytes(canonical_json(binding).encode("utf-8"))
+            return CreatorLiveP0Result(True, None, binding, digest)
+        except (
+            OSError,
+            RuntimeError,
+            subprocess.SubprocessError,
+            TypeError,
+            ValueError,
+            KeyError,
+        ) as exc:
+            code = str(exc)
+            if not code.startswith("P0_"):
+                code = "P0_IDENTITY_UNAVAILABLE"
+            return CreatorLiveP0Result(False, code[:128], None, None)
+
+    def _public_readback(self, runtime: FieldNoteCreatorLiveProofRuntime) -> dict[str, Any]:
+        readback = runtime.read_back()
+        return {
+            "proof_attempt_id": readback.proof_attempt_id,
+            "run_1_id": readback.run_1.run_id,
+            "run_2_id": readback.run_2.run_id if readback.run_2 else None,
+            "note_id": (
+                readback.captured_note.field_note_id
+                if readback.captured_note is not None
+                else None
+            ),
+            "note_path": (
+                readback.captured_note.note_path
+                if readback.captured_note is not None
+                else None
+            ),
+            "note_sha256": (
+                readback.captured_note.note_sha256
+                if readback.captured_note is not None
+                else None
+            ),
+            "proof_as_of": readback.terminal_proof_as_of,
+            "journal_sha256": _sha256_bytes(runtime.journal_path.read_bytes()),
+            "anchor_sha256": _sha256_bytes(runtime.anchor_path.read_bytes()),
+        }
+
+    def snapshot(self, base_snapshot: Mapping[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            root = self.spec.storage_root
+            if self._runtime is not None:
+                readback = self._runtime.read_back()
+                state = self._terminal_state or (
+                    "RUNNING" if self._active else readback.state
+                )
+                digest = readback.proof_attempt_id.removeprefix(
+                    "proof_a7_creator_live_cycle_005_"
+                )
+                return {
+                    "cycle_key": self.spec.cycle_key,
+                    "state": state,
+                    "stage": self._stage,
+                    "p0": {"ready": True, "failure_code": None},
+                    "launch_binding_sha256": digest if _SHA256.fullmatch(digest) else None,
+                    "binding": None,
+                    "identities": self._public_readback(self._runtime),
+                    "receipt_sha256": self._receipt_sha256,
+                    "manifest_sha256": self._manifest_sha256,
+                    "failure_code": self._terminal_failure_code,
+                    "one_attempt_no_retry": True,
+                    "replacement_permitted": False,
+                }
+            if _proof_storage_occupied(root):
+                try:
+                    runtime = FieldNoteCreatorLiveProofRuntime.load_attempt(root)
+                    readback = runtime.read_back()
+                    self._runtime = runtime
+                    state = (
+                        readback.state
+                        if readback.state in {"FAILED", "TRACE_COMPLETE"}
+                        else "OPEN_UNRESUMABLE"
+                    )
+                    self._terminal_state = state
+                    self._stage = readback.current_stage or "A7"
+                    return self.snapshot(base_snapshot)
+                except Exception:
+                    return {
+                        "cycle_key": self.spec.cycle_key,
+                        "state": "INTEGRITY_FAILURE",
+                        "stage": "proof-open",
+                        "p0": {"ready": False, "failure_code": "PROOF_STORAGE_INTEGRITY_FAILURE"},
+                        "launch_binding_sha256": None,
+                        "binding": None,
+                        "identities": None,
+                        "receipt_sha256": None,
+                        "manifest_sha256": None,
+                        "failure_code": "PROOF_STORAGE_INTEGRITY_FAILURE",
+                        "one_attempt_no_retry": True,
+                        "replacement_permitted": False,
+                    }
+            p0 = self._p0(base_snapshot)
+            return {
+                "cycle_key": self.spec.cycle_key,
+                "state": "READY" if p0.ready else "NOT_READY",
+                "stage": "P0",
+                "p0": {"ready": p0.ready, "failure_code": p0.failure_code},
+                "launch_binding_sha256": p0.launch_binding_sha256,
+                "binding": p0.binding,
+                "identities": None,
+                "receipt_sha256": None,
+                "manifest_sha256": None,
+                "failure_code": p0.failure_code,
+                "one_attempt_no_retry": True,
+                "replacement_permitted": False,
+            }
+
+    def start(self, launch_binding_sha256: str) -> dict[str, Any]:
+        if not isinstance(launch_binding_sha256, str) or not _SHA256.fullmatch(
+            launch_binding_sha256
+        ):
+            raise CreatorLiveEntrypointError(
+                "LAUNCH_BINDING_INVALID",
+                http_status=400,
+            )
+        with self._lock:
+            if (
+                self._starting
+                or self._active
+                or _proof_storage_occupied(self.spec.storage_root)
+            ):
+                raise CreatorLiveEntrypointError("CYCLE_005_ATTEMPT_EXISTS")
+            self._starting = True
+        try:
+            base_snapshot = self.controller.snapshot()
+        except Exception as exc:
+            with self._lock:
+                self._starting = False
+            raise CreatorLiveEntrypointError("P0_STATE_UNAVAILABLE") from exc
+        with self._lock:
+            p0 = self._p0(base_snapshot)
+            if not p0.ready or p0.launch_binding_sha256 is None:
+                self._starting = False
+                raise CreatorLiveEntrypointError(p0.failure_code or "P0_NOT_READY")
+            if launch_binding_sha256 != p0.launch_binding_sha256:
+                self._starting = False
+                raise CreatorLiveEntrypointError("LAUNCH_BINDING_STALE")
+            proof_attempt_id = (
+                "proof_a7_creator_live_cycle_005_" + launch_binding_sha256
+            )
+            run_1_id = "run_a7_creator_live_cycle_005_1_" + launch_binding_sha256
+            try:
+                attempt = FieldNoteCreatorLiveAttempt(
+                    proof_attempt_id=proof_attempt_id,
+                    proof_mode="CREATOR_LIVE",
+                    creator_id="Shin",
+                    authorization_observed_at=(
+                        self.spec.cycle_authorization_observed_at
+                    ),
+                )
+                repository = self.spec.repository.resolve(strict=True)
+                source = FieldNoteSourceRepositoryIdentity(
+                    repository_id=repository_id(repository),
+                    source_commit=git_output(repository, "rev-parse", "HEAD"),
+                )
+            except Exception as exc:
+                self._starting = False
+                raise CreatorLiveEntrypointError(
+                    "P0_REPOSITORY_IDENTITY_CHANGED"
+                ) from exc
+            try:
+                runtime = self.runtime_opener(
+                    self.spec.storage_root,
+                    attempt=attempt,
+                    source_repository=source,
+                    run_1_id=run_1_id,
+                    runtime=self.spec.runtime,
+                )
+            except FieldNoteCreatorLiveAttemptExistsError as exc:
+                self._starting = False
+                raise CreatorLiveEntrypointError(
+                    "CYCLE_005_ATTEMPT_EXISTS"
+                ) from exc
+            except Exception as exc:
+                self._starting = False
+                code = (
+                    "PROOF_STORAGE_INTEGRITY_FAILURE"
+                    if _proof_artifacts_exist(self.spec.storage_root)
+                    else "PROOF_OPEN_FAILED"
+                )
+                raise CreatorLiveEntrypointError(code) from exc
+            self._runtime = runtime
+            self._starting = False
+            self._active = True
+            self._stage = "proof-open"
+            try:
+                self._worker = self.worker_factory(
+                    target=self._run_sequence,
+                    args=(runtime, source, launch_binding_sha256),
+                    name="decision-os-creator-live-cycle-005",
+                    daemon=True,
+                )
+                self._worker.start()
+            except Exception as exc:
+                self._starting = False
+                self._active = False
+                try:
+                    runtime.record_stage_failure(
+                        "A1_CAPTURE",
+                        "CYCLE_005_COORDINATOR_START_FAILED",
+                    )
+                except Exception:
+                    pass
+                raise CreatorLiveEntrypointError(
+                    "CYCLE_005_COORDINATOR_START_FAILED"
+                ) from exc
+            return self.snapshot(base_snapshot)
+
+    def _fail_open_runtime(
+        self,
+        runtime: FieldNoteCreatorLiveProofRuntime,
+        code: str,
+    ) -> None:
+        try:
+            readback = runtime.read_back()
+            if readback.state != "OPEN":
+                return
+            stage = readback.current_stage
+            boundary = {
+                "A1_CAPTURE": "A1_CAPTURE",
+                "A2_RECONNECT": "A2_RECONNECT",
+                "A3_REUSE": "A3_REUSE",
+                "A4_DURABILITY": "A4_DURABILITY",
+                "A5_CONFIRMATION": "A5_CONFIRMATION",
+                "A6_REVIEW": "A6_REVIEW",
+            }.get(stage, "RUNTIME_ENFORCEMENT")
+            runtime.record_stage_failure(boundary, code[:256])
+        except Exception:
+            pass
+
+    def _run_sequence(
+        self,
+        runtime: FieldNoteCreatorLiveProofRuntime,
+        source: FieldNoteSourceRepositoryIdentity,
+        launch_binding_sha256: str,
+    ) -> None:
+        try:
+            repository = self.spec.repository.resolve(strict=True)
+            self._stage = "A1"
+            a1_bridge = FieldNoteCreatorLiveA1CaptureBridge(
+                runtime=runtime,
+                controller=self.controller,  # type: ignore[arg-type]
+                repository=repository,
+                source_repository=source,
+            )
+            a1_bridge.capture(self.spec.run_1_task)
+            after_a1 = runtime.read_back()
+            draft = self.controller.creator_live_a1_completed_draft(
+                expected_run_id=after_a1.run_1.run_id
+            )
+            note = after_a1.captured_note
+            if note is None:
+                raise ValueError("A1_NOTE_IDENTITY_MISSING")
+            self._stage = "A2"
+            run_2_id = "run_a7_creator_live_cycle_005_2_" + launch_binding_sha256
+            runtime.open_run_2(
+                FieldNoteWholeFlowRunIdentity(
+                    proof_attempt_id=after_a1.proof_attempt_id,
+                    run_id=run_2_id,
+                    started_at=self.now(),
+                    repository=source,
+                    runtime=self.spec.runtime,
+                )
+            )
+            pre_a2 = runtime.read_back()
+            exact = prepare_creator_live_a2_reconnect(
+                repository,
+                creator_live_a2_target_from_readback(pre_a2),
+            )
+            a2_bridge = FieldNoteCreatorLiveA2ReconnectBridge(
+                runtime=runtime,
+                controller=self.controller,
+                repository=repository,
+                source_repository=source,
+            )
+            a2_bridge.reconnect(self.spec.run_2_task)
+            completion = self.controller.creator_live_a2_run_completion(
+                expected_run_id=run_2_id
+            )
+            after_a2 = runtime.read_back()
+            target = after_a2.captured_note
+            if target is None:
+                raise ValueError("A2_TARGET_MISSING")
+            note_bytes = exact.note_bytes
+            self._stage = "A3"
+            evidence_as_of = self.now()
+            claim = compile_run_2_output_artifact(
+                note=target,
+                note_bytes=note_bytes,
+                run_2_id=run_2_id,
+                final_output_bytes=completion.final_output_bytes,
+                final_output_sha256=completion.final_output_sha256,
+                observed_at=evidence_as_of,
+            )
+            assessment = assess_field_note_reuse(
+                target,
+                claim,
+                note_bytes=note_bytes,
+            )
+            if assessment.state != "REUSED":
+                raise ValueError("A3_NOT_DEMONSTRABLY_REUSED")
+            runtime.record_a3_reuse(
+                assessment,
+                note=target,
+                note_bytes=note_bytes,
+            )
+
+            ledger = FieldNoteMaturityLedger(
+                repository / ".decision-os/field-notes/maturity-ledger-v0.1",
+                target,
+            )
+            self._stage = "A4"
+            commit = commit_field_note_maturity(
+                ledger,
+                FieldNoteMaturityCommitRequest(
+                    note=target,
+                    note_bytes=note_bytes,
+                    reuse_claim=claim,
+                    recorded_at=self.now(),
+                    delivery_context=completion.reconnect_receipt,
+                ),
+            )
+            if commit.assessment != assessment or commit.durable_snapshot is None:
+                raise ValueError("A4_ASSESSMENT_READBACK_MISMATCH")
+            runtime.record_a4_durability(commit.durable_snapshot)
+            self._stage = "A5"
+            runtime.record_a5_confirmation(commit)
+            self._stage = "A6"
+            review = review_field_note_maturity(
+                ledger,
+                target,
+                note_bytes=note_bytes,
+                review_as_of=self.now(),
+            )
+            runtime.record_a6_review(review)
+            self._stage = "A7"
+            terminal = runtime.read_back()
+            if terminal.run_2 is None:
+                raise ValueError("A7_RUN_2_MISSING")
+            bundle = FieldNoteWholeFlowEvidenceBundle(
+                attempt=terminal.attempt,
+                source_repository=source,
+                run_1=terminal.run_1,
+                run_2=terminal.run_2,
+                note=target,
+                note_bytes=note_bytes,
+                a1_capture=draft,
+                a2_reconnect=completion.reconnect_receipt,
+                a3_assessment=assessment,
+                a4_snapshot=commit.durable_snapshot,
+                a5_commit=commit,
+                a6_review=review,
+                proof_trace=terminal.events,
+                creator_live_readback=terminal,
+            )
+            receipt = verify_field_note_whole_flow(bundle)
+            if receipt.state != "PASS":
+                raise ValueError(receipt.failure_reason or "A7_VERIFICATION_FAILED")
+            manifest = build_portable_candidate_warehouse_manifest(bundle)
+            with self._lock:
+                self._receipt_sha256 = receipt.receipt_sha256
+                self._manifest_sha256 = manifest.manifest_id
+                self._terminal_state = "PASS"
+                self._stage = "A7"
+        except Exception as exc:
+            code = str(exc).strip() or "CREATOR_LIVE_SEQUENCE_FAILED"
+            self._fail_open_runtime(runtime, code)
+            with self._lock:
+                self._terminal_state = "FAILED"
+                self._terminal_failure_code = code[:256]
+        finally:
+            with self._lock:
+                self._active = False
+
+
+__all__ = [
+    "CYCLE_KEY",
+    "CreatorLiveCycle005Entrypoint",
+    "CreatorLiveCycle005Spec",
+    "CreatorLiveEntrypointError",
+    "CreatorLiveP0Result",
+    "RUN_1_TASK",
+    "RUN_1_TASK_SHA256",
+    "RUN_2_TASK",
+    "RUN_2_TASK_SHA256",
+    "compile_run_2_output_artifact",
+    "product_tree_sha256",
+]

--- a/decision_os/companion/field_notes_server.py
+++ b/decision_os/companion/field_notes_server.py
@@ -10,11 +10,24 @@ from decision_os.companion.field_notes_controller import (
     FieldNoteError,
     FieldNotesCompanionController,
 )
+from decision_os.companion.field_notes_creator_live_entrypoint import (
+    CreatorLiveEntrypointError,
+)
 from decision_os.companion.server import CompanionRequestHandler, CompanionServer
 
 
 class FieldNotesRequestHandler(CompanionRequestHandler):
-    """Serve Field Notes assets and three bounded state-change routes."""
+    """Serve Field Notes assets and bounded state-change routes."""
+
+    def _json(self, status: HTTPStatus, value: object) -> None:
+        controller = self.server.controller
+        if (
+            isinstance(value, dict)
+            and isinstance(controller, FieldNotesCompanionController)
+            and "creator_live_cycle_005" in value
+        ):
+            value = controller.creator_live_cycle_005_public_projection(value)
+        super()._json(status, value)
 
     def _asset(self, filename: str, content_type: str) -> None:
         if not self._request_allowed():
@@ -64,6 +77,50 @@ class FieldNotesRequestHandler(CompanionRequestHandler):
 
     def do_POST(self) -> None:
         path = urlsplit(self.path).path
+        controller = self.server.controller
+        if (
+            path != "/api/creator-live/cycles/005/start"
+            and isinstance(controller, FieldNotesCompanionController)
+            and controller.creator_live_cycle_005_mutation_blocked()
+        ):
+            if not self._request_allowed(state_change=True):
+                return
+            self._error(
+                HTTPStatus.CONFLICT,
+                "CREATOR_LIVE_CYCLE_005_ACTIVE",
+            )
+            return
+        if path == "/api/creator-live/cycles/005/start":
+            if not self._request_allowed(state_change=True):
+                return
+            value = self._read_json(strict=True)
+            if value is None:
+                return
+            if not isinstance(controller, FieldNotesCompanionController):
+                self._error(
+                    HTTPStatus.CONFLICT,
+                    "CREATOR_LIVE_ENTRYPOINT_UNAVAILABLE",
+                )
+                return
+            if (
+                set(value) != {"launch_binding_sha256"}
+                or not isinstance(value["launch_binding_sha256"], str)
+            ):
+                self._error(
+                    HTTPStatus.BAD_REQUEST,
+                    "CREATOR_LIVE_REQUEST_INVALID",
+                )
+                return
+            try:
+                snapshot = controller.creator_live_cycle_005_start(
+                    value["launch_binding_sha256"]
+                )
+            except CreatorLiveEntrypointError as exc:
+                self._error(HTTPStatus(exc.http_status), exc.code)
+                return
+            snapshot["csrf"] = self.server.csrf_token
+            self._json(HTTPStatus.ACCEPTED, snapshot)
+            return
         if path not in {
             "/api/field-notes/save",
             "/api/field-notes/skip",
@@ -76,7 +133,6 @@ class FieldNotesRequestHandler(CompanionRequestHandler):
         value = self._read_json(strict=True)
         if value is None:
             return
-        controller = self.server.controller
         if not isinstance(controller, FieldNotesCompanionController):
             self._error(HTTPStatus.CONFLICT, "Field Notes controller is unavailable.")
             return

--- a/decision_os/companion/static/app.css
+++ b/decision_os/companion/static/app.css
@@ -259,6 +259,24 @@ h3 {
   overflow-wrap: anywhere;
 }
 
+.creator-live-card {
+  border-color: #b8c8f8;
+}
+
+.creator-live-binding {
+  display: grid;
+  gap: 0.45rem 1rem;
+  grid-template-columns: minmax(9rem, max-content) minmax(0, 1fr);
+  margin: 0 0 1rem;
+}
+
+.creator-live-binding dd {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .path-value {
   font-family: ui-monospace, "SFMono-Regular", Menlo, monospace;
   font-size: 0.82rem;
@@ -796,6 +814,7 @@ dd {
   }
 
   .operation-summary,
+  .creator-live-binding,
   .result-outcomes,
   .approval-actions {
     grid-template-columns: 1fr;

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -46,6 +46,7 @@ const EMPTY_SHA256 =
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
 const byId = (id) => document.getElementById(id);
+const optionalById = (id) => document.querySelectorAll(`#${id}`)[0] || null;
 
 class CompanionUnavailableError extends Error {}
 
@@ -1824,6 +1825,86 @@ function renderBridge(bridge, repository) {
   byId("bridge-record-intervention").disabled = !hasSession;
 }
 
+function renderCreatorLiveCycle005(value) {
+  if (!optionalById("creator-live-start")) {
+    return;
+  }
+  const cycle = value && typeof value === "object" ? value : null;
+  const binding = cycle?.binding;
+  const contract = binding?.contract;
+  const runtime = binding?.runtime;
+  const tasks = binding?.tasks;
+  const state = cycle?.state || "UNAVAILABLE";
+  setText("creator-live-cycle-005-status", state.replaceAll("_", " "));
+  setText("creator-live-revision", binding?.repository?.head || "Unavailable");
+  setText(
+    "creator-live-contract",
+    contract?.source_sha256
+      ? `${contract.profile} · ${contract.source_byte_count} bytes · ${contract.source_sha256}`
+      : "Unavailable",
+  );
+  setText(
+    "creator-live-contract-authority",
+    contract?.ordinary_contract_execution_authority || "Unavailable",
+  );
+  setText(
+    "creator-live-freeze-authority",
+    contract?.guided_intake_freeze_authority_state || "Unavailable",
+  );
+  setText(
+    "creator-live-authorization",
+    binding?.authorizations?.cycle_observed_at || "2026-08-05T06:22:00Z",
+  );
+  setText(
+    "creator-live-implementation-authorization",
+    binding?.authorizations?.implementation_observed_at ||
+      "2026-08-05T08:47:00Z",
+  );
+  setText(
+    "creator-live-runtime",
+    runtime
+      ? `${runtime.provider} · ${runtime.account_type} · ${runtime.model} · ${runtime.reasoning_effort} · ${runtime.service_tier} · CLI ${runtime.codex_cli_version}`
+      : "Unavailable",
+  );
+  setText(
+    "creator-live-run-1",
+    tasks?.run_1
+      ? `${tasks.run_1.byte_count} bytes · ${tasks.run_1.sha256} · ${tasks.run_1.lane}`
+      : "832 bytes · unavailable",
+  );
+  setText(
+    "creator-live-run-2",
+    tasks?.run_2
+      ? `${tasks.run_2.byte_count} bytes · ${tasks.run_2.sha256} · ${tasks.run_2.lane}`
+      : "856 bytes · unavailable",
+  );
+  setText(
+    "creator-live-attempt-policy",
+    cycle
+      ? `${cycle.one_attempt_no_retry ? "One attempt · no retry" : "Policy unavailable"} · ${cycle.replacement_permitted ? "replacement permitted" : "no replacement"}`
+      : "One attempt · no retry · no replacement",
+  );
+  setText(
+    "creator-live-historical-boundary",
+    binding?.historical_boundary || "Unavailable",
+  );
+  setText(
+    "creator-live-p0",
+    cycle?.p0?.ready
+      ? "PASS"
+      : cycle?.p0?.failure_code || "Unavailable",
+  );
+  setText(
+    "creator-live-binding-sha256",
+    cycle?.launch_binding_sha256 || "Unavailable",
+  );
+  setText("creator-live-stage", cycle?.stage || "P0");
+  byId("creator-live-start").disabled =
+    state !== "READY" ||
+    cycle?.p0?.ready !== true ||
+    typeof cycle?.launch_binding_sha256 !== "string";
+}
+
 function render(state) {
   if (!connected) {
     return;
@@ -1930,6 +2011,10 @@ function render(state) {
   renderOrdinaryContract(state.ordinary_contract, repository);
   renderGuidedIntake(state.guided_intake, repository);
   renderBridge(state.manual_bridge, repository);
+  renderCreatorLiveCycle005(state.creator_live_cycle_005);
+  if (state.creator_live_cycle_005?.state === "RUNNING") {
+    disableStateChangingControls();
+  }
   if (["PREPARING", "FIXING"].includes(state.ordinary_contract?.state)) {
     byId("contract-file").disabled = true;
     byId("contract-import").disabled = true;
@@ -1941,6 +2026,10 @@ function render(state) {
 }
 
 function disableStateChangingControls() {
+  const creatorLiveStart = optionalById("creator-live-start");
+  if (creatorLiveStart) {
+    creatorLiveStart.disabled = true;
+  }
   byId("choose-repository").disabled = true;
   byId("ordinary-contract-file").disabled = true;
   byId("ordinary-contract-confirm").disabled = true;
@@ -2022,6 +2111,7 @@ function enterDisconnected() {
   renderOrdinaryContract(null, null);
   renderGuidedIntake(null, null);
   renderBridge(null, null);
+  renderCreatorLiveCycle005(null);
 
   setText("global-error", DISCONNECTED_MESSAGE);
   setHidden("global-error", false);
@@ -2454,6 +2544,23 @@ byId("run").addEventListener("click", async () => {
     render(state);
   } else if (latestState) {
     render(latestState);
+  }
+});
+
+optionalById("creator-live-start")?.addEventListener("click", async () => {
+  const digest = latestState?.creator_live_cycle_005?.launch_binding_sha256;
+  if (
+    byId("creator-live-start").disabled ||
+    requestActive ||
+    typeof digest !== "string"
+  ) {
+    return;
+  }
+  const state = await postJSON("/api/creator-live/cycles/005/start", {
+    launch_binding_sha256: digest,
+  });
+  if (state) {
+    render(state);
   }
 });
 

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -36,6 +36,62 @@
       </p>
     </section>
 
+    <section
+      id="creator-live-cycle-005-card"
+      class="card creator-live-card"
+      aria-labelledby="creator-live-cycle-005-heading"
+    >
+      <div class="section-heading">
+        <div>
+          <p class="step">LIVE</p>
+          <h2 id="creator-live-cycle-005-heading">Cycle 005</h2>
+        </div>
+        <span
+          id="creator-live-cycle-005-status"
+          class="status"
+          role="status"
+          aria-live="polite"
+        >Not ready</span>
+      </div>
+      <p class="boundary">
+        One fixed creator-live whole-flow attempt. The binding is content-free;
+        no task or model-output text is shown here.
+      </p>
+      <dl class="creator-live-binding">
+        <dt>Exact revision</dt>
+        <dd id="creator-live-revision">Unavailable</dd>
+        <dt>Contract identity</dt>
+        <dd id="creator-live-contract">Unavailable</dd>
+        <dt>Contract authority</dt>
+        <dd id="creator-live-contract-authority">Unavailable</dd>
+        <dt>Freeze authority</dt>
+        <dd id="creator-live-freeze-authority">Unavailable</dd>
+        <dt>Cycle authorization</dt>
+        <dd id="creator-live-authorization">2026-08-05T06:22:00Z</dd>
+        <dt>Implementation authorization</dt>
+        <dd id="creator-live-implementation-authorization">2026-08-05T08:47:00Z</dd>
+        <dt>Runtime</dt>
+        <dd id="creator-live-runtime">Unavailable</dd>
+        <dt>Run 1 identity</dt>
+        <dd id="creator-live-run-1">832 bytes · unavailable</dd>
+        <dt>Run 2 identity</dt>
+        <dd id="creator-live-run-2">856 bytes · unavailable</dd>
+        <dt>Attempt policy</dt>
+        <dd id="creator-live-attempt-policy">One attempt · no retry · no replacement</dd>
+        <dt>Historical boundary</dt>
+        <dd id="creator-live-historical-boundary">Unavailable</dd>
+        <dt>P0 readiness</dt>
+        <dd id="creator-live-p0">Unavailable</dd>
+        <dt>Launch binding</dt>
+        <dd id="creator-live-binding-sha256">Unavailable</dd>
+        <dt>Stage</dt>
+        <dd id="creator-live-stage">P0</dd>
+      </dl>
+      <button id="creator-live-start" class="primary" type="button" disabled>
+        Start Cycle 005
+      </button>
+    </section>
+
     <aside
       id="operation-awareness"
       class="operation-awareness"

--- a/tests/test_companion_process_qualification.py
+++ b/tests/test_companion_process_qualification.py
@@ -33,7 +33,7 @@ from scripts.qualify_companion_process import (
 
 
 EXPECTED_PRODUCT_TREE = (
-    "c1861df13861e562d82f95b36ba087e6bdb6da44d6faec53690f53303c8755a5"
+    "815613804a6028a33806afe096ca072c80515ee8ebb73514b96f85ca02f784d6"
 )
 LIVE_RUNTIME = Path(
     "/Users/sn/Library/Application Support/Decision OS Companion/runtime"

--- a/tests/test_field_notes_creator_live_entrypoint.py
+++ b/tests/test_field_notes_creator_live_entrypoint.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+import hashlib
+import http.client
+import json
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import threading
+import unittest
+from urllib.parse import urlsplit
+
+from decision_os.companion.field_notes_controller import (
+    FieldNotesCompanionController,
+)
+from decision_os.companion.field_notes_creator_live_entrypoint import (
+    CYCLE_AUTHORIZATION_OBSERVED_AT,
+    EXPECTED_EXECUTION_AUTHORITY,
+    EXPECTED_FREEZE_AUTHORITY,
+    IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT,
+    RUN_1_TASK,
+    RUN_1_TASK_SHA256,
+    RUN_2_TASK,
+    RUN_2_TASK_SHA256,
+    CreatorLiveCycle005Entrypoint,
+    CreatorLiveCycle005Spec,
+    CreatorLiveEntrypointError,
+    CreatorLiveP0Result,
+    compile_run_2_output_artifact,
+)
+from decision_os.companion.field_notes_reuse import FieldNoteIdentity
+from decision_os.companion.field_notes_server import configure_field_notes_server
+from decision_os.companion.server import CompanionServer
+from tests.test_companion_controller import ScriptedFactory, create_repository
+
+
+_DIGEST = "a4" * 32
+
+
+class _NoopWorker:
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _FailingWorker(_NoopWorker):
+    def start(self) -> None:
+        raise RuntimeError("fixture interruption")
+
+
+class _Controller:
+    def __init__(self, repository: Path) -> None:
+        self.repository = repository
+
+    def snapshot(self) -> dict[str, object]:
+        return {"repository": {"path": str(self.repository)}}
+
+
+class _ReadyEntrypoint(CreatorLiveCycle005Entrypoint):
+    def _p0(self, _base_snapshot: object) -> CreatorLiveP0Result:
+        binding = {
+            "schema": "test.creator-live-binding",
+            "cycle_key": "cycle-005",
+        }
+        return CreatorLiveP0Result(True, None, binding, _DIGEST)
+
+
+class _FakeHTTPEntrypoint:
+    def __init__(self, _controller: object) -> None:
+        self.started: list[str] = []
+        self.mutation_blocked = False
+
+    def snapshot(self, _base: object) -> dict[str, object]:
+        return {
+            "cycle_key": "cycle-005",
+            "state": "READY",
+            "stage": "P0",
+            "p0": {"ready": True, "failure_code": None},
+            "launch_binding_sha256": _DIGEST,
+            "binding": {
+                "repository": {"head": "a" * 40},
+                "contract": {
+                    "source_sha256": "b" * 64,
+                    "source_byte_count": 11_039,
+                    "profile": "ORDINARY_USER_PATH_CONTRACT_APPROVED_CANDIDATE_V0_1",
+                    "ordinary_contract_execution_authority": (
+                        EXPECTED_EXECUTION_AUTHORITY
+                    ),
+                    "guided_intake_freeze_authority_state": (
+                        EXPECTED_FREEZE_AUTHORITY
+                    ),
+                },
+                "authorizations": {
+                    "cycle_observed_at": CYCLE_AUTHORIZATION_OBSERVED_AT,
+                    "implementation_observed_at": (
+                        IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT
+                    ),
+                },
+                "runtime": {
+                    "provider": "openai",
+                    "account_type": "chatgpt",
+                    "model": "gpt-5.6-sol",
+                    "reasoning_effort": "ultra",
+                    "service_tier": "priority",
+                    "codex_cli_version": "0.146.0-alpha.3.1",
+                },
+                "tasks": {
+                    "run_1": {
+                        "byte_count": 832,
+                        "sha256": RUN_1_TASK_SHA256,
+                        "lane": "A1_ONLY",
+                    },
+                    "run_2": {
+                        "byte_count": 856,
+                        "sha256": RUN_2_TASK_SHA256,
+                        "lane": "EXACT_A2_ONLY",
+                    },
+                },
+                "historical_boundary": "Historical attempts remain terminal.",
+            },
+            "identities": None,
+            "receipt_sha256": None,
+            "manifest_sha256": None,
+            "failure_code": None,
+            "one_attempt_no_retry": True,
+            "replacement_permitted": False,
+        }
+
+    def start(self, digest: str) -> dict[str, object]:
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise CreatorLiveEntrypointError(
+                "LAUNCH_BINDING_INVALID",
+                http_status=400,
+            )
+        if digest != _DIGEST:
+            raise CreatorLiveEntrypointError("LAUNCH_BINDING_STALE")
+        self.started.append(digest)
+        return self.snapshot({})
+
+
+def _commit_repository(root: Path) -> Path:
+    repository = root / "repository"
+    repository.mkdir()
+    commands = (
+        ("git", "init", "-q", "-b", "main"),
+        ("git", "config", "user.email", "tests@example.invalid"),
+        ("git", "config", "user.name", "Decision OS Tests"),
+    )
+    for command in commands:
+        subprocess.run(command, cwd=repository, check=True, capture_output=True)
+    (repository / "README.md").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(("git", "add", "README.md"), cwd=repository, check=True)
+    subprocess.run(
+        ("git", "commit", "-q", "-m", "fixture"),
+        cwd=repository,
+        check=True,
+    )
+    return repository
+
+
+class CreatorLiveTaskAndEvidenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.note_bytes = (
+            b"# Execution identity\n"
+            b"Bind the product-code baseline and execution repository HEAD as separate exact identities.\n"
+            b"A later repository commit requires bounded requalification or a Charter delta.\n"
+        )
+        self.note = FieldNoteIdentity(
+            note_path=(
+                ".decision-os/field-notes/"
+                "2026-08-05-bind-execution-identities-fixture.md"
+            ),
+            field_note_id="FN-FIXTURE-005",
+            note_sha256=hashlib.sha256(self.note_bytes).hexdigest(),
+            origin_run_id="run-1-fixture",
+        )
+        self.run_2_id = "run-2-fixture"
+        self.structure = self.note_bytes.splitlines()[1]
+
+    def output(self, structure: bytes | None = None) -> bytes:
+        exact = self.structure if structure is None else structure
+        return b"\n".join(
+            (
+                f"note_path={self.note.note_path}".encode(),
+                f"note_id={self.note.field_note_id}".encode(),
+                f"note_sha256={self.note.note_sha256}".encode(),
+                f"run_2_id={self.run_2_id}".encode(),
+                b"exact_structure=" + exact,
+            )
+        )
+
+    def compile(self, output: bytes):
+        return compile_run_2_output_artifact(
+            note=self.note,
+            note_bytes=self.note_bytes,
+            run_2_id=self.run_2_id,
+            final_output_bytes=output,
+            final_output_sha256=hashlib.sha256(output).hexdigest(),
+            observed_at="2026-08-05T09:00:00Z",
+        )
+
+    def test_canonical_task_bytes_hashes_lanes_and_authorizations_are_exact(
+        self,
+    ) -> None:
+        self.assertEqual(832, len(RUN_1_TASK.encode("utf-8")))
+        self.assertEqual(
+            RUN_1_TASK_SHA256,
+            hashlib.sha256(RUN_1_TASK.encode("utf-8")).hexdigest(),
+        )
+        self.assertEqual(856, len(RUN_2_TASK.encode("utf-8")))
+        self.assertEqual(
+            RUN_2_TASK_SHA256,
+            hashlib.sha256(RUN_2_TASK.encode("utf-8")).hexdigest(),
+        )
+        self.assertEqual("2026-08-05T06:22:00Z", CYCLE_AUTHORIZATION_OBSERVED_AT)
+        self.assertEqual(
+            "2026-08-05T08:47:00Z",
+            IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT,
+        )
+        self.assertIn("Propose exactly one new Field Note", RUN_1_TASK)
+        self.assertNotIn("Propose another Field Note", RUN_2_TASK)
+
+    def test_a3_compiles_one_unique_exact_non_whole_utf8_range(self) -> None:
+        output = self.output()
+        claim = self.compile(output)
+        evidence = claim.use_evidence
+        self.assertIsNotNone(evidence)
+        assert evidence is not None
+        self.assertEqual("OUTPUT_ARTIFACT", evidence.evidence_class)
+        self.assertEqual("IMMEDIATE_COMPLETION_RECORD", evidence.evidence_origin)
+        self.assertTrue(evidence.structure_binding.verifies(self.note, self.note_bytes))
+        self.assertEqual(hashlib.sha256(output).hexdigest(), evidence.evidence_sha256)
+        self.assertEqual("UNKNOWN", claim.outcome_evaluation.outcome)
+        self.assertEqual("HOLD", claim.disposition.action)
+
+    def test_a3_rejects_fuzzy_semantic_normalized_and_whole_note_claims(self) -> None:
+        variants = (
+            self.output(self.structure.replace(b"exact", b"similar")),
+            self.output(self.structure.lower()),
+            self.output(self.structure.replace(b" ", b"  ")),
+            self.output() + b"\n" + self.note_bytes,
+        )
+        for output in variants:
+            with self.subTest(output=output[-80:]):
+                with self.assertRaises(ValueError):
+                    self.compile(output)
+
+    def test_a3_rejects_missing_lineage_wrong_output_hash_and_ambiguity(self) -> None:
+        missing = self.output().replace(self.note.note_sha256.encode(), b"0" * 64)
+        with self.assertRaisesRegex(ValueError, "A3_OUTPUT_ARTIFACT_LINEAGE_MISSING"):
+            self.compile(missing)
+        output = self.output()
+        with self.assertRaisesRegex(ValueError, "A3_OUTPUT_ARTIFACT_IDENTITY_INVALID"):
+            compile_run_2_output_artifact(
+                note=self.note,
+                note_bytes=self.note_bytes,
+                run_2_id=self.run_2_id,
+                final_output_bytes=output,
+                final_output_sha256="0" * 64,
+                observed_at="2026-08-05T09:00:00Z",
+            )
+        tied_note_bytes = b"# Fixture\n" + b"A" * 48 + b"\n" + b"B" * 48 + b"\n"
+        tied_note = FieldNoteIdentity(
+            note_path=self.note.note_path,
+            field_note_id=self.note.field_note_id,
+            note_sha256=hashlib.sha256(tied_note_bytes).hexdigest(),
+            origin_run_id=self.note.origin_run_id,
+        )
+        tied_output = b"\n".join(
+            (
+                tied_note.note_path.encode(),
+                tied_note.field_note_id.encode(),
+                tied_note.note_sha256.encode(),
+                self.run_2_id.encode(),
+                b"A" * 48,
+                b"B" * 48,
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "A3_EXACT_STRUCTURE_AMBIGUOUS"):
+            compile_run_2_output_artifact(
+                note=tied_note,
+                note_bytes=tied_note_bytes,
+                run_2_id=self.run_2_id,
+                final_output_bytes=tied_output,
+                final_output_sha256=hashlib.sha256(tied_output).hexdigest(),
+                observed_at="2026-08-05T09:00:00Z",
+            )
+
+
+class CreatorLiveAttemptIdentityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.repository = _commit_repository(self.root)
+        self.spec = CreatorLiveCycle005Spec(
+            repository=self.repository,
+            remote="fixture",
+            protected_history=(),
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def entrypoint(self) -> _ReadyEntrypoint:
+        return _ReadyEntrypoint(
+            _Controller(self.repository),
+            spec=self.spec,
+            worker_factory=_NoopWorker,
+        )
+
+    def test_preopen_mismatch_is_unconsumed_and_invokes_no_worker(self) -> None:
+        entrypoint = self.entrypoint()
+        with self.assertRaisesRegex(CreatorLiveEntrypointError, "LAUNCH_BINDING_STALE"):
+            entrypoint.start("5" * 64)
+        self.assertFalse(self.spec.storage_root.exists())
+        self.assertIsNone(entrypoint._worker)
+
+    def test_open_is_durable_deterministic_and_duplicate_has_no_replacement(self) -> None:
+        entrypoint = self.entrypoint()
+        snapshot = entrypoint.start(_DIGEST)
+        expected = "proof_a7_creator_live_cycle_005_" + _DIGEST
+        self.assertEqual(expected, snapshot["identities"]["proof_attempt_id"])
+        self.assertTrue(entrypoint._worker.started)
+        self.assertTrue(entrypoint._runtime.journal_path.is_file())
+        self.assertTrue(entrypoint._runtime.anchor_path.is_file())
+        with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
+            entrypoint.start(_DIGEST)
+        with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
+            entrypoint.start("6" * 64)
+        self.assertEqual(
+            {entrypoint._runtime.journal_path.name, entrypoint._runtime.anchor_path.name},
+            {path.name for path in self.spec.storage_root.iterdir()},
+        )
+
+    def test_restart_exposes_open_unresumable_and_cannot_create_replacement(self) -> None:
+        self.entrypoint().start(_DIGEST)
+        restarted = self.entrypoint()
+        snapshot = restarted.snapshot(_Controller(self.repository).snapshot())
+        self.assertEqual("OPEN_UNRESUMABLE", snapshot["state"])
+        self.assertEqual(
+            "proof_a7_creator_live_cycle_005_" + _DIGEST,
+            snapshot["identities"]["proof_attempt_id"],
+        )
+        with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
+            restarted.start(_DIGEST)
+
+    def test_postopen_coordinator_failure_consumes_one_terminal_attempt(self) -> None:
+        entrypoint = _ReadyEntrypoint(
+            _Controller(self.repository),
+            spec=self.spec,
+            worker_factory=_FailingWorker,
+        )
+        with self.assertRaisesRegex(
+            CreatorLiveEntrypointError,
+            "CYCLE_005_COORDINATOR_START_FAILED",
+        ):
+            entrypoint.start(_DIGEST)
+        self.assertEqual("FAILED", entrypoint._runtime.read_back().state)
+        restarted = self.entrypoint()
+        snapshot = restarted.snapshot(_Controller(self.repository).snapshot())
+        self.assertEqual("FAILED", snapshot["state"])
+        with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
+            restarted.start(_DIGEST)
+
+    def test_concurrent_clicks_resolve_to_one_open_attempt(self) -> None:
+        entrypoint = self.entrypoint()
+        outcomes: list[str] = []
+        gate = threading.Barrier(3)
+
+        def start() -> None:
+            gate.wait()
+            try:
+                entrypoint.start(_DIGEST)
+                outcomes.append("accepted")
+            except CreatorLiveEntrypointError as exc:
+                outcomes.append(exc.code)
+
+        workers = [threading.Thread(target=start) for _ in range(2)]
+        for worker in workers:
+            worker.start()
+        gate.wait()
+        for worker in workers:
+            worker.join(timeout=5)
+        self.assertCountEqual(
+            ["accepted", "CYCLE_005_ATTEMPT_EXISTS"],
+            outcomes,
+        )
+        self.assertEqual(2, len(tuple(self.spec.storage_root.iterdir())))
+
+    def test_partial_storage_is_integrity_failure_and_permanently_occupied(self) -> None:
+        self.spec.storage_root.mkdir(parents=True)
+        (self.spec.storage_root / "creator-live-proof-v0.2.jsonl").write_bytes(b"{")
+        entrypoint = self.entrypoint()
+        snapshot = entrypoint.snapshot(_Controller(self.repository).snapshot())
+        self.assertEqual("INTEGRITY_FAILURE", snapshot["state"])
+        with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
+            entrypoint.start(_DIGEST)
+
+
+class CreatorLiveHTTPTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        repository = create_repository(self.root)
+        self.controller = FieldNotesCompanionController(
+            state_path=self.root / "state.json",
+            picker_script=self.root / "picker.applescript",
+            picker_runner=lambda _script: str(repository),
+            adapter_factory=ScriptedFactory("read_only"),
+            creator_live_entrypoint_factory=_FakeHTTPEntrypoint,
+        )
+        self.controller.select_repository(repository)
+        static_root = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+        )
+        self.server = CompanionServer(self.controller, static_root=static_root)
+        configure_field_notes_server(self.server)
+        self.server.start_background()
+
+    def tearDown(self) -> None:
+        self.server.close()
+        self.temporary.cleanup()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: bytes | None = None,
+        content_type: str | None = "application/json",
+        cookie: str | None = None,
+        csrf: str | None = None,
+        origin: str | None = None,
+        host: str | None = None,
+    ) -> tuple[int, dict[str, str], bytes]:
+        connection = http.client.HTTPConnection("127.0.0.1", self.server.port)
+        headers: dict[str, str] = {}
+        if payload is not None and content_type is not None:
+            headers["Content-Type"] = content_type
+        if cookie is not None:
+            headers["Cookie"] = cookie
+        if csrf is not None:
+            headers["X-Decision-OS-CSRF"] = csrf
+        if origin is not None:
+            headers["Origin"] = origin
+        if host is not None:
+            headers["Host"] = host
+        connection.request(method, path, body=payload, headers=headers)
+        response = connection.getresponse()
+        raw = response.read()
+        response_headers = {key.lower(): value for key, value in response.getheaders()}
+        status = response.status
+        connection.close()
+        return status, response_headers, raw
+
+    def bootstrap(self) -> tuple[str, str]:
+        path = urlsplit(self.server.bootstrap_url).path
+        status, headers, _raw = self.request("GET", path, content_type=None)
+        self.assertEqual(303, status)
+        cookie = headers["set-cookie"].split(";", 1)[0]
+        status, _headers, raw = self.request(
+            "GET", "/api/state", cookie=cookie, content_type=None
+        )
+        self.assertEqual(200, status)
+        return cookie, json.loads(raw)["csrf"]
+
+    def post(self, raw: bytes, cookie: str, csrf: str, **kwargs: object) -> int:
+        status, _headers, _body = self.request(
+            "POST",
+            "/api/creator-live/cycles/005/start",
+            payload=raw,
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+            **kwargs,
+        )
+        return status
+
+    def test_route_requires_private_session_loopback_origin_and_csrf(self) -> None:
+        raw = json.dumps({"launch_binding_sha256": _DIGEST}).encode()
+        self.assertEqual(401, self.post(raw, "", ""))
+        cookie, csrf = self.bootstrap()
+        self.assertEqual(403, self.post(raw, cookie, csrf, host="attacker.invalid"))
+        status, _headers, _body = self.request(
+            "POST",
+            "/api/creator-live/cycles/005/start",
+            payload=raw,
+            cookie=cookie,
+            csrf=csrf,
+            origin="http://attacker.invalid",
+        )
+        self.assertEqual(403, status)
+        status, _headers, _body = self.request(
+            "POST",
+            "/api/creator-live/cycles/005/start",
+            payload=raw,
+            cookie=cookie,
+            origin=self.server.origin,
+        )
+        self.assertEqual(403, status)
+
+    def test_route_is_strict_and_caller_controls_only_lowercase_digest(self) -> None:
+        cookie, csrf = self.bootstrap()
+        invalid = (
+            b"{}",
+            b'{"launch_binding_sha256":"' + _DIGEST.encode() + b'","extra":1}',
+            b'{"launch_binding_sha256":"' + _DIGEST.encode() + b'","launch_binding_sha256":"' + _DIGEST.encode() + b'"}',
+            b'{"launch_binding_sha256":"' + _DIGEST.upper().encode() + b'"}',
+            b'{"launch_binding_sha256":"short"}',
+        )
+        for raw in invalid:
+            with self.subTest(raw=raw):
+                self.assertEqual(400, self.post(raw, cookie, csrf))
+        self.assertEqual(
+            415,
+            self.post(
+                json.dumps({"launch_binding_sha256": _DIGEST}).encode(),
+                cookie,
+                csrf,
+                content_type="text/plain",
+            ),
+        )
+        stale = json.dumps({"launch_binding_sha256": "7" * 64}).encode()
+        self.assertEqual(409, self.post(stale, cookie, csrf))
+
+    def test_exact_route_returns_202_and_ordinary_run_is_not_reused(self) -> None:
+        cookie, csrf = self.bootstrap()
+        raw = json.dumps({"launch_binding_sha256": _DIGEST}).encode()
+        status, _headers, body = self.request(
+            "POST",
+            "/api/creator-live/cycles/005/start",
+            payload=raw,
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(202, status)
+        self.assertEqual(_DIGEST, json.loads(body)["creator_live_cycle_005"]["launch_binding_sha256"])
+        self.assertEqual([_DIGEST], self.controller._creator_live_cycle_005.started)
+        ordinary = json.dumps({"task": ""}).encode()
+        status, _headers, _body = self.request(
+            "POST",
+            "/api/run",
+            payload=ordinary,
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertNotEqual(202, status)
+        self.assertEqual([_DIGEST], self.controller._creator_live_cycle_005.started)
+
+    def test_http_projection_removes_private_run_content(self) -> None:
+        snapshot = {
+            "creator_live_cycle_005": {
+                "state": "RUNNING",
+                "stage": "A2",
+                "failure_code": None,
+            },
+            "run": {
+                "task": RUN_2_TASK,
+                "result": "PRIVATE MODEL OUTPUT",
+                "field_note": {"markdown": "PRIVATE NOTE"},
+                "approval": {"hidden": "PRIVATE"},
+            },
+        }
+        projected = self.controller.creator_live_cycle_005_public_projection(snapshot)
+        encoded = json.dumps(projected)
+        self.assertNotIn(RUN_2_TASK, encoded)
+        self.assertNotIn("PRIVATE MODEL OUTPUT", encoded)
+        self.assertNotIn("PRIVATE NOTE", encoded)
+        self.assertNotIn("PRIVATE", encoded)
+        self.assertEqual(["A2"], projected["run"]["progress"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the dedicated authenticated `POST /api/creator-live/cycles/005/start` production entrypoint
- bind exact repository, Contract lineage and raw authorities, runtime/network boundary, canonical task bytes, historical manifest, and source/installed tree equality before proof opening
- enforce one deterministic durable Cycle 005 proof identity with no retry or replacement
- add content-free Cycle 005 UI and strict HTTP/private-session boundary
- compile exact A3 UTF-8 output-artifact evidence and drive the existing A1–A7 components without altering ordinary `/api/run`

## Qualification
- `python -m unittest discover`: 1189 passed, 2 expected skips
- focused entrypoint/controller/server/reconnect/process tests: 104 passed, 2 expected skips
- `node --check decision_os/companion/static/app.js`
- Python compilation
- `git diff --check`
- source product tree: `815613804a6028a33806afe096ca072c80515ee8ebb73514b96f85ca02f784d6`

No live model invocation or real Cycle 005 proof opening was performed.