### PR TITLE
13-95: Repair terminal Creator-Live run projection

### DIFF
--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -2036,6 +2036,15 @@ class FieldNotesCompanionController(CompanionController):
         }:
             return snapshot
         state = cycle.get("state")
+        if state in {
+            "FAILED",
+            "TRACE_COMPLETE",
+            "PASS",
+            "OPEN_UNRESUMABLE",
+            "INTEGRITY_FAILURE",
+        }:
+            snapshot["run"] = CompanionController._empty_run()
+            return snapshot
         public_state = (
             "running"
             if state == "RUNNING"

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -3358,11 +3358,33 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                   },
                 },
               };
+              const terminalCycle005 = {
+                cycle_key: "cycle-005",
+                state: "FAILED",
+                stage: "A3",
+                failure_code: "SYNTHETIC_TERMINAL_EVIDENCE",
+                storage_occupied: true,
+                start_allowed: false,
+                p0: {
+                  ready: true,
+                  failure_code: null,
+                },
+                launch_binding_sha256: "5".repeat(64),
+                identities: {
+                  proof_attempt_id: "cycle-005-attempt-001",
+                  terminal_stage: "A3",
+                  failure_code: "SYNTHETIC_TERMINAL_EVIDENCE",
+                  journal_sha256: "6".repeat(64),
+                  anchor_sha256: "7".repeat(64),
+                  readback_sha256: "8".repeat(64),
+                },
+              };
               function state(run, ordinaryContract = interpretationOnly) {
                 return {
                   csrf: "browser-csrf",
                   repository: { name: "repo", path: "/tmp/repo" },
                   run,
+                  creator_live_cycle_005: terminalCycle005,
                   ordinary_contract: ordinaryContract,
                   guided_intake: null,
                   manual_bridge: {
@@ -3665,6 +3687,24 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                     advancedContractContent.inert &&
                     !advanced.open &&
                     document.getElementById("advanced-audit-content").inert
+                  );
+                  const boundedTaskCard = document.getElementById(
+                    "bounded-task-card",
+                  );
+                  document.body.dataset.creatorTerminalOrdinaryEntry = String(
+                    !boundedTaskCard.hidden &&
+                    task.disabled === false &&
+                    !document.getElementById("run").disabled &&
+                    document.getElementById("creator-live-cycle-005-status").textContent ===
+                      "FAILED" &&
+                    document.getElementById("creator-live-failure-code").textContent ===
+                      "SYNTHETIC_TERMINAL_EVIDENCE" &&
+                    document.getElementById("creator-live-start").hidden &&
+                    !document.getElementById("creator-live-terminal-label").hidden &&
+                    !advancedResearch.open &&
+                    advancedResearchContent.inert &&
+                    !advancedContract.open &&
+                    advancedContractContent.inert
                   );
                   document.getElementById("run").click();
                   document.body.dataset.startImmediate = String(
@@ -3969,6 +4009,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             "context-ready",
             "context-switch-blocked",
             "ordinary-entry-ready",
+            "creator-terminal-ordinary-entry",
             "ordinary-run-request",
             "no-contract-guided-route",
             "working",

--- a/tests/test_field_notes_creator_live_entrypoint.py
+++ b/tests/test_field_notes_creator_live_entrypoint.py
@@ -955,7 +955,97 @@ class CreatorLiveHTTPTests(unittest.TestCase):
         self.assertNotIn("PRIVATE MODEL OUTPUT", encoded)
         self.assertNotIn("PRIVATE NOTE", encoded)
         self.assertNotIn("PRIVATE", encoded)
+        self.assertEqual("creator_live_cycle_005", projected["run"]["run_type"])
+        self.assertEqual("running", projected["run"]["state"])
         self.assertEqual(["A2"], projected["run"]["progress"])
+        self.assertEqual("", projected["run"]["result"])
+        self.assertEqual([], projected["run"]["file_actions"])
+        self.assertEqual([], projected["run"]["read_evidence"])
+        self.assertIsNone(projected["run"]["runtime"])
+        self.assertIsNone(projected["run"]["approval"])
+
+    def test_terminal_projection_preserves_evidence_and_restores_safe_idle(
+        self,
+    ) -> None:
+        for terminal_state in (
+            "FAILED",
+            "TRACE_COMPLETE",
+            "PASS",
+            "OPEN_UNRESUMABLE",
+            "INTEGRITY_FAILURE",
+        ):
+            with self.subTest(terminal_state=terminal_state):
+                cycle = {
+                    "cycle_key": "cycle-005",
+                    "state": terminal_state,
+                    "stage": "A3",
+                    "failure_code": "HISTORICAL_FAILURE",
+                    "identities": {
+                        "proof_attempt_id": "cycle-005-attempt-001",
+                        "journal_sha256": "1" * 64,
+                        "anchor_sha256": "2" * 64,
+                    },
+                }
+                cycle_before = json.loads(json.dumps(cycle, sort_keys=True))
+                snapshot = {
+                    "creator_live_cycle_005": cycle,
+                    "run": {
+                        "run_type": "bounded_task",
+                        "state": "completed",
+                        "task": RUN_2_TASK,
+                        "result": "PRIVATE MODEL OUTPUT",
+                        "field_note": {"markdown": "PRIVATE NOTE"},
+                        "runtime": {"model": "PRIVATE MODEL"},
+                        "approval": {"hidden": "PRIVATE APPROVAL"},
+                    },
+                }
+
+                projected = self.controller.creator_live_cycle_005_public_projection(
+                    snapshot
+                )
+
+                self.assertEqual(cycle_before, projected["creator_live_cycle_005"])
+                self.assertEqual(
+                    {
+                        "run_type": "bounded_task",
+                        "task_mode": None,
+                        "state": "idle",
+                        "progress": [],
+                        "result": "",
+                        "file_actions": [],
+                        "read_evidence": [],
+                        "outcomes": {
+                            "execution": {
+                                "state": "not_started",
+                                "label": "Not started",
+                            },
+                            "file_change": {
+                                "state": "none",
+                                "label": "No file was modified",
+                            },
+                            "verification": {
+                                "state": "not_started",
+                                "label": "Not started",
+                                "reason": None,
+                            },
+                        },
+                        "runtime": None,
+                        "receipt_delta": None,
+                        "approval": None,
+                        "error": None,
+                        "failure": None,
+                    },
+                    projected["run"],
+                )
+                encoded_run = json.dumps(projected["run"], sort_keys=True)
+                for private in (
+                    RUN_2_TASK,
+                    "PRIVATE MODEL OUTPUT",
+                    "PRIVATE NOTE",
+                    "PRIVATE MODEL",
+                    "PRIVATE APPROVAL",
+                ):
+                    self.assertNotIn(private, encoded_run)
 
     def test_terminal_http_state_is_allowlisted_and_duplicate_start_is_409(
         self,
@@ -971,11 +1061,21 @@ class CreatorLiveHTTPTests(unittest.TestCase):
             content_type=None,
         )
         self.assertEqual(200, status)
-        cycle = json.loads(raw)["creator_live_cycle_005"]
+        state = json.loads(raw)
+        cycle = state["creator_live_cycle_005"]
+        run = state["run"]
         encoded = json.dumps(cycle, sort_keys=True)
         self.assertEqual("FAILED", cycle["state"])
         self.assertIsNone(cycle["binding"])
         self.assertFalse(cycle["start_allowed"])
+        self.assertEqual("bounded_task", run["run_type"])
+        self.assertEqual("idle", run["state"])
+        self.assertIsNone(run["task_mode"])
+        self.assertEqual("", run["result"])
+        self.assertEqual([], run["file_actions"])
+        self.assertEqual([], run["read_evidence"])
+        self.assertIsNone(run["runtime"])
+        self.assertIsNone(run["approval"])
         for private in (
             RUN_1_TASK,
             RUN_2_TASK,
@@ -986,6 +1086,20 @@ class CreatorLiveHTTPTests(unittest.TestCase):
             "/Users/sn/Documents/v13/decision-os-v13-loopkit",
         ):
             self.assertNotIn(private, encoded)
+        terminal_evidence = json.loads(json.dumps(cycle, sort_keys=True))
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/new-run",
+            payload=b"{}",
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status)
+        refreshed = json.loads(raw)
+        self.assertEqual(terminal_evidence, refreshed["creator_live_cycle_005"])
+        self.assertEqual("bounded_task", refreshed["run"]["run_type"])
+        self.assertEqual("idle", refreshed["run"]["state"])
         status, _headers, body = self.request(
             "POST",
             "/api/creator-live/cycles/005/start",


### PR DESCRIPTION
## Summary

- preserve the content-free Creator-Live run projection while Cycle 005 is active
- replace the public run with a fresh canonical bounded-task idle projection once Cycle 005 is terminal
- preserve the dedicated terminal Cycle 005 evidence projection without exposing the underlying private coordinator run
- leave Cycle 006 unchanged because it has no equivalent ordinary-run projection

## Root cause

`creator_live_cycle_005_public_projection()` replaced `snapshot["run"]` for every Cycle 005 state other than READY / NOT_READY / UNAVAILABLE. Canonical terminal evidence therefore continued to project `run_type = "creator_live_cycle_005"`, which correctly caused the client to hide and disable the bounded Task surface.

## Behavior after repair

- RUNNING or an unrecognized non-terminal state: existing fail-closed, content-free Creator-Live run projection
- FAILED / TRACE_COMPLETE / PASS / OPEN_UNRESUMABLE / INTEGRITY_FAILURE: dedicated Cycle 005 evidence remains unchanged; ordinary `run` is overwritten with a new canonical `bounded_task` / `idle` projection

## Privacy and scope

The terminal path constructs a fresh bounded-idle allowlisted object. It never returns or copies the underlying coordinator task, result, model/runtime, approval, file actions, or read evidence.

Changed files are limited to the projection and focused regressions. README, Candidate, A1–A7, Cycle 005/006 proof/evidence storage, journals/anchors, and publication material are unchanged.

## Tests

- `python3 -B -m unittest -v tests.test_field_notes_creator_live_entrypoint` — 24 passed
- `python3 -B -m unittest -v tests.test_companion_server` — 36 passed
- controller / ordinary-path / compiler / process qualification suites — 76 passed, 2 environment-gated skips
- acceleration / Cycle 006 suites — 131 passed, 4 environment-gated skips
- `node --check decision_os/companion/static/app.js`
- `git diff --check`

The browser qualification uses a mocked Run endpoint; Shin's real README task was not executed.