### PR TITLE
Preserve the approved real-dogfood README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,17 @@ In one bounded private-repository evidence path, fresh AI contexts selected rele
 
 This is bounded evidence, not proof across all models or repositories. Final adoption authority remains with the Decision Owner.
 
+The current separate creator-live Cycle 006 record is bounded terminal failure
+evidence: one authorized attempt reached `A1_CAPTURE` and stopped with
+`A1_CANDIDATE_INDEPENDENCE_NOT_PASS`. No Note was saved or durably captured,
+no real After was produced, and Run 2 and A2–A7 were not run.
+
+This establishes only that terminal boundary. It does not establish A1–A7
+success, Compactor success, successful reconnect or reuse, behavior
+preservation or `10/10`, generalization, superiority, or external-user
+validation. [Read the Cycle 006 terminal public
+evidence.](validation/a7_creator_live_cycle_006_terminal_public_evidence_001.md)
+
 Example prompt:
 
 > Review my repository's current operational problem. Use V13 only where relevant. Identify the Field Notes that directly apply, explain what may be worth adopting, and state what should not be imported. Do not modify files or start execution.


### PR DESCRIPTION
## What changed

- Preserve the exact human-approved README mutation produced by the first real Companion dogfood.
- Add only the 11-line bounded Cycle 006 terminal-evidence paragraph already present in Shin’s original dogfood working tree.

## Provenance and scope

- Canonical base: `b63e02e6e5a3ebaeab996966c7d34f34ec036ebe`
- Source dogfood README SHA-256: `37e0a17c9c0238f125d365b2fe8d80fc31463de0397e9b32a7bae472af260d83`
- The branch README is byte-for-byte identical to that source.
- Changed files: `README.md` only.
- The approved wording was copied exactly; it was not rewritten or improved.
- Shin’s original dirty working tree was not reset, stashed, cleaned, or modified.

## Checks

- Source/branch README byte comparison: PASS
- README SHA-256 match: PASS
- `git diff --check`: PASS
- Referenced Cycle 006 evidence path exists: PASS
- Model/task invocation count: 0
