### PR TITLE
Synchronize Compound Loop canonical restart state

### DIFF
--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,10 +1,16 @@
 # Current Signal
 
-## Canonical Current State — V13 Post-Audit Product Gate
+## Canonical Current State — V13 Compound Loop Build
 
 ```text
 Current Layer:
-V13 — Post-Audit Product Gate
+V13 — Compound Loop Build
+
+Product Roadmap:
+Companion Product Roadmap v0.3 FIXED
+
+Product Direction:
+Human-Seat-Preserving Autonomous Compounding
 
 V12 State:
 PASS
@@ -16,20 +22,25 @@ F3 CLOSED
 REPAIR CLOSURE PASS
 
 Current Gate:
-HOLD — PRODUCT VALUE GAP
+GO — BOUNDED COMPOUND LOOP PROOF
+
+Build Scope:
+Stage A → Stage B → Stage C in order
+
+First Live Cap:
+3 total bounded Runs
 
 Repository:
 shin4141/decision-os-v13-loopkit
 
 Active Branch:
-main after repair merge
+main
 
 Pre-Public Technical Repair:
 COMPLETE
 
-Established Product Gap:
-The current Companion can safely execute one bounded Run, but Shin has not
-established that it provides enough value to prefer using it over direct Codex.
+Public Core / Private Operator Boundary:
+FIXED
 
 Release Authority:
 NONE
@@ -38,8 +49,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-Evaluate the minimum Compound Loop capability required for V13 to become
-meaningfully preferable to direct Codex for its intended use.
+Implement and verify Stage A Supervisor Judgment, then continue to Stage B
+and Stage C only after each prior Completion Line is satisfied.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,10 +1,16 @@
 # Current Codex Handoff - V13 LoopKit
 
-## Canonical Current State — V13 Post-Audit Product Gate
+## Canonical Current State — V13 Compound Loop Build
 
 ```text
 Current Layer:
-V13 — Post-Audit Product Gate
+V13 — Compound Loop Build
+
+Product Roadmap:
+Companion Product Roadmap v0.3 FIXED
+
+Product Direction:
+Human-Seat-Preserving Autonomous Compounding
 
 V12 State:
 PASS
@@ -16,20 +22,25 @@ F3 CLOSED
 REPAIR CLOSURE PASS
 
 Current Gate:
-HOLD — PRODUCT VALUE GAP
+GO — BOUNDED COMPOUND LOOP PROOF
+
+Build Scope:
+Stage A → Stage B → Stage C in order
+
+First Live Cap:
+3 total bounded Runs
 
 Repository:
 shin4141/decision-os-v13-loopkit
 
 Active Branch:
-main after repair merge
+main
 
 Pre-Public Technical Repair:
 COMPLETE
 
-Established Product Gap:
-The current Companion can safely execute one bounded Run, but Shin has not
-established that it provides enough value to prefer using it over direct Codex.
+Public Core / Private Operator Boundary:
+FIXED
 
 Release Authority:
 NONE
@@ -38,8 +49,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-Evaluate the minimum Compound Loop capability required for V13 to become
-meaningfully preferable to direct Codex for its intended use.
+Implement and verify Stage A Supervisor Judgment, then continue to Stage B
+and Stage C only after each prior Completion Line is satisfied.
 ```
 
 Everything below this boundary is preserved historical material as of its own


### PR DESCRIPTION
## What changed

- synchronize the top canonical-current-state blocks in `docs/current_signal.md` and `handoff/current_codex_handoff.md`
- set the current layer, roadmap, product direction, gate, build order, and first live cap for the Compound Loop build
- preserve V12 PASS, F1–F3 repair closure, and the release/publication prohibitions
- preserve both historical tails byte-for-byte

## Why

Roadmap v0.3 is fixed and PR #125 is merged, so the restart surfaces must point to Stage A Supervisor Judgment instead of the obsolete Product Value Gap.

## Validation

- `python -B -m decision_os check .` — PASS
- `python -B -m unittest tests.test_decision_os_handoff_acceptance` — PASS (56 cases)
- remaining CLI cases — PASS (5 cases)
- `git diff --check` — PASS
- exactly two authorized files changed
- historical tails SHA-256 identical to `9811c9f0`

One repository test assertion expecting `v12_state == BLOCK` fails identically on untouched canonical `9811c9f0`, whose current state already says `V12 State: PASS`; it is a pre-existing stale assertion and is not modified because this synchronization is explicitly limited to the two restart surfaces.