### PR TITLE
Forward-only creator-live evidence persistence and terminal projection

### DIFF
--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -122,6 +122,13 @@ class FieldNoteCreatorLiveA2RunCompletion:
     """Typed exact reconnect evidence observed from one completed Run 2."""
 
     run_id: str
+    task_byte_count: int
+    task_sha256: str
+    transmission_ordinal: int
+    normal_terminal: bool
+    turn_status: str
+    runtime_status: str
+    failure_diagnostic_absent: bool
     actual_runtime_identity: CodexRuntimeIdentity
     reconnect_receipt: FieldNoteReconnectReceipt
     final_output_bytes: bytes
@@ -131,6 +138,19 @@ class FieldNoteCreatorLiveA2RunCompletion:
         if (
             not isinstance(self.run_id, str)
             or not self.run_id.strip()
+            or type(self.task_byte_count) is not int
+            or self.task_byte_count <= 0
+            or not isinstance(self.task_sha256, str)
+            or len(self.task_sha256) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.task_sha256
+            )
+            or self.transmission_ordinal != 2
+            or self.normal_terminal is not True
+            or self.turn_status != "completed"
+            or self.runtime_status != "NORMAL_TERMINAL"
+            or self.failure_diagnostic_absent is not True
             or not isinstance(
                 self.actual_runtime_identity,
                 CodexRuntimeIdentity,
@@ -179,6 +199,8 @@ class FieldNotesCompanionController(CompanionController):
         self._creator_live_a2_reconnect_target: (
             FieldNoteCreatorLiveA2ReconnectTarget | None
         ) = None
+        self._creator_live_a2_task_byte_count: int | None = None
+        self._creator_live_a2_task_sha256: str | None = None
         self._creator_live_a2_completed_run_id: str | None = None
         self._creator_live_a2_run_completion: (
             FieldNoteCreatorLiveA2RunCompletion | None
@@ -237,6 +259,8 @@ class FieldNotesCompanionController(CompanionController):
 
     def _clear_creator_live_a2_locked(self) -> None:
         self._creator_live_a2_reconnect_target = None
+        self._creator_live_a2_task_byte_count = None
+        self._creator_live_a2_task_sha256 = None
         self._creator_live_a2_completed_run_id = None
         self._creator_live_a2_run_completion = None
         self._creator_live_a2_failure_reason = None
@@ -293,6 +317,14 @@ class FieldNotesCompanionController(CompanionController):
 
         if not isinstance(target, FieldNoteCreatorLiveA2ReconnectTarget):
             raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
+        try:
+            task_bytes = task.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise FieldNoteCreatorLiveA2ReconnectError(
+                "A2_TARGET_INVALID"
+            ) from exc
+        if not task_bytes:
+            raise FieldNoteCreatorLiveA2ReconnectError("A2_TARGET_INVALID")
         with self._condition:
             self._require_no_active_run()
             if self._creator_live_a1_capture_config is not None:
@@ -302,11 +334,15 @@ class FieldNotesCompanionController(CompanionController):
             self._clear_field_note_locked()
             self._clear_creator_live_a2_locked()
             self._creator_live_a2_reconnect_target = target
+            self._creator_live_a2_task_byte_count = len(task_bytes)
+            self._creator_live_a2_task_sha256 = hashlib.sha256(
+                task_bytes
+            ).hexdigest()
         try:
             return super().start_run(task, task_mode="manual")
         except Exception:
             with self._condition:
-                self._creator_live_a2_reconnect_target = None
+                self._clear_creator_live_a2_locked()
             raise
 
     def new_run(self) -> dict[str, Any]:
@@ -633,8 +669,26 @@ class FieldNotesCompanionController(CompanionController):
                     final_output_bytes = b""
             if reconnect_failure is None:
                 assert result.runtime_identity is not None
+                if (
+                    self._creator_live_a2_task_byte_count is None
+                    or self._creator_live_a2_task_sha256 is None
+                ):
+                    reconnect_failure = "A2_TARGET_INVALID"
+            if reconnect_failure is None:
+                assert result.runtime_identity is not None
+                assert self._creator_live_a2_task_byte_count is not None
+                assert self._creator_live_a2_task_sha256 is not None
                 reconnect_completion = FieldNoteCreatorLiveA2RunCompletion(
                     run_id=result.run_id,
+                    task_byte_count=self._creator_live_a2_task_byte_count,
+                    task_sha256=self._creator_live_a2_task_sha256,
+                    transmission_ordinal=2,
+                    normal_terminal=result.normal_terminal,
+                    turn_status=result.turn_status,
+                    runtime_status=result.status,
+                    failure_diagnostic_absent=(
+                        result.failure_diagnostic is None
+                    ),
                     actual_runtime_identity=result.runtime_identity,
                     reconnect_receipt=reconnect_receipt,
                     final_output_bytes=final_output_bytes,
@@ -663,6 +717,7 @@ class FieldNotesCompanionController(CompanionController):
                 self._creator_live_a2_reconnect_target = None
                 self._creator_live_a2_run_completion = reconnect_completion
                 self._creator_live_a2_failure_reason = reconnect_failure
+                self._run["result"] = ""
             self._creator_live_a1_run_completion = completion
             if capture is not None:
                 self._creator_live_a1_completed_draft = draft
@@ -823,6 +878,23 @@ class FieldNotesCompanionController(CompanionController):
                     or "A2_TARGET_INVALID"
                 )
             return completion
+
+    def release_creator_live_a2_run_completion(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> None:
+        """Discard the controller-owned transient Run 2 output bytes."""
+
+        with self._condition:
+            if (
+                not isinstance(expected_run_id, str)
+                or not expected_run_id
+                or self._creator_live_a2_completed_run_id != expected_run_id
+            ):
+                raise FieldNoteError("A2_TARGET_RUN_2_MISMATCH")
+            self._creator_live_a2_run_completion = None
+            self._run["result"] = ""
 
     def creator_live_a2_failure_reason(
         self,
@@ -1534,7 +1606,7 @@ class FieldNotesCompanionController(CompanionController):
             "running"
             if state == "RUNNING"
             else "completed"
-            if state == "PASS"
+            if state in {"PASS", "TRACE_COMPLETE"}
             else "needs_attention"
         )
         snapshot["run"] = {

--- a/decision_os/companion/field_notes_creator_live.py
+++ b/decision_os/companion/field_notes_creator_live.py
@@ -96,6 +96,36 @@ CREATOR_LIVE_ANCHOR_SCHEMA_V2 = (
 )
 CREATOR_LIVE_JOURNAL_FILENAME_V2 = "creator-live-proof-v0.2.jsonl"
 CREATOR_LIVE_ANCHOR_FILENAME_V2 = "creator-live-proof-v0.2.anchor.jsonl"
+CREATOR_LIVE_JOURNAL_SCHEMA_V3 = (
+    "decision-os.field-note-creator-live-proof-journal.v0.3"
+)
+CREATOR_LIVE_RECORD_SCHEMA_V3 = (
+    "decision-os.field-note-creator-live-proof-record.v0.3"
+)
+CREATOR_LIVE_READBACK_SCHEMA_V3 = (
+    "decision-os.field-note-creator-live-proof-readback.v0.3"
+)
+CREATOR_LIVE_ANCHOR_SCHEMA_V3 = (
+    "decision-os.field-note-creator-live-proof-anchor.v0.3"
+)
+CREATOR_LIVE_JOURNAL_FILENAME_V3 = "creator-live-proof-v0.3.jsonl"
+CREATOR_LIVE_ANCHOR_FILENAME_V3 = "creator-live-proof-v0.3.anchor.jsonl"
+TERMINAL_PROJECTION_BINDING_SCHEMA = (
+    "decision-os.field-note-creator-live-terminal-projection-binding.v0.1"
+)
+RUN_2_OUTPUT_IDENTITY_SCHEMA = (
+    "decision-os.field-note-creator-live-run-2-output-identity.v0.1"
+)
+OUTPUT_ARTIFACT_IDENTITY_SCHEMA = (
+    "decision-os.field-note-creator-live-output-artifact-identity.v0.1"
+)
+A3_COMPILER_AUDIT_SCHEMA = (
+    "decision-os.field-note-creator-live-a3-compiler-audit.v0.1"
+)
+A3_COMPILER_VERSION = (
+    "decision-os.creator-live-a3-exact-output-artifact-compiler.v0.1"
+)
+A3_COMPILER_BRANCH = "EXACT_UTF8_NON_WHOLE_UNIQUE_SOURCE_UNIQUE_OUTPUT"
 A1_CAPTURE_COMMIT_SCHEMA = (
     "decision-os.field-note-creator-live-a1-capture-commit.v0.1"
 )
@@ -112,6 +142,8 @@ JournalRecordKind = Literal[
     "ATTEMPT_OPENED",
     "RUN_1_OPENED",
     "RUN_2_OPENED",
+    "RUN_2_OUTPUT_IDENTITY_RECORDED",
+    "A3_COMPILER_AUDIT_RECORDED",
     "CHECKPOINT",
     "ATTEMPT_FAILED",
     "TRACE_COMPLETED",
@@ -127,6 +159,310 @@ _STAGES: tuple[TraceStage, ...] = (
 )
 _READBACK_AUTHORITY = object()
 _A1_CAPTURE_COMMIT_AUTHORITY = object()
+
+
+def _identity_text(value: Any, label: str, *, maximum: int = 512) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value != value.strip()
+        or len(value) > maximum
+        or "\x00" in value
+        or "\n" in value
+        or "\r" in value
+    ):
+        raise FieldNoteCreatorLiveValidationError(f"{label} is invalid.")
+    return value
+
+
+def _identity_sha256(value: Any, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise FieldNoteCreatorLiveValidationError(f"{label} is invalid.")
+    return value
+
+
+def _identity_count(value: Any, label: str, *, positive: bool = False) -> int:
+    if (
+        type(value) is not int
+        or value < (1 if positive else 0)
+    ):
+        raise FieldNoteCreatorLiveValidationError(f"{label} is invalid.")
+    return value
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveContractIdentity:
+    profile: str
+    title: str
+    source_byte_count: int
+    source_sha256: str
+    wrapper_sha256: str
+    interpretation_sha256: str
+
+    def __post_init__(self) -> None:
+        _identity_text(self.profile, "Contract profile", maximum=128)
+        _identity_text(self.title, "Contract title", maximum=256)
+        _identity_count(
+            self.source_byte_count,
+            "Contract source byte count",
+            positive=True,
+        )
+        _identity_sha256(self.source_sha256, "Contract source SHA-256")
+        _identity_sha256(self.wrapper_sha256, "Contract wrapper SHA-256")
+        _identity_sha256(
+            self.interpretation_sha256,
+            "Contract interpretation SHA-256",
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "profile": self.profile,
+            "title": self.title,
+            "source_byte_count": self.source_byte_count,
+            "source_sha256": self.source_sha256,
+            "wrapper_sha256": self.wrapper_sha256,
+            "interpretation_sha256": self.interpretation_sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> FieldNoteCreatorLiveContractIdentity:
+        fields = {
+            "profile",
+            "title",
+            "source_byte_count",
+            "source_sha256",
+            "wrapper_sha256",
+            "interpretation_sha256",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "Contract terminal projection identity is invalid."
+            )
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveTaskIdentity:
+    byte_count: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _identity_count(self.byte_count, "Task byte count", positive=True)
+        _identity_sha256(self.sha256, "Task SHA-256")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"byte_count": self.byte_count, "sha256": self.sha256}
+
+    @classmethod
+    def from_dict(cls, value: Any) -> FieldNoteCreatorLiveTaskIdentity:
+        if not isinstance(value, dict) or set(value) != {"byte_count", "sha256"}:
+            raise FieldNoteCreatorLiveValidationError(
+                "Task terminal projection identity is invalid."
+            )
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveHistoricalBoundary:
+    cycle_key: str
+    state: str
+    failure_boundary: str
+    failure_code: str
+
+    def __post_init__(self) -> None:
+        _identity_text(self.cycle_key, "Historical Cycle key", maximum=128)
+        _identity_text(self.state, "Historical state", maximum=64)
+        _identity_text(
+            self.failure_boundary,
+            "Historical failure boundary",
+            maximum=128,
+        )
+        _identity_text(self.failure_code, "Historical failure code", maximum=256)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "cycle_key": self.cycle_key,
+            "state": self.state,
+            "failure_boundary": self.failure_boundary,
+            "failure_code": self.failure_code,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> FieldNoteCreatorLiveHistoricalBoundary:
+        fields = {"cycle_key", "state", "failure_boundary", "failure_code"}
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "Historical terminal projection boundary is invalid."
+            )
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveTerminalProjectionBinding:
+    schema: str
+    launch_binding_sha256: str
+    contract_identity: FieldNoteCreatorLiveContractIdentity
+    ordinary_contract_execution_authority: str
+    guided_intake_freeze_authority: str
+    implementation_authorization_observed_at: str
+    run_1_task: FieldNoteCreatorLiveTaskIdentity
+    run_2_task: FieldNoteCreatorLiveTaskIdentity
+    historical_boundary: FieldNoteCreatorLiveHistoricalBoundary
+    retry_count: int
+    replacement_count: int
+
+    def __post_init__(self) -> None:
+        if self.schema != TERMINAL_PROJECTION_BINDING_SCHEMA:
+            raise FieldNoteCreatorLiveValidationError(
+                "Terminal projection binding schema is invalid."
+            )
+        _identity_sha256(self.launch_binding_sha256, "Launch binding SHA-256")
+        if not isinstance(
+            self.contract_identity,
+            FieldNoteCreatorLiveContractIdentity,
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Contract terminal projection identity is invalid."
+            )
+        if self.ordinary_contract_execution_authority != "INTERPRETATION_ONLY":
+            raise FieldNoteCreatorLiveValidationError(
+                "Ordinary Contract authority changed."
+            )
+        if self.guided_intake_freeze_authority != (
+            "IMMUTABLE_INTERPRETATION_ONLY"
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Guided Intake freeze authority changed."
+            )
+        _parse_time(
+            self.implementation_authorization_observed_at,
+            "Implementation authorization observation",
+        )
+        if not isinstance(self.run_1_task, FieldNoteCreatorLiveTaskIdentity) or (
+            not isinstance(self.run_2_task, FieldNoteCreatorLiveTaskIdentity)
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Terminal projection task identity is invalid."
+            )
+        if not isinstance(
+            self.historical_boundary,
+            FieldNoteCreatorLiveHistoricalBoundary,
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Historical terminal projection boundary is invalid."
+            )
+        if self.retry_count != 0 or self.replacement_count != 0:
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live retry or replacement count widened."
+            )
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        launch_binding_sha256: str,
+        contract_identity: FieldNoteCreatorLiveContractIdentity,
+        ordinary_contract_execution_authority: str,
+        guided_intake_freeze_authority: str,
+        implementation_authorization_observed_at: str,
+        run_1_task: FieldNoteCreatorLiveTaskIdentity,
+        run_2_task: FieldNoteCreatorLiveTaskIdentity,
+        historical_boundary: FieldNoteCreatorLiveHistoricalBoundary,
+        retry_count: int = 0,
+        replacement_count: int = 0,
+    ) -> FieldNoteCreatorLiveTerminalProjectionBinding:
+        return cls(
+            schema=TERMINAL_PROJECTION_BINDING_SCHEMA,
+            launch_binding_sha256=launch_binding_sha256,
+            contract_identity=contract_identity,
+            ordinary_contract_execution_authority=(
+                ordinary_contract_execution_authority
+            ),
+            guided_intake_freeze_authority=guided_intake_freeze_authority,
+            implementation_authorization_observed_at=(
+                implementation_authorization_observed_at
+            ),
+            run_1_task=run_1_task,
+            run_2_task=run_2_task,
+            historical_boundary=historical_boundary,
+            retry_count=retry_count,
+            replacement_count=replacement_count,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "launch_binding_sha256": self.launch_binding_sha256,
+            "contract_identity": self.contract_identity.as_dict(),
+            "ordinary_contract_execution_authority": (
+                self.ordinary_contract_execution_authority
+            ),
+            "guided_intake_freeze_authority": (
+                self.guided_intake_freeze_authority
+            ),
+            "implementation_authorization_observed_at": (
+                self.implementation_authorization_observed_at
+            ),
+            "run_1_task": self.run_1_task.as_dict(),
+            "run_2_task": self.run_2_task.as_dict(),
+            "historical_boundary": self.historical_boundary.as_dict(),
+            "retry_count": self.retry_count,
+            "replacement_count": self.replacement_count,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Any,
+    ) -> FieldNoteCreatorLiveTerminalProjectionBinding:
+        fields = {
+            "schema",
+            "launch_binding_sha256",
+            "contract_identity",
+            "ordinary_contract_execution_authority",
+            "guided_intake_freeze_authority",
+            "implementation_authorization_observed_at",
+            "run_1_task",
+            "run_2_task",
+            "historical_boundary",
+            "retry_count",
+            "replacement_count",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "Terminal projection binding is invalid."
+            )
+        return cls(
+            schema=value["schema"],
+            launch_binding_sha256=value["launch_binding_sha256"],
+            contract_identity=FieldNoteCreatorLiveContractIdentity.from_dict(
+                value["contract_identity"]
+            ),
+            ordinary_contract_execution_authority=(
+                value["ordinary_contract_execution_authority"]
+            ),
+            guided_intake_freeze_authority=(
+                value["guided_intake_freeze_authority"]
+            ),
+            implementation_authorization_observed_at=(
+                value["implementation_authorization_observed_at"]
+            ),
+            run_1_task=FieldNoteCreatorLiveTaskIdentity.from_dict(
+                value["run_1_task"]
+            ),
+            run_2_task=FieldNoteCreatorLiveTaskIdentity.from_dict(
+                value["run_2_task"]
+            ),
+            historical_boundary=FieldNoteCreatorLiveHistoricalBoundary.from_dict(
+                value["historical_boundary"]
+            ),
+            retry_count=value["retry_count"],
+            replacement_count=value["replacement_count"],
+        )
 
 
 class FieldNoteCreatorLiveError(RuntimeError):
@@ -150,6 +486,548 @@ class FieldNoteCreatorLiveDurabilityError(FieldNoteCreatorLiveError):
 
 class FieldNoteCreatorLiveAttemptExistsError(FieldNoteCreatorLiveError):
     """The one-attempt journal already exists and cannot be replaced."""
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveOutputArtifactIdentity:
+    schema: str
+    artifact_id: str
+    proof_attempt_id: str
+    run_id: str
+    transmission_ordinal: int
+    media_type: str
+    byte_count: int
+    sha256: str
+
+    @staticmethod
+    def _body(
+        *,
+        proof_attempt_id: str,
+        run_id: str,
+        transmission_ordinal: int,
+        media_type: str,
+        byte_count: int,
+        sha256: str,
+    ) -> dict[str, Any]:
+        return {
+            "schema": OUTPUT_ARTIFACT_IDENTITY_SCHEMA,
+            "proof_attempt_id": proof_attempt_id,
+            "run_id": run_id,
+            "transmission_ordinal": transmission_ordinal,
+            "media_type": media_type,
+            "byte_count": byte_count,
+            "sha256": sha256,
+        }
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        proof_attempt_id: str,
+        run_id: str,
+        byte_count: int,
+        sha256: str,
+    ) -> FieldNoteCreatorLiveOutputArtifactIdentity:
+        _identity_text(proof_attempt_id, "Output proof-attempt ID", maximum=256)
+        _identity_text(run_id, "Output Run ID", maximum=256)
+        _identity_count(byte_count, "Output byte count", positive=True)
+        _identity_sha256(sha256, "Output SHA-256")
+        body = cls._body(
+            proof_attempt_id=proof_attempt_id,
+            run_id=run_id,
+            transmission_ordinal=2,
+            media_type="text/plain; charset=utf-8",
+            byte_count=byte_count,
+            sha256=sha256,
+        )
+        return cls(
+            **body,
+            artifact_id=_canonical_sha256(body),
+        )
+
+    def __post_init__(self) -> None:
+        body = self._body(
+            proof_attempt_id=_identity_text(
+                self.proof_attempt_id,
+                "Output proof-attempt ID",
+                maximum=256,
+            ),
+            run_id=_identity_text(self.run_id, "Output Run ID", maximum=256),
+            transmission_ordinal=self.transmission_ordinal,
+            media_type=self.media_type,
+            byte_count=self.byte_count,
+            sha256=self.sha256,
+        )
+        if (
+            self.schema != OUTPUT_ARTIFACT_IDENTITY_SCHEMA
+            or self.transmission_ordinal != 2
+            or self.media_type != "text/plain; charset=utf-8"
+            or self.byte_count > 65_536
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Output artifact fixed identity is invalid."
+            )
+        _identity_count(self.byte_count, "Output byte count", positive=True)
+        _identity_sha256(self.sha256, "Output SHA-256")
+        if self.artifact_id != _canonical_sha256(body):
+            raise FieldNoteCreatorLiveValidationError(
+                "Output artifact canonical identity is invalid."
+            )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "artifact_id": self.artifact_id,
+            "proof_attempt_id": self.proof_attempt_id,
+            "run_id": self.run_id,
+            "transmission_ordinal": self.transmission_ordinal,
+            "media_type": self.media_type,
+            "byte_count": self.byte_count,
+            "sha256": self.sha256,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Any,
+    ) -> FieldNoteCreatorLiveOutputArtifactIdentity:
+        fields = {
+            "schema",
+            "artifact_id",
+            "proof_attempt_id",
+            "run_id",
+            "transmission_ordinal",
+            "media_type",
+            "byte_count",
+            "sha256",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "Output artifact identity is invalid."
+            )
+        return cls(**value)
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveRun2OutputIdentity:
+    schema: str
+    proof_attempt_id: str
+    run_id: str
+    task_byte_count: int
+    task_sha256: str
+    transmission_ordinal: int
+    normal_terminal: bool
+    turn_status: str
+    runtime_status: str
+    failure_diagnostic_absent: bool
+    final_output_byte_count: int
+    final_output_sha256: str
+    output_artifact: FieldNoteCreatorLiveOutputArtifactIdentity
+    a3_compiler_branch: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        proof_attempt_id: str,
+        run_id: str,
+        task_byte_count: int,
+        task_sha256: str,
+        final_output_byte_count: int,
+        final_output_sha256: str,
+    ) -> FieldNoteCreatorLiveRun2OutputIdentity:
+        artifact = FieldNoteCreatorLiveOutputArtifactIdentity.create(
+            proof_attempt_id=proof_attempt_id,
+            run_id=run_id,
+            byte_count=final_output_byte_count,
+            sha256=final_output_sha256,
+        )
+        return cls(
+            schema=RUN_2_OUTPUT_IDENTITY_SCHEMA,
+            proof_attempt_id=proof_attempt_id,
+            run_id=run_id,
+            task_byte_count=task_byte_count,
+            task_sha256=task_sha256,
+            transmission_ordinal=2,
+            normal_terminal=True,
+            turn_status="completed",
+            runtime_status="NORMAL_TERMINAL",
+            failure_diagnostic_absent=True,
+            final_output_byte_count=final_output_byte_count,
+            final_output_sha256=final_output_sha256,
+            output_artifact=artifact,
+            a3_compiler_branch=A3_COMPILER_BRANCH,
+        )
+
+    def __post_init__(self) -> None:
+        _identity_text(self.proof_attempt_id, "Run 2 proof-attempt ID", maximum=256)
+        _identity_text(self.run_id, "Run 2 output Run ID", maximum=256)
+        _identity_count(self.task_byte_count, "Run 2 task byte count", positive=True)
+        _identity_sha256(self.task_sha256, "Run 2 task SHA-256")
+        _identity_count(
+            self.final_output_byte_count,
+            "Run 2 final-output byte count",
+            positive=True,
+        )
+        _identity_sha256(self.final_output_sha256, "Run 2 final-output SHA-256")
+        if (
+            self.schema != RUN_2_OUTPUT_IDENTITY_SCHEMA
+            or self.transmission_ordinal != 2
+            or self.normal_terminal is not True
+            or self.turn_status != "completed"
+            or self.runtime_status != "NORMAL_TERMINAL"
+            or self.failure_diagnostic_absent is not True
+            or self.a3_compiler_branch != A3_COMPILER_BRANCH
+            or self.final_output_byte_count > 65_536
+            or not isinstance(
+                self.output_artifact,
+                FieldNoteCreatorLiveOutputArtifactIdentity,
+            )
+            or self.output_artifact.proof_attempt_id != self.proof_attempt_id
+            or self.output_artifact.run_id != self.run_id
+            or self.output_artifact.transmission_ordinal != 2
+            or self.output_artifact.byte_count != self.final_output_byte_count
+            or self.output_artifact.sha256 != self.final_output_sha256
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Run 2 output identity is cross-bound or invalid."
+            )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proof_attempt_id": self.proof_attempt_id,
+            "run_id": self.run_id,
+            "task_byte_count": self.task_byte_count,
+            "task_sha256": self.task_sha256,
+            "transmission_ordinal": self.transmission_ordinal,
+            "normal_terminal": self.normal_terminal,
+            "turn_status": self.turn_status,
+            "runtime_status": self.runtime_status,
+            "failure_diagnostic_absent": self.failure_diagnostic_absent,
+            "final_output_byte_count": self.final_output_byte_count,
+            "final_output_sha256": self.final_output_sha256,
+            "output_artifact": self.output_artifact.as_dict(),
+            "a3_compiler_branch": self.a3_compiler_branch,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Any,
+    ) -> FieldNoteCreatorLiveRun2OutputIdentity:
+        fields = {
+            "schema",
+            "proof_attempt_id",
+            "run_id",
+            "task_byte_count",
+            "task_sha256",
+            "transmission_ordinal",
+            "normal_terminal",
+            "turn_status",
+            "runtime_status",
+            "failure_diagnostic_absent",
+            "final_output_byte_count",
+            "final_output_sha256",
+            "output_artifact",
+            "a3_compiler_branch",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "Run 2 output identity record is invalid."
+            )
+        return cls(
+            **{key: value[key] for key in fields - {"output_artifact"}},
+            output_artifact=FieldNoteCreatorLiveOutputArtifactIdentity.from_dict(
+                value["output_artifact"]
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class FieldNoteCreatorLiveA3RejectionCounts:
+    below_minimum_byte_length: int
+    whole_note_range: int
+    non_unique_source_occurrence: int
+    absent_output_occurrence: int
+    multiple_output_occurrences: int
+
+    def __post_init__(self) -> None:
+        for label, value in self.as_dict().items():
+            _identity_count(value, f"A3 rejection count {label}")
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "below_minimum_byte_length": self.below_minimum_byte_length,
+            "whole_note_range": self.whole_note_range,
+            "non_unique_source_occurrence": self.non_unique_source_occurrence,
+            "absent_output_occurrence": self.absent_output_occurrence,
+            "multiple_output_occurrences": self.multiple_output_occurrences,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> FieldNoteCreatorLiveA3RejectionCounts:
+        fields = {
+            "below_minimum_byte_length",
+            "whole_note_range",
+            "non_unique_source_occurrence",
+            "absent_output_occurrence",
+            "multiple_output_occurrences",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "A3 rejection counts are invalid."
+            )
+        return cls(**value)
+
+
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveA3CompilerAudit:
+    schema: str
+    proof_attempt_id: str
+    run_id: str
+    output_artifact_id: str
+    compiler_version: str
+    compiler_branch: str
+    source_note_byte_count: int
+    source_note_sha256: str
+    output_byte_count: int
+    output_sha256: str
+    eligible_candidate_count: int
+    rejection_counts: FieldNoteCreatorLiveA3RejectionCounts
+    longest_candidate_byte_count: int
+    winning_candidate_count: int
+    selected_source_start_byte: int | None
+    selected_source_end_byte: int | None
+    selected_output_start_byte: int | None
+    selected_output_end_byte: int | None
+    terminal_a3_code: str | None
+    audit_sha256: str
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise FieldNoteCreatorLiveValidationError(
+            "A3 compiler audits are issued only from exact compiler facts."
+        )
+
+    @classmethod
+    def issue(
+        cls,
+        *,
+        proof_attempt_id: str,
+        run_id: str,
+        output_artifact_id: str,
+        source_note_byte_count: int,
+        source_note_sha256: str,
+        output_byte_count: int,
+        output_sha256: str,
+        eligible_candidate_count: int,
+        rejection_counts: FieldNoteCreatorLiveA3RejectionCounts,
+        longest_candidate_byte_count: int,
+        winning_candidate_count: int,
+        selected_source_start_byte: int | None,
+        selected_source_end_byte: int | None,
+        selected_output_start_byte: int | None,
+        selected_output_end_byte: int | None,
+        terminal_a3_code: str | None,
+    ) -> FieldNoteCreatorLiveA3CompilerAudit:
+        _identity_text(proof_attempt_id, "A3 proof-attempt ID", maximum=256)
+        _identity_text(run_id, "A3 Run ID", maximum=256)
+        _identity_sha256(output_artifact_id, "A3 output artifact ID")
+        _identity_count(
+            source_note_byte_count,
+            "A3 source Note byte count",
+            positive=True,
+        )
+        _identity_sha256(source_note_sha256, "A3 source Note SHA-256")
+        _identity_count(output_byte_count, "A3 output byte count", positive=True)
+        _identity_sha256(output_sha256, "A3 output SHA-256")
+        _identity_count(eligible_candidate_count, "A3 eligible candidate count")
+        _identity_count(
+            longest_candidate_byte_count,
+            "A3 longest candidate byte count",
+        )
+        _identity_count(winning_candidate_count, "A3 winning candidate count")
+        if not isinstance(rejection_counts, FieldNoteCreatorLiveA3RejectionCounts):
+            raise FieldNoteCreatorLiveValidationError(
+                "A3 rejection counts are invalid."
+            )
+        offsets = (
+            selected_source_start_byte,
+            selected_source_end_byte,
+            selected_output_start_byte,
+            selected_output_end_byte,
+        )
+        if winning_candidate_count == 1:
+            if (
+                eligible_candidate_count < 1
+                or terminal_a3_code is not None
+                or any(type(value) is not int for value in offsets)
+            ):
+                raise FieldNoteCreatorLiveValidationError(
+                    "A3 winning offsets are invalid."
+                )
+            source_start = selected_source_start_byte
+            source_end = selected_source_end_byte
+            output_start = selected_output_start_byte
+            output_end = selected_output_end_byte
+            assert isinstance(source_start, int)
+            assert isinstance(source_end, int)
+            assert isinstance(output_start, int)
+            assert isinstance(output_end, int)
+            if (
+                not 0 <= source_start < source_end <= source_note_byte_count
+                or not 0 <= output_start < output_end <= output_byte_count
+                or source_end - source_start != output_end - output_start
+                or longest_candidate_byte_count != source_end - source_start
+            ):
+                raise FieldNoteCreatorLiveValidationError(
+                    "A3 winning offsets are out of bounds."
+                )
+        else:
+            if any(value is not None for value in offsets):
+                raise FieldNoteCreatorLiveValidationError(
+                    "A3 non-winning offsets must be null."
+                )
+            expected_code = (
+                "A3_EXACT_STRUCTURE_MISSING"
+                if eligible_candidate_count == 0
+                else "A3_EXACT_STRUCTURE_AMBIGUOUS"
+            )
+            if (
+                winning_candidate_count < 0
+                or terminal_a3_code != expected_code
+                or (
+                    eligible_candidate_count == 0
+                    and (
+                        winning_candidate_count != 0
+                        or longest_candidate_byte_count != 0
+                    )
+                )
+                or (
+                    eligible_candidate_count > 0
+                    and winning_candidate_count < 2
+                )
+            ):
+                raise FieldNoteCreatorLiveValidationError(
+                    "A3 terminal compiler result is invalid."
+                )
+        body = {
+            "schema": A3_COMPILER_AUDIT_SCHEMA,
+            "proof_attempt_id": proof_attempt_id,
+            "run_id": run_id,
+            "output_artifact_id": output_artifact_id,
+            "compiler_version": A3_COMPILER_VERSION,
+            "compiler_branch": A3_COMPILER_BRANCH,
+            "source_note_byte_count": source_note_byte_count,
+            "source_note_sha256": source_note_sha256,
+            "output_byte_count": output_byte_count,
+            "output_sha256": output_sha256,
+            "eligible_candidate_count": eligible_candidate_count,
+            "rejection_counts": rejection_counts.as_dict(),
+            "longest_candidate_byte_count": longest_candidate_byte_count,
+            "winning_candidate_count": winning_candidate_count,
+            "selected_source_start_byte": selected_source_start_byte,
+            "selected_source_end_byte": selected_source_end_byte,
+            "selected_output_start_byte": selected_output_start_byte,
+            "selected_output_end_byte": selected_output_end_byte,
+            "terminal_a3_code": terminal_a3_code,
+        }
+        value = object.__new__(cls)
+        for field, item in {
+            **body,
+            "rejection_counts": rejection_counts,
+            "audit_sha256": _canonical_sha256(body),
+        }.items():
+            object.__setattr__(value, field, item)
+        return value
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "proof_attempt_id": self.proof_attempt_id,
+            "run_id": self.run_id,
+            "output_artifact_id": self.output_artifact_id,
+            "compiler_version": self.compiler_version,
+            "compiler_branch": self.compiler_branch,
+            "source_note_byte_count": self.source_note_byte_count,
+            "source_note_sha256": self.source_note_sha256,
+            "output_byte_count": self.output_byte_count,
+            "output_sha256": self.output_sha256,
+            "eligible_candidate_count": self.eligible_candidate_count,
+            "rejection_counts": self.rejection_counts.as_dict(),
+            "longest_candidate_byte_count": self.longest_candidate_byte_count,
+            "winning_candidate_count": self.winning_candidate_count,
+            "selected_source_start_byte": self.selected_source_start_byte,
+            "selected_source_end_byte": self.selected_source_end_byte,
+            "selected_output_start_byte": self.selected_output_start_byte,
+            "selected_output_end_byte": self.selected_output_end_byte,
+            "terminal_a3_code": self.terminal_a3_code,
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._body(), "audit_sha256": self.audit_sha256}
+
+    @classmethod
+    def from_dict(cls, value: Any) -> FieldNoteCreatorLiveA3CompilerAudit:
+        fields = {
+            "schema",
+            "proof_attempt_id",
+            "run_id",
+            "output_artifact_id",
+            "compiler_version",
+            "compiler_branch",
+            "source_note_byte_count",
+            "source_note_sha256",
+            "output_byte_count",
+            "output_sha256",
+            "eligible_candidate_count",
+            "rejection_counts",
+            "longest_candidate_byte_count",
+            "winning_candidate_count",
+            "selected_source_start_byte",
+            "selected_source_end_byte",
+            "selected_output_start_byte",
+            "selected_output_end_byte",
+            "terminal_a3_code",
+            "audit_sha256",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise FieldNoteCreatorLiveValidationError(
+                "A3 compiler audit record is invalid."
+            )
+        if (
+            value["schema"] != A3_COMPILER_AUDIT_SCHEMA
+            or value["compiler_version"] != A3_COMPILER_VERSION
+            or value["compiler_branch"] != A3_COMPILER_BRANCH
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "A3 compiler audit fixed identity is invalid."
+            )
+        issued = cls.issue(
+            proof_attempt_id=value["proof_attempt_id"],
+            run_id=value["run_id"],
+            output_artifact_id=value["output_artifact_id"],
+            source_note_byte_count=value["source_note_byte_count"],
+            source_note_sha256=value["source_note_sha256"],
+            output_byte_count=value["output_byte_count"],
+            output_sha256=value["output_sha256"],
+            eligible_candidate_count=value["eligible_candidate_count"],
+            rejection_counts=FieldNoteCreatorLiveA3RejectionCounts.from_dict(
+                value["rejection_counts"]
+            ),
+            longest_candidate_byte_count=value["longest_candidate_byte_count"],
+            winning_candidate_count=value["winning_candidate_count"],
+            selected_source_start_byte=value["selected_source_start_byte"],
+            selected_source_end_byte=value["selected_source_end_byte"],
+            selected_output_start_byte=value["selected_output_start_byte"],
+            selected_output_end_byte=value["selected_output_end_byte"],
+            terminal_a3_code=value["terminal_a3_code"],
+        )
+        if issued.audit_sha256 != value["audit_sha256"]:
+            raise FieldNoteCreatorLiveValidationError(
+                "A3 compiler audit canonical identity is invalid."
+            )
+        return issued
 
 
 def _proposal_diagnostic_reason_matches(
@@ -639,14 +1517,21 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
                 repair_action="RECEIPT_REWRITE",
             )
         kind = value["kind"]
-        if kind not in {
+        base_kinds = {
             "ATTEMPT_OPENED",
             "RUN_1_OPENED",
             "RUN_2_OPENED",
             "CHECKPOINT",
             "ATTEMPT_FAILED",
             "TRACE_COMPLETED",
-        }:
+        }
+        v3_kinds = {
+            "RUN_2_OUTPUT_IDENTITY_RECORDED",
+            "A3_COMPILER_AUDIT_RECORDED",
+        }
+        if kind not in base_kinds | v3_kinds or (
+            kind in v3_kinds and value["schema"] != CREATOR_LIVE_RECORD_SCHEMA_V3
+        ):
             raise _JournalIntegrityError(
                 "CREATOR_LIVE_DURABLE_TRACE_TAMPERED",
                 repair_action="RECEIPT_REWRITE",
@@ -665,6 +1550,7 @@ def _parse_records(raw: bytes) -> tuple[_JournalRecord, ...]:
             value["schema"] not in {
                 CREATOR_LIVE_RECORD_SCHEMA,
                 CREATOR_LIVE_RECORD_SCHEMA_V2,
+                CREATOR_LIVE_RECORD_SCHEMA_V3,
             }
             or value["schema"] != record_schema
             or value["sequence"] != index
@@ -742,6 +1628,7 @@ def _parse_anchors(raw: bytes) -> tuple[_AnchorRecord, ...]:
             value["schema"] not in {
                 CREATOR_LIVE_ANCHOR_SCHEMA,
                 CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+                CREATOR_LIVE_ANCHOR_SCHEMA_V3,
             }
             or value["schema"] != anchor_schema
             or value["generation"] != generation
@@ -1186,7 +2073,15 @@ class FieldNoteCreatorLiveTraceReadback:
             and self.trace_chain_head_sha256 == proof_trace[-1].trace_sha256
             and self.anchor_record_count
             == self.journal_record_count
-            - (1 if self.schema == CREATOR_LIVE_READBACK_SCHEMA_V2 else 0)
+            - (
+                1
+                if self.schema
+                in {
+                    CREATOR_LIVE_READBACK_SCHEMA_V2,
+                    CREATOR_LIVE_READBACK_SCHEMA_V3,
+                }
+                else 0
+            )
             and self.journal_byte_length > 0
             and all(
                 event.runtime_provenance == self.runtime_provenance
@@ -1282,6 +2177,61 @@ class FieldNoteCreatorLiveTraceReadbackV2(FieldNoteCreatorLiveTraceReadback):
         )
 
 
+@dataclass(frozen=True, init=False)
+class FieldNoteCreatorLiveTraceReadbackV3(FieldNoteCreatorLiveTraceReadbackV2):
+    """Forward-only content-free output and compiler audit projection."""
+
+    terminal_projection_binding: FieldNoteCreatorLiveTerminalProjectionBinding
+    run_2_output_identity: FieldNoteCreatorLiveRun2OutputIdentity | None
+    a3_compiler_audit: FieldNoteCreatorLiveA3CompilerAudit | None
+
+    @classmethod
+    def _create_v3(
+        cls,
+        *,
+        terminal_projection_binding: FieldNoteCreatorLiveTerminalProjectionBinding,
+        run_2_output_identity: FieldNoteCreatorLiveRun2OutputIdentity | None,
+        a3_compiler_audit: FieldNoteCreatorLiveA3CompilerAudit | None,
+        **kwargs: Any,
+    ) -> FieldNoteCreatorLiveTraceReadbackV3:
+        if not isinstance(
+            terminal_projection_binding,
+            FieldNoteCreatorLiveTerminalProjectionBinding,
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "v0.3 terminal projection binding is invalid."
+            )
+        value = super()._create_v2(**kwargs)
+        assert isinstance(value, cls)
+        object.__setattr__(value, "schema", CREATOR_LIVE_READBACK_SCHEMA_V3)
+        object.__setattr__(
+            value,
+            "terminal_projection_binding",
+            terminal_projection_binding,
+        )
+        object.__setattr__(value, "run_2_output_identity", run_2_output_identity)
+        object.__setattr__(value, "a3_compiler_audit", a3_compiler_audit)
+        return value
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            **super()._body(),
+            "terminal_projection_binding": (
+                self.terminal_projection_binding.as_dict()
+            ),
+            "run_2_output_identity": (
+                self.run_2_output_identity.as_dict()
+                if self.run_2_output_identity is not None
+                else None
+            ),
+            "a3_compiler_audit": (
+                self.a3_compiler_audit.as_dict()
+                if self.a3_compiler_audit is not None
+                else None
+            ),
+        }
+
+
 @dataclass(frozen=True)
 class _StaticIdentity:
     attempt: FieldNoteWholeFlowAttempt | FieldNoteCreatorLiveAttempt
@@ -1293,6 +2243,9 @@ class _StaticIdentity:
     record_schema: str
     anchor_schema: str
     attempt_opened_at: str | None
+    terminal_projection_binding: (
+        FieldNoteCreatorLiveTerminalProjectionBinding | None
+    )
 
 
 def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
@@ -1302,8 +2255,12 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
             repair_action="EVIDENCE_DELETION",
         )
     payload = records[0].payload
-    if records[0].schema == CREATOR_LIVE_RECORD_SCHEMA_V2:
-        if set(payload) != {
+    if records[0].schema in {
+        CREATOR_LIVE_RECORD_SCHEMA_V2,
+        CREATOR_LIVE_RECORD_SCHEMA_V3,
+    }:
+        is_v3 = records[0].schema == CREATOR_LIVE_RECORD_SCHEMA_V3
+        required_fields = {
             "journal_schema",
             "attempt",
             "attempt_opened_at",
@@ -1311,7 +2268,17 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
             "runtime",
             "run_1_id",
             "one_attempt_no_retry",
-        } or payload["journal_schema"] != CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+        }
+        if is_v3:
+            required_fields.add("terminal_projection_binding")
+        expected_journal_schema = (
+            CREATOR_LIVE_JOURNAL_SCHEMA_V3
+            if is_v3
+            else CREATOR_LIVE_JOURNAL_SCHEMA_V2
+        )
+        if set(payload) != required_fields or payload["journal_schema"] != (
+            expected_journal_schema
+        ):
             raise _JournalIntegrityError(
                 "CREATOR_LIVE_ATTEMPT_RECORD_INVALID",
                 repair_action="RECEIPT_REWRITE",
@@ -1369,16 +2336,52 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
             runtime=runtime,
             run_1=run_1,
         )
+        terminal_projection_binding = None
+        if is_v3:
+            try:
+                terminal_projection_binding = (
+                    FieldNoteCreatorLiveTerminalProjectionBinding.from_dict(
+                        payload["terminal_projection_binding"]
+                    )
+                )
+            except FieldNoteCreatorLiveValidationError as exc:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_TERMINAL_PROJECTION_BINDING_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                ) from exc
+            _, implementation_authorization_time = _parse_time(
+                terminal_projection_binding.implementation_authorization_observed_at,
+                "Implementation authorization observation",
+            )
+            if (
+                implementation_authorization_time > opened_time
+                or not attempt.proof_attempt_id.endswith(
+                    "_" + terminal_projection_binding.launch_binding_sha256
+                )
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_TERMINAL_PROJECTION_BINDING_MISMATCH",
+                    repair_action="RECEIPT_REWRITE",
+                )
         return _StaticIdentity(
             attempt=attempt,
             repository=repository,
             runtime=runtime,
             run_1=run_1,
             provenance=provenance,
-            journal_schema=CREATOR_LIVE_JOURNAL_SCHEMA_V2,
-            record_schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
-            anchor_schema=CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+            journal_schema=expected_journal_schema,
+            record_schema=(
+                CREATOR_LIVE_RECORD_SCHEMA_V3
+                if is_v3
+                else CREATOR_LIVE_RECORD_SCHEMA_V2
+            ),
+            anchor_schema=(
+                CREATOR_LIVE_ANCHOR_SCHEMA_V3
+                if is_v3
+                else CREATOR_LIVE_ANCHOR_SCHEMA_V2
+            ),
             attempt_opened_at=opened_at,
+            terminal_projection_binding=terminal_projection_binding,
         )
     if set(payload) != {
         "journal_schema",
@@ -1428,6 +2431,7 @@ def _static_identity(records: tuple[_JournalRecord, ...]) -> _StaticIdentity:
         record_schema=CREATOR_LIVE_RECORD_SCHEMA,
         anchor_schema=CREATOR_LIVE_ANCHOR_SCHEMA,
         attempt_opened_at=None,
+        terminal_projection_binding=None,
     )
 
 
