### PR TITLE
Materialize Cycle 006 human authorization

### DIFF
--- a/decision_os/companion/field_notes_creator_live_cycle_006.py
+++ b/decision_os/companion/field_notes_creator_live_cycle_006.py
@@ -123,7 +123,7 @@ from decision_os.companion.guided_intake import (
 CYCLE_NUMBER = "006"
 CYCLE_KEY = "cycle-006"
 IMPLEMENTATION_AUTHORIZATION_OBSERVED_AT = "2026-08-06T00:50:00Z"
-LIVE_START_AUTHORIZATION_OBSERVED_AT: None = None
+LIVE_START_AUTHORIZATION_OBSERVED_AT = "2026-08-06T21:10:00Z"
 
 EXPECTED_REPOSITORY = Path("/Users/sn/Documents/v13/decision-os-v13-loopkit")
 EXPECTED_REMOTE = "https://github.com/shin4141/decision-os-v13-loopkit.git"

--- a/tests/test_field_notes_creator_live_cycle_006.py
+++ b/tests/test_field_notes_creator_live_cycle_006.py
@@ -250,7 +250,9 @@ def _canonical_ordinary_contract_snapshot(
     }
 
 
-def _full_fixture_binding() -> dict[str, object]:
+def _full_fixture_binding(
+    live_start_authorization_observed_at: str | None = None,
+) -> dict[str, object]:
     return {
         "schema": "decision-os.creator-live-cycle-006-launch-binding.v0.1",
         "cycle": {
@@ -258,7 +260,14 @@ def _full_fixture_binding() -> dict[str, object]:
             "cycle_key": "cycle-006",
             "candidate_id": "CREATOR_LIVE_AGENTS_BEFORE_AFTER_V0_2",
             "implementation_authorization_observed_at": "2026-08-06T00:50:00Z",
-            "live_start_authorization": "ABSENT",
+            "live_start_authorization": (
+                "PRESENT"
+                if live_start_authorization_observed_at is not None
+                else "ABSENT"
+            ),
+            "live_start_authorization_observed_at": (
+                live_start_authorization_observed_at
+            ),
         },
         "attempt_policy": {
             "attempt_count": 1,
@@ -372,7 +381,9 @@ class _ReadyEntrypoint(CreatorLiveCycle006Entrypoint):
         return CreatorLiveCycle006P0Result(
             True,
             None,
-            _full_fixture_binding(),
+            _full_fixture_binding(
+                self.spec.live_start_authorization_observed_at
+            ),
             _DIGEST,
         )
 
@@ -385,7 +396,10 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.repository = Path(self.temporary.name) / "repository"
         self.repository.mkdir()
-        self.spec = CreatorLiveCycle006Spec(repository=self.repository)
+        self.spec = CreatorLiveCycle006Spec(
+            repository=self.repository,
+            live_start_authorization_observed_at=None,
+        )
         self.entrypoint = _ReadyEntrypoint(
             _Controller(self.repository),
             spec=self.spec,
@@ -455,6 +469,7 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
 
     def test_snapshot_is_ready_but_start_disabled_and_private_values_redacted(self) -> None:
         snapshot = self.entrypoint.snapshot(_Controller(self.repository).snapshot())
+        self.assertIsNone(self.spec.live_start_authorization_observed_at)
         self.assertEqual((snapshot["state"], snapshot["stage"]), ("READY", "P0"))
         self.assertTrue(snapshot["p0"]["ready"])
         self.assertEqual(snapshot["live_start_authorization"], "ABSENT")
@@ -477,6 +492,58 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
             str(codex_module.CYCLE_006_CODEX_RECOVERY_RECEIPT),
         ):
             self.assertNotIn(private, encoded)
+
+    def test_default_authorization_is_ready_without_consuming_attempt(self) -> None:
+        activity: list[str] = []
+
+        def runtime_opener(*_args: object, **_kwargs: object) -> object:
+            activity.append("proof")
+            raise AssertionError("readiness must not open proof")
+
+        def worker_factory(*_args: object, **_kwargs: object) -> object:
+            activity.append("worker")
+            raise AssertionError("readiness must not allocate a worker")
+
+        spec = CreatorLiveCycle006Spec(repository=self.repository)
+        entrypoint = _ReadyEntrypoint(
+            _Controller(self.repository),
+            spec=spec,
+            runtime_opener=runtime_opener,
+            worker_factory=worker_factory,
+        )
+
+        with patch.object(
+            entrypoint,
+            "_load_fixed_task",
+            side_effect=AssertionError("readiness must not load a fixed task"),
+        ):
+            snapshot = entrypoint.snapshot(_Controller(self.repository).snapshot())
+
+        self.assertEqual(
+            cycle006.LIVE_START_AUTHORIZATION_OBSERVED_AT,
+            "2026-08-06T21:10:00Z",
+        )
+        self.assertEqual(
+            spec.live_start_authorization_observed_at,
+            "2026-08-06T21:10:00Z",
+        )
+        self.assertEqual(
+            snapshot["binding"]["cycle"][
+                "live_start_authorization_observed_at"
+            ],
+            "2026-08-06T21:10:00Z",
+        )
+        self.assertEqual(snapshot["live_start_authorization"], "PRESENT")
+        self.assertTrue(snapshot["start_allowed"])
+        self.assertTrue(snapshot["one_attempt"])
+        self.assertEqual(snapshot["retry_count"], 0)
+        self.assertEqual(snapshot["replacement_count"], 0)
+        self.assertFalse(snapshot["storage_occupied"])
+        self.assertIsNone(snapshot["proof_identity"])
+        self.assertEqual(snapshot["model_invocation_count"], 0)
+        self.assertEqual(snapshot["task_transmission_count"], 0)
+        self.assertEqual(activity, [])
+        self.assertFalse(os.path.lexists(spec.storage_root))
 
     def test_stale_then_matching_start_fail_before_storage_or_activity(self) -> None:
         with self.assertRaisesRegex(
@@ -2705,7 +2772,6 @@ class Cycle006ProtectedBindingTests(unittest.TestCase):
             spec=CreatorLiveCycle006Spec(
                 repository=ROOT,
                 runtime_root=ROOT,
-                live_start_authorization_observed_at="2026-08-06T02:00:00Z",
             ),
             runtime_version_probe=lambda _path: (
                 cycle006.EXPECTED_CODEX_RUNTIME.codex_cli_version
@@ -2755,6 +2821,12 @@ class Cycle006ProtectedBindingTests(unittest.TestCase):
         self.assertRegex(first.launch_binding_sha256 or "", r"^[0-9a-f]{64}$")
         binding = first.binding or {}
         self.assertEqual(binding["cycle"]["live_start_authorization"], "PRESENT")
+        self.assertEqual(
+            binding["cycle"]["live_start_authorization_observed_at"],
+            "2026-08-06T21:10:00Z",
+        )
+        self.assertEqual(binding["attempt_policy"]["attempt_count"], 1)
+        self.assertTrue(binding["attempt_policy"]["one_attempt"])
         self.assertEqual(binding["attempt_policy"]["retry_count"], 0)
         self.assertEqual(binding["attempt_policy"]["replacement_count"], 0)
         self.assertEqual(
@@ -3753,17 +3825,22 @@ class Cycle006ExactFinalP0Tests(unittest.TestCase):
         self.assertEqual(observed_cli, exact_cli)
         self.assertEqual(
             (snapshot["state"], snapshot["stage"]),
-            ("NOT_READY", "P0"),
+            ("READY", "P0"),
         )
-        self.assertFalse(snapshot["p0"]["ready"])
+        self.assertTrue(snapshot["p0"]["ready"])
+        self.assertIsNone(snapshot["p0"]["failure_code"])
         self.assertEqual(
-            snapshot["p0"]["failure_code"],
-            "LIVE_START_AUTHORIZATION_ABSENT",
+            snapshot["binding"]["cycle"][
+                "live_start_authorization_observed_at"
+            ],
+            "2026-08-06T21:10:00Z",
         )
-        self.assertIsNone(snapshot["binding"])
-        self.assertIsNone(snapshot["launch_binding_sha256"])
-        self.assertEqual(snapshot["live_start_authorization"], "ABSENT")
-        self.assertFalse(snapshot["start_allowed"])
+        self.assertRegex(snapshot["launch_binding_sha256"], r"^[0-9a-f]{64}$")
+        self.assertEqual(snapshot["live_start_authorization"], "PRESENT")
+        self.assertTrue(snapshot["start_allowed"])
+        self.assertTrue(snapshot["one_attempt"])
+        self.assertEqual(snapshot["retry_count"], 0)
+        self.assertEqual(snapshot["replacement_count"], 0)
         self.assertFalse(snapshot["storage_occupied"])
         self.assertIsNone(snapshot["proof_identity"])
         self.assertEqual(snapshot["model_invocation_count"], 0)

--- a/validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_2.md
+++ b/validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_2.md
@@ -1,0 +1,81 @@
+# V13 Creator-Live Cycle 006 Human Authorization Materialization Charter Delta v1.2
+
+Status: `AUTHORIZED — existing Cycle 006 live-start authority materialization and Draft PR only`
+
+Current Gate: `HOLD / PRE-OPEN AUTHORITY MATERIALIZATION`
+
+## Exact Authority and Scope
+
+Shin explicitly authorized:
+
+```text
+Cycle 006開始承認
+```
+
+The authorization was observed at exactly:
+
+```text
+2026-08-06T21:10:00Z
+2026-08-07T06:10:00+09:00
+```
+
+This authority applies only to the already-fixed Cycle 006. It authorizes only
+fixing the existing production `LIVE_START_AUTHORIZATION_OBSERVED_AT` value to
+`2026-08-06T21:10:00Z`, adding the minimum corresponding tests, and opening one
+Draft PR.
+
+This Delta is additive after
+`validation/a7_creator_live_whole_flow_reentry_charter_delta_v1_1.md`, SHA-256
+`dade3a6994e0814ae50cba7b412726e9d4a65f94c5c214b1d62bc32c3a89203d`.
+Every earlier Creator-Live Charter and Delta remains historical and
+byte-immutable.
+
+This materialization is not a generic authorization mechanism. It creates no
+CLI, environment, UI, HTTP, server, or API authority ingress.
+
+## Attempt Boundary Remains Unchanged
+
+Authority materialization and readiness evaluation are not an attempt. They
+create no proof root, proof identity, model invocation, task transmission, or
+A1–A7 activity.
+
+Proof opening remains the sole one-attempt boundary. Until proof opening, the
+one Cycle 006 attempt remains unconsumed. Cycle 006 continues to permit exactly
+one attempt, zero retries, zero replacements, no resume after interruption, no
+alternate proof identity, and no alternate proof root.
+
+## Protected Surfaces Remain Unchanged
+
+This Delta changes no:
+
+- Candidate v0.1 or Candidate v0.2;
+- prompt or fixed task;
+- A1–A7 behavior or semantics;
+- proof schema, proof identity derivation, or proof storage boundary;
+- runtime artifact binding;
+- Ordinary User Path Contract or Contract semantics;
+- server, API, UI, or public surface; or
+- release or publication authority.
+
+## Required Stop State
+
+Stop at one Draft PR with:
+
+```text
+Cycle 006: PRE-OPEN / UNCONSUMED
+live-start authorization: PRESENT
+authorization observed at: 2026-08-06T21:10:00Z
+proof root: ABSENT
+proof identity: none
+model invocation: 0
+task transmission: 0
+retry / replacement: 0 / 0
+A1–A7: NOT_RUN
+artifact behavior: NOT_RUN
+comparison result: NOT_ESTABLISHED
+publication: unauthorized
+```
+
+Do not merge, build, install, open proof, start Cycle 006, invoke the model, or
+transmit either fixed task under this implementation task. The next actor is
+`13-34 receiving AI`.


### PR DESCRIPTION
## Summary

- Source-fix the existing Cycle 006-only `LIVE_START_AUTHORIZATION_OBSERVED_AT` value to `2026-08-06T21:10:00Z`.
- Preserve the absent-authority path through explicitly constructed specs with `None`.
- Prove production-default readiness projects `PRESENT` without opening proof, allocating a worker, loading a fixed task, or changing the 1 / 0 / 0 attempt policy.
- Add Charter Delta v1.2 to preserve Shin authority provenance and the Cycle-006-only boundary.

## Root cause

The production `CreatorLiveCycle006Spec` inherited `LIVE_START_AUTHORIZATION_OBSERVED_AT = None`, while no supported production authority ingress exists. This PR materializes the already-issued Cycle 006 authorization in the existing fixed source constant; it adds no generic ingress or architecture.

## Validation

- `python3 -B -m unittest -q tests.test_field_notes_creator_live_cycle_006` — 53 tests passed, 4 declared skips
- `python3 -m py_compile decision_os/companion/field_notes_creator_live_cycle_006.py tests/test_field_notes_creator_live_cycle_006.py`
- `git diff --check 87088f169385141aefff51157716e2b4525a07b9..HEAD`
- Independent scoped diff and test reviews — no findings

## Stop boundary

No Candidate, prompt, A1–A7, proof schema, runtime artifact binding, Contract, server, API, UI, `__main__.py`, or README/public-surface change. No build/install, proof opening, Cycle start, model invocation, or task transmission was performed. The Cycle 006 proof root remains absent; model/task counts remain 0/0; retry/replacement remain 0/0; the one attempt remains unconsumed.

Next actor: `13-34 receiving AI`.