### PR TITLE
Clarify applied changes when verification needs review

### DIFF
--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -412,20 +412,49 @@ function operationPresentation(
 
   if (TERMINAL_RUN_STATES.includes(state)) {
     const needsAttention = ["unsupported", "needs_attention"].includes(state);
+    const approvedMutation = (run?.file_actions || []).some(
+      (fileAction) =>
+        fileAction?.status === "approved" &&
+        ["create", "modify"].includes((fileAction?.action || "").toLowerCase()),
+    );
+    const changeAppliedVerificationNeedsReview =
+      needsAttention &&
+      run?.outcomes?.execution?.state === "completed" &&
+      ["created", "modified"].includes(run?.outcomes?.file_change?.state) &&
+      ["unsupported", "needs_attention"].includes(
+        run?.outcomes?.verification?.state,
+      ) &&
+      approvedMutation;
     statuses.contract = contractStatus;
     statuses.task = "Complete";
-    statuses.run = needsAttention ? "Needs attention" : "Complete";
-    statuses.result = needsAttention ? "Needs attention" : "Current";
+    statuses.run = changeAppliedVerificationNeedsReview
+      ? "Complete"
+      : needsAttention
+        ? "Needs attention"
+        : "Complete";
+    statuses.result = changeAppliedVerificationNeedsReview
+      ? "Needs review"
+      : needsAttention
+        ? "Needs attention"
+        : "Current";
     return {
       currentStage: "result",
       statuses,
-      current: needsAttention ? "Run needs attention" : "Run finished",
-      happening: needsAttention
-        ? "The Run finished with a verification outcome that needs review."
-        : "The bounded Run reached its terminal result.",
-      action: needsAttention
-        ? "Review the Run verification outcome."
-        : "Nothing — this Run is complete.",
+      current: changeAppliedVerificationNeedsReview
+        ? "Change applied — verification needs review"
+        : needsAttention
+          ? "Run needs attention"
+          : "Run finished",
+      happening: changeAppliedVerificationNeedsReview
+        ? "The approved file change was applied, but verification did not complete."
+        : needsAttention
+          ? "The Run finished with a verification outcome that needs review."
+          : "The bounded Run reached its terminal result.",
+      action: changeAppliedVerificationNeedsReview
+        ? "Review why verification did not complete."
+        : needsAttention
+          ? "Review the Run verification outcome."
+          : "Nothing — this Run is complete.",
       next: "A new Run will not start automatically.",
     };
   }

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2854,14 +2854,14 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               task_mode: "manual",
               progress: ["Finalizing the local Receipt."],
               result: "The requested file was modified.",
-              file_actions: [{ action: "Modify", path: "app.js", status: "approved", access: "one-time" }],
+              file_actions: [{ action: "Modify", path: "README.md", status: "approved", access: "one-time" }],
               outcomes: {
                 execution: { state: "completed", label: "Codex turn completed" },
                 file_change: { state: "modified", label: "Modified successfully" },
                 verification: {
                   state: "unsupported",
                   label: "Unsupported — review required",
-                  reason: "unsupported_request_method:commandExecution",
+                  reason: "read_file_too_large",
                 },
               },
             };
@@ -2874,10 +2874,75 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             assert.strictEqual(elements.get("result-verification").textContent, "Unsupported — review required");
             assert.strictEqual(
               elements.get("result-verification-reason").textContent,
-              "unsupported_request_method:commandExecution",
+              "read_file_too_large",
             );
-            assert.strictEqual(elements.get("operation-current").textContent, "Run needs attention");
+            assert.strictEqual(
+              elements.get("operation-current").textContent,
+              "Change applied — verification needs review",
+            );
             assert.strictEqual(elements.get("operation-task-status").textContent, "Complete");
+            assert.strictEqual(elements.get("operation-run-status").textContent, "Complete");
+            assert.strictEqual(elements.get("operation-result-status").textContent, "Needs review");
+            assert.strictEqual(
+              elements.get("operation-happening").textContent,
+              "The approved file change was applied, but verification did not complete.",
+            );
+            assert.strictEqual(
+              elements.get("operation-action").textContent,
+              "Review why verification did not complete.",
+            );
+
+            const mutationFailure = {
+              ...terminal,
+              state: "needs_attention",
+              outcomes: {
+                execution: { state: "failed", label: "Execution failed" },
+                file_change: { state: "failed", label: "Modification failed" },
+                verification: {
+                  state: "needs_attention",
+                  label: "Needs attention",
+                  reason: "mutation_failed",
+                },
+              },
+            };
+            let preserved = sandbox.operationPresentation(
+              mutationFailure,
+              fixed,
+              { mode: "manual" },
+              repository,
+            );
+            assert.strictEqual(preserved.current, "Run needs attention");
+            assert.strictEqual(preserved.statuses.run, "Needs attention");
+
+            preserved = sandbox.operationPresentation(
+              { ...terminal, file_actions: [], outcomes: {
+                ...terminal.outcomes,
+                file_change: { state: "none", label: "No file change" },
+              } },
+              fixed,
+              { mode: "manual" },
+              repository,
+            );
+            assert.strictEqual(preserved.current, "Run needs attention");
+
+            preserved = sandbox.operationPresentation(
+              { ...terminal, state: "denied" },
+              fixed,
+              { mode: "manual" },
+              repository,
+            );
+            assert.strictEqual(preserved.current, "Run finished");
+
+            preserved = sandbox.operationPresentation(
+              { ...terminal, state: "completed", outcomes: {
+                ...terminal.outcomes,
+                verification: { state: "verified", label: "Verified" },
+              } },
+              fixed,
+              { mode: "manual" },
+              repository,
+            );
+            assert.strictEqual(preserved.current, "Run finished");
             sandbox.coordinateOperationTransition(terminal);
             assert.strictEqual(elements.get("result-heading").focusCalls.length, 1);
 
@@ -3774,7 +3839,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                   probePhase = "terminal";
                   return;
                 }
-                if (probePhase === "terminal" && current.textContent === "Run needs attention") {
+                if (
+                  probePhase === "terminal" &&
+                  current.textContent === "Change applied — verification needs review"
+                ) {
                   const focusCounts = window.__focusCounts;
                   document.body.dataset.terminal = String(
                     document.getElementById("result-state").textContent ===


### PR DESCRIPTION
## What changed

- Distinguish a successfully applied, approved file mutation from its unsupported/incomplete verification outcome.
- Present the mixed result as **“Change applied — verification needs review”**, with Run complete and Result needing review.
- Preserve the existing verification state, reason/code, fail-closed behavior, and generic presentations for mutation failure, denial, no mutation, and fully verified success.

## Why

The first real dogfood completed execution and modified the approved README file, but verification was unsupported because `handoff/current_codex_handoff.md` exceeded the read limit. The previous prominent wording, “Run needs attention,” obscured that the approved mutation had succeeded.

## Impact and safety

This is presentation/state interpretation only. It does not loosen read limits, change controller outcomes, reinterpret unsupported verification as verified, invoke a model, or alter README/Cycle evidence/Candidate/A1–A7/proof storage.

## Checks

- `python3 -m unittest tests.test_companion_server.CompanionClientBehaviorTest.test_operation_awareness_state_transition_harness`
- `python3 -m unittest tests.test_companion_server.CompanionClientBehaviorTest.test_operation_awareness_browser_transition_sequence`
- `python3 -m unittest tests.test_companion_server.CompanionClientBehaviorTest` — 7 tests passed
- `git diff --check`