@@ -1455,6 +2459,8 @@ def _project_records(
     captured_note_byte_count: int | None = None
     a1_capture_commit: FieldNoteCreatorLiveA1CaptureCommitReceipt | None = None
     a1_proposal_diagnostic: FieldNoteA1ProposalDiagnostic | None = None
+    run_2_output_identity: FieldNoteCreatorLiveRun2OutputIdentity | None = None
+    a3_compiler_audit: FieldNoteCreatorLiveA3CompilerAudit | None = None
     a3_reuse_event_id: str | None = None
     state: CreatorLiveAttemptState = "OPEN"
     failure_boundary: WholeFlowBoundary | None = None
@@ -1465,7 +2471,8 @@ def _project_records(
 
     start_index = (
         2
-        if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2
+        if static.journal_schema
+        in {CREATOR_LIVE_JOURNAL_SCHEMA_V2, CREATOR_LIVE_JOURNAL_SCHEMA_V3}
         else 1
     )
     for record in records[start_index:]:
@@ -1509,6 +2516,86 @@ def _project_records(
                     "CREATOR_LIVE_RUN_ORDER_INVALID",
                     repair_action="TIMESTAMP_CHANGE",
                 )
+            continue
+        if record.kind == "RUN_2_OUTPUT_IDENTITY_RECORDED":
+            if (
+                static.journal_schema != CREATOR_LIVE_JOURNAL_SCHEMA_V3
+                or run_2 is None
+                or len(events) != 2
+                or run_2_output_identity is not None
+                or a3_compiler_audit is not None
+                or static.terminal_projection_binding is None
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_2_OUTPUT_ORDER_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            try:
+                candidate_output_identity = (
+                    FieldNoteCreatorLiveRun2OutputIdentity.from_dict(payload)
+                )
+            except FieldNoteCreatorLiveValidationError as exc:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_2_OUTPUT_IDENTITY_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                ) from exc
+            expected_task = static.terminal_projection_binding.run_2_task
+            if (
+                candidate_output_identity.proof_attempt_id
+                != static.attempt.proof_attempt_id
+                or candidate_output_identity.run_id != run_2.run_id
+                or candidate_output_identity.task_byte_count
+                != expected_task.byte_count
+                or candidate_output_identity.task_sha256 != expected_task.sha256
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_RUN_2_OUTPUT_IDENTITY_MISMATCH",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            run_2_output_identity = candidate_output_identity
+            continue
+        if record.kind == "A3_COMPILER_AUDIT_RECORDED":
+            if (
+                static.journal_schema != CREATOR_LIVE_JOURNAL_SCHEMA_V3
+                or run_2 is None
+                or len(events) != 2
+                or run_2_output_identity is None
+                or a3_compiler_audit is not None
+                or captured_note is None
+                or captured_note_byte_count is None
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_A3_COMPILER_AUDIT_ORDER_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            try:
+                candidate_audit = FieldNoteCreatorLiveA3CompilerAudit.from_dict(
+                    payload
+                )
+            except FieldNoteCreatorLiveValidationError as exc:
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_A3_COMPILER_AUDIT_INVALID",
+                    repair_action="RECEIPT_REWRITE",
+                ) from exc
+            if (
+                candidate_audit.proof_attempt_id
+                != static.attempt.proof_attempt_id
+                or candidate_audit.run_id != run_2.run_id
+                or candidate_audit.output_artifact_id
+                != run_2_output_identity.output_artifact.artifact_id
+                or candidate_audit.output_byte_count
+                != run_2_output_identity.final_output_byte_count
+                or candidate_audit.output_sha256
+                != run_2_output_identity.final_output_sha256
+                or candidate_audit.source_note_byte_count
+                != captured_note_byte_count
+                or candidate_audit.source_note_sha256 != captured_note.note_sha256
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_A3_COMPILER_AUDIT_MISMATCH",
+                    repair_action="RECEIPT_REWRITE",
+                )
+            a3_compiler_audit = candidate_audit
             continue
         if record.kind == "CHECKPOINT":
             if set(payload) != {"event", "binding"}:
@@ -1609,6 +2696,16 @@ def _project_records(
                         repair_action="RECEIPT_REWRITE",
                     )
             elif index == 2:
+                if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3 and (
+                    run_2_output_identity is None
+                    or a3_compiler_audit is None
+                    or a3_compiler_audit.winning_candidate_count != 1
+                    or a3_compiler_audit.terminal_a3_code is not None
+                ):
+                    raise _JournalIntegrityError(
+                        "CREATOR_LIVE_A3_DURABLE_AUDIT_MISSING",
+                        repair_action="EVIDENCE_DELETION",
+                    )
                 if set(binding) != {
                     "evidence_type",
                     "evidence_sha256",
@@ -1652,7 +2749,10 @@ def _project_records(
                 "proposal_diagnostic",
                 "proposal_diagnostic_sha256",
             }
-            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            if static.journal_schema in {
+                CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+                CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+            }:
                 legacy_fields = legacy_fields | {"proof_as_of"}
                 diagnostic_fields = diagnostic_fields | {"proof_as_of"}
             if set(payload) not in {
@@ -1697,7 +2797,10 @@ def _project_records(
             failure_boundary = boundary
             failure_reason = _bounded_reason(payload["failure_reason"])
             repair_action = action
-            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            if static.journal_schema in {
+                CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+                CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+            }:
                 terminal_proof_as_of, terminal_time = _parse_time(
                     payload["proof_as_of"],
                     "Terminal Proof As-of",
@@ -1717,6 +2820,23 @@ def _project_records(
                         "CREATOR_LIVE_TERMINAL_CUTOFF_INVALID",
                         repair_action="TIMESTAMP_CHANGE",
                     )
+            if (
+                static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3
+                and boundary == "A3_REUSE"
+                and failure_reason
+                in {
+                    "A3_EXACT_STRUCTURE_MISSING",
+                    "A3_EXACT_STRUCTURE_AMBIGUOUS",
+                }
+                and (
+                    a3_compiler_audit is None
+                    or a3_compiler_audit.terminal_a3_code != failure_reason
+                )
+            ):
+                raise _JournalIntegrityError(
+                    "CREATOR_LIVE_A3_TERMINAL_AUDIT_MISMATCH",
+                    repair_action="RECEIPT_REWRITE",
+                )
             if set(payload) == diagnostic_fields:
                 if (
                     boundary != "A1_CAPTURE"
@@ -1758,12 +2878,24 @@ def _project_records(
                 "runtime_provenance_id",
                 "no_repair_verified",
             }
-            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            if static.journal_schema in {
+                CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+                CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+            }:
                 completion_fields.add("proof_as_of")
             if set(payload) != completion_fields or (
                 len(events) != len(_STAGES)
                 or run_2 is None
                 or a3_reuse_event_id is None
+                or (
+                    static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3
+                    and (
+                        run_2_output_identity is None
+                        or a3_compiler_audit is None
+                        or a3_compiler_audit.winning_candidate_count != 1
+                        or a3_compiler_audit.terminal_a3_code is not None
+                    )
+                )
                 or payload["trace_event_count"] != len(_STAGES)
                 or payload["trace_chain_head_sha256"] != previous_trace
                 or payload["runtime_provenance_id"]
@@ -1774,7 +2906,10 @@ def _project_records(
                     "CREATOR_LIVE_COMPLETION_RECORD_INVALID",
                     repair_action="RECEIPT_REWRITE",
                 )
-            if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            if static.journal_schema in {
+                CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+                CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+            }:
                 terminal_proof_as_of, terminal_time = _parse_time(
                     payload["proof_as_of"],
                     "Terminal Proof As-of",
@@ -1828,6 +2963,21 @@ def _project_records(
         anchor_sha256=hashlib.sha256(anchor_raw).hexdigest(),
         durable_readback_verified=True,
     )
+    if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3:
+        assert isinstance(static.attempt, FieldNoteCreatorLiveAttempt)
+        assert static.attempt_opened_at is not None
+        assert static.terminal_projection_binding is not None
+        return FieldNoteCreatorLiveTraceReadbackV3._create_v3(
+            terminal_projection_binding=static.terminal_projection_binding,
+            run_2_output_identity=run_2_output_identity,
+            a3_compiler_audit=a3_compiler_audit,
+            authorization_observed_at=(
+                static.attempt.authorization_observed_at
+            ),
+            attempt_opened_at=static.attempt_opened_at,
+            terminal_proof_as_of=terminal_proof_as_of,
+            **readback_fields,
+        )
     if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
         assert isinstance(static.attempt, FieldNoteCreatorLiveAttempt)
         assert static.attempt_opened_at is not None
@@ -1878,6 +3028,21 @@ def _failed_readback(
         anchor_sha256=hashlib.sha256(anchor_raw).hexdigest(),
         durable_readback_verified=False,
     )
+    if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3:
+        assert isinstance(static.attempt, FieldNoteCreatorLiveAttempt)
+        assert static.attempt_opened_at is not None
+        assert static.terminal_projection_binding is not None
+        return FieldNoteCreatorLiveTraceReadbackV3._create_v3(
+            terminal_projection_binding=static.terminal_projection_binding,
+            run_2_output_identity=None,
+            a3_compiler_audit=None,
+            authorization_observed_at=(
+                static.attempt.authorization_observed_at
+            ),
+            attempt_opened_at=static.attempt_opened_at,
+            terminal_proof_as_of=None,
+            **fields,
+        )
     if static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
         assert isinstance(static.attempt, FieldNoteCreatorLiveAttempt)
         assert static.attempt_opened_at is not None
@@ -1908,15 +3073,24 @@ class FieldNoteCreatorLiveProofRuntime:
     ) -> None:
         self._storage_root = storage_root
         is_v2 = static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2
+        is_v3 = static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3
         self._journal_path = storage_root / (
-            CREATOR_LIVE_JOURNAL_FILENAME_V2
-            if is_v2
-            else CREATOR_LIVE_JOURNAL_FILENAME
+            CREATOR_LIVE_JOURNAL_FILENAME_V3
+            if is_v3
+            else (
+                CREATOR_LIVE_JOURNAL_FILENAME_V2
+                if is_v2
+                else CREATOR_LIVE_JOURNAL_FILENAME
+            )
         )
         self._anchor_path = storage_root / (
-            CREATOR_LIVE_ANCHOR_FILENAME_V2
-            if is_v2
-            else CREATOR_LIVE_ANCHOR_FILENAME
+            CREATOR_LIVE_ANCHOR_FILENAME_V3
+            if is_v3
+            else (
+                CREATOR_LIVE_ANCHOR_FILENAME_V2
+                if is_v2
+                else CREATOR_LIVE_ANCHOR_FILENAME
+            )
         )
         self._static = static
         self._lock = threading.Lock()
@@ -1938,6 +3112,9 @@ class FieldNoteCreatorLiveProofRuntime:
         source_repository: FieldNoteSourceRepositoryIdentity,
         run_1_id: str,
         runtime: CodexRuntimeIdentity,
+        terminal_projection_binding: (
+            FieldNoteCreatorLiveTerminalProjectionBinding | None
+        ) = None,
     ) -> FieldNoteCreatorLiveProofRuntime:
         if not isinstance(attempt, FieldNoteCreatorLiveAttempt):
             raise FieldNoteCreatorLiveValidationError(
@@ -1949,6 +3126,20 @@ class FieldNoteCreatorLiveProofRuntime:
         ) or not isinstance(runtime, CodexRuntimeIdentity):
             raise FieldNoteCreatorLiveValidationError(
                 "Creator-live runtime identity is not typed."
+            )
+        is_v3 = terminal_projection_binding is not None
+        if is_v3 and not isinstance(
+            terminal_projection_binding,
+            FieldNoteCreatorLiveTerminalProjectionBinding,
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live terminal projection binding is not typed."
+            )
+        if is_v3 and not attempt.proof_attempt_id.endswith(
+            "_" + terminal_projection_binding.launch_binding_sha256
+        ):
+            raise FieldNoteCreatorLiveValidationError(
+                "Creator-live launch binding does not match the attempt."
             )
         if (
             not isinstance(run_1_id, str)
@@ -1977,6 +3168,8 @@ class FieldNoteCreatorLiveProofRuntime:
                 CREATOR_LIVE_ANCHOR_FILENAME,
                 CREATOR_LIVE_JOURNAL_FILENAME_V2,
                 CREATOR_LIVE_ANCHOR_FILENAME_V2,
+                CREATOR_LIVE_JOURNAL_FILENAME_V3,
+                CREATOR_LIVE_ANCHOR_FILENAME_V3,
             )
         ):
             raise FieldNoteCreatorLiveAttemptExistsError(
@@ -2022,13 +3215,26 @@ class FieldNoteCreatorLiveProofRuntime:
             runtime=runtime,
             run_1=run_1,
             provenance=provenance,
-            journal_schema=CREATOR_LIVE_JOURNAL_SCHEMA_V2,
-            record_schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
-            anchor_schema=CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+            journal_schema=(
+                CREATOR_LIVE_JOURNAL_SCHEMA_V3
+                if is_v3
+                else CREATOR_LIVE_JOURNAL_SCHEMA_V2
+            ),
+            record_schema=(
+                CREATOR_LIVE_RECORD_SCHEMA_V3
+                if is_v3
+                else CREATOR_LIVE_RECORD_SCHEMA_V2
+            ),
+            anchor_schema=(
+                CREATOR_LIVE_ANCHOR_SCHEMA_V3
+                if is_v3
+                else CREATOR_LIVE_ANCHOR_SCHEMA_V2
+            ),
             attempt_opened_at=attempt_opened_at,
+            terminal_projection_binding=terminal_projection_binding,
         )
         payload = {
-            "journal_schema": CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+            "journal_schema": static.journal_schema,
             "attempt": attempt.as_dict(),
             "attempt_opened_at": attempt_opened_at,
             "source_repository": source_repository.as_dict(),
@@ -2036,12 +3242,16 @@ class FieldNoteCreatorLiveProofRuntime:
             "run_1_id": run_1_id,
             "one_attempt_no_retry": True,
         }
+        if terminal_projection_binding is not None:
+            payload["terminal_projection_binding"] = (
+                terminal_projection_binding.as_dict()
+            )
         record = _JournalRecord.create(
             sequence=0,
             kind="ATTEMPT_OPENED",
             payload=payload,
             previous_record_sha256=JOURNAL_GENESIS_SHA256,
-            schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
+            schema=static.record_schema,
         )
         run_record = _JournalRecord.create(
             sequence=1,
@@ -2051,9 +3261,13 @@ class FieldNoteCreatorLiveProofRuntime:
                 "runtime_provenance": provenance.as_dict(),
             },
             previous_record_sha256=record.record_sha256,
-            schema=CREATOR_LIVE_RECORD_SCHEMA_V2,
+            schema=static.record_schema,
         )
-        path = root / CREATOR_LIVE_JOURNAL_FILENAME_V2
+        path = root / (
+            CREATOR_LIVE_JOURNAL_FILENAME_V3
+            if is_v3
+            else CREATOR_LIVE_JOURNAL_FILENAME_V2
+        )
         try:
             descriptor = os.open(
                 path,
@@ -2080,9 +3294,13 @@ class FieldNoteCreatorLiveProofRuntime:
             journal_raw=journal_raw,
             journal_records=(record, run_record),
             previous_anchor_sha256=ANCHOR_GENESIS_SHA256,
-            schema=CREATOR_LIVE_ANCHOR_SCHEMA_V2,
+            schema=static.anchor_schema,
         )
-        anchor_path = root / CREATOR_LIVE_ANCHOR_FILENAME_V2
+        anchor_path = root / (
+            CREATOR_LIVE_ANCHOR_FILENAME_V3
+            if is_v3
+            else CREATOR_LIVE_ANCHOR_FILENAME_V2
+        )
         try:
             anchor_descriptor = os.open(
                 anchor_path,
@@ -2121,11 +3339,15 @@ class FieldNoteCreatorLiveProofRuntime:
         storage_root: Path,
     ) -> FieldNoteCreatorLiveProofRuntime:
         root = Path(storage_root)
+        v3_path = root / CREATOR_LIVE_JOURNAL_FILENAME_V3
+        v3_anchor = root / CREATOR_LIVE_ANCHOR_FILENAME_V3
         v2_path = root / CREATOR_LIVE_JOURNAL_FILENAME_V2
         v2_anchor = root / CREATOR_LIVE_ANCHOR_FILENAME_V2
         v1_path = root / CREATOR_LIVE_JOURNAL_FILENAME
         v1_anchor = root / CREATOR_LIVE_ANCHOR_FILENAME
-        if v2_path.exists() or v2_anchor.exists():
+        if v3_path.exists() or v3_anchor.exists():
+            path, anchor_path = v3_path, v3_anchor
+        elif v2_path.exists() or v2_anchor.exists():
             path, anchor_path = v2_path, v2_anchor
         else:
             path, anchor_path = v1_path, v1_anchor
@@ -2206,7 +3428,10 @@ class FieldNoteCreatorLiveProofRuntime:
         kind: JournalRecordKind,
         payload: dict[str, Any],
     ) -> FieldNoteCreatorLiveTraceReadback:
-        if self._static.journal_schema != CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+        if self._static.journal_schema not in {
+            CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+            CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+        }:
             raise FieldNoteCreatorLiveStageError(
                 "Historical v0.1 creator-live attempts are read-only."
             )
@@ -2291,6 +3516,12 @@ class FieldNoteCreatorLiveProofRuntime:
                 fcntl.flock(journal_descriptor, fcntl.LOCK_UN)
                 os.close(anchor_descriptor)
                 os.close(journal_descriptor)
+        if self._static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V3:
+            directory = os.open(self._storage_root, os.O_RDONLY)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
         return self.read_back()
 
     def _terminal_failure(
@@ -2331,7 +3562,10 @@ class FieldNoteCreatorLiveProofRuntime:
             "failure_reason": bounded,
             "repair_action": repair_action,
         }
-        if self._static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+        if self._static.journal_schema in {
+            CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+            CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+        }:
             payload["proof_as_of"] = self._runtime_terminal_proof_as_of(
                 readback
             )
@@ -2445,7 +3679,10 @@ class FieldNoteCreatorLiveProofRuntime:
                 ),
                 "no_repair_verified": True,
             }
-            if self._static.journal_schema == CREATOR_LIVE_JOURNAL_SCHEMA_V2:
+            if self._static.journal_schema in {
+                CREATOR_LIVE_JOURNAL_SCHEMA_V2,
+                CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+            }:
                 completion_payload["proof_as_of"] = (
                     self._runtime_terminal_proof_as_of(completed)
                 )
@@ -2454,6 +3691,87 @@ class FieldNoteCreatorLiveProofRuntime:
                 completion_payload,
             )
         return event
+
+    def record_run_2_output_identity(
+        self,
+        identity: FieldNoteCreatorLiveRun2OutputIdentity,
+    ) -> FieldNoteCreatorLiveTraceReadbackV3:
+        readback = self._require_stage("A3_REUSE")
+        if self._static.journal_schema != CREATOR_LIVE_JOURNAL_SCHEMA_V3 or (
+            not isinstance(readback, FieldNoteCreatorLiveTraceReadbackV3)
+        ):
+            raise FieldNoteCreatorLiveStageError(
+                "Run 2 output identity requires a v0.3 attempt."
+            )
+        if (
+            not isinstance(identity, FieldNoteCreatorLiveRun2OutputIdentity)
+            or readback.run_2 is None
+            or readback.run_2_output_identity is not None
+            or readback.a3_compiler_audit is not None
+            or identity.proof_attempt_id != readback.proof_attempt_id
+            or identity.run_id != readback.run_2.run_id
+            or identity.task_byte_count
+            != readback.terminal_projection_binding.run_2_task.byte_count
+            or identity.task_sha256
+            != readback.terminal_projection_binding.run_2_task.sha256
+        ):
+            self._terminal_failure(
+                "A3_REUSE",
+                "A3_RUN_2_OUTPUT_IDENTITY_INVALID",
+            )
+        recorded = self._append(
+            "RUN_2_OUTPUT_IDENTITY_RECORDED",
+            identity.as_dict(),
+        )
+        if not isinstance(recorded, FieldNoteCreatorLiveTraceReadbackV3) or (
+            recorded.run_2_output_identity != identity
+        ):
+            raise FieldNoteCreatorLiveDurabilityError(
+                "Run 2 output identity did not survive exact read-back."
+            )
+        return recorded
+
+    def record_a3_compiler_audit(
+        self,
+        audit: FieldNoteCreatorLiveA3CompilerAudit,
+    ) -> FieldNoteCreatorLiveTraceReadbackV3:
+        readback = self._require_stage("A3_REUSE")
+        if self._static.journal_schema != CREATOR_LIVE_JOURNAL_SCHEMA_V3 or (
+            not isinstance(readback, FieldNoteCreatorLiveTraceReadbackV3)
+        ):
+            raise FieldNoteCreatorLiveStageError(
+                "A3 compiler audit requires a v0.3 attempt."
+            )
+        output_identity = readback.run_2_output_identity
+        note = readback.captured_note
+        if (
+            not isinstance(audit, FieldNoteCreatorLiveA3CompilerAudit)
+            or output_identity is None
+            or readback.a3_compiler_audit is not None
+            or readback.run_2 is None
+            or note is None
+            or readback.captured_note_byte_count is None
+            or audit.proof_attempt_id != readback.proof_attempt_id
+            or audit.run_id != readback.run_2.run_id
+            or audit.output_artifact_id
+            != output_identity.output_artifact.artifact_id
+            or audit.output_byte_count != output_identity.final_output_byte_count
+            or audit.output_sha256 != output_identity.final_output_sha256
+            or audit.source_note_byte_count != readback.captured_note_byte_count
+            or audit.source_note_sha256 != note.note_sha256
+        ):
+            self._terminal_failure(
+                "A3_REUSE",
+                "A3_COMPILER_AUDIT_IDENTITY_INVALID",
+            )
+        recorded = self._append("A3_COMPILER_AUDIT_RECORDED", audit.as_dict())
+        if not isinstance(recorded, FieldNoteCreatorLiveTraceReadbackV3) or (
+            recorded.a3_compiler_audit != audit
+        ):
+            raise FieldNoteCreatorLiveDurabilityError(
+                "A3 compiler audit did not survive exact read-back."
+            )
+        return recorded
 
     def open_run_2(
         self,
@@ -2698,6 +4016,33 @@ class FieldNoteCreatorLiveProofRuntime:
                 "A3_REUSE",
                 "A3_STRUCTURE_BINDING_INVALID",
             )
+        if isinstance(readback, FieldNoteCreatorLiveTraceReadbackV3):
+            audit = readback.a3_compiler_audit
+            output_identity = readback.run_2_output_identity
+            structure = receipt.use_evidence.structure_binding
+            if (
+                audit is None
+                or output_identity is None
+                or audit.winning_candidate_count != 1
+                or audit.terminal_a3_code is not None
+                or structure.start_byte != audit.selected_source_start_byte
+                or structure.end_byte != audit.selected_source_end_byte
+                or receipt.use_evidence.evidence_class != "OUTPUT_ARTIFACT"
+                or receipt.use_evidence.evidence_origin
+                != "IMMEDIATE_COMPLETION_RECORD"
+                or receipt.use_evidence.evidence_sha256
+                != output_identity.final_output_sha256
+                or receipt.use_evidence.evidence_ref
+                != (
+                    f"run:{readback.run_2.run_id}:final-output:bytes:"
+                    f"{audit.selected_output_start_byte}:"
+                    f"{audit.selected_output_end_byte}"
+                )
+            ):
+                self._terminal_failure(
+                    "A3_REUSE",
+                    "A3_COMPILER_AUDIT_CLAIM_MISMATCH",
+                )
         if receipt.reuse_event_id != _expected_reuse_event_id(receipt):
             self._terminal_failure("A3_REUSE", "A3_REUSE_EVENT_ID_INVALID")
         if receipt.promotion != PromotionPolicyBoundary():

--- a/decision_os/companion/field_notes_creator_live_entrypoint.py
+++ b/decision_os/companion/field_notes_creator_live_entrypoint.py
@@ -18,10 +18,21 @@ from decision_os.acceleration.model import git_output, repository_id
 from decision_os.companion.field_notes_creator_live import (
     CREATOR_LIVE_ANCHOR_FILENAME,
     CREATOR_LIVE_ANCHOR_FILENAME_V2,
+    CREATOR_LIVE_ANCHOR_FILENAME_V3,
     CREATOR_LIVE_JOURNAL_FILENAME,
     CREATOR_LIVE_JOURNAL_FILENAME_V2,
+    CREATOR_LIVE_JOURNAL_FILENAME_V3,
+    FieldNoteCreatorLiveA3CompilerAudit,
+    FieldNoteCreatorLiveA3RejectionCounts,
     FieldNoteCreatorLiveAttemptExistsError,
+    FieldNoteCreatorLiveContractIdentity,
+    FieldNoteCreatorLiveHistoricalBoundary,
     FieldNoteCreatorLiveProofRuntime,
+    FieldNoteCreatorLiveRun2OutputIdentity,
+    FieldNoteCreatorLiveTaskIdentity,
+    FieldNoteCreatorLiveTerminalProjectionBinding,
+    FieldNoteCreatorLiveTraceReadbackV2,
+    FieldNoteCreatorLiveTraceReadbackV3,
 )
 from decision_os.companion.field_notes_creator_live_capture import (
     FieldNoteCreatorLiveA1CaptureBridge,
@@ -64,7 +75,7 @@ from decision_os.companion.field_notes_whole_flow import (
 
 CYCLE_KEY = "cycle-005"
 CYCLE_AUTHORIZATION_OBSERVED_AT = "2026-08-05T06:22:00Z"
-IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT = "2026-08-05T08:47:00Z"
+IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT = "2026-08-05T12:28:00Z"
 EXPECTED_REPOSITORY = Path(
     "/Users/sn/Documents/v13/decision-os-v13-loopkit"
 )
@@ -151,7 +162,10 @@ _PROOF_FILENAMES = (
     CREATOR_LIVE_ANCHOR_FILENAME,
     CREATOR_LIVE_JOURNAL_FILENAME_V2,
     CREATOR_LIVE_ANCHOR_FILENAME_V2,
+    CREATOR_LIVE_JOURNAL_FILENAME_V3,
+    CREATOR_LIVE_ANCHOR_FILENAME_V3,
 )
+NOT_DURABLY_PERSISTED = "NOT_DURABLY_PERSISTED"
 
 PROTECTED_HISTORY: tuple[tuple[str, str], ...] = (
     (
@@ -204,6 +218,11 @@ PROTECTED_HISTORY: tuple[tuple[str, str], ...] = (
 class _Controller(Protocol):
     def creator_live_a1_completed_draft(self, *, expected_run_id: str) -> Any: ...
     def creator_live_a2_run_completion(self, *, expected_run_id: str) -> Any: ...
+    def release_creator_live_a2_run_completion(
+        self,
+        *,
+        expected_run_id: str,
+    ) -> None: ...
 
 
 class CreatorLiveEntrypointError(RuntimeError):
@@ -374,17 +393,21 @@ def _proof_storage_occupied(root: Path) -> bool:
         return True
 
 
-def compile_run_2_output_artifact(
+@dataclass(frozen=True)
+class _A3CompilerScan:
+    candidates: tuple[tuple[int, int, bytes, int], ...]
+    longest_candidate_byte_count: int
+    winners: tuple[tuple[int, int, bytes, int], ...]
+    rejection_counts: FieldNoteCreatorLiveA3RejectionCounts
+
+
+def _validate_run_2_output_artifact_inputs(
     *,
     note: FieldNoteIdentity,
     note_bytes: bytes,
-    run_2_id: str,
     final_output_bytes: bytes,
     final_output_sha256: str,
-    observed_at: str,
-) -> FieldNoteReuseClaim:
-    """Compile only a unique, exact, non-whole UTF-8 output-artifact claim."""
-
+) -> None:
     if (
         not isinstance(note_bytes, bytes)
         or _sha256_bytes(note_bytes) != note.note_sha256
@@ -406,14 +429,42 @@ def compile_run_2_output_artifact(
     ):
         if identity.encode("utf-8") not in final_output_bytes:
             raise ValueError("A3_OUTPUT_ARTIFACT_LINEAGE_MISSING")
+
+
+def _scan_run_2_output_artifact(
+    *,
+    note_bytes: bytes,
+    final_output_bytes: bytes,
+) -> _A3CompilerScan:
     candidates: list[tuple[int, int, bytes, int]] = []
+    rejection_counts = {
+        "below_minimum_byte_length": 0,
+        "whole_note_range": 0,
+        "non_unique_source_occurrence": 0,
+        "absent_output_occurrence": 0,
+        "multiple_output_occurrences": 0,
+    }
     for match in re.finditer(rb"[^\r\n]+", note_bytes):
         structure = match.group(0)
+        below_minimum = len(structure.strip()) < 32
+        whole_note = match.start() == 0 and match.end() == len(note_bytes)
+        source_occurrences = note_bytes.count(structure)
+        output_occurrences = final_output_bytes.count(structure)
+        if below_minimum:
+            rejection_counts["below_minimum_byte_length"] += 1
+        if whole_note:
+            rejection_counts["whole_note_range"] += 1
+        if source_occurrences != 1:
+            rejection_counts["non_unique_source_occurrence"] += 1
+        if output_occurrences == 0:
+            rejection_counts["absent_output_occurrence"] += 1
+        elif output_occurrences > 1:
+            rejection_counts["multiple_output_occurrences"] += 1
         if (
-            len(structure.strip()) < 32
-            or (match.start() == 0 and match.end() == len(note_bytes))
-            or note_bytes.count(structure) != 1
-            or final_output_bytes.count(structure) != 1
+            below_minimum
+            or whole_note
+            or source_occurrences != 1
+            or output_occurrences != 1
         ):
             continue
         candidates.append(
@@ -424,13 +475,28 @@ def compile_run_2_output_artifact(
                 final_output_bytes.index(structure),
             )
         )
-    if not candidates:
-        raise ValueError("A3_EXACT_STRUCTURE_MISSING")
-    longest = max(len(item[2]) for item in candidates)
+    longest = max((len(item[2]) for item in candidates), default=0)
     winners = tuple(item for item in candidates if len(item[2]) == longest)
-    if len(winners) != 1:
-        raise ValueError("A3_EXACT_STRUCTURE_AMBIGUOUS")
-    start, end, structure, output_start = winners[0]
+    return _A3CompilerScan(
+        candidates=tuple(candidates),
+        longest_candidate_byte_count=longest,
+        winners=winners,
+        rejection_counts=FieldNoteCreatorLiveA3RejectionCounts(
+            **rejection_counts
+        ),
+    )
+
+
+def _claim_from_a3_winner(
+    *,
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+    run_2_id: str,
+    final_output_sha256: str,
+    observed_at: str,
+    winner: tuple[int, int, bytes, int],
+) -> FieldNoteReuseClaim:
+    start, end, structure, output_start = winner
     binding = bind_field_note_structure(
         note,
         note_bytes,
@@ -473,6 +539,199 @@ def compile_run_2_output_artifact(
                 "Independent evidence may later confirm the exact structure's "
                 "bounded contribution."
             ),
+        ),
+    )
+
+
+def compile_run_2_output_artifact(
+    *,
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+    run_2_id: str,
+    final_output_bytes: bytes,
+    final_output_sha256: str,
+    observed_at: str,
+) -> FieldNoteReuseClaim:
+    """Compile only a unique, exact, non-whole UTF-8 output-artifact claim."""
+
+    _validate_run_2_output_artifact_inputs(
+        note=note,
+        note_bytes=note_bytes,
+        final_output_bytes=final_output_bytes,
+        final_output_sha256=final_output_sha256,
+    )
+    scan = _scan_run_2_output_artifact(
+        note_bytes=note_bytes,
+        final_output_bytes=final_output_bytes,
+    )
+    if not scan.candidates:
+        raise ValueError("A3_EXACT_STRUCTURE_MISSING")
+    if len(scan.winners) != 1:
+        raise ValueError("A3_EXACT_STRUCTURE_AMBIGUOUS")
+    return _claim_from_a3_winner(
+        note=note,
+        note_bytes=note_bytes,
+        run_2_id=run_2_id,
+        final_output_sha256=final_output_sha256,
+        observed_at=observed_at,
+        winner=scan.winners[0],
+    )
+
+
+def compile_run_2_output_artifact_audited(
+    *,
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+    run_2_id: str,
+    final_output_bytes: bytes,
+    output_identity: FieldNoteCreatorLiveRun2OutputIdentity,
+) -> tuple[
+    tuple[int, int, bytes, int] | None,
+    FieldNoteCreatorLiveA3CompilerAudit,
+]:
+    """Return transient winner facts plus their content-free typed audit."""
+
+    if (
+        not isinstance(output_identity, FieldNoteCreatorLiveRun2OutputIdentity)
+        or output_identity.run_id != run_2_id
+        or output_identity.final_output_byte_count != len(final_output_bytes)
+        or output_identity.final_output_sha256
+        != _sha256_bytes(final_output_bytes)
+    ):
+        raise ValueError("A3_OUTPUT_ARTIFACT_IDENTITY_INVALID")
+    _validate_run_2_output_artifact_inputs(
+        note=note,
+        note_bytes=note_bytes,
+        final_output_bytes=final_output_bytes,
+        final_output_sha256=output_identity.final_output_sha256,
+    )
+    scan = _scan_run_2_output_artifact(
+        note_bytes=note_bytes,
+        final_output_bytes=final_output_bytes,
+    )
+    winner = scan.winners[0] if len(scan.winners) == 1 else None
+    terminal_a3_code = (
+        None
+        if winner is not None
+        else "A3_EXACT_STRUCTURE_MISSING"
+        if not scan.candidates
+        else "A3_EXACT_STRUCTURE_AMBIGUOUS"
+    )
+    audit = FieldNoteCreatorLiveA3CompilerAudit.issue(
+        proof_attempt_id=output_identity.proof_attempt_id,
+        run_id=run_2_id,
+        output_artifact_id=output_identity.output_artifact.artifact_id,
+        source_note_byte_count=len(note_bytes),
+        source_note_sha256=note.note_sha256,
+        output_byte_count=len(final_output_bytes),
+        output_sha256=output_identity.final_output_sha256,
+        eligible_candidate_count=len(scan.candidates),
+        rejection_counts=scan.rejection_counts,
+        longest_candidate_byte_count=scan.longest_candidate_byte_count,
+        winning_candidate_count=len(scan.winners),
+        selected_source_start_byte=(winner[0] if winner is not None else None),
+        selected_source_end_byte=(winner[1] if winner is not None else None),
+        selected_output_start_byte=(winner[3] if winner is not None else None),
+        selected_output_end_byte=(
+            winner[3] + len(winner[2]) if winner is not None else None
+        ),
+        terminal_a3_code=terminal_a3_code,
+    )
+    return winner, audit
+
+
+def _claim_from_verified_a3_audit(
+    *,
+    note: FieldNoteIdentity,
+    note_bytes: bytes,
+    run_2_id: str,
+    output_identity: FieldNoteCreatorLiveRun2OutputIdentity,
+    observed_at: str,
+    winner: tuple[int, int, bytes, int],
+    audit: FieldNoteCreatorLiveA3CompilerAudit,
+) -> FieldNoteReuseClaim:
+    start, end, structure, output_start = winner
+    if (
+        audit.proof_attempt_id != output_identity.proof_attempt_id
+        or audit.run_id != run_2_id
+        or audit.output_artifact_id
+        != output_identity.output_artifact.artifact_id
+        or audit.source_note_byte_count != len(note_bytes)
+        or audit.source_note_sha256 != note.note_sha256
+        or audit.output_byte_count != output_identity.final_output_byte_count
+        or audit.output_sha256 != output_identity.final_output_sha256
+        or audit.winning_candidate_count != 1
+        or audit.terminal_a3_code is not None
+        or audit.selected_source_start_byte != start
+        or audit.selected_source_end_byte != end
+        or audit.selected_output_start_byte != output_start
+        or audit.selected_output_end_byte != output_start + len(structure)
+        or note_bytes[start:end] != structure
+    ):
+        raise ValueError("A3_COMPILER_AUDIT_READBACK_MISMATCH")
+    return _claim_from_a3_winner(
+        note=note,
+        note_bytes=note_bytes,
+        run_2_id=run_2_id,
+        final_output_sha256=output_identity.final_output_sha256,
+        observed_at=observed_at,
+        winner=winner,
+    )
+
+
+def _terminal_projection_binding_from_p0(
+    p0: CreatorLiveP0Result,
+) -> FieldNoteCreatorLiveTerminalProjectionBinding:
+    binding = p0.binding
+    if p0.launch_binding_sha256 is None or not isinstance(binding, Mapping):
+        raise ValueError("P0_TERMINAL_PROJECTION_BINDING_UNAVAILABLE")
+    contract = binding.get("contract")
+    tasks = binding.get("tasks")
+    authorizations = binding.get("authorizations")
+    historical = binding.get("historical_boundary")
+    if (
+        not isinstance(contract, Mapping)
+        or not isinstance(tasks, Mapping)
+        or not isinstance(authorizations, Mapping)
+        or not isinstance(historical, Mapping)
+        or not isinstance(tasks.get("run_1"), Mapping)
+        or not isinstance(tasks.get("run_2"), Mapping)
+    ):
+        raise ValueError("P0_TERMINAL_PROJECTION_BINDING_UNAVAILABLE")
+    run_1_task = tasks["run_1"]
+    run_2_task = tasks["run_2"]
+    return FieldNoteCreatorLiveTerminalProjectionBinding.create(
+        launch_binding_sha256=p0.launch_binding_sha256,
+        contract_identity=FieldNoteCreatorLiveContractIdentity(
+            profile=contract.get("profile"),
+            title=contract.get("title"),
+            source_byte_count=contract.get("source_byte_count"),
+            source_sha256=contract.get("source_sha256"),
+            wrapper_sha256=contract.get("wrapper_sha256"),
+            interpretation_sha256=contract.get("interpretation_sha256"),
+        ),
+        ordinary_contract_execution_authority=contract.get(
+            "ordinary_contract_execution_authority"
+        ),
+        guided_intake_freeze_authority=contract.get(
+            "guided_intake_freeze_authority_state"
+        ),
+        implementation_authorization_observed_at=authorizations.get(
+            "implementation_observed_at"
+        ),
+        run_1_task=FieldNoteCreatorLiveTaskIdentity(
+            byte_count=run_1_task.get("byte_count"),
+            sha256=run_1_task.get("sha256"),
+        ),
+        run_2_task=FieldNoteCreatorLiveTaskIdentity(
+            byte_count=run_2_task.get("byte_count"),
+            sha256=run_2_task.get("sha256"),
+        ),
+        historical_boundary=FieldNoteCreatorLiveHistoricalBoundary(
+            cycle_key=historical.get("cycle_key"),
+            state=historical.get("state"),
+            failure_boundary=historical.get("failure_boundary"),
+            failure_code=historical.get("failure_code"),
         ),
     )
 
@@ -753,6 +1012,7 @@ class CreatorLiveCycle005Entrypoint:
                 },
                 "contract": {
                     "profile": EXPECTED_CONTRACT_PROFILE,
+                    "title": EXPECTED_CONTRACT_TITLE,
                     "source_byte_count": EXPECTED_CONTRACT_BYTES,
                     "source_sha256": EXPECTED_CONTRACT_SHA256,
                     "wrapper_sha256": EXPECTED_WRAPPER_SHA256,
@@ -819,10 +1079,12 @@ class CreatorLiveCycle005Entrypoint:
                     "source_tree_sha256": source_product_tree,
                     "installed_tree_sha256": installed_product_tree,
                 },
-                "historical_boundary": (
-                    "Cycle 004 remains FAILED/A1_CAPTURE/"
-                    "A1_CAPTURE_CHRONOLOGY_INVALID; earlier proofs remain terminal."
-                ),
+                "historical_boundary": {
+                    "cycle_key": "cycle-004",
+                    "state": "FAILED",
+                    "failure_boundary": "A1_CAPTURE",
+                    "failure_code": "A1_CAPTURE_CHRONOLOGY_INVALID",
+                },
             }
             digest = _sha256_bytes(canonical_json(binding).encode("utf-8"))
             return CreatorLiveP0Result(True, None, binding, digest)
@@ -839,61 +1101,218 @@ class CreatorLiveCycle005Entrypoint:
                 code = "P0_IDENTITY_UNAVAILABLE"
             return CreatorLiveP0Result(False, code[:128], None, None)
 
-    def _public_readback(self, runtime: FieldNoteCreatorLiveProofRuntime) -> dict[str, Any]:
+    def _public_readback(
+        self,
+        runtime: FieldNoteCreatorLiveProofRuntime,
+    ) -> dict[str, Any]:
         readback = runtime.read_back()
+        if not readback.durable_readback_verified:
+            raise ValueError("PROOF_STORAGE_INTEGRITY_FAILURE")
+        prefix = "proof_a7_creator_live_cycle_005_"
+        launch_binding_sha256 = readback.proof_attempt_id.removeprefix(prefix)
+        if (
+            not _SHA256.fullmatch(launch_binding_sha256)
+            or readback.proof_attempt_id != prefix + launch_binding_sha256
+        ):
+            raise ValueError("PROOF_ATTEMPT_IDENTITY_INVALID")
+        terminal_state = readback.state
+        terminal_stage = (
+            readback.failure_boundary
+            if readback.state == "FAILED"
+            else "A7"
+            if readback.state == "TRACE_COMPLETE"
+            else readback.current_stage
+        )
+        contract_identity: dict[str, Any] | str = NOT_DURABLY_PERSISTED
+        ordinary_authority: str = NOT_DURABLY_PERSISTED
+        freeze_authority: str = NOT_DURABLY_PERSISTED
+        run_1_task: dict[str, Any] = {
+            "byte_count": NOT_DURABLY_PERSISTED,
+            "sha256": (
+                readback.a1_capture_commit.task_sha256
+                if readback.a1_capture_commit is not None
+                else NOT_DURABLY_PERSISTED
+            ),
+        }
+        run_2_task: dict[str, Any] = {
+            "byte_count": NOT_DURABLY_PERSISTED,
+            "sha256": NOT_DURABLY_PERSISTED,
+        }
+        implementation_authorization: str = NOT_DURABLY_PERSISTED
+        historical_boundary: dict[str, Any] | str = NOT_DURABLY_PERSISTED
+        retry_count: int | str = NOT_DURABLY_PERSISTED
+        replacement_count: int | str = NOT_DURABLY_PERSISTED
+        output_artifact: dict[str, Any] | str = NOT_DURABLY_PERSISTED
+        compiler: dict[str, Any] | str = NOT_DURABLY_PERSISTED
+        if isinstance(readback, FieldNoteCreatorLiveTraceReadbackV3):
+            binding = readback.terminal_projection_binding
+            contract = binding.contract_identity
+            contract_identity = {
+                "profile": contract.profile,
+                "title": contract.title,
+                "source_byte_count": contract.source_byte_count,
+                "source_sha256": contract.source_sha256,
+                "wrapper_sha256": contract.wrapper_sha256,
+                "interpretation_sha256": contract.interpretation_sha256,
+            }
+            ordinary_authority = binding.ordinary_contract_execution_authority
+            freeze_authority = binding.guided_intake_freeze_authority
+            run_1_task = {
+                "byte_count": binding.run_1_task.byte_count,
+                "sha256": binding.run_1_task.sha256,
+            }
+            run_2_task = {
+                "byte_count": binding.run_2_task.byte_count,
+                "sha256": binding.run_2_task.sha256,
+            }
+            implementation_authorization = (
+                binding.implementation_authorization_observed_at
+            )
+            historical = binding.historical_boundary
+            historical_boundary = {
+                "cycle_key": historical.cycle_key,
+                "state": historical.state,
+                "failure_boundary": historical.failure_boundary,
+                "failure_code": historical.failure_code,
+            }
+            retry_count = binding.retry_count
+            replacement_count = binding.replacement_count
+            output = readback.run_2_output_identity
+            if output is not None:
+                artifact = output.output_artifact
+                output_artifact = {
+                    "schema": artifact.schema,
+                    "artifact_id": artifact.artifact_id,
+                    "proof_attempt_id": artifact.proof_attempt_id,
+                    "run_id": artifact.run_id,
+                    "transmission_ordinal": artifact.transmission_ordinal,
+                    "media_type": artifact.media_type,
+                    "byte_count": artifact.byte_count,
+                    "sha256": artifact.sha256,
+                }
+            audit = readback.a3_compiler_audit
+            if audit is not None:
+                counts = audit.rejection_counts
+                compiler = {
+                    "compiler_version": audit.compiler_version,
+                    "compiler_branch": audit.compiler_branch,
+                    "source_note_byte_count": audit.source_note_byte_count,
+                    "source_note_sha256": audit.source_note_sha256,
+                    "output_artifact_id": audit.output_artifact_id,
+                    "output_byte_count": audit.output_byte_count,
+                    "output_sha256": audit.output_sha256,
+                    "eligible_candidate_count": audit.eligible_candidate_count,
+                    "rejection_counts": {
+                        "below_minimum_byte_length": (
+                            counts.below_minimum_byte_length
+                        ),
+                        "whole_note_range": counts.whole_note_range,
+                        "non_unique_source_occurrence": (
+                            counts.non_unique_source_occurrence
+                        ),
+                        "absent_output_occurrence": (
+                            counts.absent_output_occurrence
+                        ),
+                        "multiple_output_occurrences": (
+                            counts.multiple_output_occurrences
+                        ),
+                    },
+                    "longest_candidate_byte_count": (
+                        audit.longest_candidate_byte_count
+                    ),
+                    "winning_candidate_count": audit.winning_candidate_count,
+                    "selected_source_start_byte": (
+                        audit.selected_source_start_byte
+                    ),
+                    "selected_source_end_byte": audit.selected_source_end_byte,
+                    "selected_output_start_byte": (
+                        audit.selected_output_start_byte
+                    ),
+                    "selected_output_end_byte": audit.selected_output_end_byte,
+                    "terminal_a3_code": audit.terminal_a3_code,
+                    "audit_sha256": audit.audit_sha256,
+                }
+        elif not isinstance(readback, FieldNoteCreatorLiveTraceReadbackV2):
+            raise ValueError("PROOF_READBACK_VERSION_UNSUPPORTED")
         return {
+            "revision": readback.source_repository.source_commit,
+            "contract_identity": contract_identity,
+            "ordinary_contract_execution_authority": ordinary_authority,
+            "guided_intake_freeze_authority": freeze_authority,
+            "runtime": {
+                "account_type": readback.runtime.account_type,
+                "model": readback.runtime.model,
+                "reasoning_effort": readback.runtime.reasoning_effort,
+                "service_tier": readback.runtime.service_tier,
+                "codex_cli_version": readback.runtime.codex_cli_version,
+            },
+            "run_1_task": run_1_task,
+            "run_2_task": run_2_task,
+            "cycle_authorization_observed_at": readback.authorization_observed_at,
+            "implementation_authorization_observed_at": (
+                implementation_authorization
+            ),
+            "historical_boundary": historical_boundary,
+            "launch_binding_sha256": launch_binding_sha256,
             "proof_attempt_id": readback.proof_attempt_id,
-            "run_1_id": readback.run_1.run_id,
-            "run_2_id": readback.run_2.run_id if readback.run_2 else None,
-            "note_id": (
-                readback.captured_note.field_note_id
-                if readback.captured_note is not None
-                else None
-            ),
-            "note_path": (
-                readback.captured_note.note_path
-                if readback.captured_note is not None
-                else None
-            ),
-            "note_sha256": (
-                readback.captured_note.note_sha256
-                if readback.captured_note is not None
-                else None
-            ),
             "proof_as_of": readback.terminal_proof_as_of,
-            "journal_sha256": _sha256_bytes(runtime.journal_path.read_bytes()),
-            "anchor_sha256": _sha256_bytes(runtime.anchor_path.read_bytes()),
+            "journal_sha256": readback.journal_sha256,
+            "anchor_sha256": readback.anchor_sha256,
+            "readback_sha256": readback.readback_sha256,
+            "terminal_state": terminal_state,
+            "terminal_stage": terminal_stage,
+            "failure_code": readback.failure_reason,
+            "retry_count": retry_count,
+            "replacement_count": replacement_count,
+            "output_artifact": output_artifact,
+            "compiler": compiler,
         }
 
     def snapshot(self, base_snapshot: Mapping[str, Any]) -> dict[str, Any]:
         with self._lock:
             root = self.spec.storage_root
             if self._runtime is not None:
-                readback = self._runtime.read_back()
-                state = self._terminal_state or (
-                    "RUNNING" if self._active else readback.state
-                )
-                digest = readback.proof_attempt_id.removeprefix(
-                    "proof_a7_creator_live_cycle_005_"
-                )
-                return {
-                    "cycle_key": self.spec.cycle_key,
-                    "state": state,
-                    "stage": self._stage,
-                    "p0": {"ready": True, "failure_code": None},
-                    "launch_binding_sha256": digest if _SHA256.fullmatch(digest) else None,
-                    "binding": None,
-                    "identities": self._public_readback(self._runtime),
-                    "receipt_sha256": self._receipt_sha256,
-                    "manifest_sha256": self._manifest_sha256,
-                    "failure_code": self._terminal_failure_code,
-                    "one_attempt_no_retry": True,
-                    "replacement_permitted": False,
-                }
+                try:
+                    identities = self._public_readback(self._runtime)
+                    durable_state = identities["terminal_state"]
+                    state = (
+                        "RUNNING"
+                        if self._active
+                        else durable_state
+                        if durable_state in {"FAILED", "TRACE_COMPLETE"}
+                        else "OPEN_UNRESUMABLE"
+                    )
+                    stage = identities["terminal_stage"] or "proof-open"
+                    return {
+                        "cycle_key": self.spec.cycle_key,
+                        "state": state,
+                        "stage": stage,
+                        "p0": {
+                            "ready": False,
+                            "failure_code": "CYCLE_005_ATTEMPT_EXISTS",
+                        },
+                        "launch_binding_sha256": identities[
+                            "launch_binding_sha256"
+                        ],
+                        "binding": None,
+                        "identities": identities,
+                        "receipt_sha256": None,
+                        "manifest_sha256": None,
+                        "failure_code": identities["failure_code"],
+                        "one_attempt_no_retry": True,
+                        "replacement_permitted": False,
+                        "storage_occupied": True,
+                        "start_allowed": False,
+                    }
+                except Exception:
+                    self._runtime = None
+                    self._terminal_state = "INTEGRITY_FAILURE"
             if _proof_storage_occupied(root):
                 try:
                     runtime = FieldNoteCreatorLiveProofRuntime.load_attempt(root)
                     readback = runtime.read_back()
+                    if not readback.durable_readback_verified:
+                        raise ValueError("PROOF_STORAGE_INTEGRITY_FAILURE")
                     self._runtime = runtime
                     state = (
                         readback.state
@@ -901,7 +1320,13 @@ class CreatorLiveCycle005Entrypoint:
                         else "OPEN_UNRESUMABLE"
                     )
                     self._terminal_state = state
-                    self._stage = readback.current_stage or "A7"
+                    self._stage = (
+                        readback.failure_boundary
+                        if readback.state == "FAILED"
+                        else "A7"
+                        if readback.state == "TRACE_COMPLETE"
+                        else readback.current_stage or "proof-open"
+                    )
                     return self.snapshot(base_snapshot)
                 except Exception:
                     return {
@@ -917,6 +1342,8 @@ class CreatorLiveCycle005Entrypoint:
                         "failure_code": "PROOF_STORAGE_INTEGRITY_FAILURE",
                         "one_attempt_no_retry": True,
                         "replacement_permitted": False,
+                        "storage_occupied": True,
+                        "start_allowed": False,
                     }
             p0 = self._p0(base_snapshot)
             return {
@@ -932,6 +1359,8 @@ class CreatorLiveCycle005Entrypoint:
                 "failure_code": p0.failure_code,
                 "one_attempt_no_retry": True,
                 "replacement_permitted": False,
+                "storage_occupied": False,
+                "start_allowed": p0.ready,
             }
 
     def start(self, launch_binding_sha256: str) -> dict[str, Any]:
@@ -969,6 +1398,9 @@ class CreatorLiveCycle005Entrypoint:
             )
             run_1_id = "run_a7_creator_live_cycle_005_1_" + launch_binding_sha256
             try:
+                terminal_projection_binding = (
+                    _terminal_projection_binding_from_p0(p0)
+                )
                 attempt = FieldNoteCreatorLiveAttempt(
                     proof_attempt_id=proof_attempt_id,
                     proof_mode="CREATOR_LIVE",
@@ -985,7 +1417,9 @@ class CreatorLiveCycle005Entrypoint:
             except Exception as exc:
                 self._starting = False
                 raise CreatorLiveEntrypointError(
-                    "P0_REPOSITORY_IDENTITY_CHANGED"
+                    "P0_TERMINAL_PROJECTION_BINDING_UNAVAILABLE"
+                    if str(exc).startswith("P0_TERMINAL_PROJECTION")
+                    else "P0_REPOSITORY_IDENTITY_CHANGED"
                 ) from exc
             try:
                 runtime = self.runtime_opener(
@@ -994,6 +1428,7 @@ class CreatorLiveCycle005Entrypoint:
                     source_repository=source,
                     run_1_id=run_1_id,
                     runtime=self.spec.runtime,
+                    terminal_projection_binding=terminal_projection_binding,
                 )
             except FieldNoteCreatorLiveAttemptExistsError as exc:
                 self._starting = False
@@ -1106,20 +1541,67 @@ class CreatorLiveCycle005Entrypoint:
             completion = self.controller.creator_live_a2_run_completion(
                 expected_run_id=run_2_id
             )
-            after_a2 = runtime.read_back()
-            target = after_a2.captured_note
-            if target is None:
-                raise ValueError("A2_TARGET_MISSING")
-            note_bytes = exact.note_bytes
-            self._stage = "A3"
-            evidence_as_of = self.now()
-            claim = compile_run_2_output_artifact(
+            try:
+                after_a2 = runtime.read_back()
+                target = after_a2.captured_note
+                if target is None:
+                    raise ValueError("A2_TARGET_MISSING")
+                note_bytes = exact.note_bytes
+                reconnect_receipt = completion.reconnect_receipt
+                final_output_bytes = completion.final_output_bytes
+                output_identity = FieldNoteCreatorLiveRun2OutputIdentity.create(
+                    proof_attempt_id=after_a2.proof_attempt_id,
+                    run_id=completion.run_id,
+                    task_byte_count=completion.task_byte_count,
+                    task_sha256=completion.task_sha256,
+                    final_output_byte_count=len(final_output_bytes),
+                    final_output_sha256=completion.final_output_sha256,
+                )
+                if (
+                    completion.transmission_ordinal != 2
+                    or completion.normal_terminal is not True
+                    or completion.turn_status != "completed"
+                    or completion.runtime_status != "NORMAL_TERMINAL"
+                    or completion.failure_diagnostic_absent is not True
+                ):
+                    raise ValueError("A2_OUTPUT_IDENTITY_INVALID")
+                durable_output = runtime.record_run_2_output_identity(
+                    output_identity
+                )
+                if durable_output.run_2_output_identity != output_identity:
+                    raise ValueError("A2_OUTPUT_IDENTITY_READBACK_MISMATCH")
+                self._stage = "A3"
+                evidence_as_of = self.now()
+                winner, audit = compile_run_2_output_artifact_audited(
+                    note=target,
+                    note_bytes=note_bytes,
+                    run_2_id=run_2_id,
+                    final_output_bytes=final_output_bytes,
+                    output_identity=output_identity,
+                )
+                durable_audit = runtime.record_a3_compiler_audit(audit)
+                if durable_audit.a3_compiler_audit != audit:
+                    raise ValueError("A3_COMPILER_AUDIT_READBACK_MISMATCH")
+            finally:
+                self.controller.release_creator_live_a2_run_completion(
+                    expected_run_id=run_2_id
+                )
+                del completion
+            if audit.terminal_a3_code is not None:
+                runtime.record_stage_failure(
+                    "A3_REUSE",
+                    audit.terminal_a3_code,
+                )
+            if winner is None or durable_audit.a3_compiler_audit is None:
+                raise ValueError("A3_COMPILER_RESULT_INVALID")
+            claim = _claim_from_verified_a3_audit(
                 note=target,
                 note_bytes=note_bytes,
                 run_2_id=run_2_id,
-                final_output_bytes=completion.final_output_bytes,
-                final_output_sha256=completion.final_output_sha256,
+                output_identity=output_identity,
                 observed_at=evidence_as_of,
+                winner=winner,
+                audit=durable_audit.a3_compiler_audit,
             )
             assessment = assess_field_note_reuse(
                 target,
@@ -1146,7 +1628,7 @@ class CreatorLiveCycle005Entrypoint:
                     note_bytes=note_bytes,
                     reuse_claim=claim,
                     recorded_at=self.now(),
-                    delivery_context=completion.reconnect_receipt,
+                    delivery_context=reconnect_receipt,
                 ),
             )
             if commit.assessment != assessment or commit.durable_snapshot is None:
@@ -1174,7 +1656,7 @@ class CreatorLiveCycle005Entrypoint:
                 note=target,
                 note_bytes=note_bytes,
                 a1_capture=draft,
-                a2_reconnect=completion.reconnect_receipt,
+                a2_reconnect=reconnect_receipt,
                 a3_assessment=assessment,
                 a4_snapshot=commit.durable_snapshot,
                 a5_commit=commit,
@@ -1213,5 +1695,6 @@ __all__ = [
     "RUN_2_TASK",
     "RUN_2_TASK_SHA256",
     "compile_run_2_output_artifact",
+    "compile_run_2_output_artifact_audited",
     "product_tree_sha256",
 ]

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -1831,62 +1831,97 @@ function renderCreatorLiveCycle005(value) {
   }
   const cycle = value && typeof value === "object" ? value : null;
   const binding = cycle?.binding;
-  const contract = binding?.contract;
-  const runtime = binding?.runtime;
-  const tasks = binding?.tasks;
+  const identities = cycle?.identities;
+  const contract = identities?.contract_identity ?? binding?.contract;
+  const runtime = identities?.runtime ?? binding?.runtime;
+  const run1 = identities?.run_1_task ?? binding?.tasks?.run_1;
+  const run2 = identities?.run_2_task ?? binding?.tasks?.run_2;
+  const notDurable = "NOT_DURABLY_PERSISTED";
+  const formatTaskIdentity = (task) => {
+    if (!task) {
+      return "Unavailable";
+    }
+    if (task.byte_count === notDurable && task.sha256 === notDurable) {
+      return notDurable;
+    }
+    const byteCount =
+      task.byte_count === notDurable
+        ? notDurable
+        : `${task.byte_count} bytes`;
+    return `${byteCount} · ${task.sha256}${task.lane ? ` · ${task.lane}` : ""}`;
+  };
   const state = cycle?.state || "UNAVAILABLE";
   setText("creator-live-cycle-005-status", state.replaceAll("_", " "));
-  setText("creator-live-revision", binding?.repository?.head || "Unavailable");
+  setText(
+    "creator-live-revision",
+    identities?.revision ?? binding?.repository?.head ?? "Unavailable",
+  );
   setText(
     "creator-live-contract",
-    contract?.source_sha256
-      ? `${contract.profile} · ${contract.source_byte_count} bytes · ${contract.source_sha256}`
-      : "Unavailable",
+    typeof contract === "string"
+      ? contract
+      : contract?.source_sha256
+        ? `${contract.profile} · ${contract.title} · ${contract.source_byte_count} bytes · ${contract.source_sha256}`
+        : "Unavailable",
   );
   setText(
     "creator-live-contract-authority",
-    contract?.ordinary_contract_execution_authority || "Unavailable",
+    identities?.ordinary_contract_execution_authority ??
+      contract?.ordinary_contract_execution_authority ??
+      "Unavailable",
   );
   setText(
     "creator-live-freeze-authority",
-    contract?.guided_intake_freeze_authority_state || "Unavailable",
+    identities?.guided_intake_freeze_authority ??
+      contract?.guided_intake_freeze_authority_state ??
+      "Unavailable",
   );
   setText(
     "creator-live-authorization",
-    binding?.authorizations?.cycle_observed_at || "2026-08-05T06:22:00Z",
+    identities?.cycle_authorization_observed_at ??
+      binding?.authorizations?.cycle_observed_at ??
+      "Unavailable",
   );
   setText(
     "creator-live-implementation-authorization",
-    binding?.authorizations?.implementation_observed_at ||
-      "2026-08-05T08:47:00Z",
+    identities?.implementation_authorization_observed_at ??
+      binding?.authorizations?.implementation_observed_at ??
+      "Unavailable",
   );
   setText(
     "creator-live-runtime",
     runtime
-      ? `${runtime.provider} · ${runtime.account_type} · ${runtime.model} · ${runtime.reasoning_effort} · ${runtime.service_tier} · CLI ${runtime.codex_cli_version}`
+      ? `${runtime.account_type} · ${runtime.model} · ${runtime.reasoning_effort} · ${runtime.service_tier} · CLI ${runtime.codex_cli_version}`
       : "Unavailable",
   );
   setText(
     "creator-live-run-1",
-    tasks?.run_1
-      ? `${tasks.run_1.byte_count} bytes · ${tasks.run_1.sha256} · ${tasks.run_1.lane}`
-      : "832 bytes · unavailable",
+    formatTaskIdentity(run1),
   );
   setText(
     "creator-live-run-2",
-    tasks?.run_2
-      ? `${tasks.run_2.byte_count} bytes · ${tasks.run_2.sha256} · ${tasks.run_2.lane}`
-      : "856 bytes · unavailable",
+    formatTaskIdentity(run2),
   );
   setText(
     "creator-live-attempt-policy",
-    cycle
+    identities
+      ? identities.retry_count === notDurable &&
+        identities.replacement_count === notDurable
+        ? notDurable
+        : `${identities.retry_count} retries · ${identities.replacement_count} replacements`
+      : cycle
       ? `${cycle.one_attempt_no_retry ? "One attempt · no retry" : "Policy unavailable"} · ${cycle.replacement_permitted ? "replacement permitted" : "no replacement"}`
       : "One attempt · no retry · no replacement",
   );
+  const historical =
+    identities?.historical_boundary ?? binding?.historical_boundary;
   setText(
     "creator-live-historical-boundary",
-    binding?.historical_boundary || "Unavailable",
+    typeof historical === "string"
+      ? historical
+      : historical
+        ? `${historical.cycle_key} · ${historical.state} / ${historical.failure_boundary} / ${historical.failure_code}`
+        : "Unavailable",
   );
   setText(
     "creator-live-p0",
@@ -1896,13 +1931,72 @@ function renderCreatorLiveCycle005(value) {
   );
   setText(
     "creator-live-binding-sha256",
-    cycle?.launch_binding_sha256 || "Unavailable",
+    identities?.launch_binding_sha256 ??
+      cycle?.launch_binding_sha256 ??
+      "Unavailable",
   );
-  setText("creator-live-stage", cycle?.stage || "P0");
-  byId("creator-live-start").disabled =
-    state !== "READY" ||
-    cycle?.p0?.ready !== true ||
-    typeof cycle?.launch_binding_sha256 !== "string";
+  setText(
+    "creator-live-stage",
+    identities?.terminal_stage ?? cycle?.stage ?? "P0",
+  );
+  setText(
+    "creator-live-failure-code",
+    identities?.failure_code ?? cycle?.failure_code ?? "Unavailable",
+  );
+  setText(
+    "creator-live-proof-attempt",
+    identities?.proof_attempt_id ?? "Unavailable",
+  );
+  setText(
+    "creator-live-proof-as-of",
+    identities?.proof_as_of ?? "Unavailable",
+  );
+  setText(
+    "creator-live-journal-sha256",
+    identities?.journal_sha256 ?? "Unavailable",
+  );
+  setText(
+    "creator-live-anchor-sha256",
+    identities?.anchor_sha256 ?? "Unavailable",
+  );
+  setText(
+    "creator-live-readback-sha256",
+    identities?.readback_sha256 ?? "Unavailable",
+  );
+  const artifact = identities?.output_artifact;
+  setText(
+    "creator-live-output-artifact",
+    typeof artifact === "string"
+      ? artifact
+      : artifact
+        ? `${artifact.artifact_id} · ${artifact.byte_count} bytes · ${artifact.sha256}`
+        : "Unavailable",
+  );
+  const compiler = identities?.compiler;
+  setText(
+    "creator-live-compiler",
+    typeof compiler === "string"
+      ? compiler
+      : compiler
+        ? `${compiler.compiler_version} · ${compiler.compiler_branch} · eligible ${compiler.eligible_candidate_count} · winners ${compiler.winning_candidate_count} · ${compiler.terminal_a3_code ?? "PASS"} · ${compiler.audit_sha256}`
+        : "Unavailable",
+  );
+  const start = byId("creator-live-start");
+  const terminal = cycle?.storage_occupied === true || [
+    "FAILED",
+    "TRACE_COMPLETE",
+    "PASS",
+    "OPEN_UNRESUMABLE",
+    "INTEGRITY_FAILURE",
+  ].includes(state);
+  const startAllowed =
+    cycle?.start_allowed === true &&
+    state === "READY" &&
+    cycle?.p0?.ready === true &&
+    typeof cycle?.launch_binding_sha256 === "string";
+  start.hidden = terminal;
+  start.disabled = !startAllowed;
+  byId("creator-live-terminal-label").hidden = !terminal;
 }
 
 function render(state) {
@@ -2548,10 +2642,14 @@ byId("run").addEventListener("click", async () => {
 });
 
 optionalById("creator-live-start")?.addEventListener("click", async () => {
-  const digest = latestState?.creator_live_cycle_005?.launch_binding_sha256;
+  const cycle = latestState?.creator_live_cycle_005;
+  const digest = cycle?.launch_binding_sha256;
   if (
     byId("creator-live-start").disabled ||
     requestActive ||
+    cycle?.storage_occupied !== false ||
+    cycle?.start_allowed !== true ||
+    cycle?.state !== "READY" ||
     typeof digest !== "string"
   ) {
     return;

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -67,15 +67,15 @@
         <dt>Freeze authority</dt>
         <dd id="creator-live-freeze-authority">Unavailable</dd>
         <dt>Cycle authorization</dt>
-        <dd id="creator-live-authorization">2026-08-05T06:22:00Z</dd>
+        <dd id="creator-live-authorization">Unavailable</dd>
         <dt>Implementation authorization</dt>
-        <dd id="creator-live-implementation-authorization">2026-08-05T08:47:00Z</dd>
+        <dd id="creator-live-implementation-authorization">Unavailable</dd>
         <dt>Runtime</dt>
         <dd id="creator-live-runtime">Unavailable</dd>
         <dt>Run 1 identity</dt>
-        <dd id="creator-live-run-1">832 bytes · unavailable</dd>
+        <dd id="creator-live-run-1">Unavailable</dd>
         <dt>Run 2 identity</dt>
-        <dd id="creator-live-run-2">856 bytes · unavailable</dd>
+        <dd id="creator-live-run-2">Unavailable</dd>
         <dt>Attempt policy</dt>
         <dd id="creator-live-attempt-policy">One attempt · no retry · no replacement</dd>
         <dt>Historical boundary</dt>
@@ -86,10 +86,29 @@
         <dd id="creator-live-binding-sha256">Unavailable</dd>
         <dt>Stage</dt>
         <dd id="creator-live-stage">P0</dd>
+        <dt>Failure code</dt>
+        <dd id="creator-live-failure-code">Unavailable</dd>
+        <dt>Proof attempt</dt>
+        <dd id="creator-live-proof-attempt">Unavailable</dd>
+        <dt>Proof as-of</dt>
+        <dd id="creator-live-proof-as-of">Unavailable</dd>
+        <dt>Journal SHA-256</dt>
+        <dd id="creator-live-journal-sha256">Unavailable</dd>
+        <dt>Anchor SHA-256</dt>
+        <dd id="creator-live-anchor-sha256">Unavailable</dd>
+        <dt>Typed readback SHA-256</dt>
+        <dd id="creator-live-readback-sha256">Unavailable</dd>
+        <dt>Output artifact</dt>
+        <dd id="creator-live-output-artifact">Unavailable</dd>
+        <dt>A3 compiler</dt>
+        <dd id="creator-live-compiler">Unavailable</dd>
       </dl>
       <button id="creator-live-start" class="primary" type="button" disabled>
         Start Cycle 005
       </button>
+      <p id="creator-live-terminal-label" class="boundary" hidden>
+        TERMINAL — NO RETRY OR REPLACEMENT
+      </p>
     </section>
 
     <aside

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2164,6 +2164,149 @@ class CompanionServerTest(unittest.TestCase):
 
 
 class CompanionClientBehaviorTest(unittest.TestCase):
+    def test_creator_live_terminal_render_removes_all_start_paths(self) -> None:
+        node = shutil.which("node")
+        self.assertIsNotNone(node, "Node.js is required for client behavior tests.")
+        static_root = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+        )
+        html = (static_root / "index.html").read_text(encoding="utf-8")
+        javascript = (static_root / "app.js").read_text(encoding="utf-8")
+        self.assertIn("TERMINAL — NO RETRY OR REPLACEMENT", html)
+        self.assertNotIn("832 bytes · unavailable", html)
+        self.assertNotIn("856 bytes · unavailable", html)
+        self.assertNotIn("2026-08-05T08:47:00Z", html)
+        harness = textwrap.dedent(
+            r"""
+            "use strict";
+            const assert = require("assert");
+            const fs = require("fs");
+            const vm = require("vm");
+            const source = fs.readFileSync(process.argv[1], "utf8");
+            const renderStart = source.indexOf("function renderCreatorLiveCycle005");
+            const renderEnd = source.indexOf("\nfunction render(state)", renderStart);
+            const clickStart = source.indexOf(
+              'optionalById("creator-live-start")?.addEventListener("click"'
+            );
+            const clickEnd = source.indexOf(
+              '\n\nbyId("new-run").addEventListener',
+              clickStart,
+            );
+            assert(renderStart >= 0 && renderEnd > renderStart);
+            assert(clickStart >= 0 && clickEnd > clickStart);
+
+            const ids = [
+              "creator-live-start", "creator-live-terminal-label",
+              "creator-live-cycle-005-status", "creator-live-revision",
+              "creator-live-contract", "creator-live-contract-authority",
+              "creator-live-freeze-authority", "creator-live-authorization",
+              "creator-live-implementation-authorization", "creator-live-runtime",
+              "creator-live-run-1", "creator-live-run-2",
+              "creator-live-attempt-policy", "creator-live-historical-boundary",
+              "creator-live-p0", "creator-live-binding-sha256",
+              "creator-live-stage", "creator-live-failure-code",
+              "creator-live-proof-attempt", "creator-live-proof-as-of",
+              "creator-live-journal-sha256", "creator-live-anchor-sha256",
+              "creator-live-readback-sha256", "creator-live-output-artifact",
+              "creator-live-compiler",
+            ];
+            const elements = Object.fromEntries(ids.map((id) => [id, {
+              id, textContent: "", hidden: false, disabled: false, listener: null,
+              addEventListener(_kind, listener) { this.listener = listener; },
+            }]));
+            let postCount = 0;
+            const context = {
+              byId: (id) => elements[id],
+              optionalById: (id) => elements[id] || null,
+              setText: (id, value) => { elements[id].textContent = String(value); },
+              latestState: null,
+              requestActive: false,
+              postJSON: async () => { postCount += 1; return null; },
+            };
+            vm.createContext(context);
+            vm.runInContext(source.slice(renderStart, renderEnd), context);
+            const cycle = {
+              state: "FAILED",
+              stage: "A3_REUSE",
+              storage_occupied: true,
+              start_allowed: false,
+              p0: { ready: false, failure_code: "CYCLE_005_ATTEMPT_EXISTS" },
+              launch_binding_sha256: "a".repeat(64),
+              identities: {
+                revision: "b".repeat(40),
+                contract_identity: "NOT_DURABLY_PERSISTED",
+                ordinary_contract_execution_authority: "NOT_DURABLY_PERSISTED",
+                guided_intake_freeze_authority: "NOT_DURABLY_PERSISTED",
+                runtime: {
+                  account_type: "chatgpt", model: "gpt-5.6-sol",
+                  reasoning_effort: "ultra", service_tier: "priority",
+                  codex_cli_version: "0.146.0-alpha.3.1",
+                },
+                run_1_task: {
+                  byte_count: "NOT_DURABLY_PERSISTED", sha256: "c".repeat(64),
+                },
+                run_2_task: {
+                  byte_count: "NOT_DURABLY_PERSISTED",
+                  sha256: "NOT_DURABLY_PERSISTED",
+                },
+                cycle_authorization_observed_at: "2026-08-05T06:22:00Z",
+                implementation_authorization_observed_at: "NOT_DURABLY_PERSISTED",
+                historical_boundary: "NOT_DURABLY_PERSISTED",
+                launch_binding_sha256: "a".repeat(64),
+                proof_attempt_id: "proof-fixture",
+                proof_as_of: "2026-08-05T11:24:40.255812Z",
+                journal_sha256: "d".repeat(64), anchor_sha256: "e".repeat(64),
+                readback_sha256: "f".repeat(64), terminal_stage: "A3_REUSE",
+                failure_code: "A3_EXACT_STRUCTURE_MISSING",
+                retry_count: "NOT_DURABLY_PERSISTED",
+                replacement_count: "NOT_DURABLY_PERSISTED",
+                output_artifact: "NOT_DURABLY_PERSISTED",
+                compiler: "NOT_DURABLY_PERSISTED",
+              },
+            };
+            context.renderCreatorLiveCycle005(cycle);
+            assert.strictEqual(elements["creator-live-start"].hidden, true);
+            assert.strictEqual(elements["creator-live-start"].disabled, true);
+            assert.strictEqual(elements["creator-live-terminal-label"].hidden, false);
+            assert.strictEqual(
+              elements["creator-live-contract"].textContent,
+              "NOT_DURABLY_PERSISTED",
+            );
+            assert.strictEqual(
+              elements["creator-live-run-1"].textContent,
+              `NOT_DURABLY_PERSISTED · ${"c".repeat(64)}`,
+            );
+            assert.strictEqual(
+              elements["creator-live-run-2"].textContent,
+              "NOT_DURABLY_PERSISTED",
+            );
+            assert.strictEqual(
+              elements["creator-live-attempt-policy"].textContent,
+              "NOT_DURABLY_PERSISTED",
+            );
+            context.latestState = { creator_live_cycle_005: cycle };
+            vm.runInContext(source.slice(clickStart, clickEnd), context);
+            elements["creator-live-start"].disabled = false;
+            Promise.resolve(elements["creator-live-start"].listener()).then(() => {
+              assert.strictEqual(postCount, 0);
+            }).catch((error) => { console.error(error); process.exitCode = 1; });
+            """
+        )
+        completed = subprocess.run(
+            [node, "-e", harness, str(static_root / "app.js")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(
+            0,
+            completed.returncode,
+            msg=f"Node terminal Cycle 005 harness failed:\n{completed.stdout}{completed.stderr}",
+        )
+
     def test_operation_awareness_state_transition_harness(self) -> None:
         node = shutil.which("node")
         self.assertIsNotNone(node, "Node.js is required for client behavior tests.")

--- a/tests/test_field_notes_creator_live.py
+++ b/tests/test_field_notes_creator_live.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 import hashlib
+import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
@@ -14,12 +15,24 @@ from decision_os.companion.field_notes_adapter import (
 )
 from decision_os.companion.field_notes_creator_live import (
     FieldNoteCreatorLiveA1CaptureCommitReceipt,
+    FieldNoteCreatorLiveA3CompilerAudit,
+    FieldNoteCreatorLiveA3RejectionCounts,
     FieldNoteCreatorLiveAttemptExistsError,
+    FieldNoteCreatorLiveContractIdentity,
     FieldNoteCreatorLiveDurabilityError,
+    FieldNoteCreatorLiveHistoricalBoundary,
     FieldNoteCreatorLiveProofRuntime,
+    FieldNoteCreatorLiveRun2OutputIdentity,
     FieldNoteCreatorLiveStageError,
+    FieldNoteCreatorLiveTaskIdentity,
+    FieldNoteCreatorLiveTerminalProjectionBinding,
     FieldNoteCreatorLiveTraceReadback,
+    FieldNoteCreatorLiveTraceReadbackV3,
     FieldNoteCreatorLiveValidationError,
+)
+from decision_os.companion.field_notes_creator_live_entrypoint import (
+    _claim_from_verified_a3_audit,
+    compile_run_2_output_artifact_audited,
 )
 from decision_os.companion.field_notes_reuse import (
     FieldNoteIdentity,
@@ -53,6 +66,9 @@ OBSERVED_AT = (
 )
 RUN_1_TASK = "Complete the bounded creator-live Run 1 task."
 RUN_1_TASK_SHA256 = hashlib.sha256(RUN_1_TASK.encode("utf-8")).hexdigest()
+RUN_2_TASK = "Complete the bounded creator-live Run 2 task."
+RUN_2_TASK_SHA256 = hashlib.sha256(RUN_2_TASK.encode("utf-8")).hexdigest()
+V3_LAUNCH_BINDING = "a4" * 32
 
 
 def proposal_diagnostic(
@@ -130,6 +146,66 @@ class CreatorLiveTestCase(unittest.TestCase):
                 source_repository=evidence.source_repository,
                 run_1_id=evidence.run_1.run_id,
                 runtime=evidence.run_1.runtime,
+            )
+
+    def terminal_projection_binding(
+        self,
+    ) -> FieldNoteCreatorLiveTerminalProjectionBinding:
+        return FieldNoteCreatorLiveTerminalProjectionBinding.create(
+            launch_binding_sha256=V3_LAUNCH_BINDING,
+            contract_identity=FieldNoteCreatorLiveContractIdentity(
+                profile="ORDINARY_USER_PATH_CONTRACT_APPROVED_CANDIDATE_V0_1",
+                title="Ordinary User Path Contract v0.1 — APPROVED CANDIDATE",
+                source_byte_count=11_039,
+                source_sha256="1" * 64,
+                wrapper_sha256="2" * 64,
+                interpretation_sha256="3" * 64,
+            ),
+            ordinary_contract_execution_authority="INTERPRETATION_ONLY",
+            guided_intake_freeze_authority=(
+                "IMMUTABLE_INTERPRETATION_ONLY"
+            ),
+            implementation_authorization_observed_at=(
+                "2026-08-05T09:58:00Z"
+            ),
+            run_1_task=FieldNoteCreatorLiveTaskIdentity(
+                byte_count=len(RUN_1_TASK.encode("utf-8")),
+                sha256=RUN_1_TASK_SHA256,
+            ),
+            run_2_task=FieldNoteCreatorLiveTaskIdentity(
+                byte_count=len(RUN_2_TASK.encode("utf-8")),
+                sha256=RUN_2_TASK_SHA256,
+            ),
+            historical_boundary=FieldNoteCreatorLiveHistoricalBoundary(
+                cycle_key="cycle-004",
+                state="FAILED",
+                failure_boundary="A1_CAPTURE",
+                failure_code="A1_CAPTURE_CHRONOLOGY_INVALID",
+            ),
+        )
+
+    def open_runtime_v3(
+        self,
+        label: str = "attempt-v3",
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        attempt = whole_flow.FieldNoteCreatorLiveAttempt(
+            proof_attempt_id="proof_a7_fixture_005_" + V3_LAUNCH_BINDING,
+            proof_mode="CREATOR_LIVE",
+            creator_id=self.bundle.attempt.creator_id,
+            authorization_observed_at="2026-08-05T09:58:00Z",
+        )
+        with patch.object(
+            creator_live,
+            "_utc_now_rfc3339",
+            side_effect=("2026-08-05T09:59:00Z", self.bundle.run_1.started_at),
+        ):
+            return FieldNoteCreatorLiveProofRuntime.open_attempt(
+                self.root / label,
+                attempt=attempt,
+                source_repository=self.bundle.source_repository,
+                run_1_id=self.bundle.run_1.run_id,
+                runtime=self.bundle.run_1.runtime,
+                terminal_projection_binding=self.terminal_projection_binding(),
             )
 
     def record_a1(
@@ -225,6 +301,71 @@ class CreatorLiveTestCase(unittest.TestCase):
         self.record_a1(runtime_path, bundle=bundle)
         self.open_run_2(runtime_path, bundle=bundle)
         return runtime_path
+
+    def ready_for_a3_v3(
+        self,
+        label: str = "attempt-v3",
+    ) -> FieldNoteCreatorLiveProofRuntime:
+        runtime_path = self.open_runtime_v3(label)
+        self.record_a1(runtime_path)
+        run_2 = replace(
+            self.bundle.run_2,
+            proof_attempt_id=runtime_path.read_back().proof_attempt_id,
+        )
+        runtime_path.open_run_2(run_2)
+        assert self.bundle.a2_reconnect is not None
+        runtime_path.record_a2_reconnect(
+            self.bundle.a2_reconnect,
+            note=self.bundle.note,
+            note_bytes=self.bundle.note_bytes,
+        )
+        return runtime_path
+
+    def run_2_output_identity(
+        self,
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        output: bytes = b"bounded fixture output",
+    ) -> FieldNoteCreatorLiveRun2OutputIdentity:
+        readback = runtime_path.read_back()
+        assert readback.run_2 is not None
+        return FieldNoteCreatorLiveRun2OutputIdentity.create(
+            proof_attempt_id=readback.proof_attempt_id,
+            run_id=readback.run_2.run_id,
+            task_byte_count=len(RUN_2_TASK.encode("utf-8")),
+            task_sha256=RUN_2_TASK_SHA256,
+            final_output_byte_count=len(output),
+            final_output_sha256=hashlib.sha256(output).hexdigest(),
+        )
+
+    def missing_a3_audit(
+        self,
+        runtime_path: FieldNoteCreatorLiveProofRuntime,
+        output_identity: FieldNoteCreatorLiveRun2OutputIdentity,
+    ) -> FieldNoteCreatorLiveA3CompilerAudit:
+        return FieldNoteCreatorLiveA3CompilerAudit.issue(
+            proof_attempt_id=output_identity.proof_attempt_id,
+            run_id=output_identity.run_id,
+            output_artifact_id=output_identity.output_artifact.artifact_id,
+            source_note_byte_count=len(self.bundle.note_bytes),
+            source_note_sha256=self.bundle.note.note_sha256,
+            output_byte_count=output_identity.final_output_byte_count,
+            output_sha256=output_identity.final_output_sha256,
+            eligible_candidate_count=0,
+            rejection_counts=FieldNoteCreatorLiveA3RejectionCounts(
+                below_minimum_byte_length=1,
+                whole_note_range=0,
+                non_unique_source_occurrence=0,
+                absent_output_occurrence=1,
+                multiple_output_occurrences=0,
+            ),
+            longest_candidate_byte_count=0,
+            winning_candidate_count=0,
+            selected_source_start_byte=None,
+            selected_source_end_byte=None,
+            selected_output_start_byte=None,
+            selected_output_end_byte=None,
+            terminal_a3_code="A3_EXACT_STRUCTURE_MISSING",
+        )
 
     def complete_runtime(
         self,
@@ -1613,6 +1754,249 @@ class CreatorLiveDurabilityTests(CreatorLiveTestCase):
         runtime_path, _ = self.complete_runtime("output", bundle=bundle)
         text = runtime_path.journal_path.read_text(encoding="utf-8")
         self.assertNotIn(ARTIFACT_SECRET, text)
+
+
+class CreatorLiveV3PersistenceTests(CreatorLiveTestCase):
+    def test_v3_open_uses_exact_journal_record_anchor_and_readback_schemas(
+        self,
+    ) -> None:
+        runtime_path = self.open_runtime_v3()
+        readback = runtime_path.read_back()
+        self.assertIsInstance(readback, FieldNoteCreatorLiveTraceReadbackV3)
+        self.assertEqual(creator_live.CREATOR_LIVE_READBACK_SCHEMA_V3, readback.schema)
+        self.assertEqual(
+            creator_live.CREATOR_LIVE_JOURNAL_FILENAME_V3,
+            runtime_path.journal_path.name,
+        )
+        self.assertEqual(
+            creator_live.CREATOR_LIVE_ANCHOR_FILENAME_V3,
+            runtime_path.anchor_path.name,
+        )
+        records = tuple(
+            json.loads(line)
+            for line in runtime_path.journal_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        )
+        self.assertEqual(
+            ("ATTEMPT_OPENED", "RUN_1_OPENED"),
+            tuple(record["kind"] for record in records),
+        )
+        self.assertTrue(
+            all(
+                record["schema"] == creator_live.CREATOR_LIVE_RECORD_SCHEMA_V3
+                for record in records
+            )
+        )
+        self.assertEqual(
+            creator_live.CREATOR_LIVE_JOURNAL_SCHEMA_V3,
+            records[0]["payload"]["journal_schema"],
+        )
+        self.assertEqual(
+            self.terminal_projection_binding().as_dict(),
+            records[0]["payload"]["terminal_projection_binding"],
+        )
+        anchors = tuple(
+            json.loads(line)
+            for line in runtime_path.anchor_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        )
+        self.assertTrue(
+            all(
+                anchor["schema"] == creator_live.CREATOR_LIVE_ANCHOR_SCHEMA_V3
+                for anchor in anchors
+            )
+        )
+
+    def test_crash_after_normal_terminal_before_output_persistence_is_open_only(
+        self,
+    ) -> None:
+        runtime_path = self.ready_for_a3_v3("v3-before-output")
+        restarted = FieldNoteCreatorLiveProofRuntime.load_attempt(
+            runtime_path.journal_path.parent
+        ).read_back()
+        self.assertEqual("OPEN", restarted.state)
+        self.assertEqual("A3_REUSE", restarted.current_stage)
+        self.assertIsNone(restarted.run_2_output_identity)
+        self.assertIsNone(restarted.a3_compiler_audit)
+
+    def test_crash_after_output_readback_before_a3_preserves_only_identity(
+        self,
+    ) -> None:
+        runtime_path = self.ready_for_a3_v3("v3-after-output")
+        identity = self.run_2_output_identity(runtime_path)
+        durable = runtime_path.record_run_2_output_identity(identity)
+        self.assertEqual(identity, durable.run_2_output_identity)
+        restarted = FieldNoteCreatorLiveProofRuntime.load_attempt(
+            runtime_path.journal_path.parent
+        ).read_back()
+        self.assertEqual(identity, restarted.run_2_output_identity)
+        self.assertIsNone(restarted.a3_compiler_audit)
+        self.assertEqual("A3_REUSE", restarted.current_stage)
+
+    def test_crash_during_compiler_audit_persistence_fails_integrity_closed(
+        self,
+    ) -> None:
+        runtime_path = self.ready_for_a3_v3("v3-torn-audit")
+        identity = self.run_2_output_identity(runtime_path)
+        runtime_path.record_run_2_output_identity(identity)
+        audit = self.missing_a3_audit(runtime_path, identity)
+        real_write = creator_live.os.write
+        calls = 0
+
+        def torn_anchor(descriptor, data):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                return 0
+            return real_write(descriptor, data)
+
+        with patch.object(creator_live.os, "write", side_effect=torn_anchor):
+            with self.assertRaises(FieldNoteCreatorLiveDurabilityError):
+                runtime_path.record_a3_compiler_audit(audit)
+        failed = runtime_path.read_back()
+        self.assertEqual("FAILED", failed.state)
+        self.assertFalse(failed.durable_readback_verified)
+
+    def test_zero_candidate_audit_is_durable_before_exact_terminal_failure(
+        self,
+    ) -> None:
+        runtime_path = self.ready_for_a3_v3("v3-zero-audit")
+        identity = self.run_2_output_identity(runtime_path)
+        runtime_path.record_run_2_output_identity(identity)
+        audit = self.missing_a3_audit(runtime_path, identity)
+        durable = runtime_path.record_a3_compiler_audit(audit)
+        self.assertEqual(audit, durable.a3_compiler_audit)
+        with self.assertRaisesRegex(
+            FieldNoteCreatorLiveStageError,
+            "A3_EXACT_STRUCTURE_MISSING",
+        ):
+            runtime_path.record_stage_failure(
+                "A3_REUSE",
+                "A3_EXACT_STRUCTURE_MISSING",
+            )
+        terminal = runtime_path.read_back()
+        self.assertEqual("FAILED", terminal.state)
+        self.assertEqual("A3_REUSE", terminal.failure_boundary)
+        self.assertEqual("A3_EXACT_STRUCTURE_MISSING", terminal.failure_reason)
+        self.assertEqual(audit, terminal.a3_compiler_audit)
+        self.assertIsNone(terminal.a3_compiler_audit.selected_source_start_byte)
+        kinds = tuple(
+            json.loads(line)["kind"]
+            for line in runtime_path.journal_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        )
+        self.assertLess(
+            kinds.index("RUN_2_OUTPUT_IDENTITY_RECORDED"),
+            kinds.index("A3_COMPILER_AUDIT_RECORDED"),
+        )
+        self.assertLess(
+            kinds.index("A3_COMPILER_AUDIT_RECORDED"),
+            kinds.index("ATTEMPT_FAILED"),
+        )
+
+    def test_one_candidate_offsets_are_durable_before_a3_checkpoint(self) -> None:
+        runtime_path = self.ready_for_a3_v3("v3-one-winner")
+        note = self.bundle.note
+        note_bytes = self.bundle.note_bytes
+        structure = max(
+            (
+                line
+                for line in note_bytes.splitlines()
+                if len(line.strip()) >= 32 and note_bytes.count(line) == 1
+            ),
+            key=len,
+        )
+        run_2 = runtime_path.read_back().run_2
+        assert run_2 is not None
+        output = b"\n".join(
+            (
+                note.note_path.encode("utf-8"),
+                note.field_note_id.encode("utf-8"),
+                note.note_sha256.encode("utf-8"),
+                run_2.run_id.encode("utf-8"),
+                structure,
+            )
+        )
+        identity = self.run_2_output_identity(runtime_path, output)
+        runtime_path.record_run_2_output_identity(identity)
+        winner, audit = compile_run_2_output_artifact_audited(
+            note=note,
+            note_bytes=note_bytes,
+            run_2_id=run_2.run_id,
+            final_output_bytes=output,
+            output_identity=identity,
+        )
+        self.assertIsNotNone(winner)
+        durable = runtime_path.record_a3_compiler_audit(audit)
+        assert winner is not None
+        assert durable.a3_compiler_audit is not None
+        claim = _claim_from_verified_a3_audit(
+            note=note,
+            note_bytes=note_bytes,
+            run_2_id=run_2.run_id,
+            output_identity=identity,
+            observed_at=OBSERVED_AT[2],
+            winner=winner,
+            audit=durable.a3_compiler_audit,
+        )
+        receipt = assess_field_note_reuse(note, claim, note_bytes=note_bytes)
+        runtime_path.record_a3_reuse(
+            receipt,
+            note=note,
+            note_bytes=note_bytes,
+        )
+        readback = runtime_path.read_back()
+        self.assertEqual(3, readback.trace_event_count)
+        self.assertEqual(
+            claim.use_evidence.structure_binding.start_byte,
+            readback.a3_compiler_audit.selected_source_start_byte,
+        )
+        kinds = tuple(
+            json.loads(line)["kind"]
+            for line in runtime_path.journal_path.read_text(
+                encoding="utf-8"
+            ).splitlines()
+        )
+        a3_checkpoint_index = max(
+            index
+            for index, kind in enumerate(kinds)
+            if kind == "CHECKPOINT"
+        )
+        self.assertLess(
+            kinds.index("A3_COMPILER_AUDIT_RECORDED"),
+            a3_checkpoint_index,
+        )
+
+    def test_cycle_005_v2_typed_readback_and_files_remain_exact(self) -> None:
+        root = (
+            Path(__file__).resolve().parents[1]
+            / ".decision-os/field-notes/proofs/cycle-005"
+        )
+        journal = root / creator_live.CREATOR_LIVE_JOURNAL_FILENAME_V2
+        anchor = root / creator_live.CREATOR_LIVE_ANCHOR_FILENAME_V2
+        before = (
+            hashlib.sha256(journal.read_bytes()).hexdigest(),
+            hashlib.sha256(anchor.read_bytes()).hexdigest(),
+        )
+        readback = FieldNoteCreatorLiveProofRuntime.load_attempt(root).read_back()
+        self.assertEqual(
+            (
+                "1de2e998804f5fb694707846b7deb0dc9d8b5f9cfc6027ad0210ddc270029322",
+                "e246757a7ba98849a6b4a694ababf473dc1a98baf1fc1ce0ea7daa3a6e7e8610",
+            ),
+            before,
+        )
+        self.assertEqual(
+            "481be90dc8751bda3d7b00714f5a0c650230dffa8974a1332881ce42c127710f",
+            readback.readback_sha256,
+        )
+        self.assertEqual(before, (
+            hashlib.sha256(journal.read_bytes()).hexdigest(),
+            hashlib.sha256(anchor.read_bytes()).hexdigest(),
+        ))
 
 
 class CreatorLiveA7AdmissionTests(CreatorLiveTestCase):

--- a/tests/test_field_notes_creator_live_entrypoint.py
+++ b/tests/test_field_notes_creator_live_entrypoint.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import threading
 import unittest
+from unittest.mock import patch
 from urllib.parse import urlsplit
 
 from decision_os.companion.field_notes_controller import (
@@ -19,6 +20,7 @@ from decision_os.companion.field_notes_creator_live_entrypoint import (
     EXPECTED_EXECUTION_AUTHORITY,
     EXPECTED_FREEZE_AUTHORITY,
     IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT,
+    NOT_DURABLY_PERSISTED,
     RUN_1_TASK,
     RUN_1_TASK_SHA256,
     RUN_2_TASK,
@@ -28,10 +30,20 @@ from decision_os.companion.field_notes_creator_live_entrypoint import (
     CreatorLiveEntrypointError,
     CreatorLiveP0Result,
     compile_run_2_output_artifact,
+    compile_run_2_output_artifact_audited,
 )
+from decision_os.companion.field_notes_creator_live import (
+    FieldNoteCreatorLiveOutputArtifactIdentity,
+    FieldNoteCreatorLiveRun2OutputIdentity,
+    FieldNoteCreatorLiveValidationError,
+)
+from decision_os.companion.field_notes_model import canonical_json
 from decision_os.companion.field_notes_reuse import FieldNoteIdentity
 from decision_os.companion.field_notes_server import configure_field_notes_server
 from decision_os.companion.server import CompanionServer
+from decision_os.companion.field_notes_whole_flow import (
+    FieldNoteSourceRepositoryIdentity,
+)
 from tests.test_companion_controller import ScriptedFactory, create_repository
 
 
@@ -65,6 +77,41 @@ class _ReadyEntrypoint(CreatorLiveCycle005Entrypoint):
         binding = {
             "schema": "test.creator-live-binding",
             "cycle_key": "cycle-005",
+            "contract": {
+                "profile": "ORDINARY_USER_PATH_CONTRACT_APPROVED_CANDIDATE_V0_1",
+                "title": "Ordinary User Path Contract v0.1 — APPROVED CANDIDATE",
+                "source_byte_count": 11_039,
+                "source_sha256": "1" * 64,
+                "wrapper_sha256": "2" * 64,
+                "interpretation_sha256": "3" * 64,
+                "ordinary_contract_execution_authority": (
+                    EXPECTED_EXECUTION_AUTHORITY
+                ),
+                "guided_intake_freeze_authority_state": (
+                    EXPECTED_FREEZE_AUTHORITY
+                ),
+            },
+            "tasks": {
+                "run_1": {
+                    "byte_count": 832,
+                    "sha256": RUN_1_TASK_SHA256,
+                },
+                "run_2": {
+                    "byte_count": 856,
+                    "sha256": RUN_2_TASK_SHA256,
+                },
+            },
+            "authorizations": {
+                "implementation_observed_at": (
+                    IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT
+                ),
+            },
+            "historical_boundary": {
+                "cycle_key": "cycle-004",
+                "state": "FAILED",
+                "failure_boundary": "A1_CAPTURE",
+                "failure_code": "A1_CAPTURE_CHRONOLOGY_INVALID",
+            },
         }
         return CreatorLiveP0Result(True, None, binding, _DIGEST)
 
@@ -87,6 +134,7 @@ class _FakeHTTPEntrypoint:
                     "source_sha256": "b" * 64,
                     "source_byte_count": 11_039,
                     "profile": "ORDINARY_USER_PATH_CONTRACT_APPROVED_CANDIDATE_V0_1",
+                    "title": "Ordinary User Path Contract v0.1 — APPROVED CANDIDATE",
                     "ordinary_contract_execution_authority": (
                         EXPECTED_EXECUTION_AUTHORITY
                     ),
@@ -120,7 +168,12 @@ class _FakeHTTPEntrypoint:
                         "lane": "EXACT_A2_ONLY",
                     },
                 },
-                "historical_boundary": "Historical attempts remain terminal.",
+                "historical_boundary": {
+                    "cycle_key": "cycle-004",
+                    "state": "FAILED",
+                    "failure_boundary": "A1_CAPTURE",
+                    "failure_code": "A1_CAPTURE_CHRONOLOGY_INVALID",
+                },
             },
             "identities": None,
             "receipt_sha256": None,
@@ -128,6 +181,8 @@ class _FakeHTTPEntrypoint:
             "failure_code": None,
             "one_attempt_no_retry": True,
             "replacement_permitted": False,
+            "storage_occupied": False,
+            "start_allowed": True,
         }
 
     def start(self, digest: str) -> dict[str, object]:
@@ -203,6 +258,21 @@ class CreatorLiveTaskAndEvidenceTests(unittest.TestCase):
             observed_at="2026-08-05T09:00:00Z",
         )
 
+    def output_identity(
+        self,
+        output: bytes,
+        *,
+        run_2_id: str | None = None,
+    ) -> FieldNoteCreatorLiveRun2OutputIdentity:
+        return FieldNoteCreatorLiveRun2OutputIdentity.create(
+            proof_attempt_id="proof-fixture-005",
+            run_id=run_2_id or self.run_2_id,
+            task_byte_count=len(RUN_2_TASK.encode("utf-8")),
+            task_sha256=RUN_2_TASK_SHA256,
+            final_output_byte_count=len(output),
+            final_output_sha256=hashlib.sha256(output).hexdigest(),
+        )
+
     def test_canonical_task_bytes_hashes_lanes_and_authorizations_are_exact(
         self,
     ) -> None:
@@ -218,7 +288,7 @@ class CreatorLiveTaskAndEvidenceTests(unittest.TestCase):
         )
         self.assertEqual("2026-08-05T06:22:00Z", CYCLE_AUTHORIZATION_OBSERVED_AT)
         self.assertEqual(
-            "2026-08-05T08:47:00Z",
+            "2026-08-05T12:28:00Z",
             IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT,
         )
         self.assertIn("Propose exactly one new Field Note", RUN_1_TASK)
@@ -263,6 +333,123 @@ class CreatorLiveTaskAndEvidenceTests(unittest.TestCase):
                 final_output_sha256="0" * 64,
                 observed_at="2026-08-05T09:00:00Z",
             )
+
+    def test_audited_a3_persists_exact_winner_offsets_and_counts(self) -> None:
+        output = self.output()
+        winner, audit = compile_run_2_output_artifact_audited(
+            note=self.note,
+            note_bytes=self.note_bytes,
+            run_2_id=self.run_2_id,
+            final_output_bytes=output,
+            output_identity=self.output_identity(output),
+        )
+        self.assertIsNotNone(winner)
+        self.assertEqual(1, audit.eligible_candidate_count)
+        self.assertEqual(1, audit.winning_candidate_count)
+        self.assertIsNone(audit.terminal_a3_code)
+        source_start = self.note_bytes.index(self.structure)
+        output_start = output.index(self.structure)
+        self.assertEqual(source_start, audit.selected_source_start_byte)
+        self.assertEqual(source_start + len(self.structure), audit.selected_source_end_byte)
+        self.assertEqual(output_start, audit.selected_output_start_byte)
+        self.assertEqual(output_start + len(self.structure), audit.selected_output_end_byte)
+        self.assertEqual(
+            hashlib.sha256(
+                canonical_json(audit._body()).encode("utf-8")
+            ).hexdigest(),
+            audit.audit_sha256,
+        )
+
+    def test_audited_a3_zero_candidate_has_counts_and_null_offsets(self) -> None:
+        output = self.output(
+            b"A semantic paraphrase that is intentionally not an exact Note range."
+        )
+        winner, audit = compile_run_2_output_artifact_audited(
+            note=self.note,
+            note_bytes=self.note_bytes,
+            run_2_id=self.run_2_id,
+            final_output_bytes=output,
+            output_identity=self.output_identity(output),
+        )
+        self.assertIsNone(winner)
+        self.assertEqual(0, audit.eligible_candidate_count)
+        self.assertEqual(0, audit.winning_candidate_count)
+        self.assertEqual("A3_EXACT_STRUCTURE_MISSING", audit.terminal_a3_code)
+        self.assertGreater(audit.rejection_counts.absent_output_occurrence, 0)
+        self.assertEqual(
+            (None, None, None, None),
+            (
+                audit.selected_source_start_byte,
+                audit.selected_source_end_byte,
+                audit.selected_output_start_byte,
+                audit.selected_output_end_byte,
+            ),
+        )
+
+    def test_audited_a3_multiple_candidate_ambiguity(self) -> None:
+        tied_note_bytes = b"# Fixture\n" + b"A" * 48 + b"\n" + b"B" * 48 + b"\n"
+        tied_note = FieldNoteIdentity(
+            note_path=self.note.note_path,
+            field_note_id=self.note.field_note_id,
+            note_sha256=hashlib.sha256(tied_note_bytes).hexdigest(),
+            origin_run_id=self.note.origin_run_id,
+        )
+        output = b"\n".join(
+            (
+                tied_note.note_path.encode(),
+                tied_note.field_note_id.encode(),
+                tied_note.note_sha256.encode(),
+                self.run_2_id.encode(),
+                b"A" * 48,
+                b"B" * 48,
+            )
+        )
+        winner, audit = compile_run_2_output_artifact_audited(
+            note=tied_note,
+            note_bytes=tied_note_bytes,
+            run_2_id=self.run_2_id,
+            final_output_bytes=output,
+            output_identity=self.output_identity(output),
+        )
+        self.assertIsNone(winner)
+        self.assertEqual(2, audit.eligible_candidate_count)
+        self.assertEqual(2, audit.winning_candidate_count)
+        self.assertEqual("A3_EXACT_STRUCTURE_AMBIGUOUS", audit.terminal_a3_code)
+        self.assertIsNone(audit.selected_source_start_byte)
+
+    def test_audited_a3_counts_multiple_output_occurrences(self) -> None:
+        output = self.output() + b"\nrepeated=" + self.structure
+        winner, audit = compile_run_2_output_artifact_audited(
+            note=self.note,
+            note_bytes=self.note_bytes,
+            run_2_id=self.run_2_id,
+            final_output_bytes=output,
+            output_identity=self.output_identity(output),
+        )
+        self.assertIsNone(winner)
+        self.assertEqual(0, audit.eligible_candidate_count)
+        self.assertEqual(
+            1,
+            audit.rejection_counts.multiple_output_occurrences,
+        )
+        self.assertEqual("A3_EXACT_STRUCTURE_MISSING", audit.terminal_a3_code)
+
+    def test_output_artifact_id_is_canonical_and_mismatch_is_rejected(self) -> None:
+        output = self.output()
+        artifact = self.output_identity(output).output_artifact
+        body = {
+            key: value
+            for key, value in artifact.as_dict().items()
+            if key != "artifact_id"
+        }
+        self.assertEqual(
+            hashlib.sha256(canonical_json(body).encode("utf-8")).hexdigest(),
+            artifact.artifact_id,
+        )
+        invalid = artifact.as_dict()
+        invalid["artifact_id"] = "0" * 64
+        with self.assertRaises(FieldNoteCreatorLiveValidationError):
+            FieldNoteCreatorLiveOutputArtifactIdentity.from_dict(invalid)
         tied_note_bytes = b"# Fixture\n" + b"A" * 48 + b"\n" + b"B" * 48 + b"\n"
         tied_note = FieldNoteIdentity(
             note_path=self.note.note_path,
@@ -337,7 +524,12 @@ class CreatorLiveAttemptIdentityTests(unittest.TestCase):
         )
 
     def test_restart_exposes_open_unresumable_and_cannot_create_replacement(self) -> None:
-        self.entrypoint().start(_DIGEST)
+        opened = self.entrypoint()
+        opened.start(_DIGEST)
+        opened._active = False
+        opened._terminal_state = "FAILED"
+        in_process = opened.snapshot(_Controller(self.repository).snapshot())
+        self.assertEqual("OPEN_UNRESUMABLE", in_process["state"])
         restarted = self.entrypoint()
         snapshot = restarted.snapshot(_Controller(self.repository).snapshot())
         self.assertEqual("OPEN_UNRESUMABLE", snapshot["state"])
@@ -360,9 +552,29 @@ class CreatorLiveAttemptIdentityTests(unittest.TestCase):
         ):
             entrypoint.start(_DIGEST)
         self.assertEqual("FAILED", entrypoint._runtime.read_back().state)
+        entrypoint._terminal_state = "PASS"
+        self.assertEqual(
+            "FAILED",
+            entrypoint.snapshot(_Controller(self.repository).snapshot())["state"],
+        )
         restarted = self.entrypoint()
         snapshot = restarted.snapshot(_Controller(self.repository).snapshot())
         self.assertEqual("FAILED", snapshot["state"])
+        self.assertIsNone(snapshot["binding"])
+        identities = snapshot["identities"]
+        self.assertEqual(
+            "ORDINARY_USER_PATH_CONTRACT_APPROVED_CANDIDATE_V0_1",
+            identities["contract_identity"]["profile"],
+        )
+        self.assertEqual(832, identities["run_1_task"]["byte_count"])
+        self.assertEqual(856, identities["run_2_task"]["byte_count"])
+        self.assertEqual(
+            IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT,
+            identities["implementation_authorization_observed_at"],
+        )
+        self.assertEqual(0, identities["retry_count"])
+        self.assertEqual(0, identities["replacement_count"])
+        self.assertNotIn(str(self.repository), json.dumps(snapshot))
         with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
             restarted.start(_DIGEST)
 
@@ -399,6 +611,173 @@ class CreatorLiveAttemptIdentityTests(unittest.TestCase):
         self.assertEqual("INTEGRITY_FAILURE", snapshot["state"])
         with self.assertRaisesRegex(CreatorLiveEntrypointError, "ATTEMPT_EXISTS"):
             entrypoint.start(_DIGEST)
+
+    def test_post_completion_readback_failure_releases_transient_output(self) -> None:
+        run_2_id = "run_a7_creator_live_cycle_005_2_" + _DIGEST
+
+        class Controller:
+            def __init__(self) -> None:
+                self._creator_live_a2_run_completion = object()
+
+            def creator_live_a1_completed_draft(
+                self, *, expected_run_id: str
+            ) -> object:
+                self.a1_run_id = expected_run_id
+                return object()
+
+            def creator_live_a2_run_completion(
+                self, *, expected_run_id: str
+            ) -> object:
+                self.asserted_run_id = expected_run_id
+                return self._creator_live_a2_run_completion
+
+            def release_creator_live_a2_run_completion(
+                self, *, expected_run_id: str
+            ) -> None:
+                self.released_run_id = expected_run_id
+                self._creator_live_a2_run_completion = None
+
+        note = object()
+
+        class Runtime:
+            def __init__(self) -> None:
+                self.read_count = 0
+
+            def read_back(self) -> object:
+                self.read_count += 1
+                if self.read_count == 1:
+                    return type(
+                        "AfterA1",
+                        (),
+                        {
+                            "proof_attempt_id": "proof-fixture",
+                            "run_1": type("Run1", (), {"run_id": "run-1"})(),
+                            "captured_note": note,
+                        },
+                    )()
+                if self.read_count == 2:
+                    return object()
+                if self.read_count == 3:
+                    raise ValueError("POST_COMPLETION_READBACK_FAILED")
+                return type("Failed", (), {"state": "FAILED"})()
+
+            def open_run_2(self, _identity: object) -> None:
+                return None
+
+        class Bridge:
+            def __init__(self, **_kwargs: object) -> None:
+                pass
+
+            def capture(self, _task: str) -> None:
+                return None
+
+            def reconnect(self, _task: str) -> None:
+                return None
+
+        controller = Controller()
+        entrypoint = CreatorLiveCycle005Entrypoint(
+            controller,
+            spec=self.spec,
+        )
+        source = FieldNoteSourceRepositoryIdentity(
+            repository_id="repo:v1:" + "a" * 64,
+            source_commit="a" * 40,
+        )
+        runtime = Runtime()
+        prepared = type("Prepared", (), {"note_bytes": b"fixture\n"})()
+        with (
+            patch(
+                "decision_os.companion.field_notes_creator_live_entrypoint."
+                "FieldNoteCreatorLiveA1CaptureBridge",
+                Bridge,
+            ),
+            patch(
+                "decision_os.companion.field_notes_creator_live_entrypoint."
+                "FieldNoteCreatorLiveA2ReconnectBridge",
+                Bridge,
+            ),
+            patch(
+                "decision_os.companion.field_notes_creator_live_entrypoint."
+                "creator_live_a2_target_from_readback",
+                return_value=object(),
+            ),
+            patch(
+                "decision_os.companion.field_notes_creator_live_entrypoint."
+                "prepare_creator_live_a2_reconnect",
+                return_value=prepared,
+            ),
+        ):
+            entrypoint._run_sequence(runtime, source, _DIGEST)
+
+        self.assertIsNone(
+            controller._creator_live_a2_run_completion,
+            entrypoint._terminal_failure_code,
+        )
+        self.assertEqual(run_2_id, controller.released_run_id)
+        self.assertEqual("FAILED", entrypoint._terminal_state)
+
+
+class CreatorLiveCycle005BackwardProjectionTests(unittest.TestCase):
+    def test_cycle_005_projects_only_exact_v2_durable_values(self) -> None:
+        entrypoint = CreatorLiveCycle005Entrypoint(object())
+        snapshot = entrypoint.snapshot({})
+        identities = snapshot["identities"]
+        self.assertEqual("FAILED", snapshot["state"])
+        self.assertEqual("A3_REUSE", snapshot["stage"])
+        self.assertFalse(snapshot["start_allowed"])
+        self.assertTrue(snapshot["storage_occupied"])
+        self.assertIsNone(snapshot["binding"])
+        self.assertEqual(
+            "bbfa49ba48254758a8b6429b2eb88d141954eac8",
+            identities["revision"],
+        )
+        self.assertEqual(NOT_DURABLY_PERSISTED, identities["contract_identity"])
+        self.assertEqual(
+            NOT_DURABLY_PERSISTED,
+            identities["run_1_task"]["byte_count"],
+        )
+        self.assertEqual(RUN_1_TASK_SHA256, identities["run_1_task"]["sha256"])
+        self.assertEqual(
+            NOT_DURABLY_PERSISTED,
+            identities["run_2_task"]["byte_count"],
+        )
+        self.assertEqual(
+            "2026-08-05T11:24:40.255812Z",
+            identities["proof_as_of"],
+        )
+        self.assertEqual(
+            "1de2e998804f5fb694707846b7deb0dc9d8b5f9cfc6027ad0210ddc270029322",
+            identities["journal_sha256"],
+        )
+        self.assertEqual(
+            "e246757a7ba98849a6b4a694ababf473dc1a98baf1fc1ce0ea7daa3a6e7e8610",
+            identities["anchor_sha256"],
+        )
+        self.assertEqual(
+            "481be90dc8751bda3d7b00714f5a0c650230dffa8974a1332881ce42c127710f",
+            identities["readback_sha256"],
+        )
+        self.assertEqual("A3_EXACT_STRUCTURE_MISSING", identities["failure_code"])
+
+    def test_cycle_005_never_reconstructs_from_contemporary_constants(self) -> None:
+        spec = CreatorLiveCycle005Spec(
+            run_1_task="CONTEMPORARY_PRIVATE_RUN_1_TASK",
+            run_2_task="CONTEMPORARY_PRIVATE_RUN_2_TASK",
+            implementation_authorization_observed_at=(
+                "2099-01-01T00:00:00Z"
+            ),
+        )
+        snapshot = CreatorLiveCycle005Entrypoint(
+            object(),
+            spec=spec,
+        ).snapshot({})
+        raw = json.dumps(snapshot, sort_keys=True)
+        self.assertNotIn("CONTEMPORARY_PRIVATE", raw)
+        self.assertNotIn("2099-01-01", raw)
+        self.assertEqual(
+            NOT_DURABLY_PERSISTED,
+            snapshot["identities"]["implementation_authorization_observed_at"],
+        )
 
 
 class CreatorLiveHTTPTests(unittest.TestCase):
@@ -577,6 +956,48 @@ class CreatorLiveHTTPTests(unittest.TestCase):
         self.assertNotIn("PRIVATE NOTE", encoded)
         self.assertNotIn("PRIVATE", encoded)
         self.assertEqual(["A2"], projected["run"]["progress"])
+
+    def test_terminal_http_state_is_allowlisted_and_duplicate_start_is_409(
+        self,
+    ) -> None:
+        cookie, csrf = self.bootstrap()
+        self.controller._creator_live_cycle_005 = CreatorLiveCycle005Entrypoint(
+            self.controller
+        )
+        status, _headers, raw = self.request(
+            "GET",
+            "/api/state",
+            cookie=cookie,
+            content_type=None,
+        )
+        self.assertEqual(200, status)
+        cycle = json.loads(raw)["creator_live_cycle_005"]
+        encoded = json.dumps(cycle, sort_keys=True)
+        self.assertEqual("FAILED", cycle["state"])
+        self.assertIsNone(cycle["binding"])
+        self.assertFalse(cycle["start_allowed"])
+        for private in (
+            RUN_1_TASK,
+            RUN_2_TASK,
+            "note_path",
+            "note_id",
+            "PRIVATE MODEL OUTPUT",
+            "protected_history",
+            "/Users/sn/Documents/v13/decision-os-v13-loopkit",
+        ):
+            self.assertNotIn(private, encoded)
+        status, _headers, body = self.request(
+            "POST",
+            "/api/creator-live/cycles/005/start",
+            payload=json.dumps(
+                {"launch_binding_sha256": cycle["launch_binding_sha256"]}
+            ).encode("utf-8"),
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(409, status)
+        self.assertEqual("CYCLE_005_ATTEMPT_EXISTS", json.loads(body)["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_field_notes_creator_live_reconnect.py
+++ b/tests/test_field_notes_creator_live_reconnect.py
@@ -510,6 +510,27 @@ class CreatorLiveExactReconnectTests(unittest.TestCase):
             {"INJECTED", "ACTIVATION_UNKNOWN"},
         )
         self.assertEqual(1, completion.reconnect_receipt.full_notes_injected)
+        task_bytes = b"fixed Run 2 task"
+        self.assertEqual(len(task_bytes), completion.task_byte_count)
+        self.assertEqual(
+            hashlib.sha256(task_bytes).hexdigest(),
+            completion.task_sha256,
+        )
+        self.assertEqual(2, completion.transmission_ordinal)
+        self.assertTrue(completion.normal_terminal)
+        self.assertEqual("completed", completion.turn_status)
+        self.assertEqual("NORMAL_TERMINAL", completion.runtime_status)
+        self.assertTrue(completion.failure_diagnostic_absent)
+        self.assertEqual(
+            hashlib.sha256(completion.final_output_bytes).hexdigest(),
+            completion.final_output_sha256,
+        )
+        self.assertEqual("", self.controller.snapshot()["run"]["result"])
+        self.controller.release_creator_live_a2_run_completion(
+            expected_run_id=self.run_2.run_id
+        )
+        self.assertIsNone(self.controller._creator_live_a2_run_completion)
+        self.assertEqual("", self.controller.snapshot()["run"]["result"])
 
     def _assert_cross_bound_terminal(
         self,

--- a/validation/a7_creator_live_whole_flow_reentry_charter_delta_v0_7.md
+++ b/validation/a7_creator_live_whole_flow_reentry_charter_delta_v0_7.md
@@ -1,0 +1,412 @@
+# V13 Creator-Live Whole-Flow Re-entry Charter Delta v0.7
+
+Status: `AUTHORIZED — implementation and non-live qualification only`
+
+## Purpose
+
+This Forward-only Delta authorizes a version-gated Creator-Live proof v0.3
+implementation that durably preserves content-free Run 2 output identity and
+A3 compiler audit identity before A3 can produce a checkpoint or terminal
+failure. It also authorizes terminal/restart projection from durable typed
+records, a read-only backward projection of Cycle 005, and removal of the
+terminal Cycle 005 Start affordance.
+
+It does not authorize a model invocation, task transmission, another proof
+opening, Cycle 005 continuation or replacement, Cycle 006 design, release, or
+publication.
+
+## Authority and Fixed History
+
+| Authority | Identity |
+| --- | --- |
+| Parent Charter | `validation/a7_creator_live_whole_flow_reentry_charter_v0_1.md` |
+| Parent Charter SHA-256 | `84e65d12e7b7dd2c86204273c7dc96c16689580e3148f9a0beb2993fd7ee0585` |
+| Delta v0.6 | `validation/a7_creator_live_whole_flow_reentry_charter_delta_v0_6.md` |
+| Delta v0.6 SHA-256 | `3c5aeeebba29ea7c59fa559cbde9d5cb10b171e0c24778c9ba9ce9930f7180b1` |
+| Implementation authorization observed at | `2026-08-05T12:28:00Z` |
+| Starting revision | `bbfa49ba48254758a8b6429b2eb88d141954eac8` |
+
+Cycle 005 remains permanently:
+
+```text
+FAILED / A3_REUSE / A3_EXACT_STRUCTURE_MISSING
+```
+
+Its fixed identities are:
+
+| Field | Identity |
+| --- | --- |
+| Launch binding | `e03a8f05be5a30e0af0e20ff983a0c89f675cb02376562f339e8899311e60bb1` |
+| Proof attempt | `proof_a7_creator_live_cycle_005_e03a8f05be5a30e0af0e20ff983a0c89f675cb02376562f339e8899311e60bb1` |
+| Journal-file SHA-256 | `1de2e998804f5fb694707846b7deb0dc9d8b5f9cfc6027ad0210ddc270029322` |
+| Anchor-file SHA-256 | `e246757a7ba98849a6b4a694ababf473dc1a98baf1fc1ce0ea7daa3a6e7e8610` |
+| Typed-readback SHA-256 | `481be90dc8751bda3d7b00714f5a0c650230dffa8974a1332881ce42c127710f` |
+
+No Cycle 005 proof byte, historical Note, prior Charter, maturity record, or
+other historical proof may be rewritten, migrated, normalized, regenerated,
+re-anchored, retried, resumed, replaced, or deleted.
+
+## Starting-State Gate
+
+Before implementation work, the executing agent verified:
+
+| Gate | Verified value |
+| --- | --- |
+| Selected repository | `/Users/sn/Documents/v13/decision-os-v13-loopkit` |
+| Branch | `main` |
+| Local main / origin/main | `bbfa49ba48254758a8b6429b2eb88d141954eac8` / exact equality |
+| Ahead / behind | `0 / 0` |
+| Tracked worktree and index | clean |
+| Git operation | none active |
+| Cycle 005 journal-file SHA-256 | exact fixed identity |
+| Cycle 005 anchor-file SHA-256 | exact fixed identity |
+| Cycle 005 typed-readback SHA-256 | exact fixed identity |
+
+Pre-existing untracked files are preserved. Any mismatch in this gate requires
+`HOLD`; it does not authorize cleanup, repair, or discard.
+
+## Version-Gated Durable Schema
+
+New attempts may use only these new schemas and filenames:
+
+```text
+decision-os.field-note-creator-live-proof-journal.v0.3
+decision-os.field-note-creator-live-proof-record.v0.3
+decision-os.field-note-creator-live-proof-anchor.v0.3
+decision-os.field-note-creator-live-proof-readback.v0.3
+creator-live-proof-v0.3.jsonl
+creator-live-proof-v0.3.anchor.jsonl
+```
+
+The v0.1 and v0.2 schemas, parsers, record ordering, anchor semantics, typed
+readback bodies, and readback hashes are frozen. v0.3 records are admitted only
+under the v0.3 record schema. No old record may be rewritten into v0.3.
+
+### Terminal projection binding
+
+For v0.3 only, `ATTEMPT_OPENED` contains one typed, content-free
+`terminal_projection_binding` with exactly:
+
+```text
+schema
+launch_binding_sha256
+contract_identity:
+  profile
+  title
+  source_byte_count
+  source_sha256
+  wrapper_sha256
+  interpretation_sha256
+ordinary_contract_execution_authority
+guided_intake_freeze_authority
+implementation_authorization_observed_at
+run_1_task:
+  byte_count
+  sha256
+run_2_task:
+  byte_count
+  sha256
+historical_boundary:
+  cycle_key
+  state
+  failure_boundary
+  failure_code
+retry_count
+replacement_count
+```
+
+Revision, runtime, Cycle authorization, and proof-attempt identity remain owned
+by their existing typed fields. The complete P0 binding is not persisted.
+
+### Run 2 output identity
+
+The journal record kind `RUN_2_OUTPUT_IDENTITY_RECORDED` has payload schema:
+
+```text
+decision-os.field-note-creator-live-run-2-output-identity.v0.1
+```
+
+It contains exactly:
+
+```text
+schema
+proof_attempt_id
+run_id
+task_byte_count
+task_sha256
+transmission_ordinal
+normal_terminal
+turn_status
+runtime_status
+failure_diagnostic_absent
+final_output_byte_count
+final_output_sha256
+output_artifact:
+  schema
+  artifact_id
+  proof_attempt_id
+  run_id
+  transmission_ordinal
+  media_type
+  byte_count
+  sha256
+a3_compiler_branch
+```
+
+Its fixed values are:
+
+```text
+transmission_ordinal = 2
+normal_terminal = true
+turn_status = completed
+runtime_status = NORMAL_TERMINAL
+failure_diagnostic_absent = true
+media_type = text/plain; charset=utf-8
+a3_compiler_branch =
+  EXACT_UTF8_NON_WHOLE_UNIQUE_SOURCE_UNIQUE_OUTPUT
+```
+
+It binds the proof and Run identities; Run 2 task byte count and SHA-256;
+verified normal-terminal facts; final-output byte count and SHA-256; a canonical
+output-artifact identity; and the exact compiler branch.
+
+```text
+EXACT_UTF8_NON_WHOLE_UNIQUE_SOURCE_UNIQUE_OUTPUT
+```
+
+The artifact identity is the SHA-256 of canonical JSON over its schema,
+proof-attempt ID, Run ID, transmission ordinal, media type, byte count, and
+SHA-256. It contains no output bytes or text.
+
+### A3 compiler audit identity
+
+The journal record kind `A3_COMPILER_AUDIT_RECORDED` has payload schema:
+
+```text
+decision-os.field-note-creator-live-a3-compiler-audit.v0.1
+```
+
+It contains exactly:
+
+```text
+schema
+proof_attempt_id
+run_id
+output_artifact_id
+compiler_version
+compiler_branch
+source_note_byte_count
+source_note_sha256
+output_byte_count
+output_sha256
+eligible_candidate_count
+rejection_counts:
+  below_minimum_byte_length
+  whole_note_range
+  non_unique_source_occurrence
+  absent_output_occurrence
+  multiple_output_occurrences
+longest_candidate_byte_count
+winning_candidate_count
+selected_source_start_byte
+selected_source_end_byte
+selected_output_start_byte
+selected_output_end_byte
+terminal_a3_code
+audit_sha256
+```
+
+The exact compiler version is:
+
+```text
+decision-os.creator-live-a3-exact-output-artifact-compiler.v0.1
+```
+
+All four offsets are populated only for exactly one winner. They are otherwise
+null. The terminal code is null for one winner,
+`A3_EXACT_STRUCTURE_MISSING` for no eligible winner, and
+`A3_EXACT_STRUCTURE_AMBIGUOUS` for an ambiguous winner set.
+
+## Mandatory Ordering
+
+The runtime must enforce:
+
+```text
+open v0.3 attempt with terminal projection binding
+→ journal fsync
+→ anchor append and fsync
+→ directory fsync
+→ exact typed readback
+→ Run 2 verified normal terminal
+→ construct content-free output identity
+→ journal/anchor/directory fsync
+→ exact typed readback
+→ enter A3 from that durable identity only
+→ run the unchanged compiler in memory
+→ construct content-free compiler audit
+→ journal/anchor/directory fsync
+→ exact typed readback and identity cross-check
+→ cross-check against durable Run 2 output and durable Note identities
+→ A3 checkpoint or exact terminal A3 failure
+→ discard transient Note and output bytes when no longer required
+```
+
+A process restart never resumes model transport or compilation. An interrupted
+open attempt remains `OPEN_UNRESUMABLE`. A torn journal or anchor append remains
+`INTEGRITY_FAILURE`. Neither state grants repair, retry, or replacement.
+
+## Frozen A3 Predicate
+
+This Delta changes evidence persistence only. A3 remains exact UTF-8 byte
+matching over a range with at least 32 non-whitespace bytes, not the whole
+Note, occurring exactly once in the source and exactly once in output. It
+admits no normalization, trimming-based equivalence, fuzzy matching, semantic
+substitution, usefulness inference, or authority inference.
+
+## Terminal Projection and Privacy
+
+After proof storage is occupied, the UI obtains its terminal projection only
+from version-appropriate durable typed readback. The public projection is an
+explicit allowlist containing only:
+
+- exact revision;
+- Contract identity;
+- ordinary Contract execution authority;
+- Guided Intake freeze authority;
+- runtime tuple;
+- Run 1 and Run 2 task byte counts and SHA-256 values;
+- Cycle and implementation authorization timestamps;
+- historical boundary;
+- launch binding and proof-attempt ID;
+- runtime-issued `proof_as_of`;
+- journal-file, anchor-file, and typed-readback SHA-256 values;
+- terminal stage and exact failure code;
+- retry and replacement counts;
+- output-artifact identity;
+- compiler identity and result.
+
+It must not expose task bodies, Note contents or paths, model-output text,
+hidden approvals, arbitrary repository paths, arbitrary journal fields, the
+complete P0 binding, or protected-history listings.
+
+Unknown fields, invalid hashes, negative counts, inconsistent offsets,
+unexpected record ordering, or mismatched artifact identities fail closed.
+
+Cycle 005 projects only fields durably present in v0.2:
+
+| Field | Exact projection |
+| --- | --- |
+| Exact revision | `bbfa49ba48254758a8b6429b2eb88d141954eac8` |
+| Contract identity | `NOT_DURABLY_PERSISTED` |
+| Ordinary Contract authority | `NOT_DURABLY_PERSISTED` |
+| Guided Intake freeze authority | `NOT_DURABLY_PERSISTED` |
+| Runtime | `chatgpt / gpt-5.6-sol / ultra / priority / CLI 0.146.0-alpha.3.1` |
+| Run 1 byte count | `NOT_DURABLY_PERSISTED` |
+| Run 1 SHA-256 | `e377fb2f9e003f3f04e8d1b10d2aef96347416d86f78305102d4671519ed3417` |
+| Run 2 byte count | `NOT_DURABLY_PERSISTED` |
+| Run 2 SHA-256 | `NOT_DURABLY_PERSISTED` |
+| Cycle authorization | `2026-08-05T06:22:00Z` |
+| Implementation authorization | `NOT_DURABLY_PERSISTED` |
+| Historical boundary | `NOT_DURABLY_PERSISTED` |
+| Launch binding | derived only from validated durable proof-attempt grammar |
+| Proof-attempt ID | `proof_a7_creator_live_cycle_005_e03a8f05be5a30e0af0e20ff983a0c89f675cb02376562f339e8899311e60bb1` |
+| Runtime `proof_as_of` | `2026-08-05T11:24:40.255812Z` |
+| Journal-file SHA-256 | `1de2e998804f5fb694707846b7deb0dc9d8b5f9cfc6027ad0210ddc270029322` |
+| Anchor-file SHA-256 | `e246757a7ba98849a6b4a694ababf473dc1a98baf1fc1ce0ea7daa3a6e7e8610` |
+| Typed-readback SHA-256 | `481be90dc8751bda3d7b00714f5a0c650230dffa8974a1332881ce42c127710f` |
+| Retry / replacement counts | `NOT_DURABLY_PERSISTED` |
+| Terminal state | `FAILED / A3_REUSE / A3_EXACT_STRUCTURE_MISSING` |
+
+Current constants and contemporary state are not substitutes for historical
+persistence. The terminal stage is read from `failure_boundary`, not transient
+coordinator state.
+
+When storage is occupied, the actionable `Start Cycle 005` control is absent
+and is replaced with:
+
+```text
+TERMINAL — NO RETRY OR REPLACEMENT
+```
+
+The backend `409 / CYCLE_005_ATTEMPT_EXISTS` guard remains authoritative.
+Keyboard and click submission paths are disabled or removed after
+terminalization and cannot issue a Start POST.
+
+## Authorized Surface
+
+Production:
+
+- `decision_os/companion/field_notes_creator_live.py`
+- `decision_os/companion/field_notes_controller.py`
+- `decision_os/companion/field_notes_creator_live_entrypoint.py`
+- `decision_os/companion/static/index.html`
+- `decision_os/companion/static/app.js`
+
+Tests:
+
+- `tests/test_field_notes_creator_live.py`
+- `tests/test_field_notes_creator_live_reconnect.py`
+- `tests/test_field_notes_creator_live_entrypoint.py`
+- `tests/test_companion_server.py`
+
+Forward-only authority:
+
+- `validation/a7_creator_live_whole_flow_reentry_charter_delta_v0_7.md`
+
+No other production file is authorized by this Delta.
+
+The Delta does not authorize changing ordinary Contract authority semantics,
+the A1 task, the A2 task, or the A3 predicate.
+
+## Qualification and Closure
+
+Qualification uses fixtures and fakes only. It includes focused source and
+installed-product suites, frozen v0.1/v0.2 compatibility, Cycle 005 exact hash
+checks, crash boundaries, strict A3 cases, projection/privacy behavior, full
+default discovery, JavaScript syntax, Python compilation, `git diff --check`,
+canonical build/install, source/installed product-tree equality, installed
+process replay, and process qualification.
+
+After independent review and forward merge, the unchanged exact Contract must
+be Forward-only fixed to the exact implementation merge. Source, installed
+runtime, Contract fixation, and running process must agree. Exact-final-merge
+P0 is non-live and must not open proof storage or invoke a model.
+
+Closure stops after exact-final-merge P0. It does not authorize another Cycle.
+
+## Stop Conditions
+
+Implementation returns `HOLD` or `BLOCK` rather than expanding scope if:
+
+- starting state or Cycle 005 hashes differ;
+- v0.2 typed-readback identity would change;
+- compatibility requires rewriting old proof records;
+- A3 would require weakening or other predicate change;
+- raw task, Note, or output text would need persistence;
+- a non-allowlisted production file must change;
+- ordinary Contract authority semantics must change;
+- Contract refix cannot bind the exact merge;
+- source/installed equality or process qualification fails;
+- model invocation, task transmission, proof opening, or historical mutation
+  appears necessary.
+
+## Rollback
+
+This rollback authority applies only before any future proof opening. Before
+merge, abandon the unmerged implementation. After merge, use a normal forward
+revert commit, rebuild and reinstall from the exact revert revision,
+Forward-only refix the unchanged Contract, and re-establish source/installed
+equality and process qualification.
+
+Installed backups may provide temporary recovery, but rollback is incomplete
+until source, installed runtime, Contract fixation, and running process agree.
+Cycle 005 and every historical proof remain byte-for-byte unchanged.
+
+If any future proof artifact already exists, preserve it; rollback no longer
+authorizes deleting or replacing that artifact, and separate disposition is
+required.
+
+## Remaining Separate Question
+
+No future Cycle identity, authorization, task pair, or preregistered basis for
+future A3 admissibility is established by this Delta.


### PR DESCRIPTION
Implements the authorized Delta v0.7 bounded surface.

- Adds version-gated v0.3 durable output identity and compiler audit records.
- Projects terminal/restart state only from durable typed records, including exact read-only Cycle 005 backward projection.
- Removes the terminal Start affordance while preserving the backend duplicate-start guard.
- Adds crash, compatibility, projection, privacy, and UI regressions.

Qualification:
- focused: 166 tests passed
- full discovery: 1,206 tests passed, 2 skipped
- JavaScript syntax, Python compilation, and git diff checks passed
- Cycle 005 journal, anchor, and typed-readback identities unchanged
- independent implementation review: PASS, no remaining findings

No model invocation, task transmission, proof opening, retry, or replacement was performed.