### PR TITLE
Stage C: add hard-capped small compound loop

### DIFF
--- a/decision_os/companion/__init__.py
+++ b/decision_os/companion/__init__.py
@@ -7,6 +7,10 @@ from .continuation import (
 )
 from .controller import CompanionController, ContinuationStateError
 from .server import CompanionServer
+from .small_compound_loop import (
+    StageCCompletionRequirement,
+    StageCContinuationRequest,
+)
 from .supervisor import (
     ContractFact,
     DecisionRoute,
@@ -28,6 +32,8 @@ __all__ = [
     "SupervisorGate",
     "SupervisorJudgment",
     "StageBContinuationRequest",
+    "StageCCompletionRequirement",
+    "StageCContinuationRequest",
     "judge_continuation",
 ]
 __version__ = "0.1.0"

--- a/decision_os/companion/continuation.py
+++ b/decision_os/companion/continuation.py
@@ -672,7 +672,7 @@ def _validate_supervisor(value: Any, run_1: Mapping[str, Any]) -> None:
         )
 
 
-def _validate_record(value: Any) -> None:
+def _validate_stage_b_record(value: Any) -> None:
     if not isinstance(value, dict) or set(value) != _RECORD_FIELDS:
         raise ContinuationIntegrityError("Persisted Stage B fields are invalid.")
     if value["schema"] != STAGE_B_SCHEMA or value["state"] not in _RECORD_STATES:
@@ -806,8 +806,23 @@ def _validate_record(value: Any) -> None:
         raise ContinuationIntegrityError("Persisted Stage B record is too large.")
 
 
+def _validate_record(value: Any) -> None:
+    if (
+        isinstance(value, dict)
+        and value.get("schema")
+        == "decision-os-stage-c-small-compound-loop-v0.1"
+    ):
+        from decision_os.companion.small_compound_loop import (
+            validate_stage_c_record,
+        )
+
+        validate_stage_c_record(value, maximum_bytes=_MAX_RECORD_BYTES)
+        return
+    _validate_stage_b_record(value)
+
+
 class StageBContinuationStore:
-    """One strict, atomic, hash-bound reconnectable Stage B record."""
+    """One strict, atomic, hash-bound reconnectable continuation record."""
 
     def __init__(self, path: Path) -> None:
         self.path = path
@@ -866,6 +881,26 @@ class StageBContinuationStore:
         if value is None:
             raise ContinuationIntegrityError("Persisted Stage B record is absent.")
         return value
+
+    def schema_hint(self) -> str | None:
+        """Return only a bounded display hint; never grant authority from it."""
+
+        try:
+            raw = self.path.read_bytes()
+            if len(raw) > _MAX_RECORD_BYTES:
+                return None
+            value = json.loads(raw)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(value, dict):
+            return None
+        schema = value.get("schema")
+        if schema in {
+            STAGE_B_SCHEMA,
+            "decision-os-stage-c-small-compound-loop-v0.1",
+        }:
+            return schema
+        return None
 
 
 __all__ = [

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -61,6 +61,15 @@ from decision_os.companion.continuation import (
     result_evidence,
     supervisor_context_from_persisted_run,
 )
+from decision_os.companion.small_compound_loop import (
+    STAGE_C_SCHEMA,
+    StageCContinuationRequest,
+    new_stage_c_record,
+    stage_c_automatic_task,
+    stage_c_outcome,
+    stage_c_residue,
+    stage_c_supervisor_context,
+)
 from decision_os.companion.intelligence_transplant import (
     IntelligenceTransplantBusyError,
     IntelligenceTransplantController,
@@ -365,35 +374,33 @@ class CompanionController:
                         "RUN_1_ACTIVE",
                         "RUN_1_COMPLETE",
                         "RUN_2_ACTIVE",
+                        "RUN_2_COMPLETE",
+                        "RUN_3_ACTIVE",
+                        "RUN_3_COMPLETE",
                     }:
                         raise ContinuationIntegrityError(
-                            "Persisted Stage B repository identity mismatches."
+                            "Persisted compound-loop repository identity "
+                            "mismatches."
                         )
                     value = None
             self._compound_loop = value
             self._compound_recovery_required = bool(
                 value is not None
                 and value.get("state")
-                in {"RUN_1_ACTIVE", "RUN_1_COMPLETE", "RUN_2_ACTIVE"}
+                in {
+                    "RUN_1_ACTIVE",
+                    "RUN_1_COMPLETE",
+                    "RUN_2_ACTIVE",
+                    "RUN_2_COMPLETE",
+                    "RUN_3_ACTIVE",
+                    "RUN_3_COMPLETE",
+                }
             )
         except (ContinuationIntegrityError, OSError):
-            self._compound_recovery_required = True
-            self._compound_loop = {
-                "schema": "decision-os-stage-b-continuation-view-v0.1",
-                "state": "BLOCKED_CORRUPT",
-                "gate": "BLOCK",
-                "decision_route": "EVIDENCE-RECOVERY",
-                "automatic_continuations_started": 0,
-                "automatic_continuation_limit": 1,
-                "error": (
-                    "Stage B continuation state is not reconnectable from "
-                    "verified persisted evidence."
-                ),
-                "next_bounded_action": (
-                    "Recover the exact persisted Stage B record under current "
-                    "repository authority."
-                ),
-            }
+            if self._continuation_store.schema_hint() == STAGE_C_SCHEMA:
+                self._set_stage_c_blocked_view()
+            else:
+                self._set_stage_b_blocked_view()
 
     @staticmethod
     def _validated_repository(candidate: Path) -> Path:
@@ -2007,6 +2014,376 @@ class CompanionController:
             "next_bounded_action": (
                 "Recover the exact persisted Goal, authority, Run evidence, "
                 "Supervisor judgment, and Task 2 binding."
+            ),
+        }
+        self._compound_recovery_required = True
+
+    def start_small_compound_loop(
+        self,
+        request: StageCContinuationRequest,
+    ) -> dict[str, Any]:
+        """Start one Stage C loop with a non-renewable three-Run cap."""
+
+        if not isinstance(request, StageCContinuationRequest):
+            raise ContinuationStateError(
+                "Stage C requires one explicit compound-loop authority envelope."
+            )
+        with self._condition:
+            repository = self._require_repository()
+            self._require_no_active_run()
+            if (
+                isinstance(self._compound_loop, dict)
+                and self._compound_loop.get("schema") == STAGE_C_SCHEMA
+                and isinstance(self._compound_loop.get("request"), dict)
+                and self._compound_loop["request"].get("goal")
+                == request.goal.strip()
+            ):
+                raise RunConflictError(
+                    "The persisted Stage C cap for this unchanged Goal cannot "
+                    "be reset or renewed."
+                )
+            if self._active_intelligence_transplant_operations:
+                raise RunConflictError(
+                    "An Intelligence Transplant action is already active."
+                )
+            persisted: dict[str, Any] | None = None
+            try:
+                normalized_paths = tuple(
+                    normalize_scope(repository, path)
+                    for path in request.allowed_mutation_paths
+                )
+                normalized_requirements = tuple(
+                    replace(
+                        requirement,
+                        evidence_path=normalize_scope(
+                            repository,
+                            requirement.evidence_path,
+                        ),
+                    )
+                    for requirement in request.completion_requirements
+                )
+                normalized_request = replace(
+                    request,
+                    completion_requirements=normalized_requirements,
+                    allowed_mutation_paths=normalized_paths,
+                )
+                repository_identity = AccelerationStore(
+                    repository
+                ).repository_id
+                chain_id = secrets.token_hex(16)
+                persisted = self._continuation_store.save(
+                    new_stage_c_record(
+                        normalized_request,
+                        chain_id=chain_id,
+                        repository_id=repository_identity,
+                    )
+                )
+                run_1_task = normalized_request.run_1_task.strip()
+                self._prepare_bounded_run_locked(
+                    repository,
+                    run_1_task,
+                    task_mode="contract",
+                    continuation={
+                        "schema": (
+                            "decision-os-bounded-run-continuation-v0.1"
+                        ),
+                        "chain_id": chain_id,
+                        "run_number": 1,
+                        "automatic": False,
+                        "source_run_id": None,
+                        "source_evidence_sha256": None,
+                        "task_sha256": hashlib.sha256(
+                            run_1_task.encode("utf-8")
+                        ).hexdigest(),
+                    },
+                )
+            except (
+                ContinuationIntegrityError,
+                OSError,
+                RepositoryIdentityError,
+                StateIntegrityError,
+                ValueError,
+            ) as exc:
+                try:
+                    if persisted is not None:
+                        persisted["state"] = "TERMINAL"
+                        persisted["outcome"] = "BLOCK"
+                        persisted["governed_stop"] = governed_stop(
+                            gate="BLOCK",
+                            route="EVIDENCE-RECOVERY",
+                            reason=(
+                                "Stage C Run 1 could not start from verified "
+                                "persisted authority and Receipt state."
+                            ),
+                            next_action=(
+                                "Recover the exact persisted Stage C authority "
+                                "and pre-Run Receipt under the unchanged Goal."
+                            ),
+                        )
+                        self._compound_loop = self._continuation_store.save(
+                            persisted
+                        )
+                except (ContinuationIntegrityError, OSError, ValueError):
+                    self._set_stage_c_blocked_view()
+                raise ContinuationStateError(
+                    "Stage C authority or persistence could not be established."
+                ) from exc
+            assert persisted is not None
+            self._compound_loop = persisted
+            self._compound_active = True
+            self._compound_recovery_required = False
+            self._compound_allowed_mutation_paths = normalized_paths
+            self._worker = threading.Thread(
+                target=self._stage_c_worker,
+                args=(repository, normalized_request),
+                name="decision-os-companion-stage-c",
+                daemon=True,
+            )
+            self._worker.start()
+            return self._snapshot_locked()
+
+    def _stage_c_worker(
+        self,
+        repository: Path,
+        request: StageCContinuationRequest,
+    ) -> None:
+        task = request.run_1_task.strip()
+        for run_number in (1, 2, 3):
+            try:
+                result = self._execute_worker_run(repository, task)
+                self._complete_run(repository, result)
+            except Exception as exc:
+                self._fail_run(repository, exc)
+                self._stage_c_execution_stop(run_number=run_number)
+                return
+            try:
+                next_task = self._stage_c_after_run(
+                    repository,
+                    result,
+                    run_number=run_number,
+                )
+            except (
+                ContinuationIntegrityError,
+                OSError,
+                RepositoryIdentityError,
+                StateIntegrityError,
+                ValueError,
+            ):
+                self._stage_c_integrity_stop()
+                return
+            if next_task is None:
+                return
+            task = next_task
+
+    def _stage_c_after_run(
+        self,
+        repository: Path,
+        result: CodexRunResult,
+        *,
+        run_number: int,
+    ) -> str | None:
+        with self._condition:
+            record = self._continuation_store.load_required()
+            continuation = self._run.get("continuation")
+            if not isinstance(continuation, dict):
+                raise ContinuationIntegrityError(
+                    "The completed Run lacks its Stage C continuation binding."
+                )
+            expected_task = (
+                None
+                if run_number == 1
+                else record["automatic_tasks"][run_number - 2]
+            )
+            if (
+                record.get("schema") != STAGE_C_SCHEMA
+                or record.get("state") != f"RUN_{run_number}_ACTIVE"
+                or record.get("repository_id")
+                != AccelerationStore(repository).repository_id
+                or len(record.get("runs", [])) != run_number - 1
+                or len(record.get("residues", [])) != run_number - 1
+                or len(record.get("supervisor_judgments", []))
+                != run_number - 1
+                or record.get("automatic_continuations_started")
+                != run_number - 1
+                or continuation.get("chain_id") != record.get("chain_id")
+                or continuation.get("run_number") != run_number
+                or continuation.get("automatic") != (run_number > 1)
+                or (
+                    expected_task is not None
+                    and (
+                        continuation.get("source_run_id")
+                        != expected_task["source_run_id"]
+                        or continuation.get("source_evidence_sha256")
+                        != expected_task["source_evidence_sha256"]
+                        or continuation.get("task_sha256")
+                        != expected_task["task_sha256"]
+                    )
+                )
+            ):
+                raise ContinuationIntegrityError(
+                    f"Run {run_number} does not match the persisted Stage C "
+                    "causal chain."
+                )
+            receipt_delta = self._run.get("receipt_delta")
+            if not isinstance(receipt_delta, dict):
+                raise ContinuationIntegrityError(
+                    f"Run {run_number} Receipt delta is not established."
+                )
+            record["runs"].append(
+                result_evidence(
+                    result,
+                    run_number=run_number,
+                    receipt_delta=receipt_delta,
+                )
+            )
+            record["state"] = f"RUN_{run_number}_COMPLETE"
+            record["residues"].append(stage_c_residue(record))
+            record = self._continuation_store.save(record)
+
+            context = stage_c_supervisor_context(record)
+            judgment = judge_continuation(result, context)
+            judgment_value = judgment.as_dict()
+            self._run["supervisor"] = judgment_value
+            self._last_supervisor_context = context
+            record["supervisor_judgments"].append(judgment_value)
+            record = self._continuation_store.save(record)
+
+            if (
+                judgment.gate.value != "GO"
+                or judgment.decision_route.value != "AI-OWNED"
+                or run_number == 3
+            ):
+                next_action = (
+                    judgment.next_bounded_action
+                    if judgment.next_bounded_action is not None
+                    else judgment.human_seat_return
+                )
+                if next_action is None:
+                    raise ContinuationIntegrityError(
+                        "The terminal Stage C judgment lacks a governed action."
+                    )
+                record["state"] = "TERMINAL"
+                record["outcome"] = stage_c_outcome(
+                    record,
+                    judgment_value,
+                )
+                record["governed_stop"] = governed_stop(
+                    gate=judgment.gate.value,
+                    route=judgment.decision_route.value,
+                    reason=judgment.reason,
+                    next_action=next_action,
+                )
+                self._compound_loop = self._continuation_store.save(record)
+                self._compound_active = False
+                self._compound_recovery_required = False
+                self._compound_allowed_mutation_paths = ()
+                self._condition.notify_all()
+                return None
+
+            automatic_task = stage_c_automatic_task(record)
+            record["automatic_tasks"].append(automatic_task)
+            record["automatic_continuations_started"] = run_number
+            record["state"] = f"RUN_{run_number + 1}_ACTIVE"
+            persisted = self._continuation_store.save(record)
+            if persisted["automatic_tasks"][-1] != automatic_task:
+                raise ContinuationIntegrityError(
+                    f"Persisted automatic Task {run_number + 1} read-back "
+                    "mismatches."
+                )
+            self._compound_loop = persisted
+            self._prepare_bounded_run_locked(
+                repository,
+                automatic_task["task"],
+                task_mode="contract",
+                continuation={
+                    "schema": "decision-os-bounded-run-continuation-v0.1",
+                    "chain_id": record["chain_id"],
+                    "run_number": run_number + 1,
+                    "automatic": True,
+                    "source_run_id": automatic_task["source_run_id"],
+                    "source_evidence_sha256": automatic_task[
+                        "source_evidence_sha256"
+                    ],
+                    "task_sha256": automatic_task["task_sha256"],
+                },
+            )
+            self._condition.notify_all()
+            return automatic_task["task"]
+
+    def _stage_c_execution_stop(self, *, run_number: int) -> None:
+        with self._condition:
+            try:
+                record = self._continuation_store.load_required()
+                if record.get("schema") != STAGE_C_SCHEMA:
+                    raise ContinuationIntegrityError(
+                        "The active continuation is not a Stage C record."
+                    )
+                record["state"] = "TERMINAL"
+                record["outcome"] = "HOLD"
+                record["governed_stop"] = governed_stop(
+                    gate="HOLD",
+                    route="EVIDENCE-RECOVERY",
+                    reason=(
+                        f"Compound Worker Run {run_number} could not complete "
+                        "safely."
+                    ),
+                    next_action=(
+                        f"Recover bounded Worker Run {run_number} execution "
+                        "evidence under the unchanged persisted authority."
+                    ),
+                )
+                self._compound_loop = self._continuation_store.save(record)
+                self._compound_recovery_required = False
+            except (ContinuationIntegrityError, OSError, ValueError):
+                self._set_stage_c_blocked_view()
+            self._compound_active = False
+            self._compound_allowed_mutation_paths = ()
+            self._condition.notify_all()
+
+    def _stage_c_integrity_stop(self) -> None:
+        with self._condition:
+            try:
+                record = self._continuation_store.load_required()
+                if record.get("schema") != STAGE_C_SCHEMA:
+                    raise ContinuationIntegrityError(
+                        "The active continuation is not a Stage C record."
+                    )
+                record["state"] = "TERMINAL"
+                record["outcome"] = "BLOCK"
+                record["governed_stop"] = governed_stop(
+                    gate="BLOCK",
+                    route="EVIDENCE-RECOVERY",
+                    reason=(
+                        "The causal Stage C compound-loop proof is not intact."
+                    ),
+                    next_action=(
+                        "Recover the exact persisted Goal, authority, preceding "
+                        "Run evidence, residue, Supervisor judgment, and Task "
+                        "binding without dispatching another Run."
+                    ),
+                )
+                self._compound_loop = self._continuation_store.save(record)
+                self._compound_recovery_required = False
+            except (ContinuationIntegrityError, OSError, ValueError):
+                self._set_stage_c_blocked_view()
+            self._compound_active = False
+            self._compound_allowed_mutation_paths = ()
+            self._condition.notify_all()
+
+    def _set_stage_c_blocked_view(self) -> None:
+        self._compound_loop = {
+            "schema": "decision-os-stage-c-compound-loop-view-v0.1",
+            "state": "BLOCKED_CORRUPT",
+            "gate": "BLOCK",
+            "decision_route": "EVIDENCE-RECOVERY",
+            "outcome": "BLOCK",
+            "automatic_continuations_started": 0,
+            "automatic_continuation_limit": 2,
+            "total_run_cap": 3,
+            "error": "The causal Stage C compound-loop proof is not intact.",
+            "next_bounded_action": (
+                "Recover the exact persisted Goal, authority, Run evidence, "
+                "residues, Supervisor judgments, and automatic Task bindings."
             ),
         }
         self._compound_recovery_required = True

--- a/decision_os/companion/server.py
+++ b/decision_os/companion/server.py
@@ -27,6 +27,7 @@ from .continuation import (
     ContinuationIntegrityError,
     StageBContinuationRequest,
 )
+from .small_compound_loop import StageCContinuationRequest
 from .guided_intake import (
     GuidedIntakeBusyError,
     GuidedIntakeConflictError,
@@ -84,7 +85,9 @@ _ORDINARY_CONTRACT_POST_ROUTES = frozenset(
         "/api/ordinary-contract/error/dismiss",
     }
 )
-_STAGE_B_POST_ROUTES = frozenset({"/api/compound-run"})
+_COMPOUND_LOOP_POST_ROUTES = frozenset(
+    {"/api/compound-run", "/api/compound-loop"}
+)
 _STATIC_FILES = {
     "/": ("index.html", "text/html; charset=utf-8"),
     "/app.js": ("app.js", "text/javascript; charset=utf-8"),
@@ -513,7 +516,7 @@ class CompanionRequestHandler(BaseHTTPRequestHandler):
             strict=(
                 path in _INTELLIGENCE_TRANSPLANT_POST_ROUTES
                 or path in _ORDINARY_CONTRACT_POST_ROUTES
-                or path in _STAGE_B_POST_ROUTES
+                or path in _COMPOUND_LOOP_POST_ROUTES
             ),
             ordinary=path in _ORDINARY_CONTRACT_POST_ROUTES,
         )
@@ -554,6 +557,25 @@ class CompanionRequestHandler(BaseHTTPRequestHandler):
                     self.server.controller.start_one_automatic_continuation(
                         request
                     )
+                )
+            elif path == "/api/compound-loop":
+                if set(value) != {"request"} or not isinstance(
+                    value["request"],
+                    dict,
+                ):
+                    raise CompanionError(
+                        "Stage C compound-loop request fields are invalid."
+                    )
+                try:
+                    request = StageCContinuationRequest.from_dict(
+                        value["request"]
+                    )
+                except ContinuationIntegrityError as exc:
+                    raise CompanionError(
+                        "Stage C compound-loop request fields are invalid."
+                    ) from exc
+                snapshot = self.server.controller.start_small_compound_loop(
+                    request
                 )
             elif path == "/api/approval":
                 if set(value) != {"choice"}:

