### PR TITLE
Integrate V8-derived temporal evidence invalidation

### DIFF
--- a/decision_os/companion/small_compound_loop.py
+++ b/decision_os/companion/small_compound_loop.py
@@ -64,6 +64,10 @@ _REQUEST_FIELDS = frozenset(
 _REQUIREMENT_FIELDS = frozenset(
     {"requirement_id", "description", "evidence_path", "expected_sha256"}
 )
+_FILE_ACTION_FIELDS = frozenset({"action", "path", "access", "status"})
+_FILE_ACTION_ACCESS = frozenset(
+    {"denied", "matched-not-verified", "newly-saved", "one-time", "reused"}
+)
 _RECORD_FIELDS = frozenset(
     {
         "schema",
@@ -374,27 +378,118 @@ def _requirements(record: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
     return tuple(item.as_dict() for item in request.completion_requirements)
 
 
+def _matching_read_run_numbers(
+    runs: list[Any],
+    requirement: Mapping[str, str],
+) -> tuple[int, ...]:
+    return tuple(
+        run_number
+        for run_number, run in enumerate(runs, start=1)
+        if isinstance(run, dict)
+        and any(
+            read.get("status") == "succeeded"
+            and read.get("path") == requirement["evidence_path"]
+            and read.get("sha256") == requirement["expected_sha256"]
+            for read in run.get("read_evidence", [])
+            if isinstance(read, dict)
+        )
+    )
+
+
+def _authorized_modify_run_numbers(
+    record: Mapping[str, Any],
+    runs: list[Any],
+    evidence_path: str,
+) -> tuple[int, ...]:
+    request = StageCContinuationRequest.from_dict(record.get("request"))
+    allowed_paths = set(request.allowed_mutation_paths)
+    modified: list[int] = []
+    for run_number, run in enumerate(runs, start=1):
+        if not isinstance(run, dict) or not isinstance(
+            run.get("file_actions"),
+            list,
+        ):
+            raise ContinuationIntegrityError("Stage C Run evidence is invalid.")
+        for action in run["file_actions"]:
+            if not isinstance(action, dict) or action.get("action") != "Modify":
+                continue
+            if (
+                set(action) != _FILE_ACTION_FIELDS
+                or not isinstance(action.get("path"), str)
+                or not action["path"]
+                or action.get("access") not in _FILE_ACTION_ACCESS
+                or action.get("status") not in {"approved", "denied"}
+                or (
+                    (action["status"] == "denied")
+                    != (action["access"] == "denied")
+                )
+            ):
+                raise ContinuationIntegrityError(
+                    "Persisted Stage C mutation evidence is invalid."
+                )
+            if (
+                action["status"] == "approved"
+                and action["path"] not in allowed_paths
+            ):
+                raise ContinuationIntegrityError(
+                    "Persisted Stage C mutation evidence exceeds authority."
+                )
+            if (
+                action["action"] == "Modify"
+                and action["status"] == "approved"
+                and action["path"] == evidence_path
+            ):
+                modified.append(run_number)
+    return tuple(modified)
+
+
+def _requirement_temporal_state(
+    record: Mapping[str, Any],
+    requirement: Mapping[str, str],
+) -> tuple[bool, bool]:
+    runs = record.get("runs")
+    if not isinstance(runs, list):
+        raise ContinuationIntegrityError("Stage C Run evidence is invalid.")
+    matching_reads = _matching_read_run_numbers(runs, requirement)
+    if not matching_reads:
+        return False, False
+    authorized_modifies = _authorized_modify_run_numbers(
+        record,
+        runs,
+        requirement["evidence_path"],
+    )
+    invalidating_modifies = tuple(
+        modify_run
+        for modify_run in authorized_modifies
+        if any(read_run < modify_run for read_run in matching_reads)
+    )
+    if not invalidating_modifies:
+        return True, False
+    last_invalidation = max(invalidating_modifies)
+    if any(read_run > last_invalidation for read_run in matching_reads):
+        return True, False
+    return False, True
+
+
 def satisfied_requirement_ids(
     record: Mapping[str, Any],
 ) -> tuple[str, ...]:
     requirements = _requirements(record)
-    runs = record.get("runs")
-    if not isinstance(runs, list):
-        raise ContinuationIntegrityError("Stage C Run evidence is invalid.")
-    satisfied: list[str] = []
-    for requirement in requirements:
-        matched = any(
-            read.get("status") == "succeeded"
-            and read.get("path") == requirement["evidence_path"]
-            and read.get("sha256") == requirement["expected_sha256"]
-            for run in runs
-            if isinstance(run, dict)
-            for read in run.get("read_evidence", [])
-            if isinstance(read, dict)
-        )
-        if matched:
-            satisfied.append(requirement["requirement_id"])
-    return tuple(satisfied)
+    return tuple(
+        requirement["requirement_id"]
+        for requirement in requirements
+        if _requirement_temporal_state(record, requirement)[0]
+    )
+
+
+def _stale_requirement_ids(
+    record: Mapping[str, Any],
+) -> tuple[str, ...]:
+    return tuple(
+        requirement["requirement_id"]
+        for requirement in _requirements(record)
+        if _requirement_temporal_state(record, requirement)[1]
+    )
 
 
 def remaining_requirements(
@@ -472,6 +567,12 @@ def stage_c_supervisor_context(
     current = runs[-1]
     current_residue = residues[-1]
     made_progress = bool(current_residue["new_requirement_ids"])
+    stale_requirement_ids = _stale_requirement_ids(record)
+    stale_requirements = tuple(
+        requirement
+        for requirement in remaining
+        if requirement["requirement_id"] in stale_requirement_ids
+    )
     evidence_ref = (
         f"stage-c:{record['chain_id']}:run-{len(runs)}:"
         f"evidence-sha256={current['evidence_sha256']}"
@@ -488,7 +589,11 @@ def stage_c_supervisor_context(
         next_bounded_action=(
             None if not remaining else _next_action(remaining[0])
         ),
-        evidence_recovery_action=request.evidence_recovery_action,
+        evidence_recovery_action=(
+            _next_action(stale_requirements[0])
+            if stale_requirements
+            else request.evidence_recovery_action
+        ),
         irreducible_human_decision=request.irreducible_human_decision,
         evidence_refs=(*request.authority_evidence_refs, evidence_ref),
         completed_runs=len(runs),
@@ -502,9 +607,12 @@ def stage_c_supervisor_context(
         evidence_sufficient=(
             ContractFact.SATISFIED
             if (
-                made_progress
-                or not remaining
-                or len(runs) >= STAGE_C_TOTAL_RUN_CAP
+                not stale_requirements
+                and (
+                    made_progress
+                    or not remaining
+                    or len(runs) >= STAGE_C_TOTAL_RUN_CAP
+                )
             )
             else ContractFact.NOT_SATISFIED
         ),

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,89 @@
+# Current Signal — V8-Derived Temporal Evidence Integration
+
+## Canonical Current State — V13 Post V8-Derived Temporal Evidence Integration
+
+```text
+Current Layer:
+V13 — Post V8-Derived Temporal Evidence Integration
+
+V12 State:
+PASS
+
+13-106 zero-declared-progress stop:
+INTEGRATED
+
+13-110 V8-derived temporal evidence invalidation:
+INTEGRATED only after this focused branch merges into main
+
+Claim:
+A matching read of a declared evidence path supports its completion requirement.
+A strictly later approved Modify of that same declared path invalidates the
+earlier current support until a strictly later matching read with the expected
+SHA-256 re-establishes it.
+
+Claim Boundary:
+Stage C uses persisted Run ordering, the exact declared evidence path, the exact
+expected hash/read evidence, and an exact approved same-path Modify action. This
+does not establish generic drift detection, semantic progress, arbitrary
+mutation history, within-Run ordering, generic Time-Tube, trajectory scores,
+dependency or Guardian models, optimal freshness, or efficiency improvement.
+
+Source Lineage:
+One V8-derived temporal-validity structure produced one bounded Stage C
+behavioral delta. This is not a claim that V8 is integrated into V13.
+
+Historical Evidence:
+Historical matching reads remain preserved. Only their current completion
+support changes after a strictly later approved same-path Modify.
+
+13-108 repository-identity candidate:
+NONCANONICAL / NOT INTEGRATED
+
+Capability Commit:
+21b402ef2bd1b28f18c5585663aa67b16b4d6b41
+
+Canonical Starting Main:
+b72ccf6fd788fef242bd23684a909960db7e34d6
+
+Active Branch:
+main
+
+Field Note 132:
+unchanged / Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the focused capability and this canonical synchronization merge.
+
+Next Authorized Action:
+None. Preserve the exact temporal-evidence claim boundary. Do not start another
+V8 transplant, self-diagnosis, release, or publication action.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact V8-derived Stage C temporal-evidence invalidation is integrated
+without deleting or rewriting historical evidence and without changing the
+zero-progress stop, Run-3 CAP, Human Seat, authority, protected objects, or
+Compound Evidence Meter.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Signal — V13 Self-Selected Capability Integration
 
 ## Canonical Current State — V13 Post Self-Selected Capability Integration

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,89 @@
+# Current Codex Handoff — V8-Derived Temporal Evidence Integration
+
+## Canonical Current State — V13 Post V8-Derived Temporal Evidence Integration
+
+```text
+Current Layer:
+V13 — Post V8-Derived Temporal Evidence Integration
+
+V12 State:
+PASS
+
+13-106 zero-declared-progress stop:
+INTEGRATED
+
+13-110 V8-derived temporal evidence invalidation:
+INTEGRATED only after this focused branch merges into main
+
+Claim:
+A matching read of a declared evidence path supports its completion requirement.
+A strictly later approved Modify of that same declared path invalidates the
+earlier current support until a strictly later matching read with the expected
+SHA-256 re-establishes it.
+
+Claim Boundary:
+Stage C uses persisted Run ordering, the exact declared evidence path, the exact
+expected hash/read evidence, and an exact approved same-path Modify action. This
+does not establish generic drift detection, semantic progress, arbitrary
+mutation history, within-Run ordering, generic Time-Tube, trajectory scores,
+dependency or Guardian models, optimal freshness, or efficiency improvement.
+
+Source Lineage:
+One V8-derived temporal-validity structure produced one bounded Stage C
+behavioral delta. This is not a claim that V8 is integrated into V13.
+
+Historical Evidence:
+Historical matching reads remain preserved. Only their current completion
+support changes after a strictly later approved same-path Modify.
+
+13-108 repository-identity candidate:
+NONCANONICAL / NOT INTEGRATED
+
+Capability Commit:
+21b402ef2bd1b28f18c5585663aa67b16b4d6b41
+
+Canonical Starting Main:
+b72ccf6fd788fef242bd23684a909960db7e34d6
+
+Active Branch:
+main
+
+Field Note 132:
+unchanged / Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the focused capability and this canonical synchronization merge.
+
+Next Authorized Action:
+None. Preserve the exact temporal-evidence claim boundary. Do not start another
+V8 transplant, self-diagnosis, release, or publication action.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact V8-derived Stage C temporal-evidence invalidation is integrated
+without deleting or rewriting historical evidence and without changing the
+zero-progress stop, Run-3 CAP, Human Seat, authority, protected objects, or
+Compound Evidence Meter.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Codex Handoff — V13 Self-Selected Capability Integration
 
 ## Canonical Current State — V13 Post Self-Selected Capability Integration

--- a/tests/test_companion_small_compound_loop.py
+++ b/tests/test_companion_small_compound_loop.py
@@ -10,6 +10,7 @@ import unittest
 from typing import Any
 
 from decision_os.acceleration.codex_adapter import (
+    CodexFileAction,
     CodexReadEvidence,
     CodexRunResult,
 )
@@ -21,6 +22,9 @@ from decision_os.companion.controller import (
 from decision_os.companion.small_compound_loop import (
     StageCCompletionRequirement,
     StageCContinuationRequest,
+    remaining_requirements,
+    satisfied_requirement_ids,
+    stage_c_outcome,
 )
 from decision_os.companion.supervisor import ContractFact
 from tests.test_companion_controller import (
@@ -84,6 +88,53 @@ def stage_c_request(**overrides: Any) -> StageCContinuationRequest:
     return StageCContinuationRequest(**values)
 
 
+def temporal_support_record(*plans: dict[str, Any]) -> dict[str, Any]:
+    runs: list[dict[str, Any]] = []
+    for plan in plans:
+        reads = [
+            {
+                "path": f"evidence-{number}.md",
+                "bytes": number,
+                "sha256": str(number) * 64,
+                "repository_identity": "b" * 40,
+                "status": "succeeded",
+                "reason": None,
+            }
+            for number in plan.get("evidence", ())
+        ]
+        reads.extend(
+            {
+                "path": f"evidence-{number}.md",
+                "bytes": number,
+                "sha256": "f" * 64,
+                "repository_identity": "b" * 40,
+                "status": "succeeded",
+                "reason": None,
+            }
+            for number in plan.get("nonmatching_evidence", ())
+        )
+        runs.append(
+            {
+                "read_evidence": reads,
+                "file_actions": [
+                    {
+                        "action": "Modify",
+                        "path": path,
+                        "access": "one-time",
+                        "status": "approved",
+                    }
+                    for path in plan.get("modifies", ())
+                ],
+            }
+        )
+    return {
+        "request": stage_c_request(
+            allowed_mutation_paths=("evidence-1.md",),
+        ).as_dict(),
+        "runs": runs,
+    }
+
+
 class EvidenceFactory:
     """Return one predetermined Worker result per actual dispatch."""
 
@@ -119,6 +170,10 @@ class EvidenceFactory:
                 if plan == "failure":
                     raise RuntimeError("injected bounded execution failure")
                 evidence_ids = tuple(plan.get("evidence", ()))
+                nonmatching_evidence_ids = tuple(
+                    plan.get("nonmatching_evidence", ())
+                )
+                modified_paths = tuple(plan.get("modifies", ()))
                 status = plan.get("status", "NORMAL_TERMINAL")
                 normal = status == "NORMAL_TERMINAL"
                 return CodexRunResult(
@@ -130,15 +185,36 @@ class EvidenceFactory:
                     runtime_identity=runtime_identity(),
                     checkpoint_outcomes=(),
                     final_message=f"Established {evidence_ids!r}.",
-                    read_evidence=tuple(
-                        CodexReadEvidence(
-                            path=f"evidence-{number}.md",
-                            byte_count=number,
-                            sha256=str(number) * 64,
-                            repository_identity="b" * 40,
-                            status="succeeded",
+                    file_actions=tuple(
+                        CodexFileAction(
+                            action="Modify",
+                            normalized_scope=path,
+                            access="one-time",
+                            status="approved",
                         )
-                        for number in evidence_ids
+                        for path in modified_paths
+                    ),
+                    read_evidence=(
+                        tuple(
+                            CodexReadEvidence(
+                                path=f"evidence-{number}.md",
+                                byte_count=number,
+                                sha256=str(number) * 64,
+                                repository_identity="b" * 40,
+                                status="succeeded",
+                            )
+                            for number in evidence_ids
+                        )
+                        + tuple(
+                            CodexReadEvidence(
+                                path=f"evidence-{number}.md",
+                                byte_count=number,
+                                sha256="f" * 64,
+                                repository_identity="b" * 40,
+                                status="succeeded",
+                            )
+                            for number in nonmatching_evidence_ids
+                        )
                     ),
                 )
 
@@ -251,6 +327,198 @@ class StageCSmallCompoundLoopTest(unittest.TestCase):
                 "TERMINAL",
                 controller.snapshot()["compound_loop"]["state"],
             )
+
+    def test_later_authorized_modify_invalidates_historical_read(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {"evidence": (1,)},
+                {"evidence": (2,), "modifies": ("evidence-1.md",)},
+                {"evidence": (3,)},
+                {"evidence": (1,)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(
+                stage_c_request(
+                    allowed_mutation_paths=("evidence-1.md",),
+                )
+            )
+            chain = self.terminal(controller)["compound_loop"]
+
+            self.assertEqual("HOLD", chain["outcome"])
+            self.assertNotEqual("COMPLETE", chain["outcome"])
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                chain["supervisor_judgments"][-1]["decision_route"],
+            )
+            self.assertEqual(
+                ["REQ-1", "REQ-3"],
+                chain["residues"][-1]["remaining_requirement_ids"],
+            )
+            self.assertEqual(
+                ["REQ-1"],
+                chain["residues"][0]["established_requirement_ids"],
+            )
+            self.assertEqual(
+                ["REQ-2"],
+                chain["residues"][1]["established_requirement_ids"],
+            )
+            self.assertEqual(
+                ["REQ-1", "REQ-3"],
+                chain["residues"][1]["remaining_requirement_ids"],
+            )
+            self.assertEqual(1, len(chain["automatic_tasks"]))
+            self.assertEqual(
+                "REQ-2",
+                chain["automatic_tasks"][0]["selected_requirement_id"],
+            )
+            self.assertIn(
+                "reading evidence-1.md",
+                chain["governed_stop"]["next_action"],
+            )
+            self.assertEqual(2, len(factory.prompts))
+            self.assertEqual(2, len(factory.plans))
+
+            three_run_record = temporal_support_record(
+                {"evidence": (1,)},
+                {"evidence": (2,), "modifies": ("evidence-1.md",)},
+                {"evidence": (3,)},
+            )
+            self.assertEqual(
+                ("REQ-2", "REQ-3"),
+                satisfied_requirement_ids(three_run_record),
+            )
+            self.assertEqual(
+                ("REQ-1",),
+                tuple(
+                    item["requirement_id"]
+                    for item in remaining_requirements(three_run_record)
+                ),
+            )
+            self.assertEqual(
+                "HOLD",
+                stage_c_outcome(three_run_record, {"gate": "HOLD"}),
+            )
+
+    def test_post_mutation_matching_reread_reestablishes_requirement(
+        self,
+    ) -> None:
+        record = temporal_support_record(
+            {"evidence": (1,)},
+            {"evidence": (2,), "modifies": ("evidence-1.md",)},
+            {"evidence": (1, 3)},
+        )
+
+        self.assertEqual(
+            ("REQ-1", "REQ-2", "REQ-3"),
+            satisfied_requirement_ids(record),
+        )
+        self.assertEqual((), remaining_requirements(record))
+
+    def test_modify_of_different_path_does_not_invalidate_requirement(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {"evidence": (1,)},
+                {"evidence": (2,), "modifies": ("other.txt",)},
+                {"evidence": (3,)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(
+                stage_c_request(allowed_mutation_paths=("other.txt",))
+            )
+            chain = self.terminal(controller)["compound_loop"]
+
+            self.assertEqual("COMPLETE", chain["outcome"])
+            self.assertEqual(
+                ["REQ-1", "REQ-2", "REQ-3"],
+                chain["residues"][-1]["established_requirement_ids"],
+            )
+
+    def test_post_mutation_nonmatching_read_does_not_reestablish(
+        self,
+    ) -> None:
+        record = temporal_support_record(
+            {"evidence": (1,)},
+            {"evidence": (2,), "modifies": ("evidence-1.md",)},
+            {"evidence": (3,), "nonmatching_evidence": (1,)},
+        )
+
+        self.assertEqual(
+            ("REQ-2", "REQ-3"),
+            satisfied_requirement_ids(record),
+        )
+        self.assertEqual(
+            ("REQ-1",),
+            tuple(
+                item["requirement_id"]
+                for item in remaining_requirements(record)
+            ),
+        )
+
+    def test_stale_zero_progress_holds_without_dispatching_run_three(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {"evidence": (1,)},
+                {"evidence": (), "modifies": ("evidence-1.md",)},
+                {"evidence": (1, 2, 3)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(
+                stage_c_request(
+                    allowed_mutation_paths=("evidence-1.md",),
+                )
+            )
+            chain = self.terminal(controller)["compound_loop"]
+
+            self.assertEqual("HOLD", chain["outcome"])
+            self.assertEqual(2, len(chain["runs"]))
+            self.assertEqual(1, chain["automatic_continuations_started"])
+            self.assertEqual(2, len(factory.prompts))
+            self.assertEqual(1, len(factory.plans))
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                chain["supervisor_judgments"][-1]["decision_route"],
+            )
+
+    def test_stale_terminal_replay_is_identical_and_dispatch_free(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {"evidence": (1,)},
+                {"evidence": (2,), "modifies": ("evidence-1.md",)},
+                {"evidence": (3,)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(
+                stage_c_request(
+                    allowed_mutation_paths=("evidence-1.md",),
+                )
+            )
+            terminal = self.terminal(controller)["compound_loop"]
+
+            restarted_factory = EvidenceFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            replayed = restarted.snapshot()["compound_loop"]
+            self.assertEqual("HOLD", replayed["outcome"])
+            self.assertEqual(
+                terminal["record_sha256"],
+                replayed["record_sha256"],
+            )
+            self.assertEqual([], restarted_factory.prompts)
 
     def test_early_completion_after_run_one_or_two_preserves_unused_budget(
         self,
@@ -483,6 +751,68 @@ class StageCSmallCompoundLoopTest(unittest.TestCase):
                 self.assertEqual(
                     "BLOCKED_CORRUPT",
                     snapshot["compound_loop"]["state"],
+                )
+                self.assertEqual([], restarted_factory.prompts)
+
+    def test_tampered_run_order_or_mutation_evidence_blocks_replay(
+        self,
+    ) -> None:
+        def wrong_run_order(record: dict[str, Any]) -> None:
+            record["runs"][1]["run_number"] = 1
+
+        def malformed_mutation(record: dict[str, Any]) -> None:
+            record["runs"][1]["file_actions"][0]["status"] = "authorized"
+
+        for label, mutate in (
+            ("run-order", wrong_run_order),
+            ("mutation-evidence", malformed_mutation),
+        ):
+            with (
+                self.subTest(label=label),
+                tempfile.TemporaryDirectory() as temporary,
+            ):
+                root = Path(temporary)
+                repository = create_repository(root)
+                controller = self.make_controller(
+                    root,
+                    EvidenceFactory(
+                        {"evidence": (1,)},
+                        {
+                            "evidence": (2,),
+                            "modifies": ("evidence-1.md",),
+                        },
+                        {"evidence": (3,)},
+                    ),
+                )
+                controller.select_repository(repository)
+                controller.start_small_compound_loop(
+                    stage_c_request(
+                        allowed_mutation_paths=("evidence-1.md",),
+                    )
+                )
+                self.terminal(controller)
+
+                state_path = (
+                    root / "application-state" / "stage-b-continuation.json"
+                )
+                record = json.loads(state_path.read_text(encoding="utf-8"))
+                mutate(record)
+                for run in record["runs"]:
+                    run_payload = {
+                        key: value
+                        for key, value in run.items()
+                        if key != "evidence_sha256"
+                    }
+                    run["evidence_sha256"] = hash_payload(run_payload)
+                record.pop("record_sha256")
+                record["record_sha256"] = hash_payload(record)
+                state_path.write_text(json.dumps(record), encoding="utf-8")
+
+                restarted_factory = EvidenceFactory()
+                restarted = self.make_controller(root, restarted_factory)
+                self.assertEqual(
+                    "BLOCKED_CORRUPT",
+                    restarted.snapshot()["compound_loop"]["state"],
                 )
                 self.assertEqual([], restarted_factory.prompts)
 

--- a/tests/test_compound_evidence_meter.py
+++ b/tests/test_compound_evidence_meter.py
@@ -274,7 +274,7 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
         self.assertIn(
-            "Preserve the integrated narrow stop",
+            "Preserve the exact temporal-evidence claim boundary",
             payload["next_authorized_action"],
         )
         for relative_path in (
@@ -289,14 +289,27 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     maxsplit=1,
                 )[0]
                 self.assertIn(
-                    "V13 — Post Self-Selected Capability Integration",
+                    "V13 — Post V8-Derived Temporal Evidence Integration",
                     current,
                 )
                 self.assertIn(
-                    "Stage C zero-declared-progress stop",
+                    "13-106 zero-declared-progress stop:\nINTEGRATED",
                     current,
                 )
-                self.assertIn("Capability Status:\nINTEGRATED", current)
+                self.assertIn(
+                    "13-110 V8-derived temporal evidence invalidation:\n"
+                    "INTEGRATED only after this focused branch merges into main",
+                    current,
+                )
+                self.assertIn(
+                    "13-108 repository-identity candidate:\n"
+                    "NONCANONICAL / NOT INTEGRATED",
+                    current,
+                )
+                self.assertIn(
+                    "strictly later approved Modify of that same declared path",
+                    current,
+                )
                 self.assertIn(
                     "Field Note 132:\nunchanged / Verification pending",
                     current,


### PR DESCRIPTION
## What changed

- preserve historical matching reads while deriving current Stage C completion support from persisted Run ordering;
- invalidate earlier support only after a strictly later approved `Modify` of the exact declared evidence path;
- permit a strictly later matching read with the expected SHA-256 to re-establish support;
- synchronize the minimum current signal, handoff, and canonical-surface assertions.

## Why

Completion could previously remain supported by a matching historical read even after a later authorized Run modified that same declared evidence path. This bounded delta prevents `COMPLETE` from relying on that stale support.

## Boundaries

- no generic drift or semantic-progress detection;
- no within-Run temporal ordering;
- no repository-identity continuity from 13-108;
- no Compound Evidence Meter change;
- no release or package publication.

## Validation

- focused Stage C: 18/18 passed;
- companion continuation/Supervisor/controller/server interaction: 110/110 passed with required permissions;
- canonical-surface tests: 12/12 passed;
- full discovery: 1,460 tests; only 43 loopback-bind errors and three headless-Chrome aborts under the restricted sandbox, with 14 skips;
- exact environment-bound rerun: 59 tests passed, 1 skipped;
- `python -B -m decision_os check .` passed;
- `git diff --check` passed.
