### PR TITLE
Clarify LoopKit first-contact path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,34 @@
 ![Local read-only scan](https://img.shields.io/badge/scan-local%20read--only-blue)
 ![Human approval for changes](https://img.shields.io/badge/changes-human%20approval%20required-orange)
 
-## Your coding agent asks once. The next Run remembers.
+## Stop after “done” long enough to decide what happens next
+
+Decision-OS V13 LoopKit is a no-install exit gate for AI coding work. It makes
+the agent separate two decisions that are easy to blur together:
+
+1. Is the current task actually complete and restartable?
+2. Should the next loop `GO`, `HOLD`, run under a `CAP`, or `BLOCK`?
+
+Try it after your next AI-assisted task:
+
+```text
+Before starting another task, report:
+
+- Is the current task complete? PASS / DELAY / BLOCK / UNKNOWN
+- Should the next loop run? GO / HOLD / CAP / BLOCK
+- Why?
+- What is the one allowed next action?
+- What must not happen next?
+
+Do not start the next task automatically. Stop after the report.
+```
+
+That is the smallest trial: no install, fork, or repository change required.
+If it helps, use the full [Next-Action Confidence
+Check](copy-paste/next-action-confidence-check.md), then consider the
+[Fork + Codex Quickstart](docs/fork_codex_quickstart.md).
+
+## Optional Companion: your coding agent asks once. The next Run remembers.
 
 1. The agent asks whether it may modify a file.
 2. You choose **Use for this repository**.

--- a/examples/role_contract.v0_1.json
+++ b/examples/role_contract.v0_1.json
@@ -2,7 +2,7 @@
   "contract_identity": {
     "contract_id": "stage4-example-builder-001",
     "version": "0.1",
-    "contract_hash": "62edabea259a6d53710b3d8773ba22b692c631ed7c89b6a81dfa196f97afa502"
+    "contract_hash": "2a12469766b09ba4b4593b90c77990b83f251ad9044488312103d15607276267"
   },
   "assignment": {
     "task_id": "stage4-example-task-001",
@@ -48,7 +48,7 @@
       "README.md"
     ],
     "artifact_hashes": {
-      "README.md": "37e0a17c9c0238f125d365b2fe8d80fc31463de0397e9b32a7bae472af260d83"
+      "README.md": "decc254e317b693604084ecdc1e9bfe034b8d6b69b32a70404fc63d64055ad39"
     },
     "as_of": "2026-07-29T00:00:00Z"
   },

--- a/tests/test_decision_os_role_contract.py
+++ b/tests/test_decision_os_role_contract.py
@@ -636,10 +636,32 @@ class RoleContractV01Test(unittest.TestCase):
             ).read_bytes()
         ).hexdigest()
         self.assertEqual(example["specialist_lens"]["lens_hash"], lens_hash)
+        packet = example["task_artifact_packet"]
         self.assertEqual(
-            hashlib.sha256((REPO_ROOT / "README.md").read_bytes()).hexdigest(),
-            example["task_artifact_packet"]["artifact_hashes"]["README.md"],
+            "3a14dc65ea15f2d81cf3b3cd33362b3c001c0a41",
+            packet["head"],
         )
+        self.assertEqual("2026-07-29T00:00:00Z", packet["as_of"])
+        self.assertEqual(
+            "decc254e317b693604084ecdc1e9bfe034b8d6b69b32a70404fc63d64055ad39",
+            packet["artifact_hashes"]["README.md"],
+        )
+        historical_readme = subprocess.run(
+            (
+                "git",
+                "-C",
+                str(REPO_ROOT),
+                "show",
+                f"{packet['head']}:README.md",
+            ),
+            check=False,
+            capture_output=True,
+        )
+        if historical_readme.returncode == 0:
+            self.assertEqual(
+                hashlib.sha256(historical_readme.stdout).hexdigest(),
+                packet["artifact_hashes"]["README.md"],
+            )
         lens_text = (
             REPO_ROOT / "templates" / "v13_specialist_lens.md"
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Clarify LoopKit's completion-versus-continuation identity on the README first screen.
- Add a paste-ready, no-install trial with an explicit stop and identify Companion as optional.
- Repair the historical Role Contract guard so it verifies the README blob at the contract's recorded commit instead of comparing the historical packet with the mutable current README.

## Why

The first-contact README did not surface the smallest completion/continuation trial before the optional Companion path. Separately, the historical Role Contract fixture's README hash had been rebound to mutable current content, so ordinary README changes could incorrectly appear to invalidate a fixed historical artifact.

## Impact

Readers can try the bounded exit-gate behavior without installing, forking, or changing a repository. Historical Role Contract identity remains bound to commit `3a14dc65ea15f2d81cf3b3cd33362b3c001c0a41`.

## Established

- The first-contact README surface changed.
- A paste-ready no-install trial with explicit stop behavior was added.
- Companion is identified as optional.
- The historical exact-artifact guard was repaired.
- Validation passed.

## Not established

- Star increase.
- Adoption increase.
- Conversion-rate improvement.
- Time or token savings.
- External-user value.

The third-party star/adoption effect remains **UNKNOWN**.

## Validation

- Exact implementation commit: `b7528371184e3f90f6db8fe012037dd38433fe80`
- Changed-file scope: `README.md`, `examples/role_contract.v0_1.json`, `tests/test_decision_os_role_contract.py`
- README local links resolve.
- Historical README blob SHA-256 verified: `decc254e317b693604084ecdc1e9bfe034b8d6b69b32a70404fc63d64055ad39`
- `python3 -B -m unittest tests.test_decision_os_role_contract`: 45 passed
- `python3 -B -m decision_os check .`: PASS, V12 PASS / V13 HOLD
- `python3 -B -m unittest discover -s tests`: 1,452 passed / 15 skipped
- `git diff --check`: passed