--- a/decision_os/companion/small_compound_loop.py
+++ b/decision_os/companion/small_compound_loop.py
@@ -1,0 +1,873 @@
+"""Stage C hard-capped three-Run extension of the Stage B causal record."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+from typing import Any, Mapping
+
+from decision_os.acceleration.model import canonical_json, hash_payload
+from decision_os.companion.continuation import (
+    ContinuationIntegrityError,
+    _bounded_strings,
+    _bounded_text,
+    _validate_run,
+    _validate_supervisor,
+)
+from decision_os.companion.supervisor import (
+    ContractFact,
+    SupervisorContext,
+)
+
+
+STAGE_C_SCHEMA = "decision-os-stage-c-small-compound-loop-v0.1"
+STAGE_C_TOTAL_RUN_CAP = 3
+STAGE_C_AUTOMATIC_CONTINUATION_LIMIT = 2
+STAGE_C_OUTCOMES = frozenset(
+    {"COMPLETE", "HOLD", "CAP", "BLOCK", "HUMAN SEAT REQUIRED"}
+)
+_MAX_TASK_BYTES = 20_000
+_STAGE_C_STATES = frozenset(
+    {
+        "RUN_1_ACTIVE",
+        "RUN_1_COMPLETE",
+        "RUN_2_ACTIVE",
+        "RUN_2_COMPLETE",
+        "RUN_3_ACTIVE",
+        "RUN_3_COMPLETE",
+        "TERMINAL",
+    }
+)
+_REQUEST_FIELDS = frozenset(
+    {
+        "goal",
+        "run_1_task",
+        "completion_requirements",
+        "evidence_recovery_action",
+        "irreducible_human_decision",
+        "authority_evidence_refs",
+        "allowed_mutation_paths",
+        "protected_objects",
+        "max_runs",
+        "goal_unchanged",
+        "authority_sufficient",
+        "blast_radius_bounded",
+        "action_reversible_or_authorized",
+        "no_material_human_preference_required",
+        "no_external_or_irreversible_commitment",
+        "cost_boundary_intact",
+        "protected_object_and_ownership_unchanged",
+        "no_authoritative_conflict",
+        "no_truly_unanswered_human_question",
+    }
+)
+_REQUIREMENT_FIELDS = frozenset(
+    {"requirement_id", "description", "evidence_path", "expected_sha256"}
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "schema",
+        "chain_id",
+        "repository_id",
+        "state",
+        "request",
+        "runs",
+        "residues",
+        "supervisor_judgments",
+        "automatic_tasks",
+        "automatic_continuations_started",
+        "automatic_continuation_limit",
+        "total_run_cap",
+        "outcome",
+        "governed_stop",
+        "record_sha256",
+    }
+)
+_RESIDUE_FIELDS = frozenset(
+    {
+        "run_number",
+        "source_run_id",
+        "source_evidence_sha256",
+        "established_requirement_ids",
+        "new_requirement_ids",
+        "remaining_requirement_ids",
+        "residue_sha256",
+    }
+)
+_TASK_FIELDS = frozenset(
+    {
+        "task_number",
+        "source_run_number",
+        "source_run_id",
+        "source_evidence_sha256",
+        "source_judgment_sha256",
+        "goal_sha256",
+        "selected_requirement_id",
+        "selected_evidence_path",
+        "selected_expected_sha256",
+        "task",
+        "task_sha256",
+    }
+)
+_FACT_FIELDS = (
+    "goal_unchanged",
+    "authority_sufficient",
+    "blast_radius_bounded",
+    "action_reversible_or_authorized",
+    "no_material_human_preference_required",
+    "no_external_or_irreversible_commitment",
+    "cost_boundary_intact",
+    "protected_object_and_ownership_unchanged",
+    "no_authoritative_conflict",
+    "no_truly_unanswered_human_question",
+)
+
+
+@dataclass(frozen=True)
+class StageCCompletionRequirement:
+    """One predeclared completion fact, not a prewritten Worker task."""
+
+    requirement_id: str
+    description: str
+    evidence_path: str
+    expected_sha256: str
+
+    def __post_init__(self) -> None:
+        _bounded_text(
+            self.requirement_id,
+            "Completion requirement ID",
+            maximum=128,
+        )
+        _bounded_text(
+            self.description,
+            "Completion requirement description",
+            maximum=2_000,
+        )
+        _bounded_text(
+            self.evidence_path,
+            "Completion evidence path",
+            maximum=2_000,
+        )
+        if (
+            not isinstance(self.expected_sha256, str)
+            or len(self.expected_sha256) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.expected_sha256
+            )
+        ):
+            raise ValueError(
+                "Completion requirement SHA-256 must be lowercase hexadecimal."
+            )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "requirement_id": self.requirement_id.strip(),
+            "description": self.description.strip(),
+            "evidence_path": self.evidence_path.strip(),
+            "expected_sha256": self.expected_sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "StageCCompletionRequirement":
+        if not isinstance(value, dict) or set(value) != _REQUIREMENT_FIELDS:
+            raise ContinuationIntegrityError(
+                "Persisted Stage C completion requirement is invalid."
+            )
+        try:
+            return cls(**value)
+        except (TypeError, ValueError) as exc:
+            raise ContinuationIntegrityError(
+                "Persisted Stage C completion requirement is invalid."
+            ) from exc
+
+
+@dataclass(frozen=True)
+class StageCContinuationRequest:
+    """One immutable Goal and authority envelope for a maximum of three Runs."""
+
+    goal: str
+    run_1_task: str
+    completion_requirements: tuple[StageCCompletionRequirement, ...]
+    evidence_recovery_action: str | None
+    irreducible_human_decision: str | None
+    authority_evidence_refs: tuple[str, ...]
+    allowed_mutation_paths: tuple[str, ...]
+    protected_objects: tuple[str, ...]
+    max_runs: int
+    goal_unchanged: ContractFact
+    authority_sufficient: ContractFact
+    blast_radius_bounded: ContractFact
+    action_reversible_or_authorized: ContractFact
+    no_material_human_preference_required: ContractFact
+    no_external_or_irreversible_commitment: ContractFact
+    cost_boundary_intact: ContractFact
+    protected_object_and_ownership_unchanged: ContractFact
+    no_authoritative_conflict: ContractFact
+    no_truly_unanswered_human_question: ContractFact
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.goal, "Goal", maximum=_MAX_TASK_BYTES)
+        _bounded_text(self.run_1_task, "Run 1 task", maximum=_MAX_TASK_BYTES)
+        _bounded_text(
+            self.evidence_recovery_action,
+            "Evidence recovery action",
+            maximum=8_000,
+            optional=True,
+        )
+        _bounded_text(
+            self.irreducible_human_decision,
+            "Irreducible Human Seat decision",
+            maximum=8_000,
+            optional=True,
+        )
+        if (
+            not isinstance(self.completion_requirements, tuple)
+            or not 1
+            <= len(self.completion_requirements)
+            <= STAGE_C_TOTAL_RUN_CAP
+            or any(
+                not isinstance(item, StageCCompletionRequirement)
+                for item in self.completion_requirements
+            )
+        ):
+            raise ValueError(
+                "Stage C requires one to three completion requirements."
+            )
+        requirement_ids = tuple(
+            item.requirement_id.strip() for item in self.completion_requirements
+        )
+        evidence_paths = tuple(
+            item.evidence_path.strip() for item in self.completion_requirements
+        )
+        if len(set(requirement_ids)) != len(requirement_ids):
+            raise ValueError("Stage C completion requirement IDs must be unique.")
+        if len(set(evidence_paths)) != len(evidence_paths):
+            raise ValueError("Stage C completion evidence paths must be unique.")
+        _bounded_strings(
+            self.authority_evidence_refs,
+            "Authority evidence references",
+        )
+        _bounded_strings(
+            self.allowed_mutation_paths,
+            "Allowed mutation paths",
+            maximum=1,
+        )
+        _bounded_strings(
+            self.protected_objects,
+            "Protected Objects",
+            maximum=8,
+        )
+        if (
+            not isinstance(self.max_runs, int)
+            or isinstance(self.max_runs, bool)
+            or self.max_runs != STAGE_C_TOTAL_RUN_CAP
+        ):
+            raise ValueError("Stage C has one hard cap of three total Runs.")
+        for name, fact in self.contract_facts():
+            if not isinstance(fact, ContractFact):
+                raise ValueError(f"{name} must be an explicit ContractFact.")
+
+    def contract_facts(self) -> tuple[tuple[str, ContractFact], ...]:
+        return tuple((name, getattr(self, name)) for name in _FACT_FIELDS)
+
+    def as_dict(self) -> dict[str, Any]:
+        value: dict[str, Any] = {
+            "goal": self.goal.strip(),
+            "run_1_task": self.run_1_task.strip(),
+            "completion_requirements": [
+                item.as_dict() for item in self.completion_requirements
+            ],
+            "evidence_recovery_action": (
+                None
+                if self.evidence_recovery_action is None
+                else self.evidence_recovery_action.strip()
+            ),
+            "irreducible_human_decision": (
+                None
+                if self.irreducible_human_decision is None
+                else self.irreducible_human_decision.strip()
+            ),
+            "authority_evidence_refs": list(self.authority_evidence_refs),
+            "allowed_mutation_paths": list(self.allowed_mutation_paths),
+            "protected_objects": list(self.protected_objects),
+            "max_runs": self.max_runs,
+        }
+        value.update(
+            {name: fact.value for name, fact in self.contract_facts()}
+        )
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "StageCContinuationRequest":
+        if not isinstance(value, dict) or set(value) != _REQUEST_FIELDS:
+            raise ContinuationIntegrityError(
+                "Persisted Stage C authority fields are invalid."
+            )
+        for key in (
+            "completion_requirements",
+            "authority_evidence_refs",
+            "allowed_mutation_paths",
+            "protected_objects",
+        ):
+            if not isinstance(value[key], list):
+                raise ContinuationIntegrityError(
+                    "Persisted Stage C authority collections are invalid."
+                )
+        try:
+            facts = {
+                name: ContractFact(value[name]) for name in _FACT_FIELDS
+            }
+            return cls(
+                goal=value["goal"],
+                run_1_task=value["run_1_task"],
+                completion_requirements=tuple(
+                    StageCCompletionRequirement.from_dict(item)
+                    for item in value["completion_requirements"]
+                ),
+                evidence_recovery_action=value["evidence_recovery_action"],
+                irreducible_human_decision=value[
+                    "irreducible_human_decision"
+                ],
+                authority_evidence_refs=tuple(
+                    value["authority_evidence_refs"]
+                ),
+                allowed_mutation_paths=tuple(value["allowed_mutation_paths"]),
+                protected_objects=tuple(value["protected_objects"]),
+                max_runs=value["max_runs"],
+                **facts,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ContinuationIntegrityError(
+                "Persisted Stage C authority is invalid."
+            ) from exc
+
+
+def new_stage_c_record(
+    request: StageCContinuationRequest,
+    *,
+    chain_id: str,
+    repository_id: str,
+) -> dict[str, Any]:
+    return {
+        "schema": STAGE_C_SCHEMA,
+        "chain_id": chain_id,
+        "repository_id": repository_id,
+        "state": "RUN_1_ACTIVE",
+        "request": request.as_dict(),
+        "runs": [],
+        "residues": [],
+        "supervisor_judgments": [],
+        "automatic_tasks": [],
+        "automatic_continuations_started": 0,
+        "automatic_continuation_limit": (
+            STAGE_C_AUTOMATIC_CONTINUATION_LIMIT
+        ),
+        "total_run_cap": STAGE_C_TOTAL_RUN_CAP,
+        "outcome": None,
+        "governed_stop": None,
+    }
+
+
+def _requirements(record: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
+    request = StageCContinuationRequest.from_dict(record.get("request"))
+    return tuple(item.as_dict() for item in request.completion_requirements)
+
+
+def satisfied_requirement_ids(
+    record: Mapping[str, Any],
+) -> tuple[str, ...]:
+    requirements = _requirements(record)
+    runs = record.get("runs")
+    if not isinstance(runs, list):
+        raise ContinuationIntegrityError("Stage C Run evidence is invalid.")
+    satisfied: list[str] = []
+    for requirement in requirements:
+        matched = any(
+            read.get("status") == "succeeded"
+            and read.get("path") == requirement["evidence_path"]
+            and read.get("sha256") == requirement["expected_sha256"]
+            for run in runs
+            if isinstance(run, dict)
+            for read in run.get("read_evidence", [])
+            if isinstance(read, dict)
+        )
+        if matched:
+            satisfied.append(requirement["requirement_id"])
+    return tuple(satisfied)
+
+
+def remaining_requirements(
+    record: Mapping[str, Any],
+) -> tuple[dict[str, str], ...]:
+    satisfied = set(satisfied_requirement_ids(record))
+    return tuple(
+        item
+        for item in _requirements(record)
+        if item["requirement_id"] not in satisfied
+    )
+
+
+def stage_c_residue(record: Mapping[str, Any]) -> dict[str, Any]:
+    runs = record.get("runs")
+    if not isinstance(runs, list) or not 1 <= len(runs) <= 3:
+        raise ContinuationIntegrityError(
+            "Stage C residue requires one to three persisted Runs."
+        )
+    established = satisfied_requirement_ids(record)
+    previous_record = dict(record)
+    previous_record["runs"] = runs[:-1]
+    previous = set(satisfied_requirement_ids(previous_record))
+    remaining = tuple(
+        item["requirement_id"] for item in remaining_requirements(record)
+    )
+    payload: dict[str, Any] = {
+        "run_number": len(runs),
+        "source_run_id": runs[-1]["run_id"],
+        "source_evidence_sha256": runs[-1]["evidence_sha256"],
+        "established_requirement_ids": list(established),
+        "new_requirement_ids": [
+            item for item in established if item not in previous
+        ],
+        "remaining_requirement_ids": list(remaining),
+    }
+    payload["residue_sha256"] = hash_payload(payload)
+    return payload
+
+
+def _remaining_gap(record: Mapping[str, Any]) -> str:
+    remaining = remaining_requirements(record)
+    if not remaining:
+        return "No completion requirement remains; the original Goal is complete."
+    return "Unmet completion requirements: " + "; ".join(
+        f"{item['requirement_id']} — {item['description']}"
+        for item in remaining
+    )
+
+
+def _next_action(requirement: Mapping[str, str]) -> str:
+    return (
+        f"Establish completion requirement {requirement['requirement_id']} by "
+        f"reading {requirement['evidence_path']} and verifying SHA-256 "
+        f"{requirement['expected_sha256']}: {requirement['description']}"
+    )
+
+
+def stage_c_supervisor_context(
+    record: Mapping[str, Any],
+) -> SupervisorContext:
+    request = StageCContinuationRequest.from_dict(record.get("request"))
+    runs = record.get("runs")
+    residues = record.get("residues")
+    if (
+        not isinstance(runs, list)
+        or not 1 <= len(runs) <= STAGE_C_TOTAL_RUN_CAP
+        or not isinstance(residues, list)
+        or len(residues) != len(runs)
+    ):
+        raise ContinuationIntegrityError(
+            "Stage C Supervisor requires the exact persisted current Run."
+        )
+    remaining = remaining_requirements(record)
+    current = runs[-1]
+    evidence_ref = (
+        f"stage-c:{record['chain_id']}:run-{len(runs)}:"
+        f"evidence-sha256={current['evidence_sha256']}"
+    )
+    return SupervisorContext(
+        goal=request.goal,
+        established_state=(
+            f"Run {len(runs)} {current['run_id']} is persisted as "
+            f"{current['status']} with evidence SHA-256 "
+            f"{current['evidence_sha256']}. Cumulative residue: "
+            f"{canonical_json(residues[-1])}"
+        ),
+        remaining_gap=_remaining_gap(record),
+        next_bounded_action=(
+            None if not remaining else _next_action(remaining[0])
+        ),
+        evidence_recovery_action=request.evidence_recovery_action,
+        irreducible_human_decision=request.irreducible_human_decision,
+        evidence_refs=(*request.authority_evidence_refs, evidence_ref),
+        completed_runs=len(runs),
+        max_runs=STAGE_C_TOTAL_RUN_CAP,
+        goal_complete=(
+            ContractFact.SATISFIED
+            if not remaining
+            else ContractFact.NOT_SATISFIED
+        ),
+        continuation_proof_sufficient=ContractFact.SATISFIED,
+        evidence_sufficient=ContractFact.SATISFIED,
+        **{name: fact for name, fact in request.contract_facts()},
+    )
+
+
+def stage_c_automatic_task(record: Mapping[str, Any]) -> dict[str, Any]:
+    request = StageCContinuationRequest.from_dict(record.get("request"))
+    runs = record.get("runs")
+    residues = record.get("residues")
+    judgments = record.get("supervisor_judgments")
+    if (
+        record.get("state")
+        not in {"RUN_1_COMPLETE", "RUN_2_COMPLETE"}
+        or not isinstance(runs, list)
+        or len(runs) not in {1, 2}
+        or not isinstance(residues, list)
+        or len(residues) != len(runs)
+        or not isinstance(judgments, list)
+        or len(judgments) != len(runs)
+        or judgments[-1].get("gate") != "GO"
+        or judgments[-1].get("decision_route") != "AI-OWNED"
+    ):
+        raise ContinuationIntegrityError(
+            "The next Stage C Task lacks an exact persisted Supervisor GO chain."
+        )
+    remaining = remaining_requirements(record)
+    if not remaining:
+        raise ContinuationIntegrityError(
+            "A completed Stage C Goal cannot construct another Task."
+        )
+    source = runs[-1]
+    judgment = judgments[-1]
+    selected = remaining[0]
+    task_number = len(runs) + 1
+    causal_evidence = {
+        "run_id": source["run_id"],
+        "status": source["status"],
+        "evidence_sha256": source["evidence_sha256"],
+        "read_evidence": source["read_evidence"],
+        "receipt_delta": source["receipt_delta"],
+        "residue": residues[-1],
+        "supervisor_judgment": judgment,
+    }
+    task = "\n".join(
+        (
+            (
+                f"STAGE C CAUSAL AUTOMATIC CONTINUATION — RUN {task_number} "
+                f"OF HARD MAXIMUM {STAGE_C_TOTAL_RUN_CAP}"
+            ),
+            "",
+            "Original user Goal:",
+            request.goal,
+            "",
+            f"Persisted Run {len(runs)} causal evidence:",
+            canonical_json(causal_evidence),
+            "",
+            "Current remaining gap derived after the preceding Run:",
+            _remaining_gap(record),
+            "",
+            "Execute exactly this newly selected unmet completion requirement:",
+            canonical_json(selected),
+            "",
+            "Derived bounded action:",
+            _next_action(selected),
+            "",
+            "Allowed mutation path (no expansion):",
+            request.allowed_mutation_paths[0],
+            "",
+            "Protected Objects / ownership boundaries (unchanged):",
+            canonical_json(list(request.protected_objects)),
+            "",
+            (
+                "Preserve the same Goal, authority, evidence continuity, blast "
+                "radius, Human Seat contract, and three-Run total cap. Read only "
+                "the selected evidence needed for this requirement. Do not "
+                "publish, release, widen scope, or construct any later Task. "
+                "Only the controller may supervise this result and decide "
+                "whether another Run is admissible. Run 4 is forbidden."
+            ),
+        )
+    )
+    if len(task.encode("utf-8")) > _MAX_TASK_BYTES:
+        raise ContinuationIntegrityError(
+            "The causally constructed Stage C Task exceeds its bounded limit."
+        )
+    return {
+        "task_number": task_number,
+        "source_run_number": len(runs),
+        "source_run_id": source["run_id"],
+        "source_evidence_sha256": source["evidence_sha256"],
+        "source_judgment_sha256": hash_payload(judgment),
+        "goal_sha256": hashlib.sha256(
+            request.goal.encode("utf-8")
+        ).hexdigest(),
+        "selected_requirement_id": selected["requirement_id"],
+        "selected_evidence_path": selected["evidence_path"],
+        "selected_expected_sha256": selected["expected_sha256"],
+        "task": task,
+        "task_sha256": hashlib.sha256(task.encode("utf-8")).hexdigest(),
+    }
+
+
+def stage_c_outcome(
+    record: Mapping[str, Any],
+    judgment: Mapping[str, Any],
+) -> str:
+    if not remaining_requirements(record):
+        return "COMPLETE"
+    if judgment.get("gate") == "CAP":
+        return "CAP"
+    if judgment.get("decision_route") == "HUMAN-SEAT":
+        return "HUMAN SEAT REQUIRED"
+    if judgment.get("gate") == "BLOCK":
+        return "BLOCK"
+    return "HOLD"
+
+
+def _validate_residue(value: Any, expected: Mapping[str, Any]) -> None:
+    if not isinstance(value, dict) or set(value) != _RESIDUE_FIELDS:
+        raise ContinuationIntegrityError("Persisted Stage C residue is invalid.")
+    if value != expected:
+        raise ContinuationIntegrityError(
+            "Persisted Stage C residue does not match accumulated Run evidence."
+        )
+
+
+def _validate_task(value: Any, expected: Mapping[str, Any]) -> None:
+    if not isinstance(value, dict) or set(value) != _TASK_FIELDS:
+        raise ContinuationIntegrityError(
+            "Persisted Stage C automatic Task is invalid."
+        )
+    if value != expected:
+        raise ContinuationIntegrityError(
+            "Persisted Stage C Task is not the deterministic prior-Run derivation."
+        )
+
+
+def _validate_stop(value: Any) -> None:
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"gate", "route", "reason", "next_action"}
+        or any(not isinstance(item, str) or not item for item in value.values())
+    ):
+        raise ContinuationIntegrityError(
+            "Persisted Stage C governed stop is invalid."
+        )
+
+
+def _validate_state_shape(value: Mapping[str, Any]) -> None:
+    state = value["state"]
+    runs = value["runs"]
+    residues = value["residues"]
+    judgments = value["supervisor_judgments"]
+    tasks = value["automatic_tasks"]
+    started = value["automatic_continuations_started"]
+    outcome = value["outcome"]
+    stop = value["governed_stop"]
+    if state != "TERMINAL" and (outcome is not None or stop is not None):
+        raise ContinuationIntegrityError(
+            "Active Stage C state contains a terminal outcome."
+        )
+    active_shapes = {
+        "RUN_1_ACTIVE": (0, 0, 0, 0),
+        "RUN_2_ACTIVE": (1, 1, 1, 1),
+        "RUN_3_ACTIVE": (2, 2, 2, 2),
+    }
+    if state in active_shapes:
+        run_count, judgment_count, task_count, continuation_count = (
+            active_shapes[state]
+        )
+        if (
+            len(runs) != run_count
+            or len(residues) != run_count
+            or len(judgments) != judgment_count
+            or len(tasks) != task_count
+            or started != continuation_count
+        ):
+            raise ContinuationIntegrityError(
+                "Active Stage C Run state is causally invalid."
+            )
+        if judgments and (
+            judgments[-1]["gate"] != "GO"
+            or judgments[-1]["decision_route"] != "AI-OWNED"
+        ):
+            raise ContinuationIntegrityError(
+                "Active Stage C continuation lacks Supervisor GO."
+            )
+        return
+    complete_shapes = {
+        "RUN_1_COMPLETE": (1, 0),
+        "RUN_2_COMPLETE": (2, 1),
+        "RUN_3_COMPLETE": (3, 2),
+    }
+    if state in complete_shapes:
+        run_count, task_count = complete_shapes[state]
+        if (
+            len(runs) != run_count
+            or len(residues) != run_count
+            or len(tasks) != task_count
+            or started != task_count
+            or len(judgments) not in {run_count - 1, run_count}
+        ):
+            raise ContinuationIntegrityError(
+                "Completed Stage C Run state is causally invalid."
+            )
+        return
+    if state != "TERMINAL":
+        raise ContinuationIntegrityError("Persisted Stage C state is invalid.")
+    if outcome not in STAGE_C_OUTCOMES:
+        raise ContinuationIntegrityError(
+            "Terminal Stage C outcome is invalid."
+        )
+    _validate_stop(stop)
+    dispatched_runs = 1 + started
+    if (
+        len(tasks) != started
+        or len(residues) != len(runs)
+        or len(runs) not in {dispatched_runs - 1, dispatched_runs}
+        or len(judgments) not in {max(0, len(runs) - 1), len(runs)}
+    ):
+        raise ContinuationIntegrityError(
+            "Terminal Stage C causal counts are invalid."
+        )
+    remaining = remaining_requirements(value)
+    if outcome == "COMPLETE" and (
+        remaining
+        or len(runs) != dispatched_runs
+        or len(judgments) != len(runs)
+    ):
+        raise ContinuationIntegrityError(
+            "Completed Stage C outcome lacks complete evidence."
+        )
+    if outcome == "CAP" and (
+        not remaining
+        or len(judgments) != len(runs)
+        or judgments[-1]["gate"] != "CAP"
+        or stop["gate"] != "CAP"
+    ):
+        raise ContinuationIntegrityError("Stage C cap outcome is invalid.")
+    if outcome == "HUMAN SEAT REQUIRED" and (
+        not judgments
+        or judgments[-1]["decision_route"] != "HUMAN-SEAT"
+        or stop["route"] != "HUMAN-SEAT"
+    ):
+        raise ContinuationIntegrityError(
+            "Stage C Human Seat outcome is invalid."
+        )
+    if outcome == "HUMAN SEAT REQUIRED" and judgments[-1]["gate"] == "CAP":
+        raise ContinuationIntegrityError(
+            "A Stage C CAP judgment cannot be relabeled as Human Seat required."
+        )
+    if outcome == "BLOCK" and (
+        stop["gate"] != "BLOCK" or stop["route"] == "HUMAN-SEAT"
+    ):
+        raise ContinuationIntegrityError(
+            "Stage C BLOCK outcome lacks its exact governed gate."
+        )
+    if outcome == "HOLD" and stop["gate"] != "HOLD":
+        raise ContinuationIntegrityError(
+            "Stage C HOLD outcome lacks its exact governed gate."
+        )
+    if outcome == "COMPLETE" and stop["route"] != "STOP":
+        raise ContinuationIntegrityError(
+            "Stage C completion lacks its exact governed stop."
+        )
+
+
+def validate_stage_c_record(value: Any, *, maximum_bytes: int) -> None:
+    """Validate one complete or reconnectable Stage C causal record."""
+
+    if not isinstance(value, dict) or set(value) != _RECORD_FIELDS:
+        raise ContinuationIntegrityError("Persisted Stage C fields are invalid.")
+    if value["schema"] != STAGE_C_SCHEMA or value["state"] not in _STAGE_C_STATES:
+        raise ContinuationIntegrityError(
+            "Persisted Stage C schema or state is invalid."
+        )
+    if (
+        not isinstance(value["chain_id"], str)
+        or len(value["chain_id"]) != 32
+        or any(
+            character not in "0123456789abcdef"
+            for character in value["chain_id"]
+        )
+        or not isinstance(value["repository_id"], str)
+        or not value["repository_id"].startswith("repo:v1:")
+    ):
+        raise ContinuationIntegrityError("Persisted Stage C identity is invalid.")
+    StageCContinuationRequest.from_dict(value["request"])
+    runs = value["runs"]
+    residues = value["residues"]
+    judgments = value["supervisor_judgments"]
+    tasks = value["automatic_tasks"]
+    if (
+        not isinstance(runs, list)
+        or len(runs) > STAGE_C_TOTAL_RUN_CAP
+        or not isinstance(residues, list)
+        or len(residues) > len(runs)
+        or not isinstance(judgments, list)
+        or len(judgments) > len(runs)
+        or not isinstance(tasks, list)
+        or len(tasks) > STAGE_C_AUTOMATIC_CONTINUATION_LIMIT
+    ):
+        raise ContinuationIntegrityError(
+            "Persisted Stage C causal collections are invalid."
+        )
+    for index, run in enumerate(runs, start=1):
+        _validate_run(run, index)
+    for index, residue in enumerate(residues, start=1):
+        prefix = dict(value)
+        prefix["runs"] = runs[:index]
+        _validate_residue(residue, stage_c_residue(prefix))
+    for index, judgment in enumerate(judgments):
+        _validate_supervisor(judgment, runs[index])
+        evidence_ref = (
+            f"stage-c:{value['chain_id']}:run-{index + 1}:"
+            f"evidence-sha256={runs[index]['evidence_sha256']}"
+        )
+        if evidence_ref not in judgment["evidence_refs"]:
+            raise ContinuationIntegrityError(
+                "Stage C Supervisor judgment lacks current Run provenance."
+            )
+    started = value["automatic_continuations_started"]
+    if (
+        not isinstance(started, int)
+        or isinstance(started, bool)
+        or started not in {0, 1, 2}
+        or value["automatic_continuation_limit"]
+        != STAGE_C_AUTOMATIC_CONTINUATION_LIMIT
+        or value["total_run_cap"] != STAGE_C_TOTAL_RUN_CAP
+        or started != len(tasks)
+    ):
+        raise ContinuationIntegrityError(
+            "Persisted Stage C Run cap or continuation count is invalid."
+        )
+    for index, task in enumerate(tasks, start=1):
+        prefix = dict(value)
+        prefix["runs"] = runs[:index]
+        prefix["residues"] = residues[:index]
+        prefix["supervisor_judgments"] = judgments[:index]
+        prefix["state"] = f"RUN_{index}_COMPLETE"
+        _validate_task(task, stage_c_automatic_task(prefix))
+    _validate_state_shape(value)
+    claimed_hash = value["record_sha256"]
+    if not isinstance(claimed_hash, str) or len(claimed_hash) != 64:
+        raise ContinuationIntegrityError(
+            "Persisted Stage C record hash is invalid."
+        )
+    payload = {
+        key: item for key, item in value.items() if key != "record_sha256"
+    }
+    if claimed_hash != hash_payload(payload):
+        raise ContinuationIntegrityError(
+            "Persisted Stage C record hash mismatches."
+        )
+    if len(canonical_json(value).encode("utf-8")) > maximum_bytes:
+        raise ContinuationIntegrityError("Persisted Stage C record is too large.")
+
+
+__all__ = [
+    "STAGE_C_AUTOMATIC_CONTINUATION_LIMIT",
+    "STAGE_C_OUTCOMES",
+    "STAGE_C_SCHEMA",
+    "STAGE_C_TOTAL_RUN_CAP",
+    "StageCCompletionRequirement",
+    "StageCContinuationRequest",
+    "new_stage_c_record",
+    "remaining_requirements",
+    "satisfied_requirement_ids",
+    "stage_c_automatic_task",
+    "stage_c_outcome",
+    "stage_c_residue",
+    "stage_c_supervisor_context",
+    "validate_stage_c_record",
+]

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -22,10 +22,10 @@ F3 CLOSED
 REPAIR CLOSURE PASS
 
 Current Gate:
-GO — BOUNDED COMPOUND LOOP PROOF
+HOLD — STAGE C COMPLETE / STAGE D NOT AUTHORIZED
 
 Build Scope:
-Stage A → Stage B → Stage C in order
+Stage A → Stage B → Stage C COMPLETE
 
 First Live Cap:
 3 total bounded Runs
@@ -54,11 +54,20 @@ PASS
 Stage B Evidence:
 validation/stage_b_one_automatic_continuation_001.md
 
+Stage C Small Compound Loop:
+PASS
+
+Stage C Evidence:
+validation/stage_c_small_compound_loop_001.md
+
 Current Missing Closure:
-Stage C — Small Compound Loop
+Stage D — Leave-the-Desk Dogfood (NOT AUTHORIZED)
 
 Stage C Authorization:
-YES — NEXT ENGINEERING PHASE
+CONSUMED — COMPLETE
+
+Stage D Authorization:
+NO
 
 Release Authority:
 NONE
@@ -67,8 +76,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-Implement and verify Stage C — Small Compound Loop under the unchanged
-three-Run cap. Stage D, release, and publication remain unauthorized.
+None. Preserve the Stage C terminal evidence and hard three-Run cap. Stage D,
+release, and publication require a separate new Gate.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -22,10 +22,10 @@ F3 CLOSED
 REPAIR CLOSURE PASS
 
 Current Gate:
-GO — BOUNDED COMPOUND LOOP PROOF
+HOLD — STAGE C COMPLETE / STAGE D NOT AUTHORIZED
 
 Build Scope:
-Stage A → Stage B → Stage C in order
+Stage A → Stage B → Stage C COMPLETE
 
 First Live Cap:
 3 total bounded Runs
@@ -54,11 +54,20 @@ PASS
 Stage B Evidence:
 validation/stage_b_one_automatic_continuation_001.md
 
+Stage C Small Compound Loop:
+PASS
+
+Stage C Evidence:
+validation/stage_c_small_compound_loop_001.md
+
 Current Missing Closure:
-Stage C — Small Compound Loop
+Stage D — Leave-the-Desk Dogfood (NOT AUTHORIZED)
 
 Stage C Authorization:
-YES — NEXT ENGINEERING PHASE
+CONSUMED — COMPLETE
+
+Stage D Authorization:
+NO
 
 Release Authority:
 NONE
@@ -67,8 +76,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-Implement and verify Stage C — Small Compound Loop under the unchanged
-three-Run cap. Stage D, release, and publication remain unauthorized.
+None. Preserve the Stage C terminal evidence and hard three-Run cap. Stage D,
+release, and publication require a separate new Gate.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -34,6 +34,7 @@ from tests.test_companion_controller import (
     pro_design_metadata,
 )
 from tests.test_companion_continuation import stage_b_request
+from tests.test_companion_small_compound_loop import stage_c_request
 
 
 BRIDGE_POST_ROUTES = (
@@ -2202,6 +2203,55 @@ class CompanionServerTest(unittest.TestCase):
             "POST",
             "/api/compound-run",
             body={"request": stage_b_request().as_dict(), "extra": True},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(400, status)
+
+    def test_authenticated_stage_c_route_enforces_three_run_cap(self) -> None:
+        self.controller.adapter_factory = ScriptedFactory(
+            "read_only",
+            "read_only",
+            "read_only",
+            "read_only",
+        )
+        cookie, csrf = self.bootstrap()
+
+        status, _headers, raw = self.request(
+            "POST",
+            "/api/compound-loop",
+            body={"request": stage_c_request().as_dict()},
+            cookie=cookie,
+            csrf=csrf,
+            origin=self.server.origin,
+        )
+        self.assertEqual(200, status, raw.decode("utf-8", errors="replace"))
+
+        deadline = time.monotonic() + 5
+        snapshot = None
+        while time.monotonic() < deadline:
+            status, _headers, raw = self.request(
+                "GET",
+                "/api/state",
+                cookie=cookie,
+            )
+            self.assertEqual(200, status)
+            snapshot = json.loads(raw)
+            if snapshot["compound_loop"]["state"] == "TERMINAL":
+                break
+            time.sleep(0.01)
+        self.assertIsNotNone(snapshot)
+        self.assertEqual("CAP", snapshot["compound_loop"]["outcome"])
+        self.assertEqual(3, len(snapshot["compound_loop"]["runs"]))
+        self.assertEqual(2, len(snapshot["compound_loop"]["automatic_tasks"]))
+        self.assertEqual(3, snapshot["run"]["continuation"]["run_number"])
+        self.assertEqual(1, len(self.controller.adapter_factory.modes))
+
+        status, _headers, _raw = self.request(
+            "POST",
+            "/api/compound-loop",
+            body={"request": stage_c_request().as_dict(), "extra": True},
             cookie=cookie,
             csrf=csrf,
             origin=self.server.origin,

--- a/tests/test_companion_small_compound_loop.py
+++ b/tests/test_companion_small_compound_loop.py
@@ -1,0 +1,575 @@
+from __future__ import annotations
+
+from collections import deque
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import time
+import unittest
+from typing import Any
+
+from decision_os.acceleration.codex_adapter import (
+    CodexReadEvidence,
+    CodexRunResult,
+)
+from decision_os.acceleration.model import hash_payload
+from decision_os.companion.controller import (
+    CompanionController,
+    RunConflictError,
+)
+from decision_os.companion.small_compound_loop import (
+    StageCCompletionRequirement,
+    StageCContinuationRequest,
+)
+from decision_os.companion.supervisor import ContractFact
+from tests.test_companion_controller import (
+    ScriptedAdapter,
+    create_repository,
+    runtime_identity,
+    wait_for,
+)
+
+
+YES = ContractFact.SATISFIED
+NO = ContractFact.NOT_SATISFIED
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def requirement(number: int) -> StageCCompletionRequirement:
+    return StageCCompletionRequirement(
+        requirement_id=f"REQ-{number}",
+        description=f"Establish independent completion fact {number}.",
+        evidence_path=f"evidence-{number}.md",
+        expected_sha256=str(number) * 64,
+    )
+
+
+def stage_c_request(**overrides: Any) -> StageCContinuationRequest:
+    values: dict[str, Any] = {
+        "goal": (
+            "Establish three distinct evidence facts through one causally "
+            "supervised compound loop without changing repository content."
+        ),
+        "run_1_task": (
+            "Read evidence-1.md and establish only completion fact REQ-1."
+        ),
+        "completion_requirements": (
+            requirement(1),
+            requirement(2),
+            requirement(3),
+        ),
+        "evidence_recovery_action": (
+            "Recover the exact persisted Stage C causal record."
+        ),
+        "irreducible_human_decision": None,
+        "authority_evidence_refs": (
+            "docs/companion_product_roadmap_v0_3.md#stage-c",
+        ),
+        "allowed_mutation_paths": ("target.txt",),
+        "protected_objects": ("all repository content remains read-only",),
+        "max_runs": 3,
+        "goal_unchanged": YES,
+        "authority_sufficient": YES,
+        "blast_radius_bounded": YES,
+        "action_reversible_or_authorized": YES,
+        "no_material_human_preference_required": YES,
+        "no_external_or_irreversible_commitment": YES,
+        "cost_boundary_intact": YES,
+        "protected_object_and_ownership_unchanged": YES,
+        "no_authoritative_conflict": YES,
+        "no_truly_unanswered_human_question": YES,
+    }
+    values.update(overrides)
+    return StageCContinuationRequest(**values)
+
+
+class EvidenceFactory:
+    """Return one predetermined Worker result per actual dispatch."""
+
+    def __init__(self, *plans: Any) -> None:
+        self.plans = deque(plans)
+        self.prompts: list[str] = []
+
+    def __call__(
+        self,
+        engine: Any,
+        approval_provider: Any,
+        lifecycle_sink: Any,
+    ) -> Any:
+        plan = self.plans.popleft()
+        prompts = self.prompts
+
+        if plan == "mutation":
+            class RecordingMutationAdapter(ScriptedAdapter):
+                async def run(self, prompt: str) -> CodexRunResult:
+                    prompts.append(prompt)
+                    return await super().run(prompt)
+
+            return RecordingMutationAdapter(
+                engine,
+                approval_provider,
+                lifecycle_sink,
+                "mutation",
+            )
+
+        class EvidenceAdapter:
+            async def run(self, prompt: str) -> CodexRunResult:
+                prompts.append(prompt)
+                if plan == "failure":
+                    raise RuntimeError("injected bounded execution failure")
+                evidence_ids = tuple(plan.get("evidence", ()))
+                status = plan.get("status", "NORMAL_TERMINAL")
+                normal = status == "NORMAL_TERMINAL"
+                return CodexRunResult(
+                    run_id=engine.new_run_id(),
+                    normal_terminal=normal,
+                    status=status,
+                    error_type=None,
+                    turn_status="completed",
+                    runtime_identity=runtime_identity(),
+                    checkpoint_outcomes=(),
+                    final_message=f"Established {evidence_ids!r}.",
+                    read_evidence=tuple(
+                        CodexReadEvidence(
+                            path=f"evidence-{number}.md",
+                            byte_count=number,
+                            sha256=str(number) * 64,
+                            repository_identity="b" * 40,
+                            status="succeeded",
+                        )
+                        for number in evidence_ids
+                    ),
+                )
+
+        return EvidenceAdapter()
+
+
+class StageCSmallCompoundLoopTest(unittest.TestCase):
+    def make_controller(
+        self,
+        directory: Path,
+        factory: EvidenceFactory,
+    ) -> CompanionController:
+        return CompanionController(
+            state_path=directory / "application-state" / "state.json",
+            picker_runner=lambda _script: None,
+            adapter_factory=factory,
+        )
+
+    @staticmethod
+    def terminal(controller: CompanionController) -> dict[str, Any]:
+        return wait_for(
+            controller,
+            lambda state: (
+                state["compound_loop"] is not None
+                and state["compound_loop"].get("state") == "TERMINAL"
+            ),
+        )
+
+    def run_complete_chain(
+        self,
+        root: Path,
+    ) -> tuple[CompanionController, EvidenceFactory, dict[str, Any]]:
+        repository = create_repository(root)
+        factory = EvidenceFactory(
+            {"evidence": (1,)},
+            {"evidence": (2,)},
+            {"evidence": (3,)},
+            {"evidence": ()},
+        )
+        controller = self.make_controller(root, factory)
+        controller.select_repository(repository)
+        controller.start_small_compound_loop(stage_c_request())
+        return controller, factory, self.terminal(controller)
+
+    def test_three_distinct_runs_are_causal_and_run_four_is_impossible(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            controller, factory, completed = self.run_complete_chain(
+                Path(temporary)
+            )
+            chain = completed["compound_loop"]
+
+            self.assertEqual("COMPLETE", chain["outcome"])
+            self.assertEqual(3, len(chain["runs"]))
+            self.assertEqual(3, len(chain["residues"]))
+            self.assertEqual(3, len(chain["supervisor_judgments"]))
+            self.assertEqual(2, len(chain["automatic_tasks"]))
+            self.assertEqual(2, chain["automatic_continuations_started"])
+            self.assertEqual(2, chain["automatic_continuation_limit"])
+            self.assertEqual(3, chain["total_run_cap"])
+            self.assertEqual(3, len(factory.prompts))
+            self.assertEqual(1, len(factory.plans))
+
+            self.assertEqual(
+                ["REQ-1"],
+                chain["residues"][0]["established_requirement_ids"],
+            )
+            self.assertEqual(
+                ["REQ-1", "REQ-2"],
+                chain["residues"][1]["established_requirement_ids"],
+            )
+            self.assertEqual(
+                ["REQ-1", "REQ-2", "REQ-3"],
+                chain["residues"][2]["established_requirement_ids"],
+            )
+            task_2, task_3 = chain["automatic_tasks"]
+            self.assertEqual("REQ-2", task_2["selected_requirement_id"])
+            self.assertEqual("REQ-3", task_3["selected_requirement_id"])
+            self.assertNotEqual(task_2["task"], task_3["task"])
+            self.assertEqual(
+                chain["runs"][0]["run_id"],
+                task_2["source_run_id"],
+            )
+            self.assertEqual(
+                chain["runs"][1]["run_id"],
+                task_3["source_run_id"],
+            )
+            self.assertEqual(
+                chain["runs"][1]["evidence_sha256"],
+                task_3["source_evidence_sha256"],
+            )
+            self.assertNotEqual(
+                chain["runs"][0]["run_id"],
+                task_3["source_run_id"],
+            )
+            for index, judgment in enumerate(
+                chain["supervisor_judgments"],
+                start=1,
+            ):
+                self.assertEqual(
+                    chain["runs"][index - 1]["run_id"],
+                    judgment["consumed_run"]["run_id"],
+                )
+
+            time.sleep(0.05)
+            self.assertEqual(3, len(factory.prompts))
+            self.assertEqual(1, len(factory.plans))
+            self.assertEqual(
+                "TERMINAL",
+                controller.snapshot()["compound_loop"]["state"],
+            )
+
+    def test_early_completion_after_run_one_or_two_preserves_unused_budget(
+        self,
+    ) -> None:
+        cases = (
+            ("run-one", ({"evidence": (1, 2, 3)},), 1, 0),
+            (
+                "run-two",
+                ({"evidence": (1,)}, {"evidence": (2, 3)}),
+                2,
+                1,
+            ),
+        )
+        for label, plans, runs, continuations in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                repository = create_repository(root)
+                factory = EvidenceFactory(*plans, {"evidence": ()})
+                controller = self.make_controller(root, factory)
+                controller.select_repository(repository)
+                controller.start_small_compound_loop(stage_c_request())
+                chain = self.terminal(controller)["compound_loop"]
+
+                self.assertEqual("COMPLETE", chain["outcome"])
+                self.assertEqual(runs, len(chain["runs"]))
+                self.assertEqual(runs, len(factory.prompts))
+                self.assertEqual(
+                    continuations,
+                    chain["automatic_continuations_started"],
+                )
+                self.assertGreater(len(factory.plans), 0)
+
+    def test_non_go_human_seat_and_cap_all_stop_without_run_four(self) -> None:
+        cases = (
+            (
+                "abnormal-run-two",
+                stage_c_request(),
+                (
+                    {"evidence": (1,)},
+                    {
+                        "evidence": (2,),
+                        "status": "ABNORMAL_TERMINAL",
+                    },
+                ),
+                "HOLD",
+                2,
+            ),
+            (
+                "human-seat-run-one",
+                stage_c_request(authority_sufficient=NO),
+                ({"evidence": (1,)},),
+                "HUMAN SEAT REQUIRED",
+                1,
+            ),
+            (
+                "hard-cap-run-three",
+                stage_c_request(),
+                ({"evidence": (1,)}, {"evidence": (2,)}, {"evidence": (2,)}),
+                "CAP",
+                3,
+            ),
+        )
+        for label, request, plans, outcome, runs in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                repository = create_repository(root)
+                factory = EvidenceFactory(*plans, {"evidence": ()})
+                controller = self.make_controller(root, factory)
+                controller.select_repository(repository)
+                controller.start_small_compound_loop(request)
+                chain = self.terminal(controller)["compound_loop"]
+
+                self.assertEqual(outcome, chain["outcome"])
+                self.assertEqual(runs, len(chain["runs"]))
+                self.assertEqual(runs, len(chain["supervisor_judgments"]))
+                self.assertEqual(runs, len(factory.prompts))
+                self.assertGreater(len(factory.plans), 0)
+                if label == "hard-cap-run-three":
+                    with self.assertRaisesRegex(
+                        RunConflictError,
+                        "cannot be reset or renewed",
+                    ):
+                        controller.start_small_compound_loop(request)
+                    self.assertEqual(3, len(factory.prompts))
+
+    def test_run_three_execution_failure_stops_without_run_four(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {"evidence": (1,)},
+                {"evidence": (2,)},
+                "failure",
+                {"evidence": (3,)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(stage_c_request())
+            chain = self.terminal(controller)["compound_loop"]
+
+            self.assertEqual("HOLD", chain["outcome"])
+            self.assertEqual(2, len(chain["runs"]))
+            self.assertEqual(2, chain["automatic_continuations_started"])
+            self.assertEqual(3, len(factory.prompts))
+            self.assertEqual(1, len(factory.plans))
+
+    def test_run_three_cannot_widen_the_authorized_mutation_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {"evidence": (1,)},
+                {"evidence": (2,)},
+                "mutation",
+                {"evidence": (3,)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(
+                stage_c_request(allowed_mutation_paths=("other.txt",))
+            )
+            chain = self.terminal(controller)["compound_loop"]
+
+            self.assertEqual("BLOCK", chain["outcome"])
+            self.assertEqual("DENIED", chain["runs"][2]["status"])
+            self.assertEqual(
+                "BLOCK",
+                chain["supervisor_judgments"][2]["gate"],
+            )
+            self.assertEqual(3, len(factory.prompts))
+            self.assertEqual(1, len(factory.plans))
+
+    def test_rehashed_task_and_provenance_tampering_blocks_reconnect(self) -> None:
+        def change_task_2(record: dict[str, Any]) -> None:
+            injected = "independently supplied Task 2"
+            record["automatic_tasks"][0]["task"] = injected
+            record["automatic_tasks"][0]["task_sha256"] = hashlib.sha256(
+                injected.encode("utf-8")
+            ).hexdigest()
+
+        def change_task_3(record: dict[str, Any]) -> None:
+            injected = "repeated Task 2 label instead of causal Task 3"
+            record["automatic_tasks"][1]["task"] = injected
+            record["automatic_tasks"][1]["task_sha256"] = hashlib.sha256(
+                injected.encode("utf-8")
+            ).hexdigest()
+
+        cases = (
+            ("task-two", change_task_2),
+            ("task-three", change_task_3),
+            (
+                "wrong-source-run",
+                lambda record: record["automatic_tasks"][1].__setitem__(
+                    "source_run_id",
+                    record["runs"][0]["run_id"],
+                ),
+            ),
+            (
+                "wrong-source-evidence",
+                lambda record: record["automatic_tasks"][1].__setitem__(
+                    "source_evidence_sha256",
+                    record["runs"][0]["evidence_sha256"],
+                ),
+            ),
+        )
+        for label, mutate in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                self.run_complete_chain(root)
+                state_path = (
+                    root / "application-state" / "stage-b-continuation.json"
+                )
+                record = json.loads(state_path.read_text(encoding="utf-8"))
+                mutate(record)
+                record.pop("record_sha256")
+                record["record_sha256"] = hash_payload(record)
+                state_path.write_text(json.dumps(record), encoding="utf-8")
+
+                restarted_factory = EvidenceFactory()
+                restarted = self.make_controller(root, restarted_factory)
+                snapshot = restarted.snapshot()
+                self.assertEqual(
+                    "BLOCKED_CORRUPT",
+                    snapshot["compound_loop"]["state"],
+                )
+                self.assertEqual([], restarted_factory.prompts)
+
+    def test_stale_active_replay_never_dispatches_and_blocks_new_chain(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.run_complete_chain(root)
+            state_path = (
+                root / "application-state" / "stage-b-continuation.json"
+            )
+            record = json.loads(state_path.read_text(encoding="utf-8"))
+            record["state"] = "RUN_3_ACTIVE"
+            record["runs"] = record["runs"][:2]
+            record["residues"] = record["residues"][:2]
+            record["supervisor_judgments"] = record[
+                "supervisor_judgments"
+            ][:2]
+            record["outcome"] = None
+            record["governed_stop"] = None
+            record.pop("record_sha256")
+            record["record_sha256"] = hash_payload(record)
+            state_path.write_text(json.dumps(record), encoding="utf-8")
+
+            restarted_factory = EvidenceFactory({"evidence": (3,)})
+            restarted = self.make_controller(root, restarted_factory)
+            snapshot = restarted.snapshot()
+            self.assertEqual(
+                "RUN_3_ACTIVE",
+                snapshot["compound_loop"]["state"],
+            )
+            self.assertEqual([], restarted_factory.prompts)
+            with self.assertRaises(RunConflictError):
+                restarted.start_small_compound_loop(stage_c_request())
+            self.assertEqual([], restarted_factory.prompts)
+
+    def test_terminal_reconnect_is_hash_identical_and_dispatch_free(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _controller, _factory, completed = self.run_complete_chain(root)
+            restarted_factory = EvidenceFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            snapshot = restarted.snapshot()
+
+            self.assertEqual("TERMINAL", snapshot["compound_loop"]["state"])
+            self.assertEqual(
+                completed["compound_loop"]["record_sha256"],
+                snapshot["compound_loop"]["record_sha256"],
+            )
+            self.assertEqual([], restarted_factory.prompts)
+            state_path = (
+                root / "application-state" / "stage-b-continuation.json"
+            )
+            self.assertEqual(0o600, state_path.stat().st_mode & 0o777)
+
+    def test_governed_stop_and_cap_reconnect_without_dispatch(self) -> None:
+        cases = (
+            (
+                "human-seat",
+                stage_c_request(authority_sufficient=NO),
+                ({"evidence": (1,)},),
+                "HUMAN SEAT REQUIRED",
+            ),
+            (
+                "cap",
+                stage_c_request(),
+                (
+                    {"evidence": (1,)},
+                    {"evidence": (2,)},
+                    {"evidence": (2,)},
+                ),
+                "CAP",
+            ),
+        )
+        for label, request, plans, outcome in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                repository = create_repository(root)
+                controller = self.make_controller(
+                    root,
+                    EvidenceFactory(*plans),
+                )
+                controller.select_repository(repository)
+                controller.start_small_compound_loop(request)
+                terminal = self.terminal(controller)["compound_loop"]
+
+                restarted_factory = EvidenceFactory()
+                restarted = self.make_controller(root, restarted_factory)
+                snapshot = restarted.snapshot()["compound_loop"]
+                self.assertEqual(outcome, snapshot["outcome"])
+                self.assertEqual(
+                    terminal["record_sha256"],
+                    snapshot["record_sha256"],
+                )
+                self.assertEqual([], restarted_factory.prompts)
+
+    def test_real_stage_c_proof_binds_all_three_distinct_sources(self) -> None:
+        sources = (
+            (
+                "validation/stage_a_supervisor_judgment_001.md",
+                "a9b65437ea94b624ede85b2dfdb2f4f93d5a81a3bb17a5829d8f6c13a35ba77f",
+            ),
+            (
+                "validation/stage_b_one_automatic_continuation_001.md",
+                "35e3a28b4d6488e210f065646e43a4f0d2c99ece5e5bbf17186ea359f22f6fb8",
+            ),
+            (
+                "docs/companion_product_roadmap_v0_3.md",
+                "c3283a70e12d509419b0b314cf026fa59676564332913fa5c1c38abeacf73f3d",
+            ),
+        )
+        for source, expected in sources:
+            self.assertEqual(
+                expected,
+                hashlib.sha256(
+                    REPO_ROOT.joinpath(source).read_bytes()
+                ).hexdigest(),
+            )
+        proof = REPO_ROOT.joinpath(
+            "validation/stage_c_small_compound_loop_001.md"
+        ).read_text(encoding="utf-8")
+        for exact in (
+            "74e7ae5174ac73e2f295e3a4e2866cb3",
+            "57b1bfdc-10dd-4b42-b4e8-41f4027feee9",
+            "5ace2dfe-d7ca-46fe-aa43-12fffd2f0412",
+            "b2120b10-ba90-4fbb-80b9-f1aeadbc4b1f",
+            "0f804cbe44e24862de3ea97b059cd38f74eae07f8937cce0d6b7d8ff9e789d8b",
+            "36bcecf09c87ba8853c1ccf849fb28f32b84b700d4a85f44ef15fb44f1be0b6e",
+            "58b926ae5b75317466df53329cafa2cf700137b5a7b0638f03e6f79662d9cafa",
+            "Stage C Completion Line:\nPASS",
+            "Run 4:\nSTRUCTURALLY ABSENT",
+        ):
+            self.assertIn(exact, proof)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decision_os_cli.py
+++ b/tests/test_decision_os_cli.py
@@ -175,7 +175,7 @@ class DecisionOsCliTest(unittest.TestCase):
         self.assertEqual(0, completed.returncode)
         payload = decoded(completed)
         self.assertEqual("PASS", payload["v12_state"])
-        self.assertEqual("GO", payload["v13_gate"])
+        self.assertEqual("HOLD", payload["v13_gate"])
         required = next(
             item
             for item in payload["evidence"]

--- a/tests/test_decision_os_scan_cli.py
+++ b/tests/test_decision_os_scan_cli.py
@@ -102,7 +102,7 @@ PROTECTED_BLOBS = {
     ),
     "tests/test_decision_os_cli.py": (
         "100644",
-        "3ce41ed753624754147d6c4830fcd9e79ef5ff85",
+        "bafbb8d484995fcf0d4ba3af6968e6c0efb49633",
     ),
 }
 

--- a/validation/stage_c_small_compound_loop_001.md
+++ b/validation/stage_c_small_compound_loop_001.md
@@ -1,0 +1,431 @@
+# Stage C Small Compound Loop 001
+
+## Identity
+
+```text
+Stage:
+C — Small Compound Loop
+
+Starting canonical main:
+a920a796c01f0e448037a8e0390f10861b641df0
+
+Focused branch:
+codex/stage-c-small-compound-loop
+
+Automatic continuation limit:
+2
+
+Hard total Run cap:
+3
+
+Run 4:
+STRUCTURALLY ABSENT
+
+Stage D:
+NOT AUTHORIZED / NOT STARTED
+```
+
+## Real Goal
+
+```text
+Establish the exact accepted Stage A proof, accepted Stage B proof, and the
+fixed Roadmap v0.3 Stage C three-Run boundary through three distinct read-only
+actions.
+```
+
+The Goal was fixed before Run 1. The three actions were distinct and jointly
+necessary: Stage A establishes the Supervisor predecessor, Stage B establishes
+the one-continuation predecessor, and Roadmap v0.3 establishes the authorized
+Stage C outcome and cap boundary. No single read establishes that complete
+lineage.
+
+The proof used the production `CompanionController`, Stage B atomic
+continuation store, Receipt delta path, Supervisor, causal Task constructor,
+integrity validator, and reconnect loader. The Worker adapter performed actual
+local repository reads and returned content-free path, byte-count, SHA-256, and
+repository-identity evidence. It was deliberately a deterministic local reader:
+no repository file content was transmitted to an external model and no file was
+modified.
+
+```text
+Repository identity:
+a920a796c01f0e448037a8e0390f10861b641df0
+
+Worker execution lane:
+local-deterministic-repository-reader / local / no external transmission
+
+File-change approval requested:
+NO
+
+Tracked or untracked repository mutation during proof:
+NONE — pre-proof and post-proof git status were byte-for-byte identical
+```
+
+## Run 1
+
+```text
+Task:
+Read only validation/stage_a_supervisor_judgment_001.md and establish its exact
+accepted Stage A PASS identity.
+
+Run ID:
+57b1bfdc-10dd-4b42-b4e8-41f4027feee9
+
+Terminal:
+NORMAL_TERMINAL / completed normally
+
+Read evidence:
+validation/stage_a_supervisor_judgment_001.md
+5732 bytes
+SHA-256 a9b65437ea94b624ede85b2dfdb2f4f93d5a81a3bb17a5829d8f6c13a35ba77f
+repository identity a920a796c01f0e448037a8e0390f10861b641df0
+
+File actions:
+none
+
+Receipt delta:
+0 Verified Saves / 0 Verified Reuses / 0 estimated value
+
+Persisted Run 1 evidence SHA-256:
+38a294e67a51066af1815b72bea58f11f133616fec2bcd3de519a25b03785a31
+```
+
+Run 1 residue:
+
+```text
+Newly established:
+STAGE-A-PASS
+
+Still open:
+STAGE-B-PASS
+STAGE-C-BOUNDARY
+
+Residue SHA-256:
+98bc3ccdebe5febd01d38bf090037abb9a08d6fb5d47f6f025d703ec952e6b1c
+```
+
+Supervisor 1 independently consumed Run 1 and returned:
+
+```text
+GO / AI-OWNED
+
+Consumed Run:
+57b1bfdc-10dd-4b42-b4e8-41f4027feee9
+
+Judgment SHA-256:
+e065500ecf2ddfa8d7c81444cd047892ae703b07004719a4872222960351f96a
+
+Next bounded action:
+Establish STAGE-B-PASS from
+validation/stage_b_one_automatic_continuation_001.md.
+```
+
+## Automatically Constructed Task 2
+
+Task 2 was absent before Run 1. The controller constructed it only after the
+Run 1 result, Receipt delta, cumulative residue, and Supervisor 1 judgment were
+persisted and read back.
+
+```text
+Original Goal SHA-256:
+4b94ec9d1ce971352ed0fac74729e4bfe9be3804fb2ad46244753e4a0b725169
+
+Source Run ID:
+57b1bfdc-10dd-4b42-b4e8-41f4027feee9
+
+Source evidence SHA-256:
+38a294e67a51066af1815b72bea58f11f133616fec2bcd3de519a25b03785a31
+
+Source judgment SHA-256:
+e065500ecf2ddfa8d7c81444cd047892ae703b07004719a4872222960351f96a
+
+Selected requirement:
+STAGE-B-PASS
+
+Task 2 SHA-256:
+0f804cbe44e24862de3ea97b059cd38f74eae07f8937cce0d6b7d8ff9e789d8b
+```
+
+## Run 2
+
+```text
+Run ID:
+5ace2dfe-d7ca-46fe-aa43-12fffd2f0412
+
+Terminal:
+NORMAL_TERMINAL / completed normally
+
+Read evidence:
+validation/stage_b_one_automatic_continuation_001.md
+8150 bytes
+SHA-256 35e3a28b4d6488e210f065646e43a4f0d2c99ece5e5bbf17186ea359f22f6fb8
+repository identity a920a796c01f0e448037a8e0390f10861b641df0
+
+File actions:
+none
+
+Receipt delta:
+0 Verified Saves / 0 Verified Reuses / 0 estimated value
+
+Persisted Run 2 evidence SHA-256:
+72e3ee9d41d825b777fafe68168e86d788e48c7e828ef982c5e09ea3d90b8929
+```
+
+Run 2 residue increased the established state rather than replaying Run 1:
+
+```text
+Cumulatively established:
+STAGE-A-PASS
+STAGE-B-PASS
+
+New in Run 2:
+STAGE-B-PASS
+
+Still open:
+STAGE-C-BOUNDARY
+
+Residue SHA-256:
+fd30db4c8b9675fa732cfb585760ce8da0bdfdd700d149b04d9f2a365135cbc7
+```
+
+Supervisor 2 independently consumed Run 2. Run 3 did not inherit Run 2's
+authority automatically.
+
+```text
+GO / AI-OWNED
+
+Consumed Run:
+5ace2dfe-d7ca-46fe-aa43-12fffd2f0412
+
+Judgment SHA-256:
+ed6932cac6c1d7ce50cb16b86f20a7180d6cc38e91cf56bf3ee9c1a947016782
+
+Next bounded action:
+Establish STAGE-C-BOUNDARY from docs/companion_product_roadmap_v0_3.md.
+```
+
+## Automatically Constructed Task 3
+
+Task 3 was absent before Run 2. It was constructed only from the newly
+persisted Run 2 state and is not Task 2 with a changed label.
+
+```text
+Original Goal SHA-256:
+4b94ec9d1ce971352ed0fac74729e4bfe9be3804fb2ad46244753e4a0b725169
+
+Immediate source Run ID:
+5ace2dfe-d7ca-46fe-aa43-12fffd2f0412
+
+Immediate source evidence SHA-256:
+72e3ee9d41d825b777fafe68168e86d788e48c7e828ef982c5e09ea3d90b8929
+
+Immediate source judgment SHA-256:
+ed6932cac6c1d7ce50cb16b86f20a7180d6cc38e91cf56bf3ee9c1a947016782
+
+Selected requirement:
+STAGE-C-BOUNDARY
+
+Task 3 SHA-256:
+36bcecf09c87ba8853c1ccf849fb28f32b84b700d4a85f44ef15fb44f1be0b6e
+```
+
+Task 3's source is Run 2, not Run 1. Its selected path, expected identity,
+requirement, source Run, source evidence, source judgment, task body, and task
+SHA all differ from Task 2 where the causal state differs.
+
+## Run 3 and Terminal Residue
+
+```text
+Run ID:
+b2120b10-ba90-4fbb-80b9-f1aeadbc4b1f
+
+Terminal:
+NORMAL_TERMINAL / completed normally
+
+Read evidence:
+docs/companion_product_roadmap_v0_3.md
+10360 bytes
+SHA-256 c3283a70e12d509419b0b314cf026fa59676564332913fa5c1c38abeacf73f3d
+repository identity a920a796c01f0e448037a8e0390f10861b641df0
+
+File actions:
+none
+
+Receipt delta:
+0 Verified Saves / 0 Verified Reuses / 0 estimated value
+
+Persisted Run 3 evidence SHA-256:
+d5d0c07a8c58f66cb063d8fb9bae7438b2bb50bf81606f69a837f5a52a5e53fd
+```
+
+Terminal residue:
+
+```text
+Cumulatively established:
+STAGE-A-PASS
+STAGE-B-PASS
+STAGE-C-BOUNDARY
+
+New in Run 3:
+STAGE-C-BOUNDARY
+
+Remaining requirements:
+none
+
+Residue SHA-256:
+9e538c14e2fa90a20802442cc2de1750b6a15c66fbe6acbc401e24fa4c8755f4
+```
+
+Supervisor 3 independently consumed Run 3 and closed the Goal:
+
+```text
+HOLD / STOP — the Goal is complete; another Run is unnecessary
+
+Consumed Run:
+b2120b10-ba90-4fbb-80b9-f1aeadbc4b1f
+
+Judgment SHA-256:
+a2ce9ae6a7bba60992d0f97380e617e27bf43a181771d3e940a942b90940c0e4
+
+Canonical Stage C outcome:
+COMPLETE
+```
+
+The final Supervisor gate is `HOLD / STOP` because another Worker Run is not
+admissible after completion. The Stage C terminal outcome is `COMPLETE` because
+all predeclared completion requirements are established. These two fields have
+different roles and are intentionally not collapsed.
+
+## Persisted Causal Record and Restart
+
+```text
+Chain ID:
+74e7ae5174ac73e2f295e3a4e2866cb3
+
+Terminal chain state:
+TERMINAL / COMPLETE
+
+Worker Runs dispatched:
+3
+
+Automatic continuations started / limit:
+2 / 2
+
+Total Run cap:
+3
+
+Run 4 dispatches:
+0
+
+Self-authenticating record SHA-256:
+58b926ae5b75317466df53329cafa2cf700137b5a7b0638f03e6f79662d9cafa
+
+Exact serialized record file SHA-256:
+d6d5efe0e0130761afdf2c28ecc7c6aa1d1f44a48af72215ba98c8ee1f01f8df
+
+Record permissions:
+0600
+
+Fresh-controller reconnect:
+TERMINAL / COMPLETE / 3 Runs / 2 automatic continuations /
+record SHA-256 58b926ae5b75317466df53329cafa2cf700137b5a7b0638f03e6f79662d9cafa
+
+Reconnect-triggered Worker Runs:
+0
+```
+
+The record contains the immutable Goal and authority envelope, three sanitized
+Run results, Receipt deltas, three cumulative residues, three Supervisor
+judgments, both causally constructed Tasks, fixed counters, the terminal
+outcome, and its self-hash. Raw Worker messages are represented only by byte
+count and SHA-256.
+
+## Governance and Integrity Proofs
+
+- Three-Run GO path: one Goal was submitted once; only Supervisor 1 and
+  Supervisor 2 `GO / AI-OWNED` judgments permitted Runs 2 and 3.
+- Early completion: focused proofs complete at Run 1 or Run 2 and leave the
+  unused continuation budget undispatched.
+- Per-Run supervision: each persisted Run has one consuming judgment; Run 3
+  requires the persisted Supervisor 2 GO.
+- Hard cap and no Run 4: dispatch is an explicit fixed `(1, 2, 3)` structure,
+  continuation count is restricted to `0..2`, Run 3 always terminates, and an
+  unchanged Goal cannot reset or renew its persisted cap.
+- Non-GO preservation: abnormal evidence, execution failure, Human Seat,
+  HOLD, CAP, BLOCK, and evidence-recovery cases terminate before another
+  dispatch.
+- Authority preservation: Tasks carry the unchanged Goal, single allowed path,
+  Protected Objects, ownership, public exposure, and cost/cap boundaries.
+- Causal integrity: deterministic reconstruction validates Task 2 from Run 1
+  and Task 3 from Run 2, including evidence, residue, judgment, and Goal hashes.
+- Tamper resistance: rehashed changes to Task 2, Task 3, source Run, or source
+  evidence fail closed as `BLOCKED_CORRUPT`.
+- Replay resistance: a validly rehashed stale `RUN_3_ACTIVE` record reconnects
+  without dispatch and blocks a second chain; terminal reconnect is also
+  dispatch-free.
+- Restartability: COMPLETE, governed-stop, cap-exhausted, execution-failure,
+  and corrupt states preserve an inspectable terminal or recovery view.
+- Human Seat: the Stage A return contract is reused unchanged; a proved
+  authority failure terminates as `HUMAN SEAT REQUIRED` with the preserved
+  completed work and no later Run.
+
+## Claim and Authority Boundary
+
+- Stage C is a fixed maximum-three extension of the Stage B causal mechanism,
+  not a parallel engine or arbitrary-N recursion.
+- The proof establishes real local repository I/O and causal control behavior;
+  it makes no claim that an external model saw or interpreted repository file
+  content.
+- The numeric cap cannot be increased, silently reset, or renewed for the
+  unchanged Goal. A later cap change requires a separate Forward-only decision.
+- Stage D leave-the-desk dogfood is not implemented or started.
+- No Canon modification, release, publication, signing, notarization,
+  deployment, or paid-tier behavior is added.
+
+## Verification
+
+```text
+Focused Stage C compound loop:
+PASS
+
+Stage A / Stage B / controller / process / server-client regression:
+PASS
+
+Canonical-state and handoff regression:
+PASS
+
+Full repository regression:
+PASS
+
+Repository validation:
+python -B -m decision_os check . — PASS
+
+Patch hygiene:
+git diff --check — PASS
+```
+
+## Completion Line
+
+One fixed Goal entered once. Three meaningful, causally connected repository
+reads established increasing state; both automatic Tasks were constructed from
+the immediately preceding persisted Run and independent Supervisor judgment;
+the third judgment closed the Goal; no user translated a Receipt; no Run 4
+path or cap renewal exists; and a fresh controller reloaded the exact terminal
+record without another dispatch.
+
+```text
+Stage C Completion Line:
+PASS
+
+Remaining Missing Closure:
+Stage D — Leave-the-Desk Dogfood (NOT AUTHORIZED)
+
+Stage D Authorized:
+NO
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+```

--- a/validation/stage_c_small_compound_loop_001.md
+++ b/validation/stage_c_small_compound_loop_001.md
@@ -376,6 +376,10 @@ count and SHA-256.
 - The proof establishes real local repository I/O and causal control behavior;
   it makes no claim that an external model saw or interpreted repository file
   content.
+- The canonical current Gate changed from the active Stage C build `GO` to the
+  completed Stage C `HOLD`. Its one-line CLI expectation and corresponding
+  protected blob identity are co-updated as one valid Forward-only closure
+  delta; test structure and production scan behavior are unchanged.
 - The numeric cap cannot be increased, silently reset, or renewed for the
   unchanged Goal. A later cap change requires a separate Forward-only decision.
 - Stage D leave-the-desk dogfood is not implemented or started.
@@ -386,16 +390,17 @@ count and SHA-256.
 
 ```text
 Focused Stage C compound loop:
-PASS
+PASS — 10 tests
 
 Stage A / Stage B / controller / process / server-client regression:
-PASS
+PASS — 80 tests / 2 expected skips, plus 38 server-client tests
 
 Canonical-state and handoff regression:
-PASS
+PASS — 132 tests after the one Chrome probe used normal GUI permissions
 
 Full repository regression:
-PASS
+PASS — 1440 tests / 15 expected environment skips from a clean detached
+worktree
 
 Repository validation:
 python -B -m decision_os check . — PASS


### PR DESCRIPTION
## Summary

- extend the existing Stage B continuation store/controller to a fixed maximum of three total Worker Runs
- independently persist and supervise every Run before constructing Task 2 or Task 3
- bind Task 3 to the immediately preceding Run 2 evidence, residue, Receipt state, judgment, and original Goal
- preserve exact terminal outcomes, hard cap/no-Run-4 behavior, tamper/replay failure routes, and reconnectability
- record the real three-read local repository proof and close the canonical Stage C state without authorizing Stage D, release, or publication

## Verification

- Stage C focused: 10 tests passed
- Stage A/B/controller/process: 80 tests passed, 2 expected skips
- Companion server/client: 38 tests passed
- canonical/handoff: 132 tests passed (one Chrome probe rerun with normal GUI permissions)
- definitive clean detached worktree: 1,440 tests passed, 15 expected skips
- `python -B -m decision_os check .`: PASS
- `git diff --check`: PASS

## Boundaries

- hard total cap remains 3; no Run 4 path
- no arbitrary-N recursion or parallel loop engine
- Stage D not started or authorized
- release authority: NONE
- publication authority: NONE