### PR TITLE
Repair ordinary real-run closure

### DIFF
--- a/decision_os/acceleration/codex_adapter.py
+++ b/decision_os/acceleration/codex_adapter.py
@@ -40,6 +40,14 @@ CYCLE_006_CODEX_RECOVERY_RECEIPT = CYCLE_006_CODEX_PATH.with_name(
     "recovery-receipt.json"
 )
 _CYCLE_006_CODEX_MAX_BYTES = 275_653_216
+
+# The current ordinary Companion route advances independently of the
+# historical/default identity above. Reuse the already-qualified Forward-only
+# artifact and its strict verifier without discovering or trusting a mutable
+# executable at runtime.
+ORDINARY_COMPANION_CODEX_CLI_VERSION = CYCLE_006_CODEX_CLI_VERSION
+ORDINARY_COMPANION_CODEX_SHA256 = CYCLE_006_CODEX_SHA256
+ORDINARY_COMPANION_CODEX_PATH = CYCLE_006_CODEX_PATH
 CODEX_MODEL = "gpt-5.6-sol"
 CODEX_REASONING_EFFORT = "ultra"
 CODEX_SERVICE_TIER = "priority"

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -481,6 +481,13 @@ class FieldNotesCompanionController(CompanionController):
             self._require_no_active_run()
             self._clear_field_note_locked()
             self._clear_candidate_v0_2_a1_locked()
+            self._creator_live_a1_capture_config = None
+            self._creator_live_a1_completed_run_id = None
+            self._creator_live_a1_run_completion = None
+            self._creator_live_a1_completed_draft = None
+            self._creator_live_a1_failure_reason = None
+            self._creator_live_a1_direct_write_identity = None
+            self._creator_live_a1_proposal_diagnostic = None
             self._clear_creator_live_a2_locked()
             return super().start_run(task, task_mode=task_mode)
 
@@ -2037,8 +2044,8 @@ class FieldNotesCompanionController(CompanionController):
             and getattr(entrypoint, "mutation_blocked", False)
         )
 
-    @staticmethod
     def creator_live_cycle_005_public_projection(
+        self,
         snapshot: dict[str, Any],
     ) -> dict[str, Any]:
         """Redact private coordinator Runs from every HTTP projection."""
@@ -2059,7 +2066,18 @@ class FieldNotesCompanionController(CompanionController):
             "INTEGRITY_FAILURE",
         }:
             run = snapshot.get("run")
-            if isinstance(run, dict) and run.get("run_type") == "bounded_task":
+            with self._condition:
+                creator_live_owned = bool(
+                    self._creator_live_a1_capture_config is not None
+                    or self._creator_live_a2_reconnect_target is not None
+                    or self._creator_live_a1_completed_run_id is not None
+                    or self._creator_live_a2_completed_run_id is not None
+                )
+            if (
+                not creator_live_owned
+                and isinstance(run, dict)
+                and run.get("run_type") == "bounded_task"
+            ):
                 return snapshot
             snapshot["run"] = CompanionController._empty_run()
             return snapshot

--- a/decision_os/companion/field_notes_controller.py
+++ b/decision_os/companion/field_notes_controller.py
@@ -17,6 +17,8 @@ from decision_os.acceleration.codex_adapter import (
     CODEX_CLI_VERSION,
     CYCLE_006_CODEX_CLI_VERSION,
     CYCLE_006_CODEX_PATH,
+    ORDINARY_COMPANION_CODEX_CLI_VERSION,
+    ORDINARY_COMPANION_CODEX_PATH,
     CodexApproval,
     CodexLifecycleEvent,
     CodexReadEvidence,
@@ -102,6 +104,10 @@ def _field_notes_adapter_factory(
             return None
         return lambda value=provider_values[name]: value
 
+    creator_live_cycle_005_selected = bool(
+        provider_values["creator_live_a1_capture"] is not None
+        or provider_values["creator_live_a2_reconnect"] is not None
+    )
     cycle_006_selected = bool(
         provider_values["candidate_v0_2_a1"] is not None
         or provider_values["candidate_v0_2_a2"] is not None
@@ -112,6 +118,15 @@ def _field_notes_adapter_factory(
         runtime_options = {
             "executable": CYCLE_006_CODEX_PATH,
             "expected_cli_version": CYCLE_006_CODEX_CLI_VERSION,
+            "transport_factory": _Cycle006SubprocessTransport,
+        }
+    elif not creator_live_cycle_005_selected:
+        # Forward-only: the current ordinary route uses the already-preserved
+        # verified artifact. Historical Cycle 005 runs retain CODEX_CLI_VERSION.
+        engine.adapter_version = ORDINARY_COMPANION_CODEX_CLI_VERSION
+        runtime_options = {
+            "executable": ORDINARY_COMPANION_CODEX_PATH,
+            "expected_cli_version": ORDINARY_COMPANION_CODEX_CLI_VERSION,
             "transport_factory": _Cycle006SubprocessTransport,
         }
     return FieldNotesCodexAdapter(
@@ -2043,6 +2058,9 @@ class FieldNotesCompanionController(CompanionController):
             "OPEN_UNRESUMABLE",
             "INTEGRITY_FAILURE",
         }:
+            run = snapshot.get("run")
+            if isinstance(run, dict) and run.get("run_type") == "bounded_task":
+                return snapshot
             snapshot["run"] = CompanionController._empty_run()
             return snapshot
         public_state = (

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -6,6 +6,7 @@ const DISCONNECTED_MESSAGE =
 let csrfToken = "";
 let latestState = null;
 let requestActive = false;
+let requestRejectedMessage = null;
 let connected = false;
 let connectionGeneration = 0;
 let bridgeRepositoryPath = null;
@@ -2312,8 +2313,13 @@ function enterDisconnected() {
 function renderAuthenticatedState(state) {
   connected = true;
   render(state);
-  setText("global-error", "");
-  setHidden("global-error", true);
+  if (requestRejectedMessage !== null) {
+    setText("global-error", requestRejectedMessage);
+    setHidden("global-error", false);
+  } else {
+    setText("global-error", "");
+    setHidden("global-error", true);
+  }
 }
 
 async function readResponse(response) {
@@ -2352,6 +2358,8 @@ async function postJSON(path, value) {
   }
   connectionGeneration += 1;
   requestActive = true;
+  requestRejectedMessage = null;
+  setText("global-error", "");
   setHidden("global-error", true);
   try {
     const response = await fetch(path, {
@@ -2369,6 +2377,7 @@ async function postJSON(path, value) {
     return state;
   } catch (error) {
     if (error instanceof RequestRejectedError) {
+      requestRejectedMessage = error.message;
       setText("global-error", error.message);
       setHidden("global-error", false);
     } else {

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -3658,9 +3658,21 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 choice=lambda: self.fail("must not prompt"),
             )
 
-            with self.assertRaises(CodexAdapterFailure):
+            with self.assertRaises(CodexAdapterFailure) as captured:
                 await adapter.run("version mismatch")
 
+            diagnostic = captured.exception.diagnostic
+            self.assertIsNotNone(diagnostic)
+            assert diagnostic is not None
+            self.assertEqual(
+                "codex_version_verification_failed",
+                diagnostic.code,
+            )
+            self.assertEqual("version_verification", diagnostic.protocol_phase)
+            self.assertEqual(
+                "The bounded Codex Run failed closed while verifying the runtime version.",
+                diagnostic.reason,
+            )
             self.assertEqual([], factory.transports[0].sent)
             self.assertTrue(factory.transports[0].closed)
 

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -5440,6 +5440,25 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 burden: {},
               },
             };
+            const runtimeMismatchState = {
+              ...recoveredState,
+              csrf: "csrf-runtime-mismatch",
+              run: emptyRun({
+                state: "needs_attention",
+                error:
+                  "The bounded Codex Run failed closed while verifying the runtime version.",
+                failure: {
+                  code: "codex_version_verification_failed",
+                  protocol_phase: "version_verification",
+                  reason:
+                    "The bounded Codex Run failed closed while verifying the runtime version.",
+                  action: "recheck_runtime",
+                  category: "unknown",
+                  jsonrpc_code: null,
+                  protocol_method: null,
+                },
+              }),
+            };
             const switchedRepositoryState = {
               ...recoveredState,
               csrf: "csrf-switched",
@@ -7066,6 +7085,36 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 "FRESH_REPOSITORY_NAME",
               );
               assert.strictEqual(elements.get("choose-repository").disabled, false);
+
+              fetchQueue.push(() => Promise.resolve(response(recoveredState)));
+              await runNextTimer();
+              assert.strictEqual(
+                elements.get("global-error").textContent,
+                "One bounded Run is already active.",
+              );
+              assert.strictEqual(hidden("global-error"), false);
+              assert.strictEqual(elements.get("task").disabled, false);
+
+              fetchQueue.push(() => Promise.resolve(response(recoveredState)));
+              await elements.get("run").dispatch("click");
+              await settle();
+              assert.strictEqual(fetchCalls.at(-1).path, "/api/run");
+              assert.strictEqual(hidden("global-error"), true);
+
+              for (let index = 0; index < 2; index += 1) {
+                fetchQueue.push(() =>
+                  Promise.resolve(response(runtimeMismatchState)),
+                );
+                await runNextTimer();
+                assert.strictEqual(
+                  elements.get("run-error").textContent,
+                  "The bounded Codex Run failed closed while verifying the runtime version.",
+                );
+                assert.strictEqual(hidden("progress-card"), false);
+              }
+
+              fetchQueue.push(() => Promise.resolve(response(recoveredState)));
+              await runNextTimer();
 
               const oldState = deferred();
               fetchQueue.push(() => oldState.promise);

--- a/tests/test_field_notes_creator_live_cycle_006.py
+++ b/tests/test_field_notes_creator_live_cycle_006.py
@@ -444,6 +444,18 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
             self.spec.codex_executable,
             codex_module.CYCLE_006_CODEX_PATH,
         )
+        self.assertEqual(
+            codex_module.ORDINARY_COMPANION_CODEX_CLI_VERSION,
+            codex_module.CYCLE_006_CODEX_CLI_VERSION,
+        )
+        self.assertEqual(
+            codex_module.ORDINARY_COMPANION_CODEX_SHA256,
+            codex_module.CYCLE_006_CODEX_SHA256,
+        )
+        self.assertEqual(
+            codex_module.ORDINARY_COMPANION_CODEX_PATH,
+            codex_module.CYCLE_006_CODEX_PATH,
+        )
         self.assertNotEqual(
             codex_module.BUNDLED_CODEX_PATH,
             codex_module.CYCLE_006_CODEX_PATH,
@@ -918,7 +930,7 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
         self.assertFalse(os.path.lexists(entrypoint.spec.storage_root))
         self.assertFalse(entrypoint.mutation_blocked)
 
-    def test_production_factory_selects_preserved_runtime_only_for_cycle_006(
+    def test_production_factory_selects_forward_runtime_without_rewriting_history(
         self,
     ) -> None:
         factory_repository = create_repository(
@@ -1046,7 +1058,14 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
             account_type="chatgpt",
         )
         ordinary_cases = (
-            ("no-provider", None, None),
+            (
+                "current-ordinary",
+                None,
+                None,
+                codex_module.ORDINARY_COMPANION_CODEX_PATH,
+                codex_module.ORDINARY_COMPANION_CODEX_CLI_VERSION,
+                codex_module._Cycle006SubprocessTransport,
+            ),
             (
                 "historical-a1",
                 FieldNoteCreatorLiveA1CaptureConfig(
@@ -1054,10 +1073,27 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
                     expected_runtime_identity=historical_runtime,
                 ),
                 None,
+                codex_module.BUNDLED_CODEX_PATH,
+                codex_module.CODEX_CLI_VERSION,
+                codex_module._SubprocessTransport,
             ),
-            ("historical-a2", None, reconnect_target(historical_runtime)),
+            (
+                "historical-a2",
+                None,
+                reconnect_target(historical_runtime),
+                codex_module.BUNDLED_CODEX_PATH,
+                codex_module.CODEX_CLI_VERSION,
+                codex_module._SubprocessTransport,
+            ),
         )
-        for label, capture, target in ordinary_cases:
+        for (
+            label,
+            capture,
+            target,
+            expected_path,
+            expected_version,
+            expected_transport,
+        ) in ordinary_cases:
             with self.subTest(label=label):
                 engine = AccelerationEngine(
                     factory_repository,
@@ -1094,19 +1130,19 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
                     ordinary._reset_run()
                 self.assertEqual(
                     ordinary.executable,
-                    codex_module.BUNDLED_CODEX_PATH,
+                    expected_path,
                 )
                 self.assertEqual(
                     ordinary.expected_cli_version,
-                    codex_module.CODEX_CLI_VERSION,
+                    expected_version,
                 )
                 self.assertIs(
                     ordinary.transport_factory,
-                    codex_module._SubprocessTransport,
+                    expected_transport,
                 )
                 self.assertEqual(
                     engine.adapter_version,
-                    codex_module.CODEX_CLI_VERSION,
+                    expected_version,
                 )
 
 

--- a/tests/test_field_notes_creator_live_entrypoint.py
+++ b/tests/test_field_notes_creator_live_entrypoint.py
@@ -1045,7 +1045,29 @@ class CreatorLiveHTTPTests(unittest.TestCase):
                     )
                     self.assertEqual(run_before, projected["run"])
 
-    def test_terminal_projection_redacts_private_creator_live_run(self) -> None:
+    def test_ordinary_start_supersedes_transient_cycle_ownership(self) -> None:
+        self.controller._creator_live_a1_completed_run_id = "cycle-005-run-1"
+        self.controller._creator_live_a2_completed_run_id = "cycle-005-run-2"
+
+        snapshot = self.controller.start_run("Synthetic ordinary task.")
+        snapshot["creator_live_cycle_005"] = {
+            "cycle_key": "cycle-005",
+            "state": "FAILED",
+            "stage": "A3",
+            "failure_code": "HISTORICAL_FAILURE",
+        }
+        projected = self.controller.creator_live_cycle_005_public_projection(
+            snapshot
+        )
+
+        self.assertIsNone(self.controller._creator_live_a1_completed_run_id)
+        self.assertIsNone(self.controller._creator_live_a2_completed_run_id)
+        self.assertEqual("bounded_task", projected["run"]["run_type"])
+        self.assertEqual("running", projected["run"]["state"])
+
+    def test_terminal_projection_redacts_private_bounded_creator_live_run(
+        self,
+    ) -> None:
         cycle = {
             "cycle_key": "cycle-005",
             "state": "FAILED",
@@ -1061,7 +1083,7 @@ class CreatorLiveHTTPTests(unittest.TestCase):
         snapshot = {
             "creator_live_cycle_005": cycle,
             "run": {
-                "run_type": "creator_live_cycle_005",
+                "run_type": "bounded_task",
                 "state": "completed",
                 "task": RUN_2_TASK,
                 "result": "PRIVATE MODEL OUTPUT",
@@ -1070,6 +1092,8 @@ class CreatorLiveHTTPTests(unittest.TestCase):
                 "approval": {"hidden": "PRIVATE APPROVAL"},
             },
         }
+        self.controller._creator_live_a1_completed_run_id = "cycle-005-run-1"
+        self.controller._creator_live_a2_completed_run_id = "cycle-005-run-2"
 
         projected = self.controller.creator_live_cycle_005_public_projection(
             snapshot

--- a/tests/test_field_notes_creator_live_entrypoint.py
+++ b/tests/test_field_notes_creator_live_entrypoint.py
@@ -964,9 +964,48 @@ class CreatorLiveHTTPTests(unittest.TestCase):
         self.assertIsNone(projected["run"]["runtime"])
         self.assertIsNone(projected["run"]["approval"])
 
-    def test_terminal_projection_preserves_evidence_and_restores_safe_idle(
+    def test_terminal_projection_preserves_legitimate_bounded_run_states(
         self,
     ) -> None:
+        empty = self.controller._empty_run()
+        bounded_runs = {
+            "idle": empty,
+            "running": {
+                **empty,
+                "task_mode": "manual",
+                "state": "running",
+                "progress": ["Starting one fresh bounded Run."],
+            },
+            "approval": {
+                **empty,
+                "task_mode": "manual",
+                "state": "running",
+                "approval": {
+                    "repository": "repository",
+                    "action": "Modify",
+                    "path": "one.txt",
+                    "diff": "@@ -1 +1 @@\n-one\n+two\n",
+                    "reason": "One bounded change.",
+                },
+            },
+            "result": {
+                **empty,
+                "task_mode": "manual",
+                "state": "completed",
+                "result": "Bounded completion result.",
+            },
+            "failure": {
+                **empty,
+                "task_mode": "manual",
+                "state": "needs_attention",
+                "error": "The bounded Run failed closed.",
+                "failure": {
+                    "code": "bounded_failure",
+                    "reason": "The bounded Run failed closed.",
+                    "action": "recheck_runtime",
+                },
+            },
+        }
         for terminal_state in (
             "FAILED",
             "TRACE_COMPLETE",
@@ -974,78 +1013,80 @@ class CreatorLiveHTTPTests(unittest.TestCase):
             "OPEN_UNRESUMABLE",
             "INTEGRITY_FAILURE",
         ):
-            with self.subTest(terminal_state=terminal_state):
-                cycle = {
-                    "cycle_key": "cycle-005",
-                    "state": terminal_state,
-                    "stage": "A3",
-                    "failure_code": "HISTORICAL_FAILURE",
-                    "identities": {
-                        "proof_attempt_id": "cycle-005-attempt-001",
-                        "journal_sha256": "1" * 64,
-                        "anchor_sha256": "2" * 64,
-                    },
-                }
-                cycle_before = json.loads(json.dumps(cycle, sort_keys=True))
-                snapshot = {
-                    "creator_live_cycle_005": cycle,
-                    "run": {
-                        "run_type": "bounded_task",
-                        "state": "completed",
-                        "task": RUN_2_TASK,
-                        "result": "PRIVATE MODEL OUTPUT",
-                        "field_note": {"markdown": "PRIVATE NOTE"},
-                        "runtime": {"model": "PRIVATE MODEL"},
-                        "approval": {"hidden": "PRIVATE APPROVAL"},
-                    },
-                }
-
-                projected = self.controller.creator_live_cycle_005_public_projection(
-                    snapshot
-                )
-
-                self.assertEqual(cycle_before, projected["creator_live_cycle_005"])
-                self.assertEqual(
-                    {
-                        "run_type": "bounded_task",
-                        "task_mode": None,
-                        "state": "idle",
-                        "progress": [],
-                        "result": "",
-                        "file_actions": [],
-                        "read_evidence": [],
-                        "outcomes": {
-                            "execution": {
-                                "state": "not_started",
-                                "label": "Not started",
-                            },
-                            "file_change": {
-                                "state": "none",
-                                "label": "No file was modified",
-                            },
-                            "verification": {
-                                "state": "not_started",
-                                "label": "Not started",
-                                "reason": None,
-                            },
+            for label, run in bounded_runs.items():
+                with self.subTest(terminal_state=terminal_state, run=label):
+                    cycle = {
+                        "cycle_key": "cycle-005",
+                        "state": terminal_state,
+                        "stage": "A3",
+                        "failure_code": "HISTORICAL_FAILURE",
+                        "identities": {
+                            "proof_attempt_id": "cycle-005-attempt-001",
+                            "journal_sha256": "1" * 64,
+                            "anchor_sha256": "2" * 64,
                         },
-                        "runtime": None,
-                        "receipt_delta": None,
-                        "approval": None,
-                        "error": None,
-                        "failure": None,
-                    },
-                    projected["run"],
-                )
-                encoded_run = json.dumps(projected["run"], sort_keys=True)
-                for private in (
-                    RUN_2_TASK,
-                    "PRIVATE MODEL OUTPUT",
-                    "PRIVATE NOTE",
-                    "PRIVATE MODEL",
-                    "PRIVATE APPROVAL",
-                ):
-                    self.assertNotIn(private, encoded_run)
+                    }
+                    cycle_before = json.loads(json.dumps(cycle, sort_keys=True))
+                    run_before = json.loads(json.dumps(run, sort_keys=True))
+                    snapshot = {
+                        "creator_live_cycle_005": cycle,
+                        "run": json.loads(json.dumps(run, sort_keys=True)),
+                    }
+
+                    projected = (
+                        self.controller.creator_live_cycle_005_public_projection(
+                            snapshot
+                        )
+                    )
+
+                    self.assertEqual(
+                        cycle_before,
+                        projected["creator_live_cycle_005"],
+                    )
+                    self.assertEqual(run_before, projected["run"])
+
+    def test_terminal_projection_redacts_private_creator_live_run(self) -> None:
+        cycle = {
+            "cycle_key": "cycle-005",
+            "state": "FAILED",
+            "stage": "A3",
+            "failure_code": "HISTORICAL_FAILURE",
+            "identities": {
+                "proof_attempt_id": "cycle-005-attempt-001",
+                "journal_sha256": "1" * 64,
+                "anchor_sha256": "2" * 64,
+            },
+        }
+        cycle_before = json.loads(json.dumps(cycle, sort_keys=True))
+        snapshot = {
+            "creator_live_cycle_005": cycle,
+            "run": {
+                "run_type": "creator_live_cycle_005",
+                "state": "completed",
+                "task": RUN_2_TASK,
+                "result": "PRIVATE MODEL OUTPUT",
+                "field_note": {"markdown": "PRIVATE NOTE"},
+                "runtime": {"model": "PRIVATE MODEL"},
+                "approval": {"hidden": "PRIVATE APPROVAL"},
+            },
+        }
+
+        projected = self.controller.creator_live_cycle_005_public_projection(
+            snapshot
+        )
+
+        self.assertEqual(cycle_before, projected["creator_live_cycle_005"])
+        self.assertEqual("bounded_task", projected["run"]["run_type"])
+        self.assertEqual("idle", projected["run"]["state"])
+        encoded_run = json.dumps(projected["run"], sort_keys=True)
+        for private in (
+            RUN_2_TASK,
+            "PRIVATE MODEL OUTPUT",
+            "PRIVATE NOTE",
+            "PRIVATE MODEL",
+            "PRIVATE APPROVAL",
+        ):
+            self.assertNotIn(private, encoded_run)
 
     def test_terminal_http_state_is_allowlisted_and_duplicate_start_is_409(
         self,


### PR DESCRIPTION
## What changed

- Bind the current ordinary Companion route forward-only to the existing verified, content-addressed Codex `0.147.0-alpha.1.2` artifact.
- Preserve legitimate bounded-task state when historical Cycle 005 is terminal while continuing to redact private Creator-Live projections.
- Keep actionable request-rejection messages visible across normal 750-ms state polling.
- Add focused adapter, controller/projection, HTTP, and browser-harness regressions.

## Root cause

The ordinary route still expected historical Codex `0.146.0-alpha.3.1`, terminal Cycle 005 projection replaced legitimate ordinary run state with idle, and successful polling immediately cleared request errors.

## Historical and privacy boundaries

- Historical/default `CODEX_CLI_VERSION = 0.146.0-alpha.3.1` remains unchanged.
- Existing Cycle 005/006 evidence is unchanged.
- Private Creator-Live task, model, result, runtime, approval, and Field Note content remains redacted.
- Runtime verification remains fixed-path, fixed-hash, fixed-version, and fail-closed.

## Validation

- 255 focused tests run: 251 passed, 4 skipped.
- Python compilation, JavaScript syntax, and diff checks passed.
- The preserved artifact verified at SHA-256 `9f6748b4ab10ffc92c28b9ccedae89e61a302bbc011df7d276ee38f55906e481`.
- Its app-server transport started and closed with zero protocol messages, task transmissions, or model invocations.
- Synthetic runtime mismatch remains fail-closed with `codex_version_verification_failed`.
- Terminal Cycle 005 privacy regression passes for a Cycle-owned `bounded_task`, while genuine ordinary idle/running/approval/result/failure states remain visible.
- README and protected Cycle/Candidate/evidence surfaces remain unchanged.