### PR TITLE
Close first real dogfood activity and receipt UX gaps

### DIFF
--- a/decision_os/companion/static/app.css
+++ b/decision_os/companion/static/app.css
@@ -780,6 +780,35 @@ dd {
   display: none;
 }
 
+.run-activity {
+  background: var(--soft-blue);
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
+  border-radius: 12px;
+  margin: 1rem 0;
+  padding: 0.85rem 1rem;
+}
+
+.run-activity p {
+  margin: 0;
+}
+
+.run-activity-status {
+  color: var(--accent-dark);
+  font-size: 1.05rem;
+  font-weight: 780;
+}
+
+.run-activity-progress {
+  font-weight: 650;
+  margin-top: 0.35rem !important;
+}
+
+.run-activity-age {
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin-top: 0.25rem !important;
+}
+
 .visually-hidden {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);

--- a/decision_os/companion/static/app.js
+++ b/decision_os/companion/static/app.js
@@ -34,6 +34,11 @@ let preparedContractTaskStarter = null;
 let ordinaryReviewDisclosureIdentity = null;
 let currentCodexResponse = "";
 let copyResponseResetTimer = null;
+let runObservedStartedAt = null;
+let runObservedProgressAt = null;
+let runObservedProgressSignature = null;
+let runObservedLatestProgress = "";
+let runActivityVisible = false;
 
 const MAX_BRIDGE_ARTIFACT_BYTES = 1024 * 1024;
 const CONTRACT_PREVIEW_CHARACTERS = 4096;
@@ -597,6 +602,69 @@ function renderOperationAwareness(run, ordinary, repository) {
   }
 }
 
+function formatObservedDuration(milliseconds) {
+  const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pairs = hours > 0 ? [hours, minutes, seconds] : [minutes, seconds];
+  return pairs.map((value) => String(value).padStart(2, "0")).join(":");
+}
+
+function updateRunActivityClock(now = Date.now()) {
+  if (!runActivityVisible || runObservedStartedAt === null) {
+    return;
+  }
+  setText(
+    "run-activity-status",
+    `Working · ${formatObservedDuration(now - runObservedStartedAt)}`,
+  );
+  setText(
+    "run-activity-progress",
+    runObservedLatestProgress || "No progress message reported yet.",
+  );
+  if (runObservedProgressAt === null) {
+    setText("run-activity-age", "No progress update has been observed yet");
+    return;
+  }
+  const ageMilliseconds = Math.max(0, now - runObservedProgressAt);
+  const ageSeconds = Math.floor(ageMilliseconds / 1000);
+  setText(
+    "run-activity-age",
+    ageSeconds >= 30
+      ? `No new progress update for ${formatObservedDuration(ageMilliseconds)}`
+      : ageSeconds === 0
+        ? "Last progress update just now"
+        : `Last progress update ${ageSeconds}s ago`,
+  );
+}
+
+function renderRunActivity(run, now = Date.now()) {
+  if (run?.state !== "running") {
+    runObservedStartedAt = null;
+    runObservedProgressAt = null;
+    runObservedProgressSignature = null;
+    runObservedLatestProgress = "";
+    runActivityVisible = false;
+    setHidden("run-activity", true);
+    return;
+  }
+  if (runObservedStartedAt === null) {
+    runObservedStartedAt = now;
+  }
+  const progress = Array.isArray(run.progress) ? run.progress : [];
+  const progressSignature = JSON.stringify(progress);
+  if (progressSignature !== runObservedProgressSignature) {
+    runObservedProgressSignature = progressSignature;
+    runObservedProgressAt = now;
+    runObservedLatestProgress = progress.at(-1) || "";
+  }
+  const approval = operationApprovalResponsePending ? null : run.approval;
+  runActivityVisible = !approval;
+  setHidden("run-activity", !runActivityVisible);
+  updateRunActivityClock(now);
+}
+
 function resetOperationTransitionMemory() {
   operationApprovalResponsePending = false;
   operationApprovalWasVisible = false;
@@ -653,6 +721,11 @@ function beginOperationRun(taskMode) {
   const item = document.createElement("li");
   item.textContent = "Starting Run";
   progress.replaceChildren(item);
+  renderRunActivity({
+    state: "running",
+    progress: ["Starting Run"],
+    approval: null,
+  });
   renderOperationAwareness(
     {
       state: "running",
@@ -2186,6 +2259,7 @@ function render(state) {
   byId("task").disabled = !boundedRun || running;
 
   renderProgress(boundedRunView);
+  renderRunActivity(boundedRunView);
   renderResult(boundedRunView);
   renderApproval(
     operationApprovalResponsePending ? null : boundedRunView.approval,
@@ -2310,6 +2384,7 @@ function enterDisconnected() {
     error: null,
   };
   renderProgress(emptyRun);
+  renderRunActivity(emptyRun);
   renderResult(emptyRun);
   setText("run-state", "");
   setText("result-state", "");
@@ -3326,6 +3401,7 @@ byId("advanced-contract-mode").addEventListener(
 syncAdvancedAuditContainment();
 syncResearchWorkflowContainment();
 syncContractWorkflowContainment();
+window.setInterval?.(updateRunActivityClock, 1000);
 
 async function refresh() {
   if (!requestActive) {

--- a/decision_os/companion/static/field_notes.css
+++ b/decision_os/companion/static/field_notes.css
@@ -15,6 +15,10 @@
   box-shadow: 0 0.5rem 2rem rgb(0 0 0 / 0.2);
 }
 
+#field-notes-lite.field-note-reconnect-dismissed {
+  width: auto;
+}
+
 #field-notes-lite h2,
 #field-notes-lite h3,
 #field-notes-lite p {
@@ -61,6 +65,29 @@
   margin-top: 0;
   padding-top: 0;
   border-top: 0;
+}
+
+.field-note-reconnect-heading {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.field-note-reconnect-heading h2 {
+  margin-bottom: 0 !important;
+}
+
+.field-note-reconnect-close {
+  font-size: 1.35rem;
+  line-height: 1;
+  min-height: 2.5rem;
+  min-width: 2.5rem;
+  padding: 0.35rem;
+}
+
+.field-note-reconnect-reopen {
+  min-height: 2.5rem;
 }
 
 .field-note-reconnect-values {

--- a/decision_os/companion/static/field_notes.js
+++ b/decision_os/companion/static/field_notes.js
@@ -8,6 +8,8 @@
 
   let csrf = "";
   let lastSignature = "";
+  let lastSnapshot = null;
+  let dismissedReconnectSignature = null;
   let actionPending = false;
   const reconnectFields = [
     "state",
@@ -153,10 +155,46 @@
     }
   }
 
+  function reconnectSignature(receipt) {
+    return JSON.stringify(receipt || null);
+  }
+
+  function dismissReconnectReceipt(receipt) {
+    dismissedReconnectSignature = reconnectSignature(receipt);
+    const visibleReceipt = root.querySelector(".field-note-reconnect-receipt");
+    if (visibleReceipt) root.removeChild(visibleReceipt);
+    renderReconnectReceipt(receipt);
+    const reopen = root.querySelector(".field-note-reconnect-reopen");
+    root.className = root.children.length === 1
+      ? "field-note-reconnect-dismissed"
+      : "";
+    reopen?.focus();
+  }
+
   function renderReconnectReceipt(receipt) {
+    if (dismissedReconnectSignature === reconnectSignature(receipt)) {
+      const reopen = button("View receipt", () => {
+        dismissedReconnectSignature = null;
+        root.removeChild(reopen);
+        root.className = "";
+        renderReconnectReceipt(receipt);
+        root.querySelector(".field-note-reconnect-close")?.focus();
+      });
+      reopen.className = "field-note-reconnect-reopen";
+      root.appendChild(reopen);
+      return;
+    }
     const section = document.createElement("section");
     section.className = "field-note-reconnect-receipt";
-    section.appendChild(text("h2", "Field Note reconnect receipt"));
+    const heading = document.createElement("div");
+    heading.className = "field-note-reconnect-heading";
+    heading.appendChild(text("h2", "Field Note reconnect receipt"));
+    const close = button("×", () => dismissReconnectReceipt(receipt));
+    close.className = "field-note-reconnect-close";
+    close.setAttribute("aria-label", "Close Field Note reconnect receipt");
+    close.setAttribute("title", "Close");
+    heading.appendChild(close);
+    section.appendChild(heading);
 
     const values = document.createElement("dl");
     values.className = "field-note-reconnect-values";
@@ -171,6 +209,7 @@
   }
 
   function render(snapshot) {
+    lastSnapshot = snapshot;
     csrf = snapshot.csrf || csrf;
     const run = snapshot.run || null;
     const field = run && run.field_note;
@@ -193,9 +232,26 @@
       return;
     }
     root.hidden = false;
+    root.className =
+      !fieldVisible &&
+      reconnect &&
+      dismissedReconnectSignature === reconnectSignature(reconnect)
+        ? "field-note-reconnect-dismissed"
+        : "";
     if (fieldVisible) renderFieldNote(field);
     if (reconnect) renderReconnectReceipt(reconnect);
   }
+
+  document.addEventListener?.("keydown", (event) => {
+    if (event.key !== "Escape" || !lastSnapshot) return;
+    const reconnect = lastSnapshot.run?.field_note_reconnect;
+    if (
+      reconnect &&
+      dismissedReconnectSignature !== reconnectSignature(reconnect)
+    ) {
+      dismissReconnectReceipt(reconnect);
+    }
+  });
 
   async function refresh() {
     try {

--- a/decision_os/companion/static/index.html
+++ b/decision_os/companion/static/index.html
@@ -147,6 +147,11 @@
         </div>
         <span id="run-state" class="status">Idle</span>
       </div>
+      <div id="run-activity" class="run-activity hidden">
+        <p id="run-activity-status" class="run-activity-status">Working · 00:00</p>
+        <p id="run-activity-progress">No progress message reported yet.</p>
+        <p id="run-activity-age" class="run-activity-age">Last progress update just now</p>
+      </div>
       <ol id="progress" class="progress-list"></ol>
       <p id="run-error" class="error hidden" role="alert"></p>
     </section>

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2436,6 +2436,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "new-run",
               "operation-action", "operation-current", "operation-happening",
               "operation-next", "progress", "progress-card", "progress-heading",
+              "run-activity", "run-activity-age", "run-activity-progress",
+              "run-activity-status",
               "result", "result-card", "result-execution", "result-file-change",
               "result-heading", "result-state", "result-verification",
               "result-verification-reason", "run", "run-state", "task", "task-heading",
@@ -2456,8 +2458,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             );
             assert.strictEqual(elements.has("operation-contract-status"), false);
             let reducedMotion = false;
+            let now = 100000;
             const sandbox = {
               console,
+              Date: { now: () => now },
               document: {
                 createElement: () => new Element(),
                 querySelectorAll: (selector) =>
@@ -2476,6 +2480,11 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               operationLastApprovalKey: null,
               operationStartPending: false,
               operationTerminalTransitioned: false,
+              runObservedStartedAt: null,
+              runObservedProgressAt: null,
+              runObservedProgressSignature: null,
+              runObservedLatestProgress: "",
+              runActivityVisible: false,
               CONTRACT_TASK_MARKER: "Task to perform:",
               CONTRACT_TASK_PREFIX:
                 "Perform only the bounded task defined by this fixed ordinary Contract context.",
@@ -2505,6 +2514,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 "\nthis.coordinateOperationTransition = coordinateOperationTransition;" +
                 "\nthis.moveToOperationStage = moveToOperationStage;" +
                 "\nthis.beginOperationRun = beginOperationRun;" +
+                "\nthis.renderRunActivity = renderRunActivity;" +
+                "\nthis.updateRunActivityClock = updateRunActivityClock;" +
                 "\nthis.renderResult = renderResult;",
               sandbox,
             );
@@ -2795,6 +2806,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             assert.strictEqual(elements.get("operation-task-status").textContent, "Complete");
             assert.strictEqual(elements.get("progress-card").classList.contains("hidden"), false);
             assert.strictEqual(elements.get("progress-heading").focusCalls.length, 1);
+            assert.strictEqual(elements.get("run-activity").classList.contains("hidden"), false);
+            assert.strictEqual(elements.get("run-activity-status").textContent, "Working · 00:00");
+            assert.strictEqual(elements.get("run-activity-progress").textContent, "Starting Run");
+            assert.strictEqual(elements.get("run-activity-age").textContent, "Last progress update just now");
 
             sandbox.operationStartPending = false;
             const working = {
@@ -2803,11 +2818,29 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               progress: ["Starting the private Codex runtime."],
               approval: null,
             };
+            now += 2000;
+            sandbox.renderRunActivity(working);
             sandbox.coordinateOperationTransition(working);
             sandbox.renderOperationAwareness(working, fixed, repository);
             assert.strictEqual(elements.get("operation-current").textContent, "Codex is working");
             assert.strictEqual(elements.get("operation-task-status").textContent, "Complete");
             assert.strictEqual(elements.get("operation-run-status").textContent, "Waiting for system");
+            assert.strictEqual(elements.get("run-activity-status").textContent, "Working · 00:02");
+            assert.strictEqual(
+              elements.get("run-activity-progress").textContent,
+              "Starting the private Codex runtime.",
+            );
+            now += 6000;
+            sandbox.renderRunActivity(working);
+            assert.strictEqual(elements.get("run-activity-status").textContent, "Working · 00:08");
+            assert.strictEqual(elements.get("run-activity-age").textContent, "Last progress update 6s ago");
+            now += 28000;
+            sandbox.updateRunActivityClock();
+            assert.strictEqual(
+              elements.get("run-activity-age").textContent,
+              "No new progress update for 00:34",
+              "unchanged polling must not create a progress event",
+            );
             const progressFocusAfterWorking = elements.get("progress-heading").focusCalls.length;
             sandbox.coordinateOperationTransition(working);
             assert.strictEqual(
@@ -2826,6 +2859,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                 path: "decision_os/companion/static/app.js",
               },
             };
+            sandbox.renderRunActivity(approval);
             sandbox.coordinateOperationTransition(approval);
             sandbox.renderOperationAwareness(approval, fixed, repository);
             assert.strictEqual(elements.get("approval-heading").focusCalls.length, 1);
@@ -2836,11 +2870,17 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               elements.get("operation-happening").textContent,
               "Modify is requested for decision_os/companion/static/app.js.",
             );
+            assert.strictEqual(
+              elements.get("run-activity").classList.contains("hidden"),
+              true,
+              "approval must replace generic working presentation",
+            );
             sandbox.coordinateOperationTransition(approval);
             assert.strictEqual(elements.get("approval-heading").focusCalls.length, 1);
 
             elements.get("approval-overlay").classList.toggle("hidden", true);
             sandbox.coordinateOperationTransition(working);
+            sandbox.renderRunActivity(working);
             sandbox.renderOperationAwareness(working, fixed, repository);
             assert.strictEqual(elements.get("operation-current").textContent, "The Run is continuing");
             assert.strictEqual(elements.get("operation-task-status").textContent, "Complete");
@@ -2867,6 +2907,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             };
             sandbox.coordinateOperationTransition(terminal);
             sandbox.renderOperationAwareness(terminal, fixed, repository);
+            sandbox.renderRunActivity(terminal);
             sandbox.renderResult(terminal);
             assert.strictEqual(elements.get("result-heading").focusCalls.length, 1);
             assert.strictEqual(elements.get("result-state").textContent, "Review required");
@@ -2890,6 +2931,11 @@ class CompanionClientBehaviorTest(unittest.TestCase):
             assert.strictEqual(
               elements.get("operation-action").textContent,
               "Review why verification did not complete.",
+            );
+            assert.strictEqual(
+              elements.get("run-activity").classList.contains("hidden"),
+              true,
+              "terminal state must stop the activity presentation",
             );
 
             const mutationFailure = {
@@ -3805,7 +3851,13 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                     document.getElementById("operation-run-status").textContent ===
                       "Waiting for system" &&
                     document.getElementById("operation-action").textContent ===
-                      "Wait — no action is needed."
+                      "Wait — no action is needed." &&
+                    !document.getElementById("run-activity").classList.contains("hidden") &&
+                    document.getElementById("run-activity-status").textContent.startsWith(
+                      "Working · ",
+                    ) &&
+                    document.getElementById("run-activity-progress").textContent ===
+                      "Starting the private Codex runtime."
                   );
                   probePhase = "approval";
                   return;
@@ -3821,7 +3873,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                       "Save this exact permission" &&
                     document.querySelector('[data-choice="deny"]').textContent.trim() ===
                       "Deny and stop this Run" &&
-                    approvalFocusBefore === 1
+                    approvalFocusBefore === 1 &&
+                    document.getElementById("run-activity").classList.contains("hidden")
                   );
                   document.querySelector('[data-choice="allow_once"]').click();
                   document.body.dataset.approvalAnsweredImmediate = String(
@@ -3854,7 +3907,8 @@ class CompanionClientBehaviorTest(unittest.TestCase):
                     document.getElementById("result-verification-reason").textContent ===
                       "unsupported_request_method:commandExecution" &&
                     focusCounts["approval-heading"] === 1 &&
-                    focusCounts["result-heading"] === 1
+                    focusCounts["result-heading"] === 1 &&
+                    document.getElementById("run-activity").classList.contains("hidden")
                   );
                   const readEvidence = document.getElementById("read-evidence-card");
                   const readEvidenceText = document.getElementById(
@@ -5004,6 +5058,10 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "result-verification",
               "result-verification-reason",
               "run",
+              "run-activity",
+              "run-activity-age",
+              "run-activity-progress",
+              "run-activity-status",
               "run-error",
               "run-receipt",
               "run-state",
@@ -5034,6 +5092,7 @@ class CompanionClientBehaviorTest(unittest.TestCase):
               "guided-intake-error",
               "intelligence-transplant-card",
               "intelligence-transplant-error",
+              "run-activity",
               "ordinary-contract-clarification",
               "ordinary-contract-error",
               "ordinary-contract-meaning",

--- a/tests/test_field_notes_reconnect.py
+++ b/tests/test_field_notes_reconnect.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tempfile
@@ -892,6 +893,14 @@ class Element {
     this.listeners.set(name, listeners);
   }
 
+  dispatch(name, event = {}) {
+    for (const callback of this.listeners.get(name) || []) callback(event);
+  }
+
+  focus() {
+    document.activeElement = this;
+  }
+
   querySelector(selector) {
     return this.querySelectorAll(selector)[0] || null;
   }
@@ -915,14 +924,26 @@ class Element {
   }
 }
 
+const documentListeners = new Map();
 const document = {
   body: new Element("body"),
+  activeElement: null,
   createElement(tagName) {
     return new Element(tagName);
   },
+  addEventListener(name, callback) {
+    const listeners = documentListeners.get(name) || [];
+    listeners.push(callback);
+    documentListeners.set(name, listeners);
+  },
+  dispatch(name, event = {}) {
+    for (const callback of documentListeners.get(name) || []) callback(event);
+  },
 };
 const fetchQueue = [];
+let fetchCount = 0;
 async function fetchMock(path, options = {}) {
+  fetchCount += 1;
   assert.strictEqual(path, "/api/state");
   assert.strictEqual(options.credentials, "same-origin");
   assert(fetchQueue.length > 0, `Unexpected fetch: ${path}`);
@@ -1038,10 +1059,181 @@ main().catch((error) => {
     receipt.querySelectorAll("dd").map((node) => node.textContent),
     ["NO_MATCH", "NONE", "NONE", "0", "NONE", "7", "2", "321", "0", "4", "run_no_match"],
   );
-  assert.strictEqual(receipt.querySelectorAll("button").length, 0);
+  const close = receipt.querySelector(".field-note-reconnect-close");
+  assert(close);
+  assert.strictEqual(close.textContent, "×");
+  assert.strictEqual(close.getAttribute("aria-label"), "Close Field Note reconnect receipt");
   assert(!receipt.textContent.includes("fn_bounded"));
 ''',
         )
+
+    def test_receipt_close_escape_and_reopen_are_presentation_only(self) -> None:
+        initial_state = self._state(self._no_match_receipt())
+        self._run_ui_harness(
+            initial_state,
+            r'''
+  const root = document.body.children[0];
+  const originalSnapshot = JSON.stringify(initialState);
+  const originalValues = root.querySelectorAll("dd").map((node) => node.textContent);
+  const close = root.querySelector(".field-note-reconnect-close");
+  assert(close);
+  close.dispatch("click");
+  assert.strictEqual(root.querySelector(".field-note-reconnect-receipt"), null);
+  assert.strictEqual(root.className, "field-note-reconnect-dismissed");
+  assert.strictEqual(root.hidden, false);
+  const reopen = root.querySelector(".field-note-reconnect-reopen");
+  assert(reopen);
+  assert.strictEqual(reopen.textContent, "View receipt");
+  assert.strictEqual(document.activeElement, reopen);
+  assert.strictEqual(fetchCount, 1, "close must not call an API");
+  assert.strictEqual(JSON.stringify(initialState), originalSnapshot);
+
+  reopen.dispatch("click");
+  const reopened = root.querySelector(".field-note-reconnect-receipt");
+  assert(reopened);
+  assert.deepStrictEqual(
+    reopened.querySelectorAll("dd").map((node) => node.textContent),
+    originalValues,
+  );
+  assert.strictEqual(
+    document.activeElement,
+    reopened.querySelector(".field-note-reconnect-close"),
+  );
+  assert.strictEqual(fetchCount, 1, "reopen must not call an API");
+
+  document.dispatch("keydown", { key: "Escape" });
+  assert.strictEqual(root.querySelector(".field-note-reconnect-receipt"), null);
+  assert(root.querySelector(".field-note-reconnect-reopen"));
+  assert.strictEqual(fetchCount, 1, "Escape must not call an API");
+  assert.strictEqual(JSON.stringify(initialState), originalSnapshot);
+''',
+        )
+
+    def test_receipt_close_escape_and_reopen_browser(self) -> None:
+        chrome_candidates = (
+            shutil.which("google-chrome"),
+            shutil.which("chromium"),
+            shutil.which("chromium-browser"),
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        )
+        chrome = next(
+            (
+                candidate
+                for candidate in chrome_candidates
+                if candidate and Path(candidate).is_file()
+            ),
+            None,
+        )
+        if chrome is None:
+            self.skipTest("Chrome or Chromium is unavailable for browser qualification.")
+
+        static_root = (
+            Path(__file__).resolve().parents[1]
+            / "decision_os"
+            / "companion"
+            / "static"
+        )
+        stylesheet = (static_root / "field_notes.css").read_text(encoding="utf-8")
+        javascript = (static_root / "field_notes.js").read_text(encoding="utf-8")
+        initial_state = self._state(self._no_match_receipt())
+        fixture_html = f'''<!doctype html>
+<html><head><meta charset="utf-8"><style>{stylesheet}</style></head>
+<body><button id="ordinary-control" type="button">Ordinary control</button>
+<script>
+window.__snapshot = {json.dumps(initial_state)};
+window.__requests = [];
+window.__nativeSetInterval = window.setInterval;
+window.setInterval = (callback, milliseconds) => {{
+  if (milliseconds === 1000) return 1;
+  return window.__nativeSetInterval(callback, milliseconds);
+}};
+window.fetch = async (path, options = {{}}) => {{
+  window.__requests.push({{ path, method: options.method || "GET" }});
+  return {{ ok: true, json: async () => structuredClone(window.__snapshot) }};
+}};
+</script>
+<script>{javascript}</script>
+<script>
+window.setInterval = window.__nativeSetInterval;
+let ordinaryClicks = 0;
+document.getElementById("ordinary-control").addEventListener(
+  "click",
+  () => ordinaryClicks += 1,
+);
+const probe = window.setInterval(() => {{
+  const root = document.getElementById("field-notes-lite");
+  const receipt = root?.querySelector(".field-note-reconnect-receipt");
+  if (!receipt) return;
+  const originalSnapshot = JSON.stringify(window.__snapshot);
+  const postCount = () => window.__requests.filter(
+    (request) => request.method === "POST",
+  ).length;
+  receipt.querySelector(".field-note-reconnect-close").click();
+  document.getElementById("ordinary-control").click();
+  document.body.dataset.close = String(
+    !root.querySelector(".field-note-reconnect-receipt") &&
+    root.querySelector(".field-note-reconnect-reopen")?.textContent === "View receipt" &&
+    ordinaryClicks === 1 &&
+    postCount() === 0 &&
+    JSON.stringify(window.__snapshot) === originalSnapshot
+  );
+  root.querySelector(".field-note-reconnect-reopen").click();
+  document.body.dataset.reopen = String(
+    root.querySelector(".field-note-reconnect-receipt")?.textContent.includes("NO_MATCH") &&
+    postCount() === 0
+  );
+  document.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Escape" }}));
+  document.body.dataset.escape = String(
+    !root.querySelector(".field-note-reconnect-receipt") &&
+    Boolean(root.querySelector(".field-note-reconnect-reopen")) &&
+    postCount() === 0 &&
+    JSON.stringify(window.__snapshot) === originalSnapshot
+  );
+  document.body.dataset.qualified = "true";
+  window.clearInterval(probe);
+}}, 20);
+</script></body></html>'''
+
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_root = Path(temporary)
+            fixture = temporary_root / "field-note-receipt-browser.html"
+            fixture.write_text(fixture_html, encoding="utf-8")
+            chrome_process = subprocess.Popen(
+                [
+                    chrome,
+                    "--headless=new",
+                    "--disable-background-networking",
+                    "--disable-component-update",
+                    "--disable-gpu",
+                    "--disable-sync",
+                    "--no-default-browser-check",
+                    "--no-first-run",
+                    f"--user-data-dir={temporary_root / 'profile'}",
+                    "--virtual-time-budget=2000",
+                    "--dump-dom",
+                    fixture.as_uri(),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            chrome_finished = True
+            try:
+                chrome_stdout, chrome_stderr = chrome_process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                chrome_finished = False
+                chrome_process.kill()
+                chrome_stdout, chrome_stderr = chrome_process.communicate()
+        if chrome_finished:
+            self.assertEqual(0, chrome_process.returncode, chrome_stderr)
+        self.assertTrue(chrome_stdout.strip(), chrome_stderr)
+        body_match = re.search(r"<body ([^>]*)>", chrome_stdout)
+        self.assertIsNotNone(body_match, "Field Note receipt browser body missing.")
+        attributes = dict(
+            re.findall(r'data-([a-z-]+)="([^"]*)"', body_match.group(1))
+        )
+        for name in ("close", "reopen", "escape", "qualified"):
+            self.assertEqual("true", attributes.get(name), name)
 
     def test_activation_unknown_with_one_injected_note_renders_exactly(self) -> None:
         self._run_ui_harness(
@@ -1130,7 +1322,10 @@ main().catch((error) => {
   for (const forbidden of ["ACTIVATED", "REUSED", "PROMOTABLE", "success", "useful", "savings"]) {
     assert(!receipt.textContent.includes(forbidden));
   }
-  assert.strictEqual(receipt.querySelectorAll("button").length, 0);
+  assert.deepStrictEqual(
+    receipt.querySelectorAll("button").map((button) => button.textContent),
+    ["×"],
+  );
 ''',
         )
 


### PR DESCRIPTION
## What changed

- Add a client-observed Run activity panel using the existing bounded Run state and progress messages.
- Show `Working · MM:SS`, the latest observed progress message, and the age of the last actual progress-list change.
- Hide the generic working indicator during Approval and stop/reset it at terminal or disconnected state.
- Add visible × / Close and Escape dismissal for the Field Note reconnect receipt.
- Preserve the receipt in memory and provide `View receipt` to reopen it without any API call or rerun.

## Why

The first real ordinary dogfood established the full Task → Run → Approval → one-file mutation path, but exposed two trust blockers: active work was not perceptible, and the reconnect receipt could not be dismissed.

## Semantics and safety

- Elapsed time begins when this UI first observes the Run as running; it is not an ETA.
- Identical polls do not create progress events or reset progress age.
- After 30 seconds without a changed progress list, the UI says `No new progress update for MM:SS`; this is not a stall/failure claim.
- Receipt close/reopen is DOM presentation only: no receipt, evidence, Run, approval, or backend mutation.
- Runtime verification, read limits, one-file/approval boundaries, verification outcomes, and `Change applied — verification needs review` are unchanged.
- Work was performed in a clean isolated worktree at canonical base `4faa4d186283107a1aaa2c34c9481c7d7960e991`. Shin’s original dogfood README remained untouched.

## Checks

- `python3 -m unittest tests.test_companion_server.CompanionClientBehaviorTest tests.test_field_notes_reconnect.FieldNotesReconnectStaticUiTests tests.test_field_notes_lite.FieldNotesStaticUiTests`
  - 19 tests passed
  - includes headless Chrome activity lifecycle and receipt close/Escape/reopen regressions
- `git diff --check`

Model/task invocation count during qualification: 0.
