### PR TITLE
Authorize Stage D leave-the-desk dogfood

### DIFF
--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,10 +1,10 @@
 # Current Signal
 
-## Canonical Current State — V13 Compound Loop Build
+## Canonical Current State — V13 Leave-the-Desk Dogfood
 
 ```text
 Current Layer:
-V13 — Compound Loop Build
+V13 — Leave-the-Desk Dogfood
 
 Product Roadmap:
 Companion Product Roadmap v0.3 FIXED
@@ -22,10 +22,14 @@ F3 CLOSED
 REPAIR CLOSURE PASS
 
 Current Gate:
-HOLD — STAGE C COMPLETE / STAGE D NOT AUTHORIZED
+GO — STAGE D LEAVE-THE-DESK DOGFOOD
 
 Build Scope:
-Stage A → Stage B → Stage C COMPLETE
+Stage A → Stage B → Stage C COMPLETE / Stage D ACTIVE
+
+Real Goal:
+Review recent Field Notes and promote at most one verified candidate into an
+operating rule if the Concept Promotion Gate is satisfied.
 
 First Live Cap:
 3 total bounded Runs
@@ -61,13 +65,13 @@ Stage C Evidence:
 validation/stage_c_small_compound_loop_001.md
 
 Current Missing Closure:
-Stage D — Leave-the-Desk Dogfood (NOT AUTHORIZED)
+Stage D — Leave-the-Desk Dogfood
 
 Stage C Authorization:
 CONSUMED — COMPLETE
 
 Stage D Authorization:
-NO
+YES
 
 Release Authority:
 NONE
@@ -76,8 +80,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-None. Preserve the Stage C terminal evidence and hard three-Run cap. Stage D,
-release, and publication require a separate new Gate.
+Execute the authorized Stage D Field Note promotion dogfood under the hard
+three-Run cap. Release and publication remain unauthorized.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,10 +1,10 @@
 # Current Codex Handoff - V13 LoopKit
 
-## Canonical Current State — V13 Compound Loop Build
+## Canonical Current State — V13 Leave-the-Desk Dogfood
 
 ```text
 Current Layer:
-V13 — Compound Loop Build
+V13 — Leave-the-Desk Dogfood
 
 Product Roadmap:
 Companion Product Roadmap v0.3 FIXED
@@ -22,10 +22,14 @@ F3 CLOSED
 REPAIR CLOSURE PASS
 
 Current Gate:
-HOLD — STAGE C COMPLETE / STAGE D NOT AUTHORIZED
+GO — STAGE D LEAVE-THE-DESK DOGFOOD
 
 Build Scope:
-Stage A → Stage B → Stage C COMPLETE
+Stage A → Stage B → Stage C COMPLETE / Stage D ACTIVE
+
+Real Goal:
+Review recent Field Notes and promote at most one verified candidate into an
+operating rule if the Concept Promotion Gate is satisfied.
 
 First Live Cap:
 3 total bounded Runs
@@ -61,13 +65,13 @@ Stage C Evidence:
 validation/stage_c_small_compound_loop_001.md
 
 Current Missing Closure:
-Stage D — Leave-the-Desk Dogfood (NOT AUTHORIZED)
+Stage D — Leave-the-Desk Dogfood
 
 Stage C Authorization:
 CONSUMED — COMPLETE
 
 Stage D Authorization:
-NO
+YES
 
 Release Authority:
 NONE
@@ -76,8 +80,8 @@ Publication Authority:
 NONE
 
 Next Authorized Action:
-None. Preserve the Stage C terminal evidence and hard three-Run cap. Stage D,
-release, and publication require a separate new Gate.
+Execute the authorized Stage D Field Note promotion dogfood under the hard
+three-Run cap. Release and publication remain unauthorized.
 ```
 
 Everything below this boundary is preserved historical material as of its own

--- a/tests/test_decision_os_cli.py
+++ b/tests/test_decision_os_cli.py
@@ -175,7 +175,7 @@ class DecisionOsCliTest(unittest.TestCase):
         self.assertEqual(0, completed.returncode)
         payload = decoded(completed)
         self.assertEqual("PASS", payload["v12_state"])
-        self.assertEqual("HOLD", payload["v13_gate"])
+        self.assertEqual("GO", payload["v13_gate"])
         required = next(
             item
             for item in payload["evidence"]

--- a/tests/test_decision_os_scan_cli.py
+++ b/tests/test_decision_os_scan_cli.py
@@ -102,7 +102,7 @@ PROTECTED_BLOBS = {
     ),
     "tests/test_decision_os_cli.py": (
         "100644",
-        "bafbb8d484995fcf0d4ba3af6968e6c0efb49633",
+        "3ce41ed753624754147d6c4830fcd9e79ef5ff85",
     ),
 }
 


### PR DESCRIPTION
## Summary

- synchronize both canonical restart surfaces to the explicitly authorized Stage D gate
- record the fixed Field Note promotion Goal and hard three-Run execution boundary
- update the canonical CLI expectation and its protected blob identity
- preserve both historical tails byte-for-byte

## Validation

- `python -B -m unittest tests.test_decision_os_checks tests.test_decision_os_cli tests.test_decision_os_scan_cli`
- `python -B -m decision_os check .`
- `git diff --check`
- historical tail SHA-256 values unchanged