### PR TITLE
Stage B: prove one automatic continuation

### DIFF
--- a/decision_os/companion/__init__.py
+++ b/decision_os/companion/__init__.py
@@ -1,6 +1,11 @@
 """Private localhost companion for one bounded Decision OS Run."""
 
-from .controller import CompanionController
+from .continuation import (
+    ContinuationError,
+    ContinuationIntegrityError,
+    StageBContinuationRequest,
+)
+from .controller import CompanionController, ContinuationStateError
 from .server import CompanionServer
 from .supervisor import (
     ContractFact,
@@ -14,11 +19,15 @@ from .supervisor import (
 __all__ = [
     "CompanionController",
     "CompanionServer",
+    "ContinuationError",
+    "ContinuationIntegrityError",
+    "ContinuationStateError",
     "ContractFact",
     "DecisionRoute",
     "SupervisorContext",
     "SupervisorGate",
     "SupervisorJudgment",
+    "StageBContinuationRequest",
     "judge_continuation",
 ]
 __version__ = "0.1.0"

--- a/decision_os/companion/continuation.py
+++ b/decision_os/companion/continuation.py
@@ -1,0 +1,883 @@
+"""Stage B persisted, exactly-once automatic continuation contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+from typing import Any, Mapping
+
+from decision_os.acceleration.codex_adapter import CodexRunResult
+from decision_os.acceleration.model import canonical_json, hash_payload
+from decision_os.companion.supervisor import (
+    ContractFact,
+    FIRST_LIVE_MAX_RUNS,
+    SupervisorContext,
+)
+
+
+STAGE_B_SCHEMA = "decision-os-stage-b-continuation-v0.1"
+STAGE_B_AUTOMATIC_CONTINUATION_LIMIT = 1
+_MAX_RECORD_BYTES = 256 * 1024
+_MAX_TASK_BYTES = 20_000
+_RECORD_STATES = frozenset(
+    {
+        "RUN_1_ACTIVE",
+        "RUN_1_COMPLETE",
+        "RUN_2_ACTIVE",
+        "COMPLETE",
+        "STOPPED",
+        "BLOCKED",
+    }
+)
+_REQUEST_FIELDS = frozenset(
+    {
+        "goal",
+        "run_1_task",
+        "remaining_gap_after_run_1",
+        "next_bounded_action",
+        "evidence_recovery_action",
+        "irreducible_human_decision",
+        "authority_evidence_refs",
+        "allowed_mutation_paths",
+        "protected_objects",
+        "completed_runs_before",
+        "max_runs",
+        "goal_complete_after_run_1",
+        "goal_unchanged",
+        "authority_sufficient",
+        "blast_radius_bounded",
+        "action_reversible_or_authorized",
+        "no_material_human_preference_required",
+        "no_external_or_irreversible_commitment",
+        "cost_boundary_intact",
+        "protected_object_and_ownership_unchanged",
+        "no_authoritative_conflict",
+        "no_truly_unanswered_human_question",
+    }
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "chain_id",
+        "repository_id",
+        "state",
+        "request",
+        "runs",
+        "supervisor",
+        "automatic_task",
+        "automatic_continuations_started",
+        "automatic_continuation_limit",
+        "governed_stop",
+        "record_sha256",
+    }
+)
+_RUN_FIELDS = frozenset(
+    {
+        "run_number",
+        "run_id",
+        "status",
+        "normal_terminal",
+        "turn_status",
+        "error_type",
+        "unsupported_reason",
+        "runtime_identity",
+        "checkpoint_outcomes",
+        "file_actions",
+        "read_evidence",
+        "receipt_delta",
+        "final_message_bytes",
+        "final_message_sha256",
+        "evidence_sha256",
+    }
+)
+_SUPERVISOR_FIELDS = frozenset(
+    {
+        "schema",
+        "role",
+        "consumed_run",
+        "gate",
+        "reason",
+        "established_state",
+        "remaining_gap",
+        "decision_route",
+        "next_bounded_action",
+        "human_seat_return",
+        "evidence_refs",
+        "automatic_second_run_started",
+    }
+)
+
+
+class ContinuationError(RuntimeError):
+    """A Stage B request or transition cannot be executed safely."""
+
+
+class ContinuationIntegrityError(ContinuationError):
+    """Persisted Stage B state is missing, corrupt, or causally mismatched."""
+
+
+def _bounded_text(
+    value: Any,
+    label: str,
+    *,
+    maximum: int,
+    optional: bool = False,
+) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a bounded non-empty string.")
+    if len(value.encode("utf-8")) > maximum:
+        raise ValueError(f"{label} exceeds its bounded size limit.")
+    return value.strip()
+
+
+def _bounded_strings(
+    values: Any,
+    label: str,
+    *,
+    minimum: int = 1,
+    maximum: int = 16,
+) -> tuple[str, ...]:
+    if not isinstance(values, tuple) or not minimum <= len(values) <= maximum:
+        raise ValueError(f"{label} must contain {minimum} to {maximum} entries.")
+    normalized: list[str] = []
+    for value in values:
+        item = _bounded_text(value, label, maximum=2_000)
+        assert item is not None
+        normalized.append(item)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"{label} cannot contain duplicate entries.")
+    return tuple(normalized)
+
+
+@dataclass(frozen=True)
+class StageBContinuationRequest:
+    """One pre-Run authority envelope for exactly one possible continuation."""
+
+    goal: str
+    run_1_task: str
+    remaining_gap_after_run_1: str
+    next_bounded_action: str
+    evidence_recovery_action: str | None
+    irreducible_human_decision: str | None
+    authority_evidence_refs: tuple[str, ...]
+    allowed_mutation_paths: tuple[str, ...]
+    protected_objects: tuple[str, ...]
+    completed_runs_before: int
+    max_runs: int
+    goal_complete_after_run_1: ContractFact
+    goal_unchanged: ContractFact
+    authority_sufficient: ContractFact
+    blast_radius_bounded: ContractFact
+    action_reversible_or_authorized: ContractFact
+    no_material_human_preference_required: ContractFact
+    no_external_or_irreversible_commitment: ContractFact
+    cost_boundary_intact: ContractFact
+    protected_object_and_ownership_unchanged: ContractFact
+    no_authoritative_conflict: ContractFact
+    no_truly_unanswered_human_question: ContractFact
+
+    def __post_init__(self) -> None:
+        for label, value, maximum in (
+            ("Goal", self.goal, _MAX_TASK_BYTES),
+            ("Run 1 task", self.run_1_task, _MAX_TASK_BYTES),
+            ("Remaining gap", self.remaining_gap_after_run_1, 8_000),
+            ("Next bounded action", self.next_bounded_action, 8_000),
+        ):
+            _bounded_text(value, label, maximum=maximum)
+        _bounded_text(
+            self.evidence_recovery_action,
+            "Evidence recovery action",
+            maximum=8_000,
+            optional=True,
+        )
+        _bounded_text(
+            self.irreducible_human_decision,
+            "Irreducible Human Seat decision",
+            maximum=8_000,
+            optional=True,
+        )
+        _bounded_strings(
+            self.authority_evidence_refs,
+            "Authority evidence references",
+        )
+        _bounded_strings(
+            self.allowed_mutation_paths,
+            "Allowed mutation paths",
+            maximum=1,
+        )
+        _bounded_strings(
+            self.protected_objects,
+            "Protected Objects",
+            maximum=8,
+        )
+        if (
+            not isinstance(self.completed_runs_before, int)
+            or isinstance(self.completed_runs_before, bool)
+            or self.completed_runs_before < 0
+        ):
+            raise ValueError("Completed Runs before Stage B must be non-negative.")
+        if (
+            not isinstance(self.max_runs, int)
+            or isinstance(self.max_runs, bool)
+            or not 1 <= self.max_runs <= FIRST_LIVE_MAX_RUNS
+        ):
+            raise ValueError("The authorized total Run cap must be between 1 and 3.")
+        if self.completed_runs_before >= self.max_runs:
+            raise ValueError("The Run cap leaves no authority for Worker Run 1.")
+        for name, fact in self.contract_facts():
+            if not isinstance(fact, ContractFact):
+                raise ValueError(f"{name} must be an explicit ContractFact.")
+
+    def contract_facts(self) -> tuple[tuple[str, ContractFact], ...]:
+        return (
+            ("goal_complete_after_run_1", self.goal_complete_after_run_1),
+            ("goal_unchanged", self.goal_unchanged),
+            ("authority_sufficient", self.authority_sufficient),
+            ("blast_radius_bounded", self.blast_radius_bounded),
+            (
+                "action_reversible_or_authorized",
+                self.action_reversible_or_authorized,
+            ),
+            (
+                "no_material_human_preference_required",
+                self.no_material_human_preference_required,
+            ),
+            (
+                "no_external_or_irreversible_commitment",
+                self.no_external_or_irreversible_commitment,
+            ),
+            ("cost_boundary_intact", self.cost_boundary_intact),
+            (
+                "protected_object_and_ownership_unchanged",
+                self.protected_object_and_ownership_unchanged,
+            ),
+            ("no_authoritative_conflict", self.no_authoritative_conflict),
+            (
+                "no_truly_unanswered_human_question",
+                self.no_truly_unanswered_human_question,
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        value: dict[str, Any] = {
+            "goal": self.goal.strip(),
+            "run_1_task": self.run_1_task.strip(),
+            "remaining_gap_after_run_1": self.remaining_gap_after_run_1.strip(),
+            "next_bounded_action": self.next_bounded_action.strip(),
+            "evidence_recovery_action": (
+                None
+                if self.evidence_recovery_action is None
+                else self.evidence_recovery_action.strip()
+            ),
+            "irreducible_human_decision": (
+                None
+                if self.irreducible_human_decision is None
+                else self.irreducible_human_decision.strip()
+            ),
+            "authority_evidence_refs": list(self.authority_evidence_refs),
+            "allowed_mutation_paths": list(self.allowed_mutation_paths),
+            "protected_objects": list(self.protected_objects),
+            "completed_runs_before": self.completed_runs_before,
+            "max_runs": self.max_runs,
+        }
+        value.update(
+            {name: fact.value for name, fact in self.contract_facts()}
+        )
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "StageBContinuationRequest":
+        if not isinstance(value, dict) or set(value) != _REQUEST_FIELDS:
+            raise ContinuationIntegrityError(
+                "Persisted Stage B authority fields are invalid."
+            )
+        if any(
+            not isinstance(value[key], list)
+            for key in (
+                "authority_evidence_refs",
+                "allowed_mutation_paths",
+                "protected_objects",
+            )
+        ):
+            raise ContinuationIntegrityError(
+                "Persisted Stage B authority collections are invalid."
+            )
+        try:
+            facts = {
+                name: ContractFact(value[name])
+                for name in (
+                    "goal_complete_after_run_1",
+                    "goal_unchanged",
+                    "authority_sufficient",
+                    "blast_radius_bounded",
+                    "action_reversible_or_authorized",
+                    "no_material_human_preference_required",
+                    "no_external_or_irreversible_commitment",
+                    "cost_boundary_intact",
+                    "protected_object_and_ownership_unchanged",
+                    "no_authoritative_conflict",
+                    "no_truly_unanswered_human_question",
+                )
+            }
+            return cls(
+                goal=value["goal"],
+                run_1_task=value["run_1_task"],
+                remaining_gap_after_run_1=value[
+                    "remaining_gap_after_run_1"
+                ],
+                next_bounded_action=value["next_bounded_action"],
+                evidence_recovery_action=value["evidence_recovery_action"],
+                irreducible_human_decision=value[
+                    "irreducible_human_decision"
+                ],
+                authority_evidence_refs=tuple(
+                    value["authority_evidence_refs"]
+                ),
+                allowed_mutation_paths=tuple(value["allowed_mutation_paths"]),
+                protected_objects=tuple(value["protected_objects"]),
+                completed_runs_before=value["completed_runs_before"],
+                max_runs=value["max_runs"],
+                **facts,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ContinuationIntegrityError(
+                "Persisted Stage B authority is invalid."
+            ) from exc
+
+
+def result_evidence(
+    result: CodexRunResult,
+    *,
+    run_number: int,
+    receipt_delta: Mapping[str, Any],
+) -> dict[str, Any]:
+    identity = result.runtime_identity
+    payload: dict[str, Any] = {
+        "run_number": run_number,
+        "run_id": result.run_id,
+        "status": result.status,
+        "normal_terminal": result.normal_terminal,
+        "turn_status": result.turn_status,
+        "error_type": result.error_type,
+        "unsupported_reason": result.unsupported_reason,
+        "runtime_identity": (
+            None
+            if identity is None
+            else {
+                "model": identity.model,
+                "reasoning_effort": identity.reasoning_effort,
+                "service_tier": identity.service_tier,
+                "codex_cli_version": identity.codex_cli_version,
+                "account_type": identity.account_type,
+            }
+        ),
+        "checkpoint_outcomes": [
+            {
+                "status": item.status,
+                "verified": item.verified,
+                "event_hash": item.event_hash,
+            }
+            for item in result.checkpoint_outcomes
+        ],
+        "file_actions": [
+            {
+                "action": item.action,
+                "path": item.normalized_scope,
+                "access": item.access,
+                "status": item.status,
+            }
+            for item in result.file_actions
+        ],
+        "read_evidence": [
+            {
+                "path": item.path,
+                "bytes": item.byte_count,
+                "sha256": item.sha256,
+                "repository_identity": item.repository_identity,
+                "status": item.status,
+                "reason": item.reason,
+            }
+            for item in result.read_evidence
+        ],
+        "receipt_delta": dict(receipt_delta),
+        "final_message_bytes": len(result.final_message.encode("utf-8")),
+        "final_message_sha256": hashlib.sha256(
+            result.final_message.encode("utf-8")
+        ).hexdigest(),
+    }
+    payload["evidence_sha256"] = hash_payload(payload)
+    return payload
+
+
+def supervisor_context_from_persisted_run(
+    record: Mapping[str, Any],
+) -> SupervisorContext:
+    request = StageBContinuationRequest.from_dict(record["request"])
+    runs = record.get("runs")
+    if not isinstance(runs, list) or len(runs) != 1:
+        raise ContinuationIntegrityError(
+            "Stage B requires exactly one persisted Run 1 result before judgment."
+        )
+    run = runs[0]
+    evidence_ref = (
+        f"stage-b:{record['chain_id']}:run-1:"
+        f"evidence-sha256={run['evidence_sha256']}"
+    )
+    return SupervisorContext(
+        goal=request.goal,
+        established_state=(
+            f"Run 1 {run['run_id']} is persisted as {run['status']} with "
+            f"evidence SHA-256 {run['evidence_sha256']}."
+        ),
+        remaining_gap=request.remaining_gap_after_run_1,
+        next_bounded_action=request.next_bounded_action,
+        evidence_recovery_action=request.evidence_recovery_action,
+        irreducible_human_decision=request.irreducible_human_decision,
+        evidence_refs=(*request.authority_evidence_refs, evidence_ref),
+        completed_runs=request.completed_runs_before + 1,
+        max_runs=request.max_runs,
+        goal_complete=request.goal_complete_after_run_1,
+        continuation_proof_sufficient=ContractFact.SATISFIED,
+        goal_unchanged=request.goal_unchanged,
+        authority_sufficient=request.authority_sufficient,
+        blast_radius_bounded=request.blast_radius_bounded,
+        action_reversible_or_authorized=(
+            request.action_reversible_or_authorized
+        ),
+        evidence_sufficient=ContractFact.SATISFIED,
+        no_material_human_preference_required=(
+            request.no_material_human_preference_required
+        ),
+        no_external_or_irreversible_commitment=(
+            request.no_external_or_irreversible_commitment
+        ),
+        cost_boundary_intact=request.cost_boundary_intact,
+        protected_object_and_ownership_unchanged=(
+            request.protected_object_and_ownership_unchanged
+        ),
+        no_authoritative_conflict=request.no_authoritative_conflict,
+        no_truly_unanswered_human_question=(
+            request.no_truly_unanswered_human_question
+        ),
+    )
+
+
+def automatic_task_from_persisted_run(record: Mapping[str, Any]) -> dict[str, str]:
+    request = StageBContinuationRequest.from_dict(record.get("request"))
+    runs = record.get("runs")
+    supervisor = record.get("supervisor")
+    consumed_run = (
+        supervisor.get("consumed_run")
+        if isinstance(supervisor, dict)
+        else None
+    )
+    if (
+        record.get("state") != "RUN_1_COMPLETE"
+        or not isinstance(runs, list)
+        or len(runs) != 1
+        or not isinstance(supervisor, dict)
+        or not isinstance(consumed_run, dict)
+        or supervisor.get("gate") != "GO"
+        or supervisor.get("decision_route") != "AI-OWNED"
+        or consumed_run.get("run_id") != runs[0].get("run_id")
+    ):
+        raise ContinuationIntegrityError(
+            "Task 2 cannot be derived without an exact persisted Run 1 GO chain."
+        )
+    causal_evidence = {
+        "run_id": runs[0]["run_id"],
+        "status": runs[0]["status"],
+        "evidence_sha256": runs[0]["evidence_sha256"],
+        "checkpoint_outcomes": runs[0]["checkpoint_outcomes"],
+        "file_actions": runs[0]["file_actions"],
+        "read_evidence": runs[0]["read_evidence"],
+        "receipt_delta": runs[0]["receipt_delta"],
+    }
+    task = "\n".join(
+        (
+            "STAGE B AUTOMATIC CONTINUATION — RUN 2 OF 2 FOR THIS INVOCATION",
+            "",
+            "Original user Goal:",
+            request.goal,
+            "",
+            "Persisted Run 1 causal evidence:",
+            canonical_json(causal_evidence),
+            "",
+            "Established remaining gap:",
+            request.remaining_gap_after_run_1,
+            "",
+            "Execute exactly this authorized next bounded action:",
+            request.next_bounded_action,
+            "",
+            "Allowed mutation path (no expansion):",
+            request.allowed_mutation_paths[0],
+            "",
+            "Protected Objects / ownership boundaries (unchanged):",
+            canonical_json(list(request.protected_objects)),
+            "",
+            (
+                "Preserve the same Goal, authority, evidence continuity, blast "
+                "radius, and total Run cap. Do not publish, release, modify a "
+                "Protected Object, request a new user task, or start/propose Run 3."
+            ),
+        )
+    )
+    if len(task.encode("utf-8")) > _MAX_TASK_BYTES:
+        raise ContinuationIntegrityError(
+            "The causally constructed Task 2 exceeds the bounded task limit."
+        )
+    return {
+        "source_run_id": runs[0]["run_id"],
+        "source_evidence_sha256": runs[0]["evidence_sha256"],
+        "goal_sha256": hashlib.sha256(
+            request.goal.encode("utf-8")
+        ).hexdigest(),
+        "task": task,
+        "task_sha256": hashlib.sha256(task.encode("utf-8")).hexdigest(),
+    }
+
+
+def new_record(
+    request: StageBContinuationRequest,
+    *,
+    chain_id: str,
+    repository_id: str,
+) -> dict[str, Any]:
+    return {
+        "schema": STAGE_B_SCHEMA,
+        "chain_id": chain_id,
+        "repository_id": repository_id,
+        "state": "RUN_1_ACTIVE",
+        "request": request.as_dict(),
+        "runs": [],
+        "supervisor": None,
+        "automatic_task": None,
+        "automatic_continuations_started": 0,
+        "automatic_continuation_limit": STAGE_B_AUTOMATIC_CONTINUATION_LIMIT,
+        "governed_stop": None,
+    }
+
+
+def governed_stop(
+    *,
+    gate: str,
+    route: str,
+    reason: str,
+    next_action: str,
+) -> dict[str, str]:
+    return {
+        "gate": gate,
+        "route": route,
+        "reason": reason,
+        "next_action": next_action,
+    }
+
+
+def _validate_run(value: Any, expected_number: int) -> None:
+    if not isinstance(value, dict) or set(value) != _RUN_FIELDS:
+        raise ContinuationIntegrityError("Persisted Worker Run evidence is invalid.")
+    if value["run_number"] != expected_number:
+        raise ContinuationIntegrityError("Persisted Worker Run order is invalid.")
+    for key in ("run_id", "status", "final_message_sha256", "evidence_sha256"):
+        if not isinstance(value[key], str) or not value[key]:
+            raise ContinuationIntegrityError("Persisted Worker identity is invalid.")
+    if len(value["final_message_sha256"]) != 64 or len(
+        value["evidence_sha256"]
+    ) != 64:
+        raise ContinuationIntegrityError("Persisted Worker hashes are invalid.")
+    if not isinstance(value["normal_terminal"], bool):
+        raise ContinuationIntegrityError("Persisted terminal state is invalid.")
+    if value["turn_status"] is not None and not isinstance(
+        value["turn_status"],
+        str,
+    ):
+        raise ContinuationIntegrityError("Persisted turn status is invalid.")
+    for key in ("error_type", "unsupported_reason"):
+        if value[key] is not None and not isinstance(value[key], str):
+            raise ContinuationIntegrityError("Persisted Run error state is invalid.")
+    if value["runtime_identity"] is not None and not isinstance(
+        value["runtime_identity"],
+        dict,
+    ):
+        raise ContinuationIntegrityError("Persisted runtime identity is invalid.")
+    if any(
+        not isinstance(value[key], list)
+        for key in ("checkpoint_outcomes", "file_actions", "read_evidence")
+    ) or not isinstance(value["receipt_delta"], dict):
+        raise ContinuationIntegrityError("Persisted Run evidence shape is invalid.")
+    if (
+        not isinstance(value["final_message_bytes"], int)
+        or isinstance(value["final_message_bytes"], bool)
+        or value["final_message_bytes"] < 0
+    ):
+        raise ContinuationIntegrityError("Persisted message size is invalid.")
+    payload = {key: item for key, item in value.items() if key != "evidence_sha256"}
+    if value["evidence_sha256"] != hash_payload(payload):
+        raise ContinuationIntegrityError("Persisted Worker evidence hash mismatches.")
+
+
+def _validate_supervisor(value: Any, run_1: Mapping[str, Any]) -> None:
+    if not isinstance(value, dict) or set(value) != _SUPERVISOR_FIELDS:
+        raise ContinuationIntegrityError("Persisted Supervisor fields are invalid.")
+    consumed = value["consumed_run"]
+    if (
+        value["schema"] != "decision-os-supervisor-judgment-v0.1"
+        or value["role"] != "SUPERVISOR"
+        or not isinstance(consumed, dict)
+        or set(consumed) != {"run_id", "status"}
+        or consumed["run_id"] != run_1["run_id"]
+        or consumed["status"] != run_1["status"]
+        or value["gate"] not in {"GO", "HOLD", "CAP", "BLOCK"}
+        or value["decision_route"]
+        not in {"AI-OWNED", "EVIDENCE-RECOVERY", "HUMAN-SEAT", "STOP"}
+        or value["automatic_second_run_started"] is not False
+    ):
+        raise ContinuationIntegrityError("Persisted Supervisor identity is invalid.")
+    for key in ("reason", "established_state", "remaining_gap"):
+        if not isinstance(value[key], str) or not value[key]:
+            raise ContinuationIntegrityError(
+                "Persisted Supervisor narrative is invalid."
+            )
+    evidence_refs = value["evidence_refs"]
+    if (
+        not isinstance(evidence_refs, list)
+        or not evidence_refs
+        or any(not isinstance(item, str) or not item for item in evidence_refs)
+    ):
+        raise ContinuationIntegrityError("Persisted Supervisor evidence is invalid.")
+    next_action = value["next_bounded_action"]
+    human_return = value["human_seat_return"]
+    if (next_action is None) == (human_return is None):
+        raise ContinuationIntegrityError("Persisted Supervisor route is invalid.")
+    if next_action is not None and (
+        not isinstance(next_action, str) or not next_action
+    ):
+        raise ContinuationIntegrityError("Persisted Supervisor action is invalid.")
+    if human_return is not None and (
+        not isinstance(human_return, str) or not human_return
+    ):
+        raise ContinuationIntegrityError("Persisted Human Seat return is invalid.")
+    if (value["decision_route"] == "HUMAN-SEAT") != (
+        human_return is not None
+    ):
+        raise ContinuationIntegrityError(
+            "Persisted Supervisor Human Seat route is invalid."
+        )
+
+
+def _validate_record(value: Any) -> None:
+    if not isinstance(value, dict) or set(value) != _RECORD_FIELDS:
+        raise ContinuationIntegrityError("Persisted Stage B fields are invalid.")
+    if value["schema"] != STAGE_B_SCHEMA or value["state"] not in _RECORD_STATES:
+        raise ContinuationIntegrityError("Persisted Stage B schema or state is invalid.")
+    if (
+        not isinstance(value["chain_id"], str)
+        or len(value["chain_id"]) != 32
+        or any(character not in "0123456789abcdef" for character in value["chain_id"])
+        or not isinstance(value["repository_id"], str)
+        or not value["repository_id"].startswith("repo:v1:")
+    ):
+        raise ContinuationIntegrityError("Persisted Stage B identity is invalid.")
+    StageBContinuationRequest.from_dict(value["request"])
+    runs = value["runs"]
+    if not isinstance(runs, list) or len(runs) > 2:
+        raise ContinuationIntegrityError("Stage B can persist at most two Runs.")
+    for index, run in enumerate(runs, start=1):
+        _validate_run(run, index)
+    started = value["automatic_continuations_started"]
+    if (
+        not isinstance(started, int)
+        or isinstance(started, bool)
+        or started not in {0, 1}
+        or value["automatic_continuation_limit"]
+        != STAGE_B_AUTOMATIC_CONTINUATION_LIMIT
+    ):
+        raise ContinuationIntegrityError("Stage B continuation count is invalid.")
+    task = value["automatic_task"]
+    if task is not None:
+        if not isinstance(task, dict) or set(task) != {
+            "source_run_id",
+            "source_evidence_sha256",
+            "goal_sha256",
+            "task",
+            "task_sha256",
+        }:
+            raise ContinuationIntegrityError("Persisted automatic Task 2 is invalid.")
+        if not runs or task["source_run_id"] != runs[0]["run_id"]:
+            raise ContinuationIntegrityError("Task 2 source Run mismatches.")
+        if any(
+            not isinstance(task[key], str) or not task[key]
+            for key in (
+                "source_run_id",
+                "source_evidence_sha256",
+                "goal_sha256",
+                "task",
+                "task_sha256",
+            )
+        ):
+            raise ContinuationIntegrityError("Persisted Task 2 values are invalid.")
+        if task["source_evidence_sha256"] != runs[0]["evidence_sha256"]:
+            raise ContinuationIntegrityError("Task 2 evidence source mismatches.")
+        request = StageBContinuationRequest.from_dict(value["request"])
+        if task["goal_sha256"] != hashlib.sha256(
+            request.goal.encode("utf-8")
+        ).hexdigest():
+            raise ContinuationIntegrityError("Task 2 Goal identity mismatches.")
+        if task["task_sha256"] != hashlib.sha256(
+            task["task"].encode("utf-8")
+        ).hexdigest():
+            raise ContinuationIntegrityError("Task 2 content hash mismatches.")
+    if started == 1 and task is None:
+        raise ContinuationIntegrityError("Started Task 2 has no causal task record.")
+    if len(runs) == 2 and started != 1:
+        raise ContinuationIntegrityError("Run 2 lacks one continuation start.")
+    if value["state"] in {"RUN_2_ACTIVE", "COMPLETE"} and started != 1:
+        raise ContinuationIntegrityError("Stage B terminal state lacks Run 2 authority.")
+    supervisor = value["supervisor"]
+    if supervisor is not None:
+        if not runs:
+            raise ContinuationIntegrityError(
+                "Persisted Supervisor has no consumed Run."
+            )
+        _validate_supervisor(supervisor, runs[0])
+    stop = value["governed_stop"]
+    if stop is not None and (
+        not isinstance(stop, dict)
+        or set(stop) != {"gate", "route", "reason", "next_action"}
+        or any(not isinstance(item, str) or not item for item in stop.values())
+    ):
+        raise ContinuationIntegrityError("Persisted governed stop is invalid.")
+    state = value["state"]
+    if state == "RUN_1_ACTIVE" and (
+        runs
+        or supervisor is not None
+        or task is not None
+        or started
+        or stop is not None
+    ):
+        raise ContinuationIntegrityError("Active Run 1 state is causally invalid.")
+    if state == "RUN_1_COMPLETE" and (
+        len(runs) != 1 or task is not None or started or stop is not None
+    ):
+        raise ContinuationIntegrityError("Completed Run 1 state is causally invalid.")
+    if state == "RUN_2_ACTIVE" and (
+        len(runs) != 1
+        or supervisor is None
+        or supervisor.get("gate") != "GO"
+        or task is None
+        or stop is not None
+    ):
+        raise ContinuationIntegrityError("Active Run 2 state is causally invalid.")
+    if state == "COMPLETE" and (
+        len(runs) != 2
+        or supervisor is None
+        or supervisor.get("gate") != "GO"
+        or task is None
+    ):
+        raise ContinuationIntegrityError("Completed Stage B state is causally invalid.")
+    if state in {"STOPPED", "BLOCKED"} and stop is None:
+        raise ContinuationIntegrityError("Governed terminal state lacks its stop.")
+    if task is not None:
+        derivation_record = {
+            "state": "RUN_1_COMPLETE",
+            "chain_id": value["chain_id"],
+            "request": value["request"],
+            "runs": runs[:1],
+            "supervisor": supervisor,
+        }
+        if task != automatic_task_from_persisted_run(derivation_record):
+            raise ContinuationIntegrityError(
+                "Persisted Task 2 is not the deterministic Run 1 derivation."
+            )
+    claimed_hash = value["record_sha256"]
+    if not isinstance(claimed_hash, str) or len(claimed_hash) != 64:
+        raise ContinuationIntegrityError("Persisted Stage B record hash is invalid.")
+    payload = {key: item for key, item in value.items() if key != "record_sha256"}
+    if claimed_hash != hash_payload(payload):
+        raise ContinuationIntegrityError("Persisted Stage B record hash mismatches.")
+    if len(canonical_json(value).encode("utf-8")) > _MAX_RECORD_BYTES:
+        raise ContinuationIntegrityError("Persisted Stage B record is too large.")
+
+
+class StageBContinuationStore:
+    """One strict, atomic, hash-bound reconnectable Stage B record."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def save(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        value = deepcopy(dict(payload))
+        value.pop("record_sha256", None)
+        value["record_sha256"] = hash_payload(value)
+        _validate_record(value)
+        encoded = (canonical_json(value) + "\n").encode("utf-8")
+        directory = self.path.parent
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+        temporary = directory / f".stage-b-{secrets.token_hex(8)}.tmp"
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(encoded)
+            os.replace(temporary, self.path)
+            os.chmod(self.path, 0o600)
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+        return self.load_required()
+
+    def load(self) -> dict[str, Any] | None:
+        if not self.path.exists():
+            return None
+        try:
+            raw = self.path.read_bytes()
+            if len(raw) > _MAX_RECORD_BYTES:
+                raise ContinuationIntegrityError(
+                    "Persisted Stage B record is too large."
+                )
+            value = json.loads(raw)
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ContinuationIntegrityError(
+                "Persisted Stage B record is unreadable."
+            ) from exc
+        try:
+            _validate_record(value)
+        except ContinuationIntegrityError:
+            raise
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            raise ContinuationIntegrityError(
+                "Persisted Stage B record structure is invalid."
+            ) from exc
+        return deepcopy(value)
+
+    def load_required(self) -> dict[str, Any]:
+        value = self.load()
+        if value is None:
+            raise ContinuationIntegrityError("Persisted Stage B record is absent.")
+        return value
+
+
+__all__ = [
+    "ContinuationError",
+    "ContinuationIntegrityError",
+    "STAGE_B_AUTOMATIC_CONTINUATION_LIMIT",
+    "STAGE_B_SCHEMA",
+    "StageBContinuationRequest",
+    "StageBContinuationStore",
+    "automatic_task_from_persisted_run",
+    "governed_stop",
+    "new_record",
+    "result_evidence",
+    "supervisor_context_from_persisted_run",
+]

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -6,6 +6,8 @@ import asyncio
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from copy import deepcopy
+from dataclasses import replace
+import hashlib
 import io
 import json
 import os
@@ -28,7 +30,11 @@ from decision_os.acceleration.codex_adapter import (
     canonical_failure_diagnostic,
 )
 from decision_os.acceleration.engine import AccelerationEngine
-from decision_os.acceleration.model import RepositoryIdentityError, git_root
+from decision_os.acceleration.model import (
+    RepositoryIdentityError,
+    git_root,
+    normalize_scope,
+)
 from decision_os.acceleration.store import (
     AccelerationStore,
     ActiveDefaultRecord,
@@ -44,6 +50,16 @@ from decision_os.companion.guided_intake import (
     GuidedIntakeBusyError,
     GuidedIntakeController,
     GuidedIntakeIntegrityError,
+)
+from decision_os.companion.continuation import (
+    ContinuationIntegrityError,
+    StageBContinuationRequest,
+    StageBContinuationStore,
+    automatic_task_from_persisted_run,
+    governed_stop,
+    new_record,
+    result_evidence,
+    supervisor_context_from_persisted_run,
 )
 from decision_os.companion.intelligence_transplant import (
     IntelligenceTransplantBusyError,
@@ -95,6 +111,10 @@ class LifecycleEventError(CompanionError):
 
 class SupervisorStateError(CompanionError):
     """A Supervisor judgment has no exact completed Worker result."""
+
+
+class ContinuationStateError(CompanionError):
+    """A Stage B continuation request cannot be started safely."""
 
 
 class AdapterFactory(Protocol):
@@ -213,6 +233,13 @@ class CompanionController:
         self._run: dict[str, Any] = self._empty_run()
         self._last_run_result: CodexRunResult | None = None
         self._last_supervisor_context: SupervisorContext | None = None
+        self._continuation_store = StageBContinuationStore(
+            self.state_path.with_name("stage-b-continuation.json")
+        )
+        self._compound_loop: dict[str, Any] | None = None
+        self._compound_active = False
+        self._compound_recovery_required = False
+        self._compound_allowed_mutation_paths: tuple[str, ...] = ()
         self._approval_choice: str | None = None
         self._default_handles: dict[str, str] = {}
         self._worker: threading.Thread | None = None
@@ -227,6 +254,7 @@ class CompanionController:
         self._active_intelligence_transplant_operations = 0
         self._repository_selection_active = False
         self._load_last_repository()
+        self._load_compound_loop()
         if self._repository is not None:
             self._bridge = BridgeSessionController(self._repository)
             self._guided_intake = GuidedIntakeController(self._repository)
@@ -270,6 +298,7 @@ class CompanionController:
             "runtime": None,
             "receipt_delta": None,
             "supervisor": None,
+            "continuation": None,
             "approval": None,
             "error": None,
             "failure": None,
@@ -325,6 +354,46 @@ class CompanionController:
         except Exception:
             temporary.unlink(missing_ok=True)
             raise
+
+    def _load_compound_loop(self) -> None:
+        try:
+            value = self._continuation_store.load()
+            if value is not None and self._repository is not None:
+                expected = AccelerationStore(self._repository).repository_id
+                if value["repository_id"] != expected:
+                    if value.get("state") in {
+                        "RUN_1_ACTIVE",
+                        "RUN_1_COMPLETE",
+                        "RUN_2_ACTIVE",
+                    }:
+                        raise ContinuationIntegrityError(
+                            "Persisted Stage B repository identity mismatches."
+                        )
+                    value = None
+            self._compound_loop = value
+            self._compound_recovery_required = bool(
+                value is not None
+                and value.get("state")
+                in {"RUN_1_ACTIVE", "RUN_1_COMPLETE", "RUN_2_ACTIVE"}
+            )
+        except (ContinuationIntegrityError, OSError):
+            self._compound_recovery_required = True
+            self._compound_loop = {
+                "schema": "decision-os-stage-b-continuation-view-v0.1",
+                "state": "BLOCKED_CORRUPT",
+                "gate": "BLOCK",
+                "decision_route": "EVIDENCE-RECOVERY",
+                "automatic_continuations_started": 0,
+                "automatic_continuation_limit": 1,
+                "error": (
+                    "Stage B continuation state is not reconnectable from "
+                    "verified persisted evidence."
+                ),
+                "next_bounded_action": (
+                    "Recover the exact persisted Stage B record under current "
+                    "repository authority."
+                ),
+            }
 
     @staticmethod
     def _validated_repository(candidate: Path) -> Path:
@@ -383,6 +452,7 @@ class CompanionController:
                     )
                 self._write_last_repository(repository)
                 self._repository = repository
+                self._load_compound_loop()
                 self._bridge = BridgeSessionController(repository)
                 self._guided_intake = GuidedIntakeController(repository)
                 self._ordinary_user_path = OrdinaryUserPathCoordinator(
@@ -400,6 +470,8 @@ class CompanionController:
                 self._run = self._empty_run()
                 self._last_run_result = None
                 self._last_supervisor_context = None
+                self._compound_active = False
+                self._compound_allowed_mutation_paths = ()
                 return self._snapshot_locked()
         finally:
             with self._condition:
@@ -418,7 +490,11 @@ class CompanionController:
         return self._repository
 
     def _require_no_active_run(self) -> None:
-        if self._run["state"] == "running":
+        if (
+            self._run["state"] == "running"
+            or self._compound_active
+            or self._compound_recovery_required
+        ):
             raise RunConflictError("One bounded Run is already active.")
 
     def _require_bridge(self) -> BridgeSessionController:
@@ -1152,24 +1228,11 @@ class CompanionController:
                 raise RunConflictError(
                     "An Intelligence Transplant action is already active."
                 )
-            before = self._safe_receipt(repository)
-            self._run = self._empty_run()
-            self._run["task_mode"] = task_mode
-            self._run["state"] = "running"
-            self._run["progress"] = ["Preparing the bounded task."]
-            self._run["outcomes"]["execution"] = {
-                "state": "running",
-                "label": "Codex is working",
-            }
-            self._run["outcomes"]["verification"] = {
-                "state": "pending",
-                "label": "Pending",
-                "reason": None,
-            }
-            self._run["receipt_before"] = before
-            self._last_run_result = None
-            self._last_supervisor_context = None
-            self._approval_choice = None
+            self._prepare_bounded_run_locked(
+                repository,
+                task.strip(),
+                task_mode=task_mode,
+            )
             self._worker = threading.Thread(
                 target=self._run_worker,
                 args=(repository, task.strip()),
@@ -1178,6 +1241,36 @@ class CompanionController:
             )
             self._worker.start()
             return self._snapshot_locked()
+
+    def _prepare_bounded_run_locked(
+        self,
+        repository: Path,
+        task: str,
+        *,
+        task_mode: str,
+        continuation: Mapping[str, Any] | None = None,
+    ) -> None:
+        before = self._safe_receipt(repository)
+        self._run = self._empty_run()
+        self._run["task_mode"] = task_mode
+        self._run["state"] = "running"
+        self._run["progress"] = ["Preparing the bounded task."]
+        self._run["outcomes"]["execution"] = {
+            "state": "running",
+            "label": "Codex is working",
+        }
+        self._run["outcomes"]["verification"] = {
+            "state": "pending",
+            "label": "Pending",
+            "reason": None,
+        }
+        self._run["receipt_before"] = before
+        self._run["continuation"] = (
+            None if continuation is None else deepcopy(dict(continuation))
+        )
+        self._last_run_result = None
+        self._last_supervisor_context = None
+        self._approval_choice = None
 
     def _lifecycle_sink(self, event: CodexLifecycleEvent) -> None:
         if (
@@ -1206,6 +1299,12 @@ class CompanionController:
             raise ApprovalStateError("Malformed file approval request.")
         with self._condition:
             if self._run["state"] != "running":
+                return "3"
+            if (
+                self._compound_active
+                and approval.normalized_scope
+                not in self._compound_allowed_mutation_paths
+            ):
                 return "3"
             self._run["approval"] = {
                 "repository": approval.repository_name,
@@ -1247,21 +1346,28 @@ class CompanionController:
             return self._snapshot_locked()
 
     def _run_worker(self, repository: Path, task: str) -> None:
+        try:
+            result = self._execute_worker_run(repository, task)
+            self._complete_run(repository, result)
+        except Exception as exc:
+            self._fail_run(repository, exc)
+
+    def _execute_worker_run(
+        self,
+        repository: Path,
+        task: str,
+    ) -> CodexRunResult:
         engine = AccelerationEngine(
             repository,
             adapter=ADAPTER_NAME,
             adapter_version=CODEX_CLI_VERSION,
         )
-        try:
-            adapter = self.adapter_factory(
-                engine,
-                self._approval_provider,
-                self._lifecycle_sink,
-            )
-            result = asyncio.run(adapter.run(task))
-            self._complete_run(repository, result)
-        except Exception as exc:
-            self._fail_run(repository, exc)
+        adapter = self.adapter_factory(
+            engine,
+            self._approval_provider,
+            self._lifecycle_sink,
+        )
+        return asyncio.run(adapter.run(task))
 
     @staticmethod
     def _public_runtime(result: CodexRunResult) -> dict[str, str] | None:
@@ -1550,6 +1656,360 @@ class CompanionController:
             self._run["supervisor"] = judgment.as_dict()
             self._last_supervisor_context = context
             return self._snapshot_locked()
+
+    def start_one_automatic_continuation(
+        self,
+        request: StageBContinuationRequest,
+    ) -> dict[str, Any]:
+        """Start Run 1 and permit exactly one persisted GO continuation."""
+
+        if not isinstance(request, StageBContinuationRequest):
+            raise ContinuationStateError(
+                "Stage B requires one explicit continuation authority envelope."
+            )
+        with self._condition:
+            repository = self._require_repository()
+            self._require_no_active_run()
+            if self._active_intelligence_transplant_operations:
+                raise RunConflictError(
+                    "An Intelligence Transplant action is already active."
+                )
+            persisted: dict[str, Any] | None = None
+            try:
+                normalized_paths = tuple(
+                    normalize_scope(repository, path)
+                    for path in request.allowed_mutation_paths
+                )
+                normalized_request = replace(
+                    request,
+                    allowed_mutation_paths=normalized_paths,
+                )
+                repository_identity = AccelerationStore(
+                    repository
+                ).repository_id
+                chain_id = secrets.token_hex(16)
+                persisted = self._continuation_store.save(
+                    new_record(
+                        normalized_request,
+                        chain_id=chain_id,
+                        repository_id=repository_identity,
+                    )
+                )
+                self._prepare_bounded_run_locked(
+                    repository,
+                    normalized_request.run_1_task.strip(),
+                    task_mode="contract",
+                    continuation={
+                        "schema": (
+                            "decision-os-bounded-run-continuation-v0.1"
+                        ),
+                        "chain_id": chain_id,
+                        "run_number": 1,
+                        "automatic": False,
+                        "source_run_id": None,
+                        "source_evidence_sha256": None,
+                        "task_sha256": hashlib.sha256(
+                            normalized_request.run_1_task.strip().encode(
+                                "utf-8"
+                            )
+                        ).hexdigest(),
+                    },
+                )
+            except (
+                ContinuationIntegrityError,
+                OSError,
+                RepositoryIdentityError,
+                StateIntegrityError,
+                ValueError,
+            ) as exc:
+                try:
+                    if persisted is not None:
+                        persisted["state"] = "BLOCKED"
+                        persisted["governed_stop"] = governed_stop(
+                            gate="BLOCK",
+                            route="EVIDENCE-RECOVERY",
+                            reason=(
+                                "Stage B Run 1 could not start from verified "
+                                "persisted authority and Receipt state."
+                            ),
+                            next_action=(
+                                "Recover the exact persisted Stage B authority "
+                                "and pre-Run Receipt under the unchanged Goal."
+                            ),
+                        )
+                        self._compound_loop = self._continuation_store.save(
+                            persisted
+                        )
+                except (ContinuationIntegrityError, OSError, ValueError):
+                    self._set_stage_b_blocked_view()
+                raise ContinuationStateError(
+                    "Stage B authority or persistence could not be established."
+                ) from exc
+            assert persisted is not None
+            self._compound_loop = persisted
+            self._compound_active = True
+            self._compound_recovery_required = False
+            self._compound_allowed_mutation_paths = normalized_paths
+            self._worker = threading.Thread(
+                target=self._stage_b_worker,
+                args=(repository, normalized_request),
+                name="decision-os-companion-stage-b",
+                daemon=True,
+            )
+            self._worker.start()
+            return self._snapshot_locked()
+
+    def _stage_b_worker(
+        self,
+        repository: Path,
+        request: StageBContinuationRequest,
+    ) -> None:
+        try:
+            run_1 = self._execute_worker_run(
+                repository,
+                request.run_1_task.strip(),
+            )
+            self._complete_run(repository, run_1)
+        except Exception as exc:
+            self._fail_run(repository, exc)
+            self._stage_b_execution_stop(run_number=1)
+            return
+        try:
+            task_2 = self._stage_b_prepare_run_2(repository, run_1)
+        except (
+            ContinuationIntegrityError,
+            OSError,
+            RepositoryIdentityError,
+            StateIntegrityError,
+            ValueError,
+        ):
+            self._stage_b_integrity_stop()
+            return
+        if task_2 is None:
+            return
+
+        try:
+            run_2 = self._execute_worker_run(repository, task_2)
+            self._complete_run(repository, run_2)
+        except Exception as exc:
+            self._fail_run(repository, exc)
+            self._stage_b_execution_stop(run_number=2)
+            return
+        try:
+            self._stage_b_finish_run_2(run_2)
+        except (ContinuationIntegrityError, OSError, ValueError):
+            self._stage_b_integrity_stop()
+
+    def _stage_b_prepare_run_2(
+        self,
+        repository: Path,
+        run_1: CodexRunResult,
+    ) -> str | None:
+        with self._condition:
+            record = self._continuation_store.load_required()
+            if (
+                record.get("state") != "RUN_1_ACTIVE"
+                or record.get("repository_id")
+                != AccelerationStore(repository).repository_id
+                or record.get("runs")
+                or record.get("automatic_continuations_started") != 0
+                or self._run.get("continuation", {}).get("chain_id")
+                != record.get("chain_id")
+            ):
+                raise ContinuationIntegrityError(
+                    "Run 1 does not match the persisted Stage B chain."
+                )
+            receipt_delta = self._run.get("receipt_delta")
+            if not isinstance(receipt_delta, dict):
+                raise ContinuationIntegrityError(
+                    "Run 1 Receipt delta is not established."
+                )
+            record["runs"] = [
+                result_evidence(
+                    run_1,
+                    run_number=1,
+                    receipt_delta=receipt_delta,
+                )
+            ]
+            record["state"] = "RUN_1_COMPLETE"
+            record = self._continuation_store.save(record)
+            context = supervisor_context_from_persisted_run(record)
+            judgment = judge_continuation(run_1, context)
+            self._run["supervisor"] = judgment.as_dict()
+            self._last_supervisor_context = context
+            record["supervisor"] = judgment.as_dict()
+
+            if (
+                judgment.gate.value != "GO"
+                or judgment.decision_route.value != "AI-OWNED"
+            ):
+                next_action = (
+                    judgment.next_bounded_action
+                    if judgment.next_bounded_action is not None
+                    else judgment.human_seat_return
+                )
+                assert next_action is not None
+                record["state"] = "STOPPED"
+                record["governed_stop"] = governed_stop(
+                    gate=judgment.gate.value,
+                    route=judgment.decision_route.value,
+                    reason=judgment.reason,
+                    next_action=next_action,
+                )
+                self._compound_loop = self._continuation_store.save(record)
+                self._compound_active = False
+                self._compound_allowed_mutation_paths = ()
+                self._condition.notify_all()
+                return None
+
+            record = self._continuation_store.save(record)
+            automatic_task = automatic_task_from_persisted_run(record)
+            record["automatic_task"] = automatic_task
+            record["automatic_continuations_started"] = 1
+            record["state"] = "RUN_2_ACTIVE"
+            persisted = self._continuation_store.save(record)
+            persisted_task = persisted.get("automatic_task")
+            if (
+                not isinstance(persisted_task, dict)
+                or persisted_task != automatic_task
+            ):
+                raise ContinuationIntegrityError(
+                    "Persisted automatic Task 2 read-back mismatches."
+                )
+            self._compound_loop = persisted
+            self._prepare_bounded_run_locked(
+                repository,
+                automatic_task["task"],
+                task_mode="contract",
+                continuation={
+                    "schema": "decision-os-bounded-run-continuation-v0.1",
+                    "chain_id": record["chain_id"],
+                    "run_number": 2,
+                    "automatic": True,
+                    "source_run_id": automatic_task["source_run_id"],
+                    "source_evidence_sha256": automatic_task[
+                        "source_evidence_sha256"
+                    ],
+                    "task_sha256": automatic_task["task_sha256"],
+                },
+            )
+            self._condition.notify_all()
+            return automatic_task["task"]
+
+    def _stage_b_finish_run_2(self, run_2: CodexRunResult) -> None:
+        with self._condition:
+            record = self._continuation_store.load_required()
+            if (
+                record.get("state") != "RUN_2_ACTIVE"
+                or record.get("automatic_continuations_started") != 1
+                or len(record.get("runs", [])) != 1
+                or self._run.get("continuation", {}).get("run_number") != 2
+                or self._run.get("continuation", {}).get("source_run_id")
+                != record["runs"][0]["run_id"]
+            ):
+                raise ContinuationIntegrityError(
+                    "Run 2 does not match the persisted Stage B causal chain."
+                )
+            receipt_delta = self._run.get("receipt_delta")
+            if not isinstance(receipt_delta, dict):
+                raise ContinuationIntegrityError(
+                    "Run 2 Receipt delta is not established."
+                )
+            record["runs"].append(
+                result_evidence(
+                    run_2,
+                    run_number=2,
+                    receipt_delta=receipt_delta,
+                )
+            )
+            record["state"] = "COMPLETE"
+            if (
+                not run_2.normal_terminal
+                or run_2.turn_status != "completed"
+                or run_2.status
+                not in {"NORMAL_TERMINAL", "VERIFIED_SAVE", "VERIFIED_REUSE"}
+            ):
+                record["governed_stop"] = governed_stop(
+                    gate="HOLD",
+                    route="STOP",
+                    reason=(
+                        "Automatic Worker Run 2 did not establish a clean "
+                        "normal-terminal result."
+                    ),
+                    next_action=(
+                        "Preserve both Run records and recover bounded Run 2 "
+                        "evidence under the unchanged Goal."
+                    ),
+                )
+            self._compound_loop = self._continuation_store.save(record)
+            self._compound_active = False
+            self._compound_allowed_mutation_paths = ()
+            self._condition.notify_all()
+
+    def _stage_b_execution_stop(self, *, run_number: int) -> None:
+        with self._condition:
+            try:
+                record = self._continuation_store.load_required()
+                record["state"] = "STOPPED"
+                record["governed_stop"] = governed_stop(
+                    gate="HOLD",
+                    route="EVIDENCE-RECOVERY",
+                    reason=(
+                        f"Automatic compound Worker Run {run_number} could not "
+                        "complete safely."
+                    ),
+                    next_action=(
+                        f"Recover bounded Worker Run {run_number} execution "
+                        "evidence under the unchanged persisted authority."
+                    ),
+                )
+                self._compound_loop = self._continuation_store.save(record)
+                self._compound_recovery_required = False
+            except (ContinuationIntegrityError, OSError, ValueError):
+                self._set_stage_b_blocked_view()
+            self._compound_active = False
+            self._compound_allowed_mutation_paths = ()
+            self._condition.notify_all()
+
+    def _stage_b_integrity_stop(self) -> None:
+        with self._condition:
+            try:
+                record = self._continuation_store.load_required()
+                record["state"] = "BLOCKED"
+                record["governed_stop"] = governed_stop(
+                    gate="BLOCK",
+                    route="EVIDENCE-RECOVERY",
+                    reason=(
+                        "The causal Stage B continuation proof is not intact."
+                    ),
+                    next_action=(
+                        "Recover the exact persisted Goal, authority, Run 1 "
+                        "evidence, Supervisor judgment, and Task 2 binding."
+                    ),
+                )
+                self._compound_loop = self._continuation_store.save(record)
+                self._compound_recovery_required = False
+            except (ContinuationIntegrityError, OSError, ValueError):
+                self._set_stage_b_blocked_view()
+            self._compound_active = False
+            self._compound_allowed_mutation_paths = ()
+            self._condition.notify_all()
+
+    def _set_stage_b_blocked_view(self) -> None:
+        self._compound_loop = {
+            "schema": "decision-os-stage-b-continuation-view-v0.1",
+            "state": "BLOCKED_CORRUPT",
+            "gate": "BLOCK",
+            "decision_route": "EVIDENCE-RECOVERY",
+            "automatic_continuations_started": 0,
+            "automatic_continuation_limit": 1,
+            "error": "The causal Stage B continuation proof is not intact.",
+            "next_bounded_action": (
+                "Recover the exact persisted Goal, authority, Run evidence, "
+                "Supervisor judgment, and Task 2 binding."
+            ),
+        }
+        self._compound_recovery_required = True
 
     def new_run(self) -> dict[str, Any]:
         with self._condition:
@@ -1881,6 +2341,7 @@ class CompanionController:
         return {
             "repository": repository_view,
             "run": run,
+            "compound_loop": deepcopy(self._compound_loop),
             "receipt": receipt,
             "defaults": defaults,
             "manual_bridge": bridge,

--- a/decision_os/companion/server.py
+++ b/decision_os/companion/server.py
@@ -23,6 +23,10 @@ from .controller import (
     RepositorySelectionError,
     RunConflictError,
 )
+from .continuation import (
+    ContinuationIntegrityError,
+    StageBContinuationRequest,
+)
 from .guided_intake import (
     GuidedIntakeBusyError,
     GuidedIntakeConflictError,
@@ -80,6 +84,7 @@ _ORDINARY_CONTRACT_POST_ROUTES = frozenset(
         "/api/ordinary-contract/error/dismiss",
     }
 )
+_STAGE_B_POST_ROUTES = frozenset({"/api/compound-run"})
 _STATIC_FILES = {
     "/": ("index.html", "text/html; charset=utf-8"),
     "/app.js": ("app.js", "text/javascript; charset=utf-8"),
@@ -508,6 +513,7 @@ class CompanionRequestHandler(BaseHTTPRequestHandler):
             strict=(
                 path in _INTELLIGENCE_TRANSPLANT_POST_ROUTES
                 or path in _ORDINARY_CONTRACT_POST_ROUTES
+                or path in _STAGE_B_POST_ROUTES
             ),
             ordinary=path in _ORDINARY_CONTRACT_POST_ROUTES,
         )
@@ -528,6 +534,27 @@ class CompanionRequestHandler(BaseHTTPRequestHandler):
                     )
                 else:
                     snapshot = self.server.controller.start_run(value["task"])
+            elif path == "/api/compound-run":
+                if set(value) != {"request"} or not isinstance(
+                    value["request"],
+                    dict,
+                ):
+                    raise CompanionError(
+                        "Stage B continuation request fields are invalid."
+                    )
+                try:
+                    request = StageBContinuationRequest.from_dict(
+                        value["request"]
+                    )
+                except ContinuationIntegrityError as exc:
+                    raise CompanionError(
+                        "Stage B continuation request fields are invalid."
+                    ) from exc
+                snapshot = (
+                    self.server.controller.start_one_automatic_continuation(
+                        request
+                    )
+                )
             elif path == "/api/approval":
                 if set(value) != {"choice"}:
                     raise CompanionError("Approval request fields are invalid.")

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -48,10 +48,16 @@ PASS
 Stage A Evidence:
 validation/stage_a_supervisor_judgment_001.md
 
-Current Missing Closure:
-Stage B — One Automatic Continuation
+Stage B One Automatic Continuation:
+PASS
 
-Stage B Authorization:
+Stage B Evidence:
+validation/stage_b_one_automatic_continuation_001.md
+
+Current Missing Closure:
+Stage C — Small Compound Loop
+
+Stage C Authorization:
 YES — NEXT ENGINEERING PHASE
 
 Release Authority:
@@ -61,8 +67,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-Implement and verify Stage B — One Automatic Continuation. Stage C remains
-blocked until the Stage B Completion Line is satisfied.
+Implement and verify Stage C — Small Compound Loop under the unchanged
+three-Run cap. Stage D, release, and publication remain unauthorized.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -48,10 +48,16 @@ PASS
 Stage A Evidence:
 validation/stage_a_supervisor_judgment_001.md
 
-Current Missing Closure:
-Stage B — One Automatic Continuation
+Stage B One Automatic Continuation:
+PASS
 
-Stage B Authorization:
+Stage B Evidence:
+validation/stage_b_one_automatic_continuation_001.md
+
+Current Missing Closure:
+Stage C — Small Compound Loop
+
+Stage C Authorization:
 YES — NEXT ENGINEERING PHASE
 
 Release Authority:
@@ -61,8 +67,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-Implement and verify Stage B — One Automatic Continuation. Stage C remains
-blocked until the Stage B Completion Line is satisfied.
+Implement and verify Stage C — Small Compound Loop under the unchanged
+three-Run cap. Stage D, release, and publication remain unauthorized.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/tests/test_companion_continuation.py
+++ b/tests/test_companion_continuation.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+from collections import deque
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import time
+import unittest
+from typing import Any
+
+from decision_os.acceleration.model import hash_payload
+from decision_os.acceleration.store import StateIntegrityError
+from decision_os.companion.continuation import (
+    ContinuationIntegrityError,
+    StageBContinuationRequest,
+)
+from decision_os.companion.controller import (
+    CompanionController,
+    RunConflictError,
+)
+from decision_os.companion.supervisor import ContractFact
+from tests.test_companion_controller import (
+    ScriptedAdapter,
+    create_repository,
+    wait_for,
+)
+
+
+YES = ContractFact.SATISFIED
+NO = ContractFact.NOT_SATISFIED
+UNKNOWN = ContractFact.UNKNOWN
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def stage_b_request(**overrides: Any) -> StageBContinuationRequest:
+    values: dict[str, Any] = {
+        "goal": (
+            "Establish the exact target identity, then independently verify it "
+            "without changing repository content."
+        ),
+        "run_1_task": (
+            "Read target.txt and report its exact evidence without modifying it."
+        ),
+        "remaining_gap_after_run_1": (
+            "Independently verify target.txt against the persisted Run 1 evidence."
+        ),
+        "next_bounded_action": (
+            "Re-read target.txt and verify it matches the persisted Run 1 identity."
+        ),
+        "evidence_recovery_action": (
+            "Recover the exact persisted Stage B causal record."
+        ),
+        "irreducible_human_decision": None,
+        "authority_evidence_refs": (
+            "docs/companion_product_roadmap_v0_3.md#stage-b",
+        ),
+        "allowed_mutation_paths": ("target.txt",),
+        "protected_objects": ("all repository content remains read-only",),
+        "completed_runs_before": 0,
+        "max_runs": 3,
+        "goal_complete_after_run_1": NO,
+        "goal_unchanged": YES,
+        "authority_sufficient": YES,
+        "blast_radius_bounded": YES,
+        "action_reversible_or_authorized": YES,
+        "no_material_human_preference_required": YES,
+        "no_external_or_irreversible_commitment": YES,
+        "cost_boundary_intact": YES,
+        "protected_object_and_ownership_unchanged": YES,
+        "no_authoritative_conflict": YES,
+        "no_truly_unanswered_human_question": YES,
+    }
+    values.update(overrides)
+    return StageBContinuationRequest(**values)
+
+
+class RecordingFactory:
+    def __init__(self, *modes: str) -> None:
+        self.modes = deque(modes)
+        self.prompts: list[str] = []
+
+    def __call__(
+        self,
+        engine: Any,
+        approval_provider: Any,
+        lifecycle_sink: Any,
+    ) -> ScriptedAdapter:
+        mode = self.modes.popleft()
+        prompts = self.prompts
+
+        class RecordingAdapter(ScriptedAdapter):
+            async def run(self, prompt: str) -> Any:
+                prompts.append(prompt)
+                return await super().run(prompt)
+
+        return RecordingAdapter(
+            engine,
+            approval_provider,
+            lifecycle_sink,
+            mode,
+        )
+
+
+class StageBContinuationTest(unittest.TestCase):
+    def make_controller(
+        self,
+        directory: Path,
+        factory: RecordingFactory,
+    ) -> CompanionController:
+        return CompanionController(
+            state_path=directory / "application-state" / "state.json",
+            picker_runner=lambda _script: None,
+            adapter_factory=factory,
+        )
+
+    def test_one_goal_creates_one_causal_automatic_run_and_never_run_three(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "read_only", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+
+            started = controller.start_one_automatic_continuation(
+                stage_b_request()
+            )
+            self.assertEqual("running", started["run"]["state"])
+            self.assertEqual(1, started["run"]["continuation"]["run_number"])
+
+            completed = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "COMPLETE"
+                ),
+            )
+            chain = completed["compound_loop"]
+            self.assertEqual(2, len(chain["runs"]))
+            self.assertEqual(1, chain["automatic_continuations_started"])
+            self.assertEqual(1, chain["automatic_continuation_limit"])
+            self.assertEqual(2, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+            self.assertEqual(
+                stage_b_request().run_1_task,
+                factory.prompts[0],
+            )
+
+            run_1 = chain["runs"][0]
+            task_2 = chain["automatic_task"]
+            self.assertEqual(run_1["run_id"], task_2["source_run_id"])
+            self.assertEqual(
+                run_1["evidence_sha256"],
+                task_2["source_evidence_sha256"],
+            )
+            self.assertEqual(task_2["task"], factory.prompts[1])
+            self.assertIn(run_1["run_id"], factory.prompts[1])
+            self.assertIn(run_1["evidence_sha256"], factory.prompts[1])
+            self.assertIn(stage_b_request().goal, factory.prompts[1])
+            self.assertIn(
+                stage_b_request().next_bounded_action,
+                factory.prompts[1],
+            )
+            self.assertTrue(
+                completed["run"]["continuation"]["automatic"]
+            )
+            self.assertEqual(2, completed["run"]["continuation"]["run_number"])
+
+            time.sleep(0.05)
+            self.assertEqual(2, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+
+    def test_non_go_routes_never_start_run_two(self) -> None:
+        cases = (
+            (
+                "goal-complete",
+                {"goal_complete_after_run_1": YES},
+                "HOLD",
+                "STOP",
+            ),
+            (
+                "authority-block",
+                {"authority_sufficient": NO},
+                "BLOCK",
+                "HUMAN-SEAT",
+            ),
+            (
+                "unknown-authority",
+                {"authority_sufficient": UNKNOWN},
+                "BLOCK",
+                "EVIDENCE-RECOVERY",
+            ),
+            (
+                "cap",
+                {"completed_runs_before": 2},
+                "CAP",
+                "HUMAN-SEAT",
+            ),
+            (
+                "protected-object",
+                {"protected_object_and_ownership_unchanged": NO},
+                "BLOCK",
+                "HUMAN-SEAT",
+            ),
+        )
+        for label, overrides, gate, route in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                repository = create_repository(root)
+                factory = RecordingFactory("read_only", "read_only")
+                controller = self.make_controller(root, factory)
+                controller.select_repository(repository)
+
+                controller.start_one_automatic_continuation(
+                    stage_b_request(**overrides)
+                )
+                stopped = wait_for(
+                    controller,
+                    lambda state: (
+                        state["compound_loop"] is not None
+                        and state["compound_loop"].get("state") == "STOPPED"
+                    ),
+                )
+
+                chain = stopped["compound_loop"]
+                self.assertEqual(1, len(chain["runs"]))
+                self.assertEqual(0, chain["automatic_continuations_started"])
+                self.assertIsNone(chain["automatic_task"])
+                self.assertEqual(gate, chain["supervisor"]["gate"])
+                self.assertEqual(route, chain["supervisor"]["decision_route"])
+                self.assertEqual(1, len(factory.prompts))
+                self.assertEqual(1, len(factory.modes))
+
+    def test_out_of_scope_mutation_is_denied_before_continuation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("mutation", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+
+            controller.start_one_automatic_continuation(
+                stage_b_request(allowed_mutation_paths=("other.txt",))
+            )
+            stopped = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "STOPPED"
+                ),
+            )
+
+            chain = stopped["compound_loop"]
+            self.assertEqual("DENIED", chain["runs"][0]["status"])
+            self.assertEqual("BLOCK", chain["supervisor"]["gate"])
+            self.assertEqual("STOP", chain["supervisor"]["decision_route"])
+            self.assertEqual(0, chain["automatic_continuations_started"])
+            self.assertEqual(1, len(factory.prompts))
+
+    def test_insufficient_run_1_evidence_never_starts_run_two(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("typed_result_failure", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+
+            controller.start_one_automatic_continuation(stage_b_request())
+            stopped = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "STOPPED"
+                ),
+            )
+
+            chain = stopped["compound_loop"]
+            self.assertEqual("HOLD", chain["supervisor"]["gate"])
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                chain["supervisor"]["decision_route"],
+            )
+            self.assertEqual(0, chain["automatic_continuations_started"])
+            self.assertEqual(1, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+
+    def test_automatic_run_2_cannot_expand_mutation_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "mutation", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+
+            controller.start_one_automatic_continuation(
+                stage_b_request(allowed_mutation_paths=("other.txt",))
+            )
+            completed = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "COMPLETE"
+                ),
+            )
+
+            chain = completed["compound_loop"]
+            self.assertEqual(2, len(chain["runs"]))
+            self.assertEqual("DENIED", chain["runs"][1]["status"])
+            self.assertEqual(1, chain["automatic_continuations_started"])
+            self.assertEqual("HOLD", chain["governed_stop"]["gate"])
+            self.assertEqual("STOP", chain["governed_stop"]["route"])
+            self.assertEqual(2, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+
+    def test_run_1_persistence_failure_blocks_before_run_two(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            original_save = controller._continuation_store.save
+            calls = 0
+
+            def fail_second_save(payload: Any) -> dict[str, Any]:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise ContinuationIntegrityError(
+                        "injected persisted Run 1 failure"
+                    )
+                return original_save(payload)
+
+            controller._continuation_store.save = fail_second_save  # type: ignore[method-assign]
+            controller.start_one_automatic_continuation(stage_b_request())
+            blocked = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "BLOCKED"
+                ),
+            )
+
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                blocked["compound_loop"]["governed_stop"]["route"],
+            )
+            self.assertEqual(0, blocked["compound_loop"]["automatic_continuations_started"])
+            self.assertEqual(1, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+
+    def test_run_1_receipt_failure_governs_stop_before_run_two(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            original_receipt = controller._safe_receipt
+            calls = 0
+
+            def fail_post_run_receipt(target: Path) -> dict[str, Any]:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise StateIntegrityError("injected Receipt failure")
+                return original_receipt(target)
+
+            controller._safe_receipt = fail_post_run_receipt  # type: ignore[method-assign]
+            controller.start_one_automatic_continuation(stage_b_request())
+            stopped = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "STOPPED"
+                ),
+            )
+
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                stopped["compound_loop"]["governed_stop"]["route"],
+            )
+            self.assertEqual([], stopped["compound_loop"]["runs"])
+            self.assertEqual(
+                0,
+                stopped["compound_loop"]["automatic_continuations_started"],
+            )
+            self.assertEqual(1, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+
+    def test_run_2_execution_failure_is_restartable_and_never_recurses(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "failure", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+
+            controller.start_one_automatic_continuation(stage_b_request())
+            stopped = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "STOPPED"
+                    and state["compound_loop"].get("governed_stop") is not None
+                ),
+            )
+
+            chain = stopped["compound_loop"]
+            self.assertEqual(1, chain["automatic_continuations_started"])
+            self.assertEqual("EVIDENCE-RECOVERY", chain["governed_stop"]["route"])
+            self.assertEqual(2, len(factory.prompts))
+            self.assertEqual(1, len(factory.modes))
+            self.assertEqual("needs_attention", stopped["run"]["state"])
+
+            reconnected = self.make_controller(root, RecordingFactory())
+            snapshot = reconnected.snapshot()
+            self.assertEqual("STOPPED", snapshot["compound_loop"]["state"])
+            self.assertEqual(
+                chain["record_sha256"],
+                snapshot["compound_loop"]["record_sha256"],
+            )
+
+    def test_completed_chain_reconnects_without_dispatching_another_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_one_automatic_continuation(stage_b_request())
+            completed = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "COMPLETE"
+                ),
+            )
+
+            restarted_factory = RecordingFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            snapshot = restarted.snapshot()
+            self.assertEqual("COMPLETE", snapshot["compound_loop"]["state"])
+            self.assertEqual(2, len(snapshot["compound_loop"]["runs"]))
+            self.assertEqual(
+                completed["compound_loop"]["record_sha256"],
+                snapshot["compound_loop"]["record_sha256"],
+            )
+            self.assertEqual([], restarted_factory.prompts)
+            state_path = (
+                root / "application-state" / "stage-b-continuation.json"
+            )
+            self.assertEqual(0o600, state_path.stat().st_mode & 0o777)
+
+    def test_corrupt_restart_state_blocks_without_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_one_automatic_continuation(stage_b_request())
+            wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "COMPLETE"
+                ),
+            )
+            state_path = (
+                root / "application-state" / "stage-b-continuation.json"
+            )
+            record = json.loads(state_path.read_text(encoding="utf-8"))
+            record["automatic_continuations_started"] = 0
+            state_path.write_text(json.dumps(record), encoding="utf-8")
+
+            restarted_factory = RecordingFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            snapshot = restarted.snapshot()
+
+            self.assertEqual(
+                "BLOCKED_CORRUPT",
+                snapshot["compound_loop"]["state"],
+            )
+            self.assertEqual("BLOCK", snapshot["compound_loop"]["gate"])
+            self.assertEqual([], restarted_factory.prompts)
+
+    def test_rehashed_independent_task_two_is_rejected_as_corrupt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root,
+                RecordingFactory("read_only", "read_only"),
+            )
+            controller.select_repository(repository)
+            controller.start_one_automatic_continuation(stage_b_request())
+            wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "COMPLETE"
+                ),
+            )
+            state_path = (
+                root / "application-state" / "stage-b-continuation.json"
+            )
+            record = json.loads(state_path.read_text(encoding="utf-8"))
+            injected = "independently supplied second task"
+            record["automatic_task"]["task"] = injected
+            record["automatic_task"]["task_sha256"] = hashlib.sha256(
+                injected.encode("utf-8")
+            ).hexdigest()
+            record.pop("record_sha256")
+            record["record_sha256"] = hash_payload(record)
+            state_path.write_text(json.dumps(record), encoding="utf-8")
+
+            restarted_factory = RecordingFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            snapshot = restarted.snapshot()
+
+            self.assertEqual(
+                "BLOCKED_CORRUPT",
+                snapshot["compound_loop"]["state"],
+            )
+            self.assertEqual([], restarted_factory.prompts)
+
+    def test_interrupted_run_one_record_blocks_a_new_chain(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(
+                root,
+                RecordingFactory("read_only", "read_only"),
+            )
+            controller.select_repository(repository)
+            controller.start_one_automatic_continuation(stage_b_request())
+            wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "COMPLETE"
+                ),
+            )
+            state_path = (
+                root / "application-state" / "stage-b-continuation.json"
+            )
+            record = json.loads(state_path.read_text(encoding="utf-8"))
+            record["state"] = "RUN_1_COMPLETE"
+            record["runs"] = record["runs"][:1]
+            record["automatic_task"] = None
+            record["automatic_continuations_started"] = 0
+            record["governed_stop"] = None
+            record.pop("record_sha256")
+            record["record_sha256"] = hash_payload(record)
+            state_path.write_text(json.dumps(record), encoding="utf-8")
+
+            restarted_factory = RecordingFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            self.assertEqual(
+                "RUN_1_COMPLETE",
+                restarted.snapshot()["compound_loop"]["state"],
+            )
+            with self.assertRaises(RunConflictError):
+                restarted.start_one_automatic_continuation(stage_b_request())
+            self.assertEqual([], restarted_factory.prompts)
+
+    def test_real_stage_b_record_is_bound_to_exact_stage_a_evidence(self) -> None:
+        stage_a = (
+            REPO_ROOT / "validation" / "stage_a_supervisor_judgment_001.md"
+        )
+        self.assertEqual(
+            "a9b65437ea94b624ede85b2dfdb2f4f93d5a81a3bb17a5829d8f6c13a35ba77f",
+            hashlib.sha256(stage_a.read_bytes()).hexdigest(),
+        )
+        record = (
+            REPO_ROOT
+            / "validation"
+            / "stage_b_one_automatic_continuation_001.md"
+        ).read_text(encoding="utf-8")
+        for exact in (
+            "abce9db4-d24f-479d-b33b-2cb7fa4cc206",
+            "ae9b117f-d170-463c-95ad-3ea40c98efa4",
+            "8ce582c8fc082aa2ca2adcfc82d17f813128cbc1c8f6a6fb6f9e950b07ebfd01",
+            "277d323fd75ba60ac8f5f03757ff5dac6c29939b36be56a2458271cb5038a302",
+            "fada414d4f667eefbc7f6e73f62c8fcc641221c623e9c73773ca2df7458e5c6d",
+            "Stage B Completion Line:\nPASS",
+        ):
+            self.assertIn(exact, record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -33,6 +33,7 @@ from tests.test_companion_controller import (
     create_repository,
     pro_design_metadata,
 )
+from tests.test_companion_continuation import stage_b_request
 
 
 BRIDGE_POST_ROUTES = (
@@ -2155,6 +2156,57 @@ class CompanionServerTest(unittest.TestCase):
             origin=self.server.origin,
         )
         self.assertEqual(200, status)
+
+    def test_authenticated_stage_b_route_runs_exactly_one_continuation(
+        self,
+    ) -> None:
+        self.controller.adapter_factory = ScriptedFactory(
+            "read_only",
+            "read_only",
+        )
+        cookie, csrf = self.bootstrap()
+
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/compound-run",
+            body={"request": stage_b_request().as_dict()},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status, raw.decode("utf-8", errors="replace"))
+
+        deadline = time.monotonic() + 5
+        snapshot = None
+        while time.monotonic() < deadline:
+            status, _headers, raw = self.request(
+                "GET",
+                "/api/state",
+                cookie=cookie,
+            )
+            self.assertEqual(200, status)
+            snapshot = json.loads(raw)
+            if snapshot["compound_loop"]["state"] == "COMPLETE":
+                break
+            time.sleep(0.01)
+        self.assertIsNotNone(snapshot)
+        self.assertEqual("COMPLETE", snapshot["compound_loop"]["state"])
+        self.assertEqual(2, len(snapshot["compound_loop"]["runs"]))
+        self.assertEqual(
+            1,
+            snapshot["compound_loop"]["automatic_continuations_started"],
+        )
+        self.assertEqual(2, snapshot["run"]["continuation"]["run_number"])
+
+        status, _headers, _raw = self.request(
+            "POST",
+            "/api/compound-run",
+            body={"request": stage_b_request().as_dict(), "extra": True},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(400, status)
 
     def test_public_state_exposes_opaque_default_handle_only(self) -> None:
         self.server.close()

--- a/validation/stage_b_one_automatic_continuation_001.md
+++ b/validation/stage_b_one_automatic_continuation_001.md
@@ -232,6 +232,35 @@ not persisted; only their byte counts and SHA-256 identities are retained.
 - No cross-vendor supervision, Canon modification, self-modification, release,
   publication, or paid-tier behavior is added.
 
+## Verification
+
+```text
+Focused Stage B continuation:
+PASS — 13 tests
+
+Supervisor, Stage B, controller, and process qualification:
+PASS — 70 tests run / 2 expected environment skips
+
+Companion server and client behavior:
+PASS — 37 tests
+
+Canonical-state and handoff regression:
+PASS — 94 tests
+
+Clean-worktree repository full regression at 14005d1:
+PASS — 1429 tests run / 15 expected environment skips
+
+Persisted real-proof reload under final implementation:
+PASS — COMPLETE / 2 Runs / 1 automatic continuation /
+record SHA-256 fada414d4f667eefbc7f6e73f62c8fcc641221c623e9c73773ca2df7458e5c6d
+
+Repository validation:
+python -B -m decision_os check . — PASS
+
+Patch hygiene:
+git diff --check — PASS
+```
+
 ## Completion Line
 
 One user Goal produced two causally connected real bounded Runs without manual

--- a/validation/stage_b_one_automatic_continuation_001.md
+++ b/validation/stage_b_one_automatic_continuation_001.md
@@ -1,0 +1,252 @@
+# Stage B One Automatic Continuation 001
+
+## Identity
+
+```text
+Stage:
+B — One Automatic Continuation
+
+Starting canonical main:
+ffcbf610fca7ac97af8b261d6e583c8c84138054
+
+Focused branch:
+codex/stage-b-one-automatic-continuation
+
+Automatic continuation limit:
+1
+
+First live total Run cap:
+3
+
+Stage C behavior:
+NOT IMPLEMENTED / NOT STARTED
+```
+
+## Real Goal
+
+```text
+Verify the Stage A judgment record twice: first establish its exact identity
+and PASS state, then independently confirm from the same persisted evidence
+that Stage A started no automatic Run 2.
+```
+
+This Goal genuinely required two bounded read-only actions. Run 1 established
+the file identity and Stage A PASS state. The independent confirmation of the
+same identity and the Stage A no-Run-2 boundary remained open after Run 1.
+
+The target was fixed before execution:
+
+```text
+Path:
+validation/stage_a_supervisor_judgment_001.md
+
+Mutation authority:
+none required / all repository content remained read-only
+
+Protected Objects:
+all tracked and untracked repository content;
+Goal and repository ownership
+```
+
+## Runtime
+
+Both Runs used the qualified ordinary Companion runtime:
+
+```text
+Runtime:
+ChatGPT / gpt-5.6-sol / ultra / priority
+
+Codex CLI:
+0.147.0-alpha.1.2
+
+File-change approval requested:
+NO
+
+Tracked or untracked repository mutation:
+NONE
+```
+
+## Run 1
+
+```text
+Run ID:
+abce9db4-d24f-479d-b33b-2cb7fa4cc206
+
+Terminal:
+NORMAL_TERMINAL / completed normally
+
+Read evidence:
+validation/stage_a_supervisor_judgment_001.md
+5732 bytes
+SHA-256 a9b65437ea94b624ede85b2dfdb2f4f93d5a81a3bb17a5829d8f6c13a35ba77f
+repository identity ffcbf610fca7ac97af8b261d6e583c8c84138054
+
+File actions:
+none
+
+Receipt delta:
+0 Verified Saves / 0 Verified Reuses / 0 estimated value
+
+Persisted Run 1 evidence SHA-256:
+8ce582c8fc082aa2ca2adcfc82d17f813128cbc1c8f6a6fb6f9e950b07ebfd01
+```
+
+## Supervisor Judgment
+
+```json
+{
+  "automatic_second_run_started": false,
+  "consumed_run": {
+    "run_id": "abce9db4-d24f-479d-b33b-2cb7fa4cc206",
+    "status": "NORMAL_TERMINAL"
+  },
+  "decision_route": "AI-OWNED",
+  "gate": "GO",
+  "human_seat_return": null,
+  "next_bounded_action": "Re-read validation/stage_a_supervisor_judgment_001.md, verify it matches the exact persisted Run 1 file identity, and confirm that the Stage A record says automatic Run 2 was not started. Do not modify any file.",
+  "reason": "The Worker result is complete and every Human Seat return-contract invariant remains satisfied.",
+  "remaining_gap": "Independently confirm the same file identity and its recorded automatic Run 2 boundary from the persisted Run 1 evidence.",
+  "role": "SUPERVISOR",
+  "schema": "decision-os-supervisor-judgment-v0.1"
+}
+```
+
+The Stage A judgment itself remained judgment-only. Its
+`automatic_second_run_started` field remained `false`. The Stage B orchestrator
+separately consumed the persisted `GO / AI-OWNED` judgment and used its own
+hard one-continuation authority.
+
+## Automatically Constructed Run 2
+
+No Task 2 was supplied after Run 1. The controller constructed it only after:
+
+1. persisting and reading back the original Goal and authority envelope;
+2. persisting and reading back Run 1 evidence and Receipt delta;
+3. obtaining `GO / AI-OWNED` from the existing Supervisor;
+4. binding the Task to the exact source Run and evidence hashes;
+5. persisting and reading back the constructed Task before execution.
+
+```text
+Source Run ID:
+abce9db4-d24f-479d-b33b-2cb7fa4cc206
+
+Source evidence SHA-256:
+8ce582c8fc082aa2ca2adcfc82d17f813128cbc1c8f6a6fb6f9e950b07ebfd01
+
+Original Goal SHA-256:
+8d7adcc5184369952ced6bc16a431459ea46573c0c07934006515b1cc00d9ced
+
+Constructed Task 2 SHA-256:
+277d323fd75ba60ac8f5f03757ff5dac6c29939b36be56a2458271cb5038a302
+
+Automatic continuations started / Stage B limit:
+1 / 1
+```
+
+The constructed Task included the original Goal, Run 1 ID, Run 1 evidence
+SHA-256, exact read evidence, Receipt delta, remaining gap, next bounded action,
+allowed path, Protected Objects, total cap, and an explicit no-Run-3 boundary.
+
+## Run 2
+
+```text
+Run ID:
+ae9b117f-d170-463c-95ad-3ea40c98efa4
+
+Terminal:
+NORMAL_TERMINAL / completed normally
+
+Read evidence:
+validation/stage_a_supervisor_judgment_001.md
+5732 bytes
+SHA-256 a9b65437ea94b624ede85b2dfdb2f4f93d5a81a3bb17a5829d8f6c13a35ba77f
+repository identity ffcbf610fca7ac97af8b261d6e583c8c84138054
+
+File actions:
+none
+
+Receipt delta:
+0 Verified Saves / 0 Verified Reuses / 0 estimated value
+
+Persisted Run 2 evidence SHA-256:
+1a3ea79ff2a2b61ab9b01605066a4e635125aa718e848af86e19a58c087e43a4
+```
+
+Run 2 confirmed the exact Run 1 file identity and the Stage A record's
+`automatic_second_run_started: false` boundary. The two Runs observed the same
+path, byte count, repository identity, and SHA-256.
+
+## Persisted Causal Record and Restart
+
+```text
+Chain ID:
+13ee5fec37be6ee8c592265b45cb4329
+
+Terminal chain state:
+COMPLETE
+
+Self-authenticating record SHA-256:
+fada414d4f667eefbc7f6e73f62c8fcc641221c623e9c73773ca2df7458e5c6d
+
+Exact serialized record file SHA-256:
+b7a1c9bb1214b6905cb00bc312308f5dadc5be73f5f71236f6fd5acab2d18a8f
+
+Record permissions:
+0600
+
+Fresh-controller reconnect:
+COMPLETE / 2 Runs / 1 automatic continuation /
+record SHA-256 fada414d4f667eefbc7f6e73f62c8fcc641221c623e9c73773ca2df7458e5c6d
+
+Reconnect-triggered model Runs:
+0
+```
+
+The persisted record contains the bounded Goal and authority, both sanitized
+Run results, Receipt deltas, Supervisor judgment, exact constructed Task 2,
+causal hashes, continuation count, and terminal state. Raw model messages are
+not persisted; only their byte counts and SHA-256 identities are retained.
+
+## Required Boundary Proofs
+
+- `GO / AI-OWNED` starts exactly one causally constructed Run 2.
+- Goal complete, authority failure, unknown authority, exhausted cap, and
+  Protected Object or ownership change stop after Run 1.
+- abnormal or insufficient Run 1 evidence routes to AI-owned evidence recovery
+  and does not start Run 2.
+- an out-of-scope mutation request is denied in Run 1 or automatic Run 2.
+- Run 1 persistence or read-back failure blocks before Run 2 construction.
+- Run 2 execution failure preserves the causal record and starts no Run 3.
+- completed and governed-stop records reconnect without model dispatch.
+- corrupted persisted state returns `BLOCK / EVIDENCE-RECOVERY`.
+- the existing Stage A real acceptance result remains `HOLD / STOP` with zero
+  Run 2.
+
+## Claim and Authority Boundary
+
+- Stage B implements one automatic continuation only.
+- There is no recursive controller path and no Stage C three-Run behavior.
+- The total first-live cap remains three Runs.
+- Goal, authority, blast radius, Protected Objects, ownership, external
+  exposure, and cost boundaries cannot be expanded by Task 2 construction.
+- No cross-vendor supervision, Canon modification, self-modification, release,
+  publication, or paid-tier behavior is added.
+
+## Completion Line
+
+One user Goal produced two causally connected real bounded Runs without manual
+translation of Receipt 1 into Task 2. Exactly one automatic continuation was
+started, the Stage A Human Seat and non-GO boundaries remained intact, no
+authority or blast-radius expansion occurred, and the terminal causal state
+was successfully reconnected by a fresh controller without another model Run.
+
+```text
+Stage B Completion Line:
+PASS
+
+Remaining Missing Closure:
+Stage C — Small Compound Loop
+
+Stage C Authorized:
+YES — only after Stage B is merged into canonical main
+```


### PR DESCRIPTION
## Summary

- persist one bounded Stage B causal record over Goal, authority, Worker evidence, Supervisor judgment, Task 2, and both Receipts
- automatically derive and execute exactly one Run 2 only for `GO / AI-OWNED`
- preserve Stage A non-GO, Human Seat, authority, blast-radius, cost-cap, and restart boundaries
- record the real two-Run proof and advance only the canonical Stage C authorization

## Validation

- real qualified Companion proof: `COMPLETE / 2 Runs / 1 automatic continuation`
- focused Supervisor/Stage B/controller/process: 70 tests, 2 expected skips
- Companion server/client: 37 tests
- canonical/handoff: 94 tests
- clean full regression: 1,429 tests, 15 expected skips
- `python -B -m decision_os check .`
- `git diff --check`

Release authority: none. Publication authority: none. Stage C is not implemented or started in this PR.