### PR TITLE
Fix candidate proof-root preservation guard

### DIFF
--- a/tests/test_field_notes_creator_live_candidate.py
+++ b/tests/test_field_notes_creator_live_candidate.py
@@ -878,8 +878,22 @@ class BehaviorAndBundleTests(unittest.TestCase):
         self.assertEqual(assemble_public_bundle(**arguments), assemble_public_bundle(**arguments))
 
     def test_58_no_cycle_or_proof_root_created(self):
-        self.assertFalse((ROOT / ".decision-os").exists())
-        self.assertNotIn("cycle-", (ROOT / "decision_os/companion/field_notes_creator_live_candidate.py").read_text(encoding="utf-8").casefold())
+        proof_parent = ROOT / ".decision-os/field-notes/proofs"
+        if proof_parent.exists():
+            self.assertEqual(
+                {
+                    "cycle-005",
+                    "proof_a7_creator_live_002_1d4c714b11c3f614",
+                    "proof_a7_creator_live_003_94a0d625f4d155f5",
+                    "proof_a7_creator_live_004_862c2f5cfdf7b134",
+                    "proof_a7_creator_live_005_1f0c0263566af0a8",
+                },
+                {path.name for path in proof_parent.iterdir()},
+            )
+        module = (
+            ROOT / "decision_os/companion/field_notes_creator_live_candidate.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("cycle-", module.casefold())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Narrow the candidate P0 proof-root test to the actual authorization boundary: accept the exact five pre-existing Cycle005/historical proof roots, reject missing, renamed, or additional roots, and retain the ban on numeric Cycle references in the candidate module.

## Why

Full canonical discovery exposed that the original assertion incorrectly required the repository-level `.decision-os` directory to be absent. That directory and its historical Cycle005/proof roots predated this work and were explicitly required to be preserved.

## Impact

Test-only correction. No production code, candidate identity, task bytes, proof state, Cycle data, model transport, or Contract semantics change.

## Checks

- focused candidate suite: 82/82 PASS
- repaired guard against canonical proof-root baseline: PASS
- diff whitespace check: PASS
- independent read-only repair review: PASS, no blocking findings