### PR TITLE
Stop Stage C after zero-declared-progress runs

### DIFF
--- a/decision_os/companion/small_compound_loop.py
+++ b/decision_os/companion/small_compound_loop.py
@@ -470,6 +470,8 @@ def stage_c_supervisor_context(
         )
     remaining = remaining_requirements(record)
     current = runs[-1]
+    current_residue = residues[-1]
+    made_progress = bool(current_residue["new_requirement_ids"])
     evidence_ref = (
         f"stage-c:{record['chain_id']}:run-{len(runs)}:"
         f"evidence-sha256={current['evidence_sha256']}"
@@ -497,7 +499,15 @@ def stage_c_supervisor_context(
             else ContractFact.NOT_SATISFIED
         ),
         continuation_proof_sufficient=ContractFact.SATISFIED,
-        evidence_sufficient=ContractFact.SATISFIED,
+        evidence_sufficient=(
+            ContractFact.SATISFIED
+            if (
+                made_progress
+                or not remaining
+                or len(runs) >= STAGE_C_TOTAL_RUN_CAP
+            )
+            else ContractFact.NOT_SATISFIED
+        ),
         **{name: fact for name, fact in request.contract_facts()},
     )
 

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,78 @@
+# Current Signal — V13 Self-Selected Capability Integration
+
+## Canonical Current State — V13 Post Self-Selected Capability Integration
+
+```text
+Current Layer:
+V13 — Post Self-Selected Capability Integration
+
+V12 State:
+PASS
+
+13-104 Autonomous Next-1.01 Selection:
+PASS / integrated
+
+13-106 Missing-Capability Self-Diagnosis:
+PASS
+
+13-106 Selected Capability:
+Stage C zero-declared-progress stop
+
+Capability Status:
+INTEGRATED
+
+Claim Boundary:
+V13 detects only when a clean Stage C Worker Run newly establishes none of its
+declared completion requirements while work remains, then stops automatic
+continuation at HOLD / EVIDENCE-RECOVERY. This is not general semantic progress
+or stagnation detection.
+
+Integration Condition:
+This block becomes canonical only when capability commit
+3bccf213690f855747c0c71631a223d4813a9a35 and this closure-only delta merge
+into main.
+
+Canonical Starting Main:
+937a2ab8bf2fe1b6401485594ae156140cf8b749
+
+Active Branch:
+main
+
+Field Note 132:
+unchanged / Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the focused capability and closure-only deltas merge.
+
+Next Authorized Action:
+None. Preserve the integrated narrow stop and its exact declared-requirement
+claim boundary. Do not start another self-diagnosis or 1.01.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact bounded Stage C zero-declared-progress stop is integrated
+without changing completion, Run-3 CAP, Human Seat, authority, protected-object,
+Supervisor/Worker, historical-evidence, or Meter semantics.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Signal — Compound Evidence Meter v0.1 Closure
 
 ## Canonical Current State — V13 Post-Dogfood Measurement

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,78 @@
+# Current Codex Handoff — V13 Self-Selected Capability Integration
+
+## Canonical Current State — V13 Post Self-Selected Capability Integration
+
+```text
+Current Layer:
+V13 — Post Self-Selected Capability Integration
+
+V12 State:
+PASS
+
+13-104 Autonomous Next-1.01 Selection:
+PASS / integrated
+
+13-106 Missing-Capability Self-Diagnosis:
+PASS
+
+13-106 Selected Capability:
+Stage C zero-declared-progress stop
+
+Capability Status:
+INTEGRATED
+
+Claim Boundary:
+V13 detects only when a clean Stage C Worker Run newly establishes none of its
+declared completion requirements while work remains, then stops automatic
+continuation at HOLD / EVIDENCE-RECOVERY. This is not general semantic progress
+or stagnation detection.
+
+Integration Condition:
+This block becomes canonical only when capability commit
+3bccf213690f855747c0c71631a223d4813a9a35 and this closure-only delta merge
+into main.
+
+Canonical Starting Main:
+937a2ab8bf2fe1b6401485594ae156140cf8b749
+
+Active Branch:
+main
+
+Field Note 132:
+unchanged / Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the focused capability and closure-only deltas merge.
+
+Next Authorized Action:
+None. Preserve the integrated narrow stop and its exact declared-requirement
+claim boundary. Do not start another self-diagnosis or 1.01.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact bounded Stage C zero-declared-progress stop is integrated
+without changing completion, Run-3 CAP, Human Seat, authority, protected-object,
+Supervisor/Worker, historical-evidence, or Meter semantics.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Codex Handoff — Compound Evidence Meter v0.1 Closure
 
 ## Canonical Current State — V13 Post-Dogfood Measurement

--- a/tests/test_companion_server.py
+++ b/tests/test_companion_server.py
@@ -2209,7 +2209,7 @@ class CompanionServerTest(unittest.TestCase):
         )
         self.assertEqual(400, status)
 
-    def test_authenticated_stage_c_route_enforces_three_run_cap(self) -> None:
+    def test_authenticated_stage_c_route_stops_after_no_progress(self) -> None:
         self.controller.adapter_factory = ScriptedFactory(
             "read_only",
             "read_only",
@@ -2242,11 +2242,11 @@ class CompanionServerTest(unittest.TestCase):
                 break
             time.sleep(0.01)
         self.assertIsNotNone(snapshot)
-        self.assertEqual("CAP", snapshot["compound_loop"]["outcome"])
-        self.assertEqual(3, len(snapshot["compound_loop"]["runs"]))
-        self.assertEqual(2, len(snapshot["compound_loop"]["automatic_tasks"]))
-        self.assertEqual(3, snapshot["run"]["continuation"]["run_number"])
-        self.assertEqual(1, len(self.controller.adapter_factory.modes))
+        self.assertEqual("HOLD", snapshot["compound_loop"]["outcome"])
+        self.assertEqual(1, len(snapshot["compound_loop"]["runs"]))
+        self.assertEqual(0, len(snapshot["compound_loop"]["automatic_tasks"]))
+        self.assertEqual(1, snapshot["run"]["continuation"]["run_number"])
+        self.assertEqual(3, len(self.controller.adapter_factory.modes))
 
         status, _headers, _raw = self.request(
             "POST",

--- a/tests/test_companion_small_compound_loop.py
+++ b/tests/test_companion_small_compound_loop.py
@@ -283,6 +283,54 @@ class StageCSmallCompoundLoopTest(unittest.TestCase):
                 )
                 self.assertGreater(len(factory.plans), 0)
 
+    def test_normal_terminal_without_new_evidence_stops_before_retry(self) -> None:
+        cases = (
+            ("run-one", ({"evidence": ()},), 1, 0),
+            (
+                "run-two",
+                ({"evidence": (1,)}, {"evidence": (1,)}),
+                2,
+                1,
+            ),
+        )
+        for label, plans, run_count, continuation_count in cases:
+            with (
+                self.subTest(label=label),
+                tempfile.TemporaryDirectory() as temporary,
+            ):
+                root = Path(temporary)
+                repository = create_repository(root)
+                factory = EvidenceFactory(*plans, {"evidence": (2,)})
+                controller = self.make_controller(root, factory)
+                controller.select_repository(repository)
+                controller.start_small_compound_loop(stage_c_request())
+                chain = self.terminal(controller)["compound_loop"]
+
+                self.assertEqual("HOLD", chain["outcome"])
+                self.assertEqual(run_count, len(chain["runs"]))
+                self.assertEqual(
+                    run_count,
+                    len(chain["supervisor_judgments"]),
+                )
+                self.assertEqual(
+                    continuation_count,
+                    chain["automatic_continuations_started"],
+                )
+                self.assertEqual(
+                    continuation_count,
+                    len(chain["automatic_tasks"]),
+                )
+                self.assertEqual(run_count, len(factory.prompts))
+                self.assertEqual(1, len(factory.plans))
+                self.assertEqual(
+                    "EVIDENCE-RECOVERY",
+                    chain["supervisor_judgments"][-1]["decision_route"],
+                )
+                self.assertIn(
+                    "not justified by sufficient evidence",
+                    chain["supervisor_judgments"][-1]["reason"],
+                )
+
     def test_non_go_human_seat_and_cap_all_stop_without_run_four(self) -> None:
         cases = (
             (

--- a/tests/test_compound_evidence_meter.py
+++ b/tests/test_compound_evidence_meter.py
@@ -273,7 +273,39 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
         self.assertEqual(EXIT_OK, exit_code)
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
-        self.assertIn("Preserve the completed meter", payload["next_authorized_action"])
+        self.assertIn(
+            "Preserve the integrated narrow stop",
+            payload["next_authorized_action"],
+        )
+        for relative_path in (
+            "docs/current_signal.md",
+            "handoff/current_codex_handoff.md",
+        ):
+            with self.subTest(relative_path=relative_path):
+                current = (REPO_ROOT / relative_path).read_text(
+                    encoding="utf-8"
+                ).split(
+                    "Everything below this boundary is preserved historical",
+                    maxsplit=1,
+                )[0]
+                self.assertIn(
+                    "V13 — Post Self-Selected Capability Integration",
+                    current,
+                )
+                self.assertIn(
+                    "Stage C zero-declared-progress stop",
+                    current,
+                )
+                self.assertIn("Capability Status:\nINTEGRATED", current)
+                self.assertIn(
+                    "Field Note 132:\nunchanged / Verification pending",
+                    current,
+                )
+                self.assertIn(
+                    "Compound Evidence Meter:\nunchanged",
+                    current,
+                )
+                self.assertIn("HOLD — NO NEXT AUTHORITY", current)
 
     def test_historical_surface_tails_are_byte_for_byte_preserved(self) -> None:
         cases = (


### PR DESCRIPTION
## Summary

- Stop Stage C at `HOLD / EVIDENCE-RECOVERY` when a clean Worker Run newly establishes none of its declared completion requirements while work remains.
- Preserve normal progress, completed-Goal handling, the total three-Run cap, Run-3 `CAP`, Human Seat and authority boundaries, protected objects, Supervisor/Worker separation, and historical evidence.
- Synchronize the current canonical signal and handoff for the post-integration state without modifying the Compound Evidence Meter or its ledger.

## Root cause

A clean normal-terminal Worker Run was previously sufficient to continue even when it established zero declared completion requirements. That could spend another automatic Run without demonstrated progress in the declared-requirement model.

## Claim boundary

This detects one narrow form of zero declared progress. It does not claim general semantic progress or stagnation detection, Goal-effect completion, optimal Run allocation, resource savings, Next-Actor Selection, or global efficiency improvement.

## Reviewed commits

- `3bccf213690f855747c0c71631a223d4813a9a35` — capability delta
- `c112c91f902a443867fa697352c3ff7ec26c5e11` — closure-only canonical synchronization

## Validation

- affected Stage C/server: 49 passed, 185 subtests passed
- Stage A/B/controller: 54 passed, 9 subtests passed
- canonical/check surfaces: 75 passed, 65 subtests passed
- clean-worktree full suite: 1,438 passed, 15 skipped, 986 subtests passed
- `python -B -m decision_os check .`: PASS; V12 `PASS`; V13 `HOLD`; no contradictions or missing closure
- `git diff --check`: PASS

No merge, release, tag, package publication, outreach, or Compound Evidence Meter admission is included.