### PR TITLE
Bind Cycle 006 to the preserved Codex runtime

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -23,6 +23,23 @@ BUNDLED_CODEX_PATH = Path(
     "/Applications/ChatGPT.app/Contents/Resources/codex"
 )
 CODEX_CLI_VERSION = "0.146.0-alpha.3.1"
+
+# Cycle 006 is intentionally Forward-only.  Keep the historical/default
+# bundled identity above unchanged and bind only the migrated Cycle 006 route
+# to this preserved, content-addressed artifact.
+CYCLE_006_CODEX_CLI_VERSION = "0.147.0-alpha.1.2"
+CYCLE_006_CODEX_SHA256 = (
+    "9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481"
+)
+CYCLE_006_CODEX_PATH = Path(
+    "/Users/sn/Library/Application Support/Decision OS Companion/"
+    "runtime-artifacts/codex/"
+    f"{CYCLE_006_CODEX_SHA256}/codex"
+)
+CYCLE_006_CODEX_RECOVERY_RECEIPT = CYCLE_006_CODEX_PATH.with_name(
+    "recovery-receipt.json"
+)
+_CYCLE_006_CODEX_MAX_BYTES = 275_653_216
 CODEX_MODEL = "gpt-5.6-sol"
 CODEX_REASONING_EFFORT = "ultra"
 CODEX_SERVICE_TIER = "priority"
@@ -75,6 +92,126 @@ _READ_TOOL_SPEC = {
         },
     },
 }
+
+
+def _runtime_stat_identity(value: os.stat_result) -> tuple[int, ...]:
+    """Return fields that must remain stable throughout artifact checking."""
+
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _runtime_parent_chain_identity(path: Path) -> tuple[tuple[int, ...], ...]:
+    """Reject symlink traversal and bind every directory in the fixed path."""
+
+    identities: list[tuple[int, ...]] = []
+    for parent in reversed(path.parents):
+        try:
+            observed = parent.lstat()
+        except OSError as exc:
+            raise ValueError("P0_CODEX_CLI_UNAVAILABLE") from exc
+        if stat.S_ISLNK(observed.st_mode):
+            raise ValueError("P0_CODEX_CLI_SYMLINK")
+        if not stat.S_ISDIR(observed.st_mode):
+            raise ValueError("P0_CODEX_CLI_UNAVAILABLE")
+        identities.append(
+            (observed.st_dev, observed.st_ino, observed.st_mode)
+        )
+    return tuple(identities)
+
+
+def _verify_cycle_006_codex_runtime_identity(
+    executable: Path,
+) -> tuple[str, tuple[int, ...]]:
+    """Return the version and stable file identity of the fixed artifact.
+
+    The caller supplies a configured path only so a substituted configuration
+    can be rejected.  The expected path, full binary digest, and version are
+    fixed constants rather than runtime-discovered or PATH-resolved values.
+    """
+
+    configured = Path(executable)
+    if configured != CYCLE_006_CODEX_PATH:
+        raise ValueError("P0_CODEX_CLI_PATH_MISMATCH")
+    parent_chain = _runtime_parent_chain_identity(configured)
+    try:
+        before = configured.lstat()
+    except OSError as exc:
+        raise ValueError("P0_CODEX_CLI_UNAVAILABLE") from exc
+    if stat.S_ISLNK(before.st_mode):
+        raise ValueError("P0_CODEX_CLI_SYMLINK")
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or stat.S_IMODE(before.st_mode) != 0o755
+    ):
+        raise ValueError("P0_CODEX_CLI_NOT_REGULAR_EXECUTABLE")
+    if before.st_size > _CYCLE_006_CODEX_MAX_BYTES:
+        raise ValueError("P0_CODEX_CLI_SHA256_MISMATCH")
+
+    digest = hashlib.sha256()
+    try:
+        with configured.open("rb") as stream:
+            opened = os.fstat(stream.fileno())
+            if _runtime_stat_identity(opened) != _runtime_stat_identity(before):
+                raise ValueError("P0_CODEX_CLI_IDENTITY_CHANGED")
+            while block := stream.read(1024 * 1024):
+                digest.update(block)
+            after_read = os.fstat(stream.fileno())
+    except ValueError:
+        raise
+    except OSError as exc:
+        raise ValueError("P0_CODEX_CLI_UNAVAILABLE") from exc
+    if _runtime_stat_identity(after_read) != _runtime_stat_identity(before):
+        raise ValueError("P0_CODEX_CLI_IDENTITY_CHANGED")
+    if digest.hexdigest() != CYCLE_006_CODEX_SHA256:
+        raise ValueError("P0_CODEX_CLI_SHA256_MISMATCH")
+
+    try:
+        completed = subprocess.run(
+            (str(configured), "--version"),
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ValueError("P0_CODEX_CLI_VERSION_PROBE_FAILED") from exc
+    if completed.returncode != 0:
+        raise ValueError("P0_CODEX_CLI_VERSION_PROBE_FAILED")
+    expected_stdout = (
+        f"codex-cli {CYCLE_006_CODEX_CLI_VERSION}\n".encode("ascii")
+    )
+    if completed.stdout != expected_stdout:
+        raise ValueError("P0_CODEX_CLI_VERSION_MISMATCH")
+    try:
+        after_probe = configured.lstat()
+    except OSError as exc:
+        raise ValueError("P0_CODEX_CLI_IDENTITY_CHANGED") from exc
+    if _runtime_stat_identity(after_probe) != _runtime_stat_identity(before):
+        raise ValueError("P0_CODEX_CLI_IDENTITY_CHANGED")
+    try:
+        ending_parent_chain = _runtime_parent_chain_identity(configured)
+    except ValueError as exc:
+        raise ValueError("P0_CODEX_CLI_IDENTITY_CHANGED") from exc
+    if ending_parent_chain != parent_chain:
+        raise ValueError("P0_CODEX_CLI_IDENTITY_CHANGED")
+    return (
+        CYCLE_006_CODEX_CLI_VERSION,
+        _runtime_stat_identity(after_probe),
+    )
+
+
+def verify_cycle_006_codex_runtime_artifact(executable: Path) -> str:
+    """Verify the sole Forward-only Cycle 006 Codex executable."""
+
+    version, _identity = _verify_cycle_006_codex_runtime_identity(executable)
+    return version
 
 
 def _trailing_line_ending(value: str) -> str:
@@ -829,6 +966,13 @@ class _SubprocessTransport:
             return self._failure_category
 
     def start(self) -> None:
+        self._probe_version()
+        self._launch()
+        self._start_stderr_drain()
+
+    def _probe_version(self) -> None:
+        """Read the historical/default transport's CLI identity."""
+
         if not self.executable.is_file():
             raise CodexAdapterUnavailable(
                 f"Bundled Codex executable is unavailable at {self.executable}.",
@@ -854,6 +998,10 @@ class _SubprocessTransport:
                 diagnostic=_failure_diagnostic("version_verification"),
             )
         self._version = observed[len(prefix) :].strip()
+
+    def _launch(self) -> None:
+        """Spawn the configured executable without resolving through PATH."""
+
         try:
             self._process = subprocess.Popen(
                 (
@@ -888,6 +1036,8 @@ class _SubprocessTransport:
                 "Bundled Codex app-server could not be started.",
                 diagnostic=_failure_diagnostic("transport_start"),
             ) from exc
+
+    def _start_stderr_drain(self) -> None:
         self._stderr_thread = threading.Thread(
             target=self._drain_stderr,
             name="decision-os-codex-stderr",
@@ -974,6 +1124,54 @@ class _SubprocessTransport:
                 process.wait(timeout=2)
         if self._stderr_thread is not None:
             self._stderr_thread.join(timeout=1)
+
+
+class _Cycle006SubprocessTransport(_SubprocessTransport):
+    """Strictly bind the fixed Cycle 006 artifact around one exact launch."""
+
+    def _strict_identity(self) -> tuple[str, tuple[int, ...]]:
+        try:
+            return _verify_cycle_006_codex_runtime_identity(self.executable)
+        except ValueError as exc:
+            raise CodexAdapterFailure(
+                "The fixed Cycle 006 Codex runtime failed artifact verification.",
+                diagnostic=_failure_diagnostic("version_verification"),
+            ) from exc
+
+    def _current_identity(self) -> tuple[int, ...]:
+        try:
+            current = self.executable.lstat()
+        except OSError as exc:
+            raise CodexAdapterFailure(
+                "The fixed Cycle 006 Codex runtime changed before launch.",
+                diagnostic=_failure_diagnostic("version_verification"),
+            ) from exc
+        return _runtime_stat_identity(current)
+
+    def start(self) -> None:
+        version, verified_identity = self._strict_identity()
+        if self._current_identity() != verified_identity:
+            raise CodexAdapterFailure(
+                "The fixed Cycle 006 Codex runtime changed before launch.",
+                diagnostic=_failure_diagnostic("version_verification"),
+            )
+        self._version = version
+        self._launch()
+        try:
+            post_version, post_identity = self._strict_identity()
+            if (
+                post_version != version
+                or post_identity != verified_identity
+                or self._current_identity() != verified_identity
+            ):
+                raise CodexAdapterFailure(
+                    "The fixed Cycle 006 Codex runtime changed during launch.",
+                    diagnostic=_failure_diagnostic("version_verification"),
+                )
+        except Exception:
+            self.close()
+            raise
+        self._start_stderr_drain()
 
 
 TransportFactory = Callable[[Path], AppServerTransport]

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -15,6 +15,8 @@ from typing import Any, Callable
 from decision_os.acceleration.codex_adapter import (
     ADAPTER_NAME,
     CODEX_CLI_VERSION,
+    CYCLE_006_CODEX_CLI_VERSION,
+    CYCLE_006_CODEX_PATH,
     CodexApproval,
     CodexLifecycleEvent,
     CodexReadEvidence,
@@ -22,6 +24,7 @@ from decision_os.acceleration.codex_adapter import (
     CodexRuntimeIdentity,
     _READ_MAX_BYTES,
     _READ_MAX_DISTINCT_PATHS,
+    _Cycle006SubprocessTransport,
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.companion.controller import (
@@ -68,6 +71,49 @@ def _field_notes_adapter_factory(
     candidate_v0_2_a1_provider: Any = None,
     candidate_v0_2_a2_provider: Any = None,
 ) -> FieldNotesCodexAdapter:
+    # The controller creates a fresh adapter for one worker.  Snapshot the
+    # four paired values once so route selection and the adapter's run reset
+    # cannot observe different Candidate/capture state.
+    provider_values = {
+        "creator_live_a1_capture": (
+            creator_live_a1_capture_provider()
+            if creator_live_a1_capture_provider is not None
+            else None
+        ),
+        "creator_live_a2_reconnect": (
+            creator_live_a2_reconnect_provider()
+            if creator_live_a2_reconnect_provider is not None
+            else None
+        ),
+        "candidate_v0_2_a1": (
+            candidate_v0_2_a1_provider()
+            if candidate_v0_2_a1_provider is not None
+            else None
+        ),
+        "candidate_v0_2_a2": (
+            candidate_v0_2_a2_provider()
+            if candidate_v0_2_a2_provider is not None
+            else None
+        ),
+    }
+
+    def fixed_provider(name: str, original: Any) -> Any:
+        if original is None:
+            return None
+        return lambda value=provider_values[name]: value
+
+    cycle_006_selected = bool(
+        provider_values["candidate_v0_2_a1"] is not None
+        or provider_values["candidate_v0_2_a2"] is not None
+    )
+    runtime_options: dict[str, Any] = {}
+    if cycle_006_selected:
+        engine.adapter_version = CYCLE_006_CODEX_CLI_VERSION
+        runtime_options = {
+            "executable": CYCLE_006_CODEX_PATH,
+            "expected_cli_version": CYCLE_006_CODEX_CLI_VERSION,
+            "transport_factory": _Cycle006SubprocessTransport,
+        }
     return FieldNotesCodexAdapter(
         engine,
         input_func=lambda: None,
@@ -76,12 +122,25 @@ def _field_notes_adapter_factory(
         lifecycle_sink=lifecycle_sink,
         trusted_source_model_class=trusted_source_model_class,
         trusted_target_model_class=trusted_target_model_class,
-        creator_live_a1_capture_provider=creator_live_a1_capture_provider,
-        creator_live_a2_reconnect_provider=(
-            creator_live_a2_reconnect_provider
+        creator_live_a1_capture_provider=fixed_provider(
+            "creator_live_a1_capture",
+            creator_live_a1_capture_provider,
         ),
-        candidate_v0_2_a1_provider=candidate_v0_2_a1_provider,
-        candidate_v0_2_a2_provider=candidate_v0_2_a2_provider,
+        creator_live_a2_reconnect_provider=(
+            fixed_provider(
+                "creator_live_a2_reconnect",
+                creator_live_a2_reconnect_provider,
+            )
+        ),
+        candidate_v0_2_a1_provider=fixed_provider(
+            "candidate_v0_2_a1",
+            candidate_v0_2_a1_provider,
+        ),
+        candidate_v0_2_a2_provider=fixed_provider(
+            "candidate_v0_2_a2",
+            candidate_v0_2_a2_provider,
+        ),
+        **runtime_options,
     )
 
 

--- a/decision_os/companion/field_notes_creator_live_cycle_006.py
+++ b/decision_os/companion/field_notes_creator_live_cycle_006.py
@@ -15,8 +15,12 @@ import time
 from typing import Any, Callable, Mapping, Protocol
 
 from decision_os.acceleration.codex_adapter import (
-    BUNDLED_CODEX_PATH,
+    CYCLE_006_CODEX_CLI_VERSION,
+    CYCLE_006_CODEX_PATH,
+    CYCLE_006_CODEX_RECOVERY_RECEIPT,
+    CYCLE_006_CODEX_SHA256,
     CodexRuntimeIdentity,
+    verify_cycle_006_codex_runtime_artifact,
 )
 from decision_os.acceleration.model import git_output
 from decision_os.acceleration.model import repository_id
@@ -143,6 +147,13 @@ EXPECTED_INTERPRETATION_SHA256 = (
 EXPECTED_EXECUTION_AUTHORITY = "INTERPRETATION_ONLY"
 EXPECTED_FREEZE_AUTHORITY = "IMMUTABLE_INTERPRETATION_ONLY"
 EXPECTED_GATE = "CLEAR ENOUGH TO FREEZE"
+RUNTIME_MIGRATION_AS_OF = "2026-08-07"
+FORWARD_RUNTIME_CHARTER_PATH = (
+    "validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_1.md"
+)
+FORWARD_RUNTIME_CHARTER_SHA256 = (
+    "dade3a6994e0814ae50cba7b412726e9d4a65f94c5c214b1d62bc32c3a89203d"
+)
 
 EXPECTED_RUNTIME = {
     "provider": "openai",
@@ -150,7 +161,10 @@ EXPECTED_RUNTIME = {
     "model": "gpt-5.6-sol",
     "reasoning_effort": "ultra",
     "service_tier": "priority",
-    "codex_cli_version": "0.146.0-alpha.3.1",
+    "codex_cli_version": CYCLE_006_CODEX_CLI_VERSION,
+    "codex_binary_sha256": CYCLE_006_CODEX_SHA256,
+    "runtime_as_of": RUNTIME_MIGRATION_AS_OF,
+    "artifact_custody": "PRESERVED_CONTENT_ADDRESSED",
     "sandbox": "read-only",
     "model_sandbox_network": False,
     "provider_transport_required": True,
@@ -296,6 +310,7 @@ class CreatorLiveCycle006Spec:
     repository: Path = EXPECTED_REPOSITORY
     remote: str = EXPECTED_REMOTE
     runtime_root: Path | None = None
+    codex_executable: Path = CYCLE_006_CODEX_PATH
     live_start_authorization_observed_at: str | None = (
         LIVE_START_AUTHORIZATION_OBSERVED_AT
     )
@@ -318,30 +333,10 @@ def _sha256(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def _bundled_codex_cli_version(executable: Path) -> str:
-    """Read the local CLI identity without starting app-server or a model."""
+def _cycle_006_codex_cli_version(executable: Path) -> str:
+    """Verify the fixed artifact without starting app-server or a model."""
 
-    target = executable.resolve(strict=True)
-    if not target.is_file():
-        raise ValueError("P0_CODEX_CLI_UNAVAILABLE")
-    try:
-        completed = subprocess.run(
-            (str(target), "--version"),
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise ValueError("P0_CODEX_CLI_UNAVAILABLE") from exc
-    prefix = "codex-cli "
-    observed = completed.stdout.strip()
-    if completed.returncode != 0 or not observed.startswith(prefix):
-        raise ValueError("P0_CODEX_CLI_UNAVAILABLE")
-    version = observed.removeprefix(prefix).strip()
-    if not version or "\n" in version or "\r" in version:
-        raise ValueError("P0_CODEX_CLI_UNAVAILABLE")
-    return version
+    return verify_cycle_006_codex_runtime_artifact(executable)
 
 
 def _strict_object(raw: bytes, label: str) -> dict[str, Any]:
@@ -755,7 +750,7 @@ class CreatorLiveCycle006Entrypoint:
         ),
         worker_factory: Callable[..., Any] = threading.Thread,
         runtime_version_probe: Callable[[Path], str] = (
-            _bundled_codex_cli_version
+            _cycle_006_codex_cli_version
         ),
         timeout_seconds: float = 900.0,
     ) -> None:
@@ -782,6 +777,9 @@ class CreatorLiveCycle006Entrypoint:
         self._manifest_sha256: str | None = None
         self._post_a1_readback_sha256: str | None = None
         self._a3_overlay_sha256: str | None = None
+        self._runtime_verification_cache: tuple[
+            tuple[Any, ...], str | None
+        ] | None = None
 
     @property
     def mutation_blocked(self) -> bool:
@@ -789,18 +787,58 @@ class CreatorLiveCycle006Entrypoint:
             return self._starting or self._active
 
     def _require_runtime_binary_identity(self) -> None:
-        failure_code = self._runtime_binary_failure_code()
+        # Status polling may reuse evidence while the complete stat identity is
+        # unchanged.  Proof opening never does: re-read and re-probe here.
+        failure_code = self._runtime_binary_failure_code(force=True)
         if failure_code is not None:
             raise CreatorLiveCycle006Error(failure_code)
 
-    def _runtime_binary_failure_code(self) -> str | None:
+    def _runtime_binary_cache_key(self) -> tuple[Any, ...]:
         try:
-            observed = self.runtime_version_probe(BUNDLED_CODEX_PATH)
+            observed = self.spec.codex_executable.lstat()
+        except OSError:
+            return (str(self.spec.codex_executable), "UNAVAILABLE")
+        return (
+            str(self.spec.codex_executable),
+            observed.st_dev,
+            observed.st_ino,
+            observed.st_mode,
+            observed.st_nlink,
+            observed.st_size,
+            observed.st_mtime_ns,
+            observed.st_ctime_ns,
+        )
+
+    def _runtime_binary_failure_code(self, *, force: bool = False) -> str | None:
+        before_key = self._runtime_binary_cache_key()
+        with self._lock:
+            if (
+                not force
+                and self._runtime_verification_cache is not None
+                and self._runtime_verification_cache[0] == before_key
+            ):
+                return self._runtime_verification_cache[1]
+        try:
+            observed = self.runtime_version_probe(self.spec.codex_executable)
+        except ValueError as exc:
+            code = str(exc)
+            failure_code = (
+                code if code.startswith("P0_") else "P0_CODEX_CLI_UNAVAILABLE"
+            )
         except Exception:
-            return "P0_CODEX_CLI_UNAVAILABLE"
-        if observed != self.spec.runtime.codex_cli_version:
-            return "P0_CODEX_CLI_VERSION_MISMATCH"
-        return None
+            failure_code = "P0_CODEX_CLI_UNAVAILABLE"
+        else:
+            failure_code = (
+                "P0_CODEX_CLI_VERSION_MISMATCH"
+                if observed != self.spec.runtime.codex_cli_version
+                else None
+            )
+        after_key = self._runtime_binary_cache_key()
+        if after_key != before_key:
+            return "P0_CODEX_CLI_IDENTITY_CHANGED"
+        with self._lock:
+            self._runtime_verification_cache = (after_key, failure_code)
+        return failure_code
 
     def _outer_gate_failure_code(self) -> str | None:
         """Validate non-proof outer gates in their required fail-closed order."""
@@ -1579,6 +1617,7 @@ class CreatorLiveCycle006Entrypoint:
                 repository != EXPECTED_REPOSITORY.resolve(strict=True)
                 or self.spec.remote != EXPECTED_REMOTE
                 or self.spec.runtime != EXPECTED_CODEX_RUNTIME
+                or self.spec.codex_executable != CYCLE_006_CODEX_PATH
             ):
                 raise ValueError("P0_FIXED_EXECUTION_IDENTITY_MISMATCH")
             outer_gate_failure = self._outer_gate_failure_code()
@@ -1633,6 +1672,21 @@ class CreatorLiveCycle006Entrypoint:
                 for item in charter_lineage
             ):
                 raise ValueError("P0_CHARTER_V1_0_MISSING")
+            forward_charter = repository / FORWARD_RUNTIME_CHARTER_PATH
+            if (
+                not forward_charter.is_file()
+                or forward_charter.is_symlink()
+                or _sha256(forward_charter.read_bytes())
+                != FORWARD_RUNTIME_CHARTER_SHA256
+                or not any(
+                    item == {
+                        "path": FORWARD_RUNTIME_CHARTER_PATH,
+                        "sha256": FORWARD_RUNTIME_CHARTER_SHA256,
+                    }
+                    for item in charter_lineage
+                )
+            ):
+                raise ValueError("P0_FORWARD_RUNTIME_CHARTER_MISMATCH")
             tasks = {
                 "run_1": {
                     "path": FIXED_TASK_IDENTITIES[0].path,
@@ -1734,6 +1788,22 @@ class CreatorLiveCycle006Entrypoint:
                         "project_document_injection",
                         "arbitrary_write_edit_delete",
                     ],
+                },
+                "runtime_artifact": {
+                    "configured_path": str(self.spec.codex_executable),
+                    "expected_path": str(CYCLE_006_CODEX_PATH),
+                    "binary_sha256": CYCLE_006_CODEX_SHA256,
+                    "recovery_receipt_path": str(
+                        CYCLE_006_CODEX_RECOVERY_RECEIPT
+                    ),
+                    "version_stdout": (
+                        f"codex-cli {CYCLE_006_CODEX_CLI_VERSION}\n"
+                    ),
+                    "regular_file_required": True,
+                    "executable_required": True,
+                    "symlink_permitted": False,
+                    "path_fallback_permitted": False,
+                    "chatgpt_app_fallback_permitted": False,
                 },
                 "historical_boundary": historical,
                 "comparison": {

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -4,6 +4,7 @@ from collections import deque
 import hashlib
 import io
 import json
+import os
 from pathlib import Path
 import subprocess
 import tempfile
@@ -11,6 +12,7 @@ import unittest
 from typing import Any
 from unittest.mock import patch
 
+from decision_os.acceleration import codex_adapter as codex_module
 from decision_os.acceleration.codex_adapter import (
     ADAPTER_NAME,
     CODEX_CLI_VERSION,
@@ -87,6 +89,7 @@ def handshake_messages(
     *,
     thread_id: str,
     turn_id: str,
+    cli_version: str = CODEX_CLI_VERSION,
     model: str = CODEX_MODEL,
     effort: str = CODEX_REASONING_EFFORT,
     service_tier: str = CODEX_SERVICE_TIER,
@@ -110,7 +113,7 @@ def handshake_messages(
                 "codexHome": "/tmp/codex-home",
                 "platformFamily": "unix",
                 "platformOs": "macos",
-                "userAgent": f"codex_cli_rs/{CODEX_CLI_VERSION}",
+                "userAgent": f"codex_cli_rs/{cli_version}",
             },
         },
         {
@@ -163,7 +166,7 @@ def handshake_messages(
                 },
                 "serviceTier": service_tier,
                 "thread": {
-                    "cliVersion": CODEX_CLI_VERSION,
+                    "cliVersion": cli_version,
                     "cwd": cwd,
                     "ephemeral": ephemeral,
                     "id": thread_id,
@@ -588,8 +591,10 @@ class FakeTransportFactory:
         self.scripts = deque(scripts)
         self.versions = deque(versions or [CODEX_CLI_VERSION] * len(scripts))
         self.transports: list[FakeTransport] = []
+        self.executables: list[Path] = []
 
-    def __call__(self, _executable: Path) -> FakeTransport:
+    def __call__(self, executable: Path) -> FakeTransport:
+        self.executables.append(executable)
         transport = FakeTransport(
             self.scripts.popleft(),
             version=self.versions.popleft(),
@@ -650,6 +655,29 @@ def adapter_for(
 
 
 class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _write_cycle_runtime(
+        target: Path,
+        *,
+        version: str | None = None,
+        exit_code: int = 0,
+        mark_use: bool = False,
+    ) -> str:
+        observed_version = version or codex_module.CYCLE_006_CODEX_CLI_VERSION
+        lines = ["#!/bin/sh"]
+        if mark_use:
+            lines.append(f"printf 'used\\n' > '{target}.used'")
+        lines.extend(
+            (
+                f"printf 'codex-cli {observed_version}\\n'",
+                f"exit {exit_code}",
+                "",
+            )
+        )
+        target.write_text("\n".join(lines), encoding="utf-8")
+        target.chmod(0o755)
+        return hashlib.sha256(target.read_bytes()).hexdigest()
+
     def test_untrusted_failure_diagnostics_are_canonically_rebuilt(self) -> None:
         private = "PRIVATE raw exception, source, prompt, and secret"
 
@@ -4401,6 +4429,423 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 catalog_requests[1]["params"]["cursor"],
             )
 
+    def test_cycle_006_preserved_artifact_is_accepted_and_launched_exactly(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            preserved = root / "preserved-codex"
+            digest = self._write_cycle_runtime(preserved, mark_use=True)
+            hostile_directory = root / "hostile-path"
+            hostile_directory.mkdir()
+            hostile = hostile_directory / "codex"
+            self._write_cycle_runtime(hostile, mark_use=True)
+            process = FakeProcess("")
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    preserved,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    digest,
+                ),
+                patch.object(
+                    codex_module,
+                    "BUNDLED_CODEX_PATH",
+                    hostile,
+                ),
+                patch.dict(os.environ, {"PATH": str(hostile_directory)}),
+            ):
+                completed = subprocess.CompletedProcess(
+                    args=(str(preserved), "--version"),
+                    returncode=0,
+                    stdout=(
+                        f"codex-cli {codex_module.CYCLE_006_CODEX_CLI_VERSION}\n"
+                    ).encode("ascii"),
+                    stderr=b"",
+                )
+                with (
+                    patch.object(
+                        codex_module.subprocess,
+                        "run",
+                        return_value=completed,
+                    ) as version_probe,
+                    patch.object(
+                        codex_module.subprocess,
+                        "Popen",
+                        return_value=process,
+                    ) as popen,
+                ):
+                    transport = codex_module._Cycle006SubprocessTransport(
+                        preserved
+                    )
+                    transport.start()
+                    transport.close()
+
+                observed = codex_module.verify_cycle_006_codex_runtime_artifact(
+                    preserved
+                )
+
+            self.assertEqual(
+                codex_module.CYCLE_006_CODEX_CLI_VERSION,
+                observed,
+            )
+            command = popen.call_args.args[0]
+            self.assertEqual(str(preserved), command[0])
+            self.assertNotEqual(str(hostile), command[0])
+            for call in version_probe.call_args_list:
+                self.assertEqual(str(preserved), call.args[0][0])
+            self.assertFalse(Path(f"{hostile}.used").exists())
+
+    def test_cycle_006_version_stdout_is_byte_exact(self) -> None:
+        cases = (
+            b"codex-cli 0.147.0-alpha.1.2\r\n",
+            b"codex-cli 0.147.0-alpha.1.2\r",
+            b"codex-cli 0.147.0-alpha.1.2\nextra",
+        )
+        for stdout in cases:
+            with self.subTest(stdout=stdout), tempfile.TemporaryDirectory() as directory:
+                executable = Path(directory).resolve() / "codex"
+                digest = self._write_cycle_runtime(executable)
+                completed = subprocess.CompletedProcess(
+                    args=(str(executable), "--version"),
+                    returncode=0,
+                    stdout=stdout,
+                    stderr=b"",
+                )
+                with (
+                    patch.object(
+                        codex_module,
+                        "CYCLE_006_CODEX_PATH",
+                        executable,
+                    ),
+                    patch.object(
+                        codex_module,
+                        "CYCLE_006_CODEX_SHA256",
+                        digest,
+                    ),
+                    patch.object(
+                        codex_module.subprocess,
+                        "run",
+                        return_value=completed,
+                    ),
+                    self.assertRaisesRegex(
+                        ValueError,
+                        "P0_CODEX_CLI_VERSION_MISMATCH",
+                    ),
+                ):
+                    codex_module.verify_cycle_006_codex_runtime_artifact(
+                        executable
+                    )
+
+    def test_cycle_006_wrong_sha_and_modified_bytes_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            executable = Path(directory).resolve() / "codex"
+            original_sha = self._write_cycle_runtime(executable)
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    executable,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    "0" * 64,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_SHA256_MISMATCH",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    executable
+                )
+
+            oversized = Path(directory).resolve() / "oversized-codex"
+            oversized.write_bytes(b"#!/bin/sh\n")
+            oversized.chmod(0o755)
+            with oversized.open("r+b") as stream:
+                stream.truncate(codex_module._CYCLE_006_CODEX_MAX_BYTES + 1)
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    oversized,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_SHA256_MISMATCH",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    oversized
+                )
+
+            executable.write_bytes(executable.read_bytes() + b"# modified\n")
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    executable,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    original_sha,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_SHA256_MISMATCH",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    executable
+                )
+
+    def test_cycle_006_missing_and_symlink_artifacts_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            missing = root / "missing-codex"
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    missing,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_UNAVAILABLE",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(missing)
+
+            nonexecutable = root / "nonexecutable-codex"
+            nonexecutable.write_text(
+                "#!/bin/sh\nprintf 'codex-cli 0.147.0-alpha.1.2\\n'\n",
+                encoding="utf-8",
+            )
+            nonexecutable.chmod(0o644)
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    nonexecutable,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_NOT_REGULAR_EXECUTABLE",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    nonexecutable
+                )
+
+            nonexecutable.chmod(0o777)
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    nonexecutable,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    hashlib.sha256(nonexecutable.read_bytes()).hexdigest(),
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_NOT_REGULAR_EXECUTABLE",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    nonexecutable
+                )
+
+            target = root / "target-codex"
+            digest = self._write_cycle_runtime(target)
+            linked = root / "linked-codex"
+            linked.symlink_to(target)
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    linked,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    digest,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_SYMLINK",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(linked)
+
+            real_parent = root / "real-parent"
+            real_parent.mkdir()
+            nested_target = real_parent / "codex"
+            nested_digest = self._write_cycle_runtime(nested_target)
+            linked_parent = root / "linked-parent"
+            linked_parent.symlink_to(real_parent, target_is_directory=True)
+            nested_link = linked_parent / "codex"
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    nested_link,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    nested_digest,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_SYMLINK",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    nested_link
+                )
+
+    def test_cycle_006_wrong_version_and_nonzero_probe_are_rejected(self) -> None:
+        cases = (
+            (
+                "wrong-version",
+                "0.147.0-alpha.1.3",
+                0,
+                "P0_CODEX_CLI_VERSION_MISMATCH",
+            ),
+            (
+                "nonzero",
+                codex_module.CYCLE_006_CODEX_CLI_VERSION,
+                9,
+                "P0_CODEX_CLI_VERSION_PROBE_FAILED",
+            ),
+        )
+        for label, version, exit_code, expected in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                executable = Path(directory).resolve() / "codex"
+                digest = self._write_cycle_runtime(
+                    executable,
+                    version=version,
+                    exit_code=exit_code,
+                )
+                with (
+                    patch.object(
+                        codex_module,
+                        "CYCLE_006_CODEX_PATH",
+                        executable,
+                    ),
+                    patch.object(
+                        codex_module,
+                        "CYCLE_006_CODEX_SHA256",
+                        digest,
+                    ),
+                    self.assertRaisesRegex(ValueError, expected),
+                ):
+                    codex_module.verify_cycle_006_codex_runtime_artifact(
+                        executable
+                    )
+
+    def test_cycle_006_configured_path_and_prelaunch_verification_fail_closed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            preserved = root / "preserved-codex"
+            digest = self._write_cycle_runtime(preserved)
+            mutable_chatgpt = root / "ChatGPT.app" / "codex"
+            mutable_chatgpt.parent.mkdir()
+            self._write_cycle_runtime(mutable_chatgpt)
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    preserved,
+                ),
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_SHA256",
+                    digest,
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "P0_CODEX_CLI_PATH_MISMATCH",
+                ),
+            ):
+                codex_module.verify_cycle_006_codex_runtime_artifact(
+                    mutable_chatgpt
+                )
+
+            missing = root / "missing-preserved"
+            with (
+                patch.object(
+                    codex_module,
+                    "CYCLE_006_CODEX_PATH",
+                    missing,
+                ),
+                patch.object(
+                    codex_module.subprocess,
+                    "Popen",
+                ) as popen,
+                self.assertRaises(CodexAdapterFailure),
+            ):
+                codex_module._Cycle006SubprocessTransport(missing).start()
+            popen.assert_not_called()
+
+    def test_cycle_006_identity_drift_cannot_launch_or_continue(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            executable = Path(directory).resolve() / "codex"
+            self._write_cycle_runtime(executable)
+            identity = codex_module._runtime_stat_identity(executable.lstat())
+            stale = (*identity[:-1], identity[-1] - 1)
+            with (
+                patch.object(
+                    codex_module,
+                    "_verify_cycle_006_codex_runtime_identity",
+                    return_value=(
+                        codex_module.CYCLE_006_CODEX_CLI_VERSION,
+                        stale,
+                    ),
+                ),
+                patch.object(codex_module.subprocess, "Popen") as popen,
+                self.assertRaises(CodexAdapterFailure),
+            ):
+                codex_module._Cycle006SubprocessTransport(executable).start()
+            popen.assert_not_called()
+
+            process = FakeProcess("")
+            verifier = patch.object(
+                codex_module,
+                "_verify_cycle_006_codex_runtime_identity",
+                side_effect=(
+                    (
+                        codex_module.CYCLE_006_CODEX_CLI_VERSION,
+                        identity,
+                    ),
+                    ValueError("P0_CODEX_CLI_IDENTITY_CHANGED"),
+                ),
+            )
+            with (
+                verifier,
+                patch.object(
+                    codex_module.subprocess,
+                    "Popen",
+                    return_value=process,
+                ) as popen,
+                self.assertRaises(CodexAdapterFailure),
+            ):
+                codex_module._Cycle006SubprocessTransport(executable).start()
+            popen.assert_called_once()
+            self.assertTrue(process.terminated)
+
     def test_subprocess_transport_frames_jsonl_and_isolates_tools(
         self,
     ) -> None:
@@ -4440,6 +4885,7 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual({"id": 1, "result": {"ok": True}}, received)
             command = popen.call_args.args[0]
+            self.assertEqual(str(executable), command[0])
             self.assertEqual("app-server", command[-1])
             self.assertIn("features.hooks=false", command)
             self.assertIn("features.shell_tool=false", command)

--- a/tests/test_field_notes_creator_live_cycle_006.py
+++ b/tests/test_field_notes_creator_live_cycle_006.py
@@ -15,6 +15,7 @@ import unittest
 from unittest.mock import patch
 from urllib.parse import urlsplit
 
+from decision_os.acceleration import codex_adapter as codex_module
 from decision_os.acceleration.codex_adapter import (
     ADAPTER_NAME,
     CODEX_CLI_VERSION,
@@ -33,6 +34,7 @@ from decision_os.companion.field_notes_adapter import (
 from decision_os.companion.field_notes_controller import (
     FieldNoteError,
     FieldNotesCompanionController,
+    _field_notes_adapter_factory,
 )
 from decision_os.companion.field_notes_creator_live_entrypoint import (
     CreatorLiveEntrypointError,
@@ -59,13 +61,13 @@ from decision_os.companion.field_notes_reconnect import (
 )
 from decision_os.companion.server import CompanionServer
 from tests.test_acceleration_codex_adapter import (
-    FakeTransportFactory,
+    FakeTransportFactory as AdapterFakeTransportFactory,
     approval_request,
     change,
     completed_agent_message,
     completed_item,
     completed_turn,
-    handshake_messages,
+    handshake_messages as adapter_handshake_messages,
     resolved_request,
     started_item,
 )
@@ -78,6 +80,38 @@ _STALE = "7" * 64
 _RUN_CANONICAL = (
     os.environ.get("DECISION_OS_RUN_CYCLE_006_CANONICAL_TESTS") == "1"
 )
+
+
+class FakeTransportFactory(AdapterFakeTransportFactory):
+    """Cycle 006 fake transport with the Forward-only CLI identity."""
+
+    def __init__(
+        self,
+        scripts: list[list[dict[str, object]]],
+        *,
+        versions: list[str] | None = None,
+    ) -> None:
+        super().__init__(
+            scripts,  # type: ignore[arg-type]
+            versions=versions
+            or [codex_module.CYCLE_006_CODEX_CLI_VERSION] * len(scripts),
+        )
+
+
+def handshake_messages(
+    repository: Path,
+    **kwargs: object,
+) -> list[dict[str, object]]:
+    """Build one fake transcript carrying the Cycle 006 CLI identity."""
+
+    kwargs.setdefault(
+        "cli_version",
+        codex_module.CYCLE_006_CODEX_CLI_VERSION,
+    )
+    return adapter_handshake_messages(  # type: ignore[return-value]
+        repository,
+        **kwargs,  # type: ignore[arg-type]
+    )
 
 
 def _candidate_proposal() -> dict[str, object]:
@@ -374,13 +408,38 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
                 "model": "gpt-5.6-sol",
                 "reasoning_effort": "ultra",
                 "service_tier": "priority",
-                "codex_cli_version": "0.146.0-alpha.3.1",
+                "codex_cli_version": "0.147.0-alpha.1.2",
+                "codex_binary_sha256": (
+                    "9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481"
+                ),
+                "runtime_as_of": "2026-08-07",
+                "artifact_custody": "PRESERVED_CONTENT_ADDRESSED",
                 "sandbox": "read-only",
                 "model_sandbox_network": False,
                 "provider_transport_required": True,
                 "fresh_ephemeral_thread_per_run": True,
                 "repository_cwd": "canonical-selected-repository",
             },
+        )
+        self.assertEqual(codex_module.CODEX_CLI_VERSION, "0.146.0-alpha.3.1")
+        self.assertEqual(
+            cycle006.EXPECTED_CODEX_RUNTIME.codex_cli_version,
+            codex_module.CYCLE_006_CODEX_CLI_VERSION,
+        )
+        self.assertEqual(
+            self.spec.codex_executable,
+            codex_module.CYCLE_006_CODEX_PATH,
+        )
+        self.assertNotEqual(
+            codex_module.BUNDLED_CODEX_PATH,
+            codex_module.CYCLE_006_CODEX_PATH,
+        )
+        charter = ROOT / cycle006.FORWARD_RUNTIME_CHARTER_PATH
+        self.assertTrue(charter.is_file())
+        self.assertFalse(charter.is_symlink())
+        self.assertEqual(
+            cycle006._sha256(charter.read_bytes()),
+            cycle006.FORWARD_RUNTIME_CHARTER_SHA256,
         )
         identity = future_proof_identity(_DIGEST)
         self.assertEqual(
@@ -414,6 +473,8 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
             "PRIVATE_PREPARATION",
             "PRIVATE_DERIVATION",
             "proof_a7_creator_live_cycle_006_" + _DIGEST,
+            str(codex_module.CYCLE_006_CODEX_PATH),
+            str(codex_module.CYCLE_006_CODEX_RECOVERY_RECEIPT),
         ):
             self.assertNotIn(private, encoded)
 
@@ -647,7 +708,7 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
             model="other-model",
             reasoning_effort="ultra",
             service_tier="priority",
-            codex_cli_version="0.146.0-alpha.3.1",
+            codex_cli_version="0.147.0-alpha.1.2",
             account_type="chatgpt",
         )
         result = CreatorLiveCycle006Entrypoint(
@@ -656,6 +717,19 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
         )._p0(_Controller(ROOT).snapshot())
         self.assertFalse(result.ready)
         self.assertEqual(result.failure_code, "P0_FIXED_EXECUTION_IDENTITY_MISMATCH")
+
+        mutable_app_result = CreatorLiveCycle006Entrypoint(
+            _Controller(ROOT),
+            spec=CreatorLiveCycle006Spec(
+                repository=ROOT,
+                codex_executable=codex_module.BUNDLED_CODEX_PATH,
+            ),
+        )._p0(_Controller(ROOT).snapshot())
+        self.assertFalse(mutable_app_result.ready)
+        self.assertEqual(
+            mutable_app_result.failure_code,
+            "P0_FIXED_EXECUTION_IDENTITY_MISMATCH",
+        )
 
         target = self.repository.parent / "alternate-storage"
         target.mkdir()
@@ -670,7 +744,7 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
         entrypoint = CreatorLiveCycle006Entrypoint(
             _Controller(self.repository),
             spec=CreatorLiveCycle006Spec(repository=self.repository),
-            runtime_version_probe=lambda _path: "0.147.0-alpha.1.2",
+            runtime_version_probe=lambda _path: "0.147.0-alpha.1.3",
         )
         with self.assertRaisesRegex(
             CreatorLiveCycle006Error,
@@ -678,6 +752,295 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
         ):
             entrypoint._require_runtime_binary_identity()
         self.assertFalse(os.path.lexists(self.spec.storage_root))
+
+    def test_runtime_polling_reuses_stable_evidence_but_preproof_rechecks(
+        self,
+    ) -> None:
+        executable = self.repository.parent / "preserved-codex"
+        executable.write_bytes(b"fixed-runtime")
+        executable.chmod(0o755)
+        calls: list[Path] = []
+
+        def probe(path: Path) -> str:
+            calls.append(path)
+            return cycle006.EXPECTED_CODEX_RUNTIME.codex_cli_version
+
+        entrypoint = CreatorLiveCycle006Entrypoint(
+            _Controller(self.repository),
+            spec=CreatorLiveCycle006Spec(
+                repository=self.repository,
+                codex_executable=executable,
+            ),
+            runtime_version_probe=probe,
+        )
+        self.assertIsNone(entrypoint._runtime_binary_failure_code())
+        self.assertIsNone(entrypoint._runtime_binary_failure_code())
+        self.assertEqual(calls, [executable])
+
+        entrypoint._require_runtime_binary_identity()
+        self.assertEqual(calls, [executable, executable])
+
+        def mutating_probe(path: Path) -> str:
+            path.write_bytes(b"changed-runtime-bytes")
+            path.chmod(0o755)
+            return cycle006.EXPECTED_CODEX_RUNTIME.codex_cli_version
+
+        drifting = CreatorLiveCycle006Entrypoint(
+            _Controller(self.repository),
+            spec=CreatorLiveCycle006Spec(
+                repository=self.repository,
+                codex_executable=executable,
+            ),
+            runtime_version_probe=mutating_probe,
+        )
+        with self.assertRaisesRegex(
+            CreatorLiveCycle006Error,
+            "P0_CODEX_CLI_IDENTITY_CHANGED",
+        ):
+            drifting._require_runtime_binary_identity()
+
+    def test_runtime_verification_precedes_proof_and_model_transmission(
+        self,
+    ) -> None:
+        binding = deepcopy(_full_fixture_binding())
+        repository_identity = "repo:v1:" + "c" * 64
+        head = "b" * 40
+        binding["repository"]["repository_id"] = repository_identity
+        binding["repository"]["head"] = head
+        calls: list[str] = []
+
+        class AuthorizedReady(CreatorLiveCycle006Entrypoint):
+            def _p0(self, _base_snapshot: object) -> CreatorLiveCycle006P0Result:
+                return CreatorLiveCycle006P0Result(
+                    True,
+                    None,
+                    deepcopy(binding),
+                    _DIGEST,
+                )
+
+        def failed_verification(_path: Path) -> str:
+            calls.append("verify")
+            raise ValueError("P0_CODEX_CLI_SHA256_MISMATCH")
+
+        entrypoint = AuthorizedReady(
+            _Controller(self.repository),
+            spec=CreatorLiveCycle006Spec(
+                repository=self.repository,
+                live_start_authorization_observed_at="2026-08-07T00:00:00Z",
+            ),
+            runtime_version_probe=failed_verification,
+            runtime_opener=lambda *_args, **_kwargs: calls.append("proof"),
+            worker_factory=lambda *_args, **_kwargs: calls.append("worker"),
+        )
+        with (
+            patch.object(cycle006, "repository_id", return_value=repository_identity),
+            patch.object(cycle006, "git_output", return_value=head),
+            patch.object(
+                entrypoint,
+                "_load_fixed_task",
+                side_effect=AssertionError("task must not be loaded"),
+            ),
+            self.assertRaisesRegex(
+                CreatorLiveCycle006Error,
+                "P0_CODEX_CLI_SHA256_MISMATCH",
+            ),
+        ):
+            entrypoint.start(_DIGEST)
+
+        self.assertEqual(calls, ["verify"])
+        self.assertFalse(os.path.lexists(entrypoint.spec.storage_root))
+        self.assertFalse(entrypoint.mutation_blocked)
+
+    def test_production_factory_selects_preserved_runtime_only_for_cycle_006(
+        self,
+    ) -> None:
+        factory_repository = create_repository(
+            Path(self.temporary.name),
+            "factory-repository",
+        )
+
+        def reconnect_target(
+            runtime: codex_module.CodexRuntimeIdentity,
+        ) -> exact_a2.FieldNoteCreatorLiveA2ReconnectTarget:
+            return exact_a2.FieldNoteCreatorLiveA2ReconnectTarget._issue(
+                authority=exact_a2._A2_TARGET_AUTHORITY,
+                proof_attempt_id="proof-factory",
+                run_1_id="run-a1",
+                run_2_id="run-a2",
+                field_note_id="fn-factory",
+                note_relative_path=".decision-os/field-notes/fn-factory.md",
+                note_sha256="a" * 64,
+                note_byte_count=1,
+                source_repository_id="repo:v1:" + "b" * 64,
+                source_commit="c" * 40,
+                expected_runtime_identity=runtime,
+            )
+
+        candidate_a1 = FieldNoteCreatorLiveCandidateV02A1Config(
+            run_id="run-cycle-006",
+            expected_runtime_identity=cycle006.EXPECTED_CODEX_RUNTIME,
+            contract_identity_sha256="c" * 64,
+        )
+        capture_a1 = FieldNoteCreatorLiveA1CaptureConfig(
+            run_id=candidate_a1.run_id,
+            expected_runtime_identity=cycle006.EXPECTED_CODEX_RUNTIME,
+        )
+        candidate_a2 = FieldNoteCreatorLiveCandidateV02A2Config(
+            readback_path="/fixed/readback.json",
+            readback_sha256="d" * 64,
+        )
+        target_a2 = reconnect_target(cycle006.EXPECTED_CODEX_RUNTIME)
+        for label, capture, target, a1, a2 in (
+            ("run-1", capture_a1, None, candidate_a1, None),
+            ("run-2", None, target_a2, None, candidate_a2),
+        ):
+            with self.subTest(label=label):
+                calls = {"capture": 0, "target": 0, "a1": 0, "a2": 0}
+
+                def stateful(name: str, value: object) -> Callable[[], object | None]:
+                    def provider() -> object | None:
+                        calls[name] += 1
+                        return value if calls[name] == 1 else None
+
+                    return provider
+
+                engine = AccelerationEngine(
+                    factory_repository,
+                    adapter=ADAPTER_NAME,
+                    adapter_version=CODEX_CLI_VERSION,
+                )
+                adapter = _field_notes_adapter_factory(
+                    engine,
+                    lambda _approval: None,
+                    lambda _event: None,
+                    creator_live_a1_capture_provider=(
+                        stateful("capture", capture) if capture is not None else None
+                    ),
+                    creator_live_a2_reconnect_provider=(
+                        stateful("target", target) if target is not None else None
+                    ),
+                    candidate_v0_2_a1_provider=(
+                        stateful("a1", a1) if a1 is not None else None
+                    ),
+                    candidate_v0_2_a2_provider=(
+                        stateful("a2", a2) if a2 is not None else None
+                    ),
+                )
+                with patch.object(
+                    adapter_module,
+                    "prepare_creator_live_a2_reconnect",
+                    return_value=SimpleNamespace(plan=None),
+                ), patch.object(
+                    candidate_v02,
+                    "read_post_a1_readback_v0_2",
+                    return_value=SimpleNamespace(),
+                ), patch.object(
+                    candidate_v02,
+                    "require_post_a1_gate_for_a2",
+                ):
+                    adapter._reset_run()
+                self.assertEqual(
+                    adapter.executable,
+                    codex_module.CYCLE_006_CODEX_PATH,
+                )
+                self.assertEqual(
+                    adapter.expected_cli_version,
+                    codex_module.CYCLE_006_CODEX_CLI_VERSION,
+                )
+                self.assertIs(
+                    adapter.transport_factory,
+                    codex_module._Cycle006SubprocessTransport,
+                )
+                self.assertEqual(
+                    engine.adapter_version,
+                    codex_module.CYCLE_006_CODEX_CLI_VERSION,
+                )
+                self.assertEqual(
+                    {name: count for name, count in calls.items() if count},
+                    {
+                        name: 1
+                        for name, value in (
+                            ("capture", capture),
+                            ("target", target),
+                            ("a1", a1),
+                            ("a2", a2),
+                        )
+                        if value is not None
+                    },
+                )
+                self.assertIs(adapter._candidate_v0_2_a1, a1)
+                self.assertIs(adapter._candidate_v0_2_a2, a2)
+
+        historical_runtime = codex_module.CodexRuntimeIdentity(
+            model=codex_module.CODEX_MODEL,
+            reasoning_effort=codex_module.CODEX_REASONING_EFFORT,
+            service_tier=codex_module.CODEX_SERVICE_TIER,
+            codex_cli_version=codex_module.CODEX_CLI_VERSION,
+            account_type="chatgpt",
+        )
+        ordinary_cases = (
+            ("no-provider", None, None),
+            (
+                "historical-a1",
+                FieldNoteCreatorLiveA1CaptureConfig(
+                    run_id="historical-a1",
+                    expected_runtime_identity=historical_runtime,
+                ),
+                None,
+            ),
+            ("historical-a2", None, reconnect_target(historical_runtime)),
+        )
+        for label, capture, target in ordinary_cases:
+            with self.subTest(label=label):
+                engine = AccelerationEngine(
+                    factory_repository,
+                    adapter=ADAPTER_NAME,
+                    adapter_version=CODEX_CLI_VERSION,
+                )
+                ordinary = _field_notes_adapter_factory(
+                    engine,
+                    lambda _approval: None,
+                    lambda _event: None,
+                    creator_live_a1_capture_provider=(
+                        (lambda value=capture: value)
+                        if capture is not None
+                        else None
+                    ),
+                    creator_live_a2_reconnect_provider=(
+                        (lambda value=target: value)
+                        if target is not None
+                        else None
+                    ),
+                )
+                with patch.object(
+                    adapter_module,
+                    "prepare_creator_live_a2_reconnect",
+                    return_value=SimpleNamespace(plan=None),
+                ), patch.object(
+                    candidate_v02,
+                    "read_post_a1_readback_v0_2",
+                    return_value=SimpleNamespace(),
+                ), patch.object(
+                    candidate_v02,
+                    "require_post_a1_gate_for_a2",
+                ):
+                    ordinary._reset_run()
+                self.assertEqual(
+                    ordinary.executable,
+                    codex_module.BUNDLED_CODEX_PATH,
+                )
+                self.assertEqual(
+                    ordinary.expected_cli_version,
+                    codex_module.CODEX_CLI_VERSION,
+                )
+                self.assertIs(
+                    ordinary.transport_factory,
+                    codex_module._SubprocessTransport,
+                )
+                self.assertEqual(
+                    engine.adapter_version,
+                    codex_module.CODEX_CLI_VERSION,
+                )
 
 
 class Cycle006OuterGateProofAccessTests(unittest.TestCase):
@@ -722,7 +1085,7 @@ class Cycle006OuterGateProofAccessTests(unittest.TestCase):
         )
 
     def test_cli_mismatch_returns_before_historical_proof_access(self) -> None:
-        entrypoint, activity = self._entrypoint(runtime_version="0.147.0-alpha.1.2")
+        entrypoint, activity = self._entrypoint(runtime_version="0.147.0-alpha.1.3")
         with (
             patch.object(cycle006, "EXPECTED_REPOSITORY", self.repository),
             patch.object(
@@ -948,7 +1311,7 @@ class Cycle006CandidateAdapterIsolationTests(unittest.IsolatedAsyncioTestCase):
             AccelerationEngine(
                 self.repository,
                 adapter=ADAPTER_NAME,
-                adapter_version=CODEX_CLI_VERSION,
+                adapter_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             ),
             input_func=lambda: self.fail("no public input permitted"),
             stdout=io.StringIO(),
@@ -956,6 +1319,7 @@ class Cycle006CandidateAdapterIsolationTests(unittest.IsolatedAsyncioTestCase):
                 "no public approval permitted"
             ),
             transport_factory=factory,
+            expected_cli_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             creator_live_a1_capture_provider=lambda: (
                 FieldNoteCreatorLiveA1CaptureConfig(
                     run_id=run_id,
@@ -1013,12 +1377,13 @@ class Cycle006CandidateAdapterIsolationTests(unittest.IsolatedAsyncioTestCase):
             AccelerationEngine(
                 self.repository,
                 adapter=ADAPTER_NAME,
-                adapter_version=CODEX_CLI_VERSION,
+                adapter_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             ),
             input_func=lambda: self.fail("no public input permitted"),
             stdout=io.StringIO(),
             approval_provider=lambda approval: approvals.append(approval) or "deny",
             transport_factory=factory,
+            expected_cli_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             creator_live_a2_reconnect_provider=lambda: target,
             candidate_v0_2_a2_provider=lambda: (
                 FieldNoteCreatorLiveCandidateV02A2Config(
@@ -2110,12 +2475,13 @@ class Cycle006CandidateAdapterIsolationTests(unittest.IsolatedAsyncioTestCase):
             AccelerationEngine(
                 self.repository,
                 adapter=ADAPTER_NAME,
-                adapter_version=CODEX_CLI_VERSION,
+                adapter_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             ),
             input_func=lambda: self.fail("no public input permitted"),
             stdout=io.StringIO(),
             approval_provider=lambda approval: approvals.append(approval) or "deny",
             transport_factory=factory,
+            expected_cli_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             creator_live_a2_reconnect_provider=lambda: target,
             candidate_v0_2_a2_provider=lambda: (
                 FieldNoteCreatorLiveCandidateV02A2Config(
@@ -2227,7 +2593,7 @@ class Cycle006CandidateAdapterIsolationTests(unittest.IsolatedAsyncioTestCase):
             AccelerationEngine(
                 self.repository,
                 adapter=ADAPTER_NAME,
-                adapter_version=CODEX_CLI_VERSION,
+                adapter_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             ),
             input_func=lambda: self.fail("no public input permitted"),
             stdout=io.StringIO(),
@@ -2235,6 +2601,7 @@ class Cycle006CandidateAdapterIsolationTests(unittest.IsolatedAsyncioTestCase):
                 "no public approval permitted"
             ),
             transport_factory=factory,
+            expected_cli_version=codex_module.CYCLE_006_CODEX_CLI_VERSION,
             creator_live_a2_reconnect_provider=lambda: target,
             candidate_v0_2_a2_provider=lambda: (
                 FieldNoteCreatorLiveCandidateV02A2Config(
@@ -2407,6 +2774,26 @@ class Cycle006ProtectedBindingTests(unittest.TestCase):
         self.assertIn(
             "project_document_injection",
             binding["runtime"]["disabled_capabilities"],
+        )
+        self.assertEqual(
+            binding["runtime_artifact"],
+            {
+                "configured_path": str(codex_module.CYCLE_006_CODEX_PATH),
+                "expected_path": str(codex_module.CYCLE_006_CODEX_PATH),
+                "binary_sha256": codex_module.CYCLE_006_CODEX_SHA256,
+                "recovery_receipt_path": str(
+                    codex_module.CYCLE_006_CODEX_RECOVERY_RECEIPT
+                ),
+                "version_stdout": (
+                    "codex-cli "
+                    f"{codex_module.CYCLE_006_CODEX_CLI_VERSION}\n"
+                ),
+                "regular_file_required": True,
+                "executable_required": True,
+                "symlink_permitted": False,
+                "path_fallback_permitted": False,
+                "chatgpt_app_fallback_permitted": False,
+            },
         )
         self.assertEqual(binding["comparison"]["result_before_execution"], "NOT_ESTABLISHED")
         self.assertFalse(binding["comparison"]["lane_b_human_ai_manual"]["candidate_visible"])
@@ -3359,30 +3746,20 @@ class Cycle006ExactFinalP0Tests(unittest.TestCase):
             )
             state = controller.select_repository(repository)
             snapshot = state["creator_live_cycle_006"]
-        observed_cli = cycle006._bundled_codex_cli_version(
-            cycle006.BUNDLED_CODEX_PATH
+        observed_cli = cycle006._cycle_006_codex_cli_version(
+            cycle006.CYCLE_006_CODEX_PATH
         )
         exact_cli = cycle006.EXPECTED_CODEX_RUNTIME.codex_cli_version
-        if observed_cli == exact_cli:
-            self.assertEqual(
-                (snapshot["state"], snapshot["stage"]),
-                ("NOT_READY", "P0"),
-            )
-            self.assertFalse(snapshot["p0"]["ready"])
-            self.assertEqual(
-                snapshot["p0"]["failure_code"],
-                "LIVE_START_AUTHORIZATION_ABSENT",
-            )
-        else:
-            self.assertEqual(
-                (snapshot["state"], snapshot["stage"]),
-                ("NOT_READY", "P0"),
-            )
-            self.assertFalse(snapshot["p0"]["ready"])
-            self.assertEqual(
-                snapshot["p0"]["failure_code"],
-                "P0_CODEX_CLI_VERSION_MISMATCH",
-            )
+        self.assertEqual(observed_cli, exact_cli)
+        self.assertEqual(
+            (snapshot["state"], snapshot["stage"]),
+            ("NOT_READY", "P0"),
+        )
+        self.assertFalse(snapshot["p0"]["ready"])
+        self.assertEqual(
+            snapshot["p0"]["failure_code"],
+            "LIVE_START_AUTHORIZATION_ABSENT",
+        )
         self.assertIsNone(snapshot["binding"])
         self.assertIsNone(snapshot["launch_binding_sha256"])
         self.assertEqual(snapshot["live_start_authorization"], "ABSENT")

--- a/validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_1.md
+++ b/validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_1.md
@@ -1,0 +1,246 @@
+# V13 Creator-Live Cycle 006 Forward-Only Runtime Migration Charter Delta v1.1
+
+Status: `AUTHORIZED — bounded Forward-only implementation and Draft PR only`
+
+Current Gate: `HOLD / RUNTIME MIGRATION NOT YET QUALIFIED`
+
+## Purpose and Current Authority
+
+This Delta is the explicit current authority for the smallest Cycle
+006-specific Forward-only runtime migration. It authorizes only:
+
+- binding Cycle 006 to the fixed preserved Codex artifact named below;
+- adding fail-closed verification before proof opening and task transmission;
+- focused fake/fixture tests and non-live static qualification; and
+- one Draft PR for review.
+
+It does not authorize merge, Companion build or install, Contract refix,
+fresh-process production qualification, exact P0, proof opening, live start,
+model invocation, task transmission, Candidate execution, retry, replacement,
+publication, release, or external claims.
+
+This Delta is additive after
+`validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_0.md`, SHA-256
+`9e05844eaed474ee9197245986d1a2fb5a877cbef5e0baa6f53e26952932cd3f`.
+Every earlier Creator-Live Charter and Delta remains historical and
+byte-immutable.
+
+Field Note 129 is advisory origin evidence only. Its lifecycle remains
+`Verification pending` and its Canon promotion remains `HOLD`. It did not
+authorize this migration or this Charter change. The bounded 13-91
+responsibility transfer and this Delta supply the present implementation
+authority.
+
+## Historical Runtime As-of Remains Valid
+
+PR #36 recorded completed creator-owned live evidence under the runtime
+observed at that time:
+
+```text
+Observed path:
+/Applications/ChatGPT.app/Contents/Resources/codex
+
+Observed runtime:
+codex-cli 0.146.0-alpha.3.1
+
+Observed execution identity:
+gpt-5.6-sol / ultra / priority / codex-cli 0.146.0-alpha.3.1
+```
+
+The validation record was introduced by
+`9a441bce42abcec1f6385ce9bbe36dfb818d398e` and merged by PR #36 at
+`e6e2ba7a1be8612eb781c565c7c2bb9d012b129d`.
+
+That evidence remains valid under its original As-of because it records the
+runtime identity observed for those completed Runs. A later change at the same
+application path does not retroactively change, invalidate, replace, or
+reinterpret the earlier observation. This Delta does not assert that all
+historical Codex activity used the new artifact.
+
+## Why the Historical Artifact Cannot Be Recovered
+
+The exact `0.146.0-alpha.3.1` executable is not locally or canonically
+recoverable as an artifact. The mutable ChatGPT application path later
+reported `0.147.0-alpha.1.2`, and a bounded read-only search found no locally
+recoverable executable reporting the earlier version.
+
+No preserved old binary, binary SHA-256, content-addressed custody object,
+authoritative package or archive, or exact recovery route was established.
+The historical bytes and SHA-256 therefore remain `UNKNOWN`. This is not a
+claim about a particular destructive cause or updater. It is a bounded custody
+finding: the observation survived as evidence, while the executable did not
+survive as a rerunnable fixed object.
+
+The unavailable historical artifact must not be reconstructed, substituted,
+or treated as a PATH-resolved future prerequisite.
+
+## New Forward-Only Runtime As-of
+
+The new Cycle 006 runtime identity is fixed Forward-only as follows:
+
+| Field | Exact value |
+| --- | --- |
+| Migration As-of | `2026-08-07` |
+| Artifact custody recorded at | `2026-08-06T15:38:01Z` |
+| Codex CLI | `0.147.0-alpha.1.2` |
+| Binary SHA-256 | `9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481` |
+| Size | `275653216` bytes |
+| Mode | `0755` |
+| File type | regular executable |
+| Symlink | `false` |
+
+Preserved executable:
+
+```text
+/Users/sn/Library/Application Support/Decision OS Companion/runtime-artifacts/codex/9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481/codex
+```
+
+Recovery receipt:
+
+```text
+/Users/sn/Library/Application Support/Decision OS Companion/runtime-artifacts/codex/9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481/recovery-receipt.json
+```
+
+The receipt records custody only and did not itself authorize migration, P0,
+a model invocation, task transmission, or proof creation. This Delta supplies
+the current bounded migration authority.
+
+The preserved content-addressed path is the sole Cycle 006 execution identity.
+The mutable ChatGPT application path and PATH lookup are not Cycle 006
+identities or fallbacks.
+
+## Fixed Compatibility Assessment
+
+Assessment verdict:
+
+```text
+PASS — FORWARD-ONLY MIGRATION QUALIFIABLE
+```
+
+The fixed no-turn assessment established protocol-level compatibility for:
+
+- app-server startup and initialize;
+- ChatGPT authentication;
+- `gpt-5.6-sol` / `ultra` / `priority`;
+- `thread/start` schema;
+- experimental dynamic typed tools;
+- read-only sandbox with model network `false`;
+- `on-request` / user approval boundaries;
+- fresh ephemeral threads;
+- project-document isolation;
+- runtime identity projection;
+- unsupported-request fail-closed behavior; and
+- schema-level terminal lifecycle handling.
+
+No model turn, Candidate task, proof attempt, approval request, or file
+mutation occurred during the assessment. The result is bounded to the fixed
+Cycle 006 protocol surface; it does not establish broad runtime architecture,
+live behavior, exact P0, or Cycle 006 execution.
+
+## Fail-Closed Runtime Binding
+
+Before any future model transmission, the production Cycle 006 route must
+verify in this order:
+
+1. the configured path equals the exact preserved path;
+2. the path exists;
+3. the artifact is a regular executable file;
+4. the artifact is not a symlink;
+5. the full binary SHA-256 equals the fixed SHA-256;
+6. `<preserved-path> --version` exits `0`;
+7. stdout is exactly `codex-cli 0.147.0-alpha.1.2` plus its final LF;
+8. the adapter launches that exact absolute preserved executable;
+9. no PATH fallback is available;
+10. no ChatGPT application-path fallback is available; and
+11. substitution fails before proof opening or task transmission.
+
+Verification is repeated immediately before the adapter launches the
+preserved executable so drift after proof opening still fails before task or
+model transmission. The adapter may not discover or select another runtime.
+
+## Protected Semantics Remain Unchanged
+
+This migration changes no Candidate or proof meaning:
+
+- Candidate v0.1 remains byte-immutable and historical;
+- Candidate v0.2 identity, source, task pair, tools, Gates, and behavior suite
+  remain unchanged;
+- A1–A7, generated Witness, and A3 overlay semantics remain unchanged;
+- proof schemas and proof identity derivation remain unchanged;
+- Cycle 005 terminal evidence remains unchanged;
+- the Ordinary User Path Contract and authority meanings remain unchanged;
+- the P0 Gate order remains unchanged apart from the fixed runtime artifact
+  prerequisite; and
+- publication remains unauthorized.
+
+Cycle 006 still permits exactly one future attempt, zero retries, zero
+replacements, no resume after interruption, no alternate proof identity, and
+no alternate proof root.
+
+## Current Protected State
+
+```text
+Cycle 006: UNSTARTED
+model invocation: 0
+task transmission: 0
+retry / replacement: 0 / 0
+proof root: ABSENT
+exact P0: NOT_RUN
+live-start authority: ABSENT
+artifact behavior: NOT_RUN
+comparison result: NOT_ESTABLISHED
+```
+
+Compatibility `PASS` does not promote this state to live `GO`. The
+live-start decision remains a separate Human Seat authority held by Shin.
+
+## Rollback Boundary
+
+Before merge, abandon the unmerged implementation. After a later merge but
+before proof opening, use a normal Forward revert, rebuild and install the
+exact revert, refix the unchanged Contract, and re-establish source/installed
+equality and process qualification under separate authority.
+
+Preserve the new custody artifact and receipt as historical evidence. Preserve
+all Charter, Candidate, Cycle 005, and proof history. Never delete or rewrite
+Cycle 006 proof storage.
+
+Because the historical executable is unavailable, rollback returns Cycle 006
+to safe `HOLD / NOT_READY`. It does not recreate a runnable
+`0.146.0-alpha.3.1` artifact and does not permit PATH, ChatGPT application-path,
+or version downgrade fallback.
+
+If a future proof has opened, this rollback authority no longer applies to the
+attempt. The attempt and its storage must remain preserved under the
+one-attempt rule.
+
+## Re-evaluation and Stop Conditions
+
+Re-evaluate before any execution if any of these change or become uncertain:
+
+- configured or preserved path;
+- existence, regular-file type, executable mode, or symlink state;
+- full binary SHA-256;
+- version-probe exit status or exact stdout;
+- recovery-receipt custody;
+- app-server protocol or schema;
+- ChatGPT authentication or model entitlement;
+- fixed compatibility findings;
+- Charter lineage; or
+- any Candidate, A1–A7, Witness, proof, one-attempt, or authority invariant.
+
+Return `HOLD` or `BLOCK` on drift or contradiction. Any later runtime version
+or artifact requires another additive Forward-only Delta; do not edit this
+Delta in place.
+
+## Completion and Stop Boundary
+
+This bounded migration is complete only when the minimum implementation,
+v1.1 Delta, fail-closed tests, one full default discovery pass, static checks,
+and one Draft PR are present.
+
+Stop at Draft PR review with exact P0 `NOT_RUN`, Cycle 006 `UNSTARTED`, model
+invocation and task transmission `0`, retry/replacement `0 / 0`, and proof root
+`ABSENT`.
+
+Next actor: `13-34 receiving AI`.


### PR DESCRIPTION
## 13-91 — Cycle 006 Forward-Only runtime migration

### Canonical base and scope

- Base: `1ff82c796541e879deb3374f718d02b82a10fdb3`
- Head: `9f340a30d8caa53bdd71f5931c9788b98ac7000b`
- Branch: `codex/13-91-cycle-006-forward-runtime-migration`
- Changed only the three required production files, two directly corresponding test files, and Charter Delta v1.1.

### Migration

- Keeps the historical/default ChatGPT.app runtime unchanged at `0.146.0-alpha.3.1`.
- Selects the preserved runtime only for Candidate v0.2 Cycle 006.
- Fixed Cycle 006 identity:
  - Version: `codex-cli 0.147.0-alpha.1.2`
  - SHA-256: `9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481`
  - Path: `/Users/sn/Library/Application Support/Decision OS Companion/runtime-artifacts/codex/9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481/codex`
  - Receipt: sibling `recovery-receipt.json`
- Enforces fixed path, ancestor/final symlink rejection, exact `0755` regular-file mode, bounded size/full SHA, exit-zero and byte-exact version output, no PATH fallback, no ChatGPT.app fallback, and strict verification around launch.
- Snapshots paired Candidate/capture providers once and aligns Cycle 006 engine event stamping without changing ordinary/Cycle 005 defaults.
- Routine status polling reuses stat-keyed evidence; the pre-proof check always forces a fresh verification.

### Charter

- Added `validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_1.md`
- SHA-256: `dade3a6994e0814ae50cba7b412726e9d4a65f94c5c214b1d62bc32c3a89203d`
- Preserves historical As-of evidence, Candidate/proof semantics, one-attempt and 0/0 retry/replacement rules, exact-P0 NOT_RUN, live authority absent, and the Forward-only rollback boundary.

### Validation

- Focused: 120 tests passed; 4 intentionally gated skips.
- Related Field Notes regressions: 149 tests passed; 1 intentional skip.
- Full discovery (run once, both Cycle 006 opt-ins explicitly unset): 1,395 tests passed; 7 intentional skips.
- Static: Python compile, `node --check`, 55 tracked JSON parses, Charter SHA, and `git diff --check` passed.
- No build/install, exact P0, Cycle 006 start, model invocation, task transmission, or production proof opening occurred.
- Canonical Cycle 006 proof root remains absent.

### Rollback and review boundary

Forward-only rollback is code/config reversal to HOLD; there is no fallback to the unrecoverable historical artifact.

Residual for receiving-AI review: on macOS, path-based `execve` cannot atomically bind the previously hashed file descriptor. Pre/post verification detects persistent drift and terminates before protocol use, but a malicious same-UID swap/execute/restore race is not eliminated without a larger suspended-spawn/process-vnode attestation design or stronger custody authority. This Draft remains at HOLD pending review; it is not authorization to run exact P0 or start Cycle 006.

Next actor: 13-34 receiving AI.