### PR TITLE
Close Fable F3 creator-local test coupling

### DIFF
--- a/tests/test_field_notes_creator_live_cycle_006.py
+++ b/tests/test_field_notes_creator_live_cycle_006.py
@@ -80,6 +80,27 @@ _STALE = "7" * 64
 _RUN_CANONICAL = (
     os.environ.get("DECISION_OS_RUN_CYCLE_006_CANONICAL_TESTS") == "1"
 )
+_CREATOR_LOCAL_CYCLE_006_PROOF_ROOT = (
+    ROOT / ".decision-os/field-notes/proofs/cycle-006"
+)
+
+
+def _require_creator_local_cycle_006_identity(test: unittest.TestCase) -> None:
+    try:
+        cycle006.EXPECTED_REPOSITORY.resolve(strict=True)
+        codex_module.CYCLE_006_CODEX_PATH.resolve(strict=True)
+    except OSError:
+        test.skipTest(
+            "Creator-local Cycle 006 fixed execution identity is absent; "
+            "noncanonical-spec P0 qualification requires the preserved "
+            "repository and content-addressed runtime."
+        )
+    if not _CREATOR_LOCAL_CYCLE_006_PROOF_ROOT.exists():
+        test.skipTest(
+            "Creator-local Cycle 006 durable proof storage is absent; "
+            "noncanonical-spec P0 qualification requires the preserved local "
+            "fixed execution evidence."
+        )
 
 
 class FakeTransportFactory(AdapterFakeTransportFactory):
@@ -783,6 +804,7 @@ class Cycle006IdentityAndBoundaryTests(unittest.TestCase):
         self.assertFalse(os.path.lexists(self.spec.storage_root))
 
     def test_noncanonical_spec_and_symlinked_storage_parent_fail_p0(self) -> None:
+        _require_creator_local_cycle_006_identity(self)
         other_runtime = cycle006.CodexRuntimeIdentity(
             model="other-model",
             reasoning_effort="ultra",

--- a/tests/test_field_notes_creator_live_entrypoint.py
+++ b/tests/test_field_notes_creator_live_entrypoint.py
@@ -48,6 +48,19 @@ from tests.test_companion_controller import ScriptedFactory, create_repository
 
 
 _DIGEST = "a4" * 32
+ROOT = Path(__file__).resolve().parents[1]
+_CREATOR_LOCAL_CYCLE_005_PROOF_ROOT = (
+    ROOT / ".decision-os/field-notes/proofs/cycle-005"
+)
+
+
+def _require_creator_local_cycle_005_proof(test: unittest.TestCase) -> None:
+    if not _CREATOR_LOCAL_CYCLE_005_PROOF_ROOT.exists():
+        test.skipTest(
+            "Creator-local Cycle 005 durable proof storage is absent; "
+            "terminal projection qualification requires the preserved local "
+            "v0.2 journal and anchor."
+        )
 
 
 class _NoopWorker:
@@ -719,6 +732,7 @@ class CreatorLiveAttemptIdentityTests(unittest.TestCase):
 
 class CreatorLiveCycle005BackwardProjectionTests(unittest.TestCase):
     def test_cycle_005_projects_only_exact_v2_durable_values(self) -> None:
+        _require_creator_local_cycle_005_proof(self)
         entrypoint = CreatorLiveCycle005Entrypoint(object())
         snapshot = entrypoint.snapshot({})
         identities = snapshot["identities"]
@@ -760,6 +774,7 @@ class CreatorLiveCycle005BackwardProjectionTests(unittest.TestCase):
         self.assertEqual("A3_EXACT_STRUCTURE_MISSING", identities["failure_code"])
 
     def test_cycle_005_never_reconstructs_from_contemporary_constants(self) -> None:
+        _require_creator_local_cycle_005_proof(self)
         spec = CreatorLiveCycle005Spec(
             run_1_task="CONTEMPORARY_PRIVATE_RUN_1_TASK",
             run_2_task="CONTEMPORARY_PRIVATE_RUN_2_TASK",
@@ -1115,6 +1130,7 @@ class CreatorLiveHTTPTests(unittest.TestCase):
     def test_terminal_http_state_is_allowlisted_and_duplicate_start_is_409(
         self,
     ) -> None:
+        _require_creator_local_cycle_005_proof(self)
         cookie, csrf = self.bootstrap()
         self.controller._creator_live_cycle_005 = CreatorLiveCycle005Entrypoint(
             self.controller


### PR DESCRIPTION
## Summary

- classify only the four confirmed creator-environment-coupled tests as creator-local qualifications
- skip the three Cycle 005 projection checks only when the checkout-local durable v0.2 proof root is absent
- skip the Cycle 006 noncanonical-spec P0 check only when the preserved fixed repository/runtime identity or checkout-local Cycle 006 proof root is absent
- preserve every existing strong assertion when the creator prerequisites are present

## Root cause

Fresh third-party clones do not contain creator-local `.decision-os` proof storage or the fixed Cycle 006 creator execution identity. Production therefore truthfully returns `NOT_READY` / `P0_IDENTITY_UNAVAILABLE`, while these four tests unconditionally expected creator-machine terminal or fixed-mismatch results.

## Qualification

- four exact tests, creator state absent: 4 explicit skips, 0 failures
- all three creator-live test files, creator state absent: 165 passed, 9 skipped, 133 subtests passed
- four exact tests, preserved creator evidence present: 4 passed; Cycle 005/006 evidence hashes unchanged
- complete non-root suite: 1386 passed, 15 skipped, 947 subtests passed; 0 failures
- git diff --check: passed

Only two directly necessary test files changed. Production code, canonical-state documents, role contract, README, CI, and F4–F7 are unchanged.