### PR TITLE
Integrate V6 safety non-dilution

### DIFF
--- a/decision_os/companion/supervisor.py
+++ b/decision_os/companion/supervisor.py
@@ -507,16 +507,43 @@ def judge_continuation(
             "Answer the single proved Human Seat question recorded in the evidence.",
         ),
     )
-    for _name, fact, gate, reason, human_return in human_conditions:
-        if fact == ContractFact.NOT_SATISFIED:
-            return _judgment(
-                result,
-                context,
-                gate=gate,
-                reason=reason,
-                route=DecisionRoute.HUMAN_SEAT,
-                human_return=_human_return(context, human_return),
+    failed_human_conditions = tuple(
+        condition
+        for condition in human_conditions
+        if condition[1] == ContractFact.NOT_SATISFIED
+    )
+    if failed_human_conditions:
+        failed_blocks = tuple(
+            condition
+            for condition in failed_human_conditions
+            if condition[2] == SupervisorGate.BLOCK
+        )
+        primary = (
+            failed_blocks[0]
+            if failed_blocks
+            else failed_human_conditions[0]
+        )
+        _name, _fact, gate, reason, human_return = primary
+        if len(failed_human_conditions) > 1:
+            failed_names = ", ".join(
+                condition[0] for condition in failed_human_conditions
             )
+            reason = (
+                f"{reason} Simultaneous failed Human Seat conditions: "
+                f"{failed_names}."
+            )
+        return _judgment(
+            result,
+            context,
+            gate=gate,
+            reason=reason,
+            route=DecisionRoute.HUMAN_SEAT,
+            human_return=(
+                human_return
+                if failed_blocks and len(failed_human_conditions) > 1
+                else _human_return(context, human_return)
+            ),
+        )
 
     if context.next_bounded_action is None:
         return _judgment(

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,90 @@
+# Current Signal — V6 Safety Non-Dilution Integration
+
+## Canonical Current State — V13 Post V6 Safety Non-Dilution Integration
+
+```text
+Current Layer:
+V13 — Decision Structure Transplant Integration / V6 Safety Non-Dilution
+
+V12 State:
+PASS
+
+V6-derived Safety Non-Dilution:
+INTEGRATED
+
+Bounded Claim:
+Existing BLOCK Human Seat failures cannot be diluted by earlier simultaneous
+HOLD/CAP failures.
+
+Claim Boundary:
+At Supervisor Human Seat commitment, all established NOT_SATISFIED
+human_conditions are evaluated. An existing BLOCK is selected over simultaneous
+earlier HOLD/CAP failures, every failed-condition identity is preserved in
+canonical condition order, exactly one deterministic Human Seat action is
+returned, and no automatic continuation is dispatched. If no BLOCK exists,
+existing first-match HOLD/CAP behavior remains unchanged. This does not
+establish a general Gate severity lattice.
+
+V8-derived temporal evidence invalidation:
+unchanged / integrated
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+a1e66127ddd4db8219805e113a71700c88ef93b3
+
+Canonicalization Condition:
+This block becomes canonical only when capability commit
+a1e66127ddd4db8219805e113a71700c88ef93b3 and this synchronization delta merge
+into main.
+
+Canonical Starting Main:
+5c510345d96ac1524ee625fd86ebd2be89277258
+
+Active Branch:
+main
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the exact capability and this canonical synchronization merge.
+
+Next Authorized Action:
+None. Preserve the exact BLOCK non-dilution claim boundary. Do not start another
+Decision transplant, release, publication, or Meter change.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact V6-derived BLOCK non-dilution capability is integrated without
+a broader Gate severity ordering and without changing UNKNOWN, goal-complete
+STOP, Run-cap CAP, zero-progress, V8 temporal-evidence, authority,
+protected-object, or Compound Evidence Meter semantics. No next Decision
+transplant is authorized.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Signal — V8-Derived Temporal Evidence Integration
 
 ## Canonical Current State — V13 Post V8-Derived Temporal Evidence Integration

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,90 @@
+# Current Codex Handoff — V6 Safety Non-Dilution Integration
+
+## Canonical Current State — V13 Post V6 Safety Non-Dilution Integration
+
+```text
+Current Layer:
+V13 — Decision Structure Transplant Integration / V6 Safety Non-Dilution
+
+V12 State:
+PASS
+
+V6-derived Safety Non-Dilution:
+INTEGRATED
+
+Bounded Claim:
+Existing BLOCK Human Seat failures cannot be diluted by earlier simultaneous
+HOLD/CAP failures.
+
+Claim Boundary:
+At Supervisor Human Seat commitment, all established NOT_SATISFIED
+human_conditions are evaluated. An existing BLOCK is selected over simultaneous
+earlier HOLD/CAP failures, every failed-condition identity is preserved in
+canonical condition order, exactly one deterministic Human Seat action is
+returned, and no automatic continuation is dispatched. If no BLOCK exists,
+existing first-match HOLD/CAP behavior remains unchanged. This does not
+establish a general Gate severity lattice.
+
+V8-derived temporal evidence invalidation:
+unchanged / integrated
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+a1e66127ddd4db8219805e113a71700c88ef93b3
+
+Canonicalization Condition:
+This block becomes canonical only when capability commit
+a1e66127ddd4db8219805e113a71700c88ef93b3 and this synchronization delta merge
+into main.
+
+Canonical Starting Main:
+5c510345d96ac1524ee625fd86ebd2be89277258
+
+Active Branch:
+main
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the exact capability and this canonical synchronization merge.
+
+Next Authorized Action:
+None. Preserve the exact BLOCK non-dilution claim boundary. Do not start another
+Decision transplant, release, publication, or Meter change.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact V6-derived BLOCK non-dilution capability is integrated without
+a broader Gate severity ordering and without changing UNKNOWN, goal-complete
+STOP, Run-cap CAP, zero-progress, V8 temporal-evidence, authority,
+protected-object, or Compound Evidence Meter semantics. No next Decision
+transplant is authorized.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Codex Handoff — V8-Derived Temporal Evidence Integration
 
 ## Canonical Current State — V13 Post V8-Derived Temporal Evidence Integration

--- a/tests/test_companion_continuation.py
+++ b/tests/test_companion_continuation.py
@@ -423,6 +423,51 @@ class StageBContinuationTest(unittest.TestCase):
                 snapshot["compound_loop"]["record_sha256"],
             )
 
+    def test_aggregated_block_replays_identically_without_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = RecordingFactory("read_only", "read_only")
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_one_automatic_continuation(
+                stage_b_request(
+                    goal_unchanged=NO,
+                    authority_sufficient=NO,
+                )
+            )
+            stopped = wait_for(
+                controller,
+                lambda state: (
+                    state["compound_loop"] is not None
+                    and state["compound_loop"].get("state") == "STOPPED"
+                ),
+            )
+
+            chain = stopped["compound_loop"]
+            supervisor = chain["supervisor"]
+            self.assertEqual("BLOCK", supervisor["gate"])
+            self.assertEqual("HUMAN-SEAT", supervisor["decision_route"])
+            self.assertEqual(
+                "Decide whether to authorize the proposed next bounded action.",
+                supervisor["human_seat_return"],
+            )
+            self.assertIn(
+                "Simultaneous failed Human Seat conditions: "
+                "goal_unchanged, authority_sufficient.",
+                supervisor["reason"],
+            )
+            self.assertEqual(0, chain["automatic_continuations_started"])
+            self.assertIsNone(chain["automatic_task"])
+            self.assertEqual(1, len(factory.prompts))
+
+            restarted_factory = RecordingFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            replayed = restarted.snapshot()["compound_loop"]
+            self.assertEqual(supervisor, replayed["supervisor"])
+            self.assertEqual(chain["record_sha256"], replayed["record_sha256"])
+            self.assertEqual([], restarted_factory.prompts)
+
     def test_completed_chain_reconnects_without_dispatching_another_run(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_companion_supervisor.py
+++ b/tests/test_companion_supervisor.py
@@ -225,6 +225,145 @@ class CompanionSupervisorTest(unittest.TestCase):
             judgment.human_seat_return,
         )
 
+    def test_simultaneous_goal_and_authority_failures_commit_block(self) -> None:
+        judgment = judge_continuation(
+            completed_result(),
+            context(
+                goal_unchanged=NO,
+                authority_sufficient=NO,
+            ),
+        )
+
+        self.assertEqual(SupervisorGate.BLOCK, judgment.gate)
+        self.assertEqual(DecisionRoute.HUMAN_SEAT, judgment.decision_route)
+        self.assertEqual(
+            "Decide whether to authorize the proposed next bounded action.",
+            judgment.human_seat_return,
+        )
+        self.assertIn(
+            "Simultaneous failed Human Seat conditions: "
+            "goal_unchanged, authority_sufficient.",
+            judgment.reason,
+        )
+        self.assertFalse(judgment.automatic_second_run_started)
+
+    def test_cost_cap_cannot_hide_later_protected_object_block(self) -> None:
+        judgment = judge_continuation(
+            completed_result(),
+            context(
+                cost_boundary_intact=NO,
+                protected_object_and_ownership_unchanged=NO,
+            ),
+        )
+
+        self.assertEqual(SupervisorGate.BLOCK, judgment.gate)
+        self.assertEqual(DecisionRoute.HUMAN_SEAT, judgment.decision_route)
+        self.assertEqual(
+            "Decide whether to change the Protected Object or ownership boundary.",
+            judgment.human_seat_return,
+        )
+        self.assertIn(
+            "cost_boundary_intact, "
+            "protected_object_and_ownership_unchanged",
+            judgment.reason,
+        )
+        self.assertFalse(judgment.automatic_second_run_started)
+
+    def test_block_primary_cannot_be_replaced_by_lower_failure_override(self) -> None:
+        judgment = judge_continuation(
+            completed_result(),
+            context(
+                goal_unchanged=NO,
+                authority_sufficient=NO,
+                irreducible_human_decision=(
+                    "Decide only whether to change the declared Goal."
+                ),
+            ),
+        )
+
+        self.assertEqual(SupervisorGate.BLOCK, judgment.gate)
+        self.assertEqual(
+            "Decide whether to authorize the proposed next bounded action.",
+            judgment.human_seat_return,
+        )
+
+    def test_multiple_blocks_use_first_canonical_block_and_preserve_all(self) -> None:
+        judgment = judge_continuation(
+            completed_result(),
+            context(
+                authority_sufficient=NO,
+                blast_radius_bounded=NO,
+                no_authoritative_conflict=NO,
+            ),
+        )
+
+        self.assertEqual(SupervisorGate.BLOCK, judgment.gate)
+        self.assertEqual(DecisionRoute.HUMAN_SEAT, judgment.decision_route)
+        self.assertEqual(
+            "Decide whether to authorize the proposed next bounded action.",
+            judgment.human_seat_return,
+        )
+        self.assertIn(
+            "authority_sufficient, blast_radius_bounded, "
+            "no_authoritative_conflict",
+            judgment.reason,
+        )
+        self.assertFalse(judgment.automatic_second_run_started)
+
+    def test_multiple_holds_keep_first_canonical_human_seat_action(self) -> None:
+        judgment = judge_continuation(
+            completed_result(),
+            context(
+                goal_unchanged=NO,
+                no_material_human_preference_required=NO,
+            ),
+        )
+
+        self.assertEqual(SupervisorGate.HOLD, judgment.gate)
+        self.assertEqual(
+            "Decide whether to change the declared Goal or Aspire direction.",
+            judgment.human_seat_return,
+        )
+        self.assertIn(
+            "goal_unchanged, no_material_human_preference_required",
+            judgment.reason,
+        )
+
+    def test_cap_and_hold_keep_existing_canonical_order_without_block(self) -> None:
+        cases = (
+            (
+                {
+                    "goal_unchanged": NO,
+                    "cost_boundary_intact": NO,
+                },
+                SupervisorGate.HOLD,
+                "Decide whether to change the declared Goal or Aspire direction.",
+                "goal_unchanged, cost_boundary_intact",
+            ),
+            (
+                {
+                    "cost_boundary_intact": NO,
+                    "no_truly_unanswered_human_question": NO,
+                },
+                SupervisorGate.CAP,
+                "Decide whether to expand the authorized cost boundary.",
+                (
+                    "cost_boundary_intact, "
+                    "no_truly_unanswered_human_question"
+                ),
+            ),
+        )
+        for overrides, gate, human_return, failed_names in cases:
+            with self.subTest(gate=gate.value, failed_names=failed_names):
+                judgment = judge_continuation(
+                    completed_result(),
+                    context(**overrides),
+                )
+
+                self.assertEqual(gate, judgment.gate)
+                self.assertEqual(human_return, judgment.human_seat_return)
+                self.assertIn(failed_names, judgment.reason)
+
     def test_known_authority_expansion_returns_to_human_seat(self) -> None:
         judgment = judge_continuation(
             completed_result(),
@@ -254,6 +393,41 @@ class CompanionSupervisorTest(unittest.TestCase):
             "Recover the missing evidence from the bounded Run and retry judgment.",
             judgment.next_bounded_action,
         )
+
+    def test_unknown_and_not_satisfied_remain_separate_fail_closed_paths(self) -> None:
+        cases = (
+            (
+                {
+                    "goal_unchanged": UNKNOWN,
+                    "authority_sufficient": NO,
+                },
+                SupervisorGate.HOLD,
+                "goal_unchanged",
+            ),
+            (
+                {
+                    "goal_unchanged": NO,
+                    "authority_sufficient": UNKNOWN,
+                },
+                SupervisorGate.BLOCK,
+                "authority_sufficient",
+            ),
+        )
+        for overrides, gate, unknown_name in cases:
+            with self.subTest(unknown_name=unknown_name):
+                judgment = judge_continuation(
+                    completed_result(),
+                    context(**overrides),
+                )
+
+                self.assertEqual(gate, judgment.gate)
+                self.assertEqual(
+                    DecisionRoute.EVIDENCE_RECOVERY,
+                    judgment.decision_route,
+                )
+                self.assertIn(unknown_name, judgment.reason)
+                self.assertNotIn("Simultaneous failed", judgment.reason)
+                self.assertIsNone(judgment.human_seat_return)
 
     def test_insufficient_evidence_holds_without_human_question(self) -> None:
         judgment = judge_continuation(
@@ -322,6 +496,19 @@ class CompanionSupervisorTest(unittest.TestCase):
         self.assertIn("4/3 total Runs", judgment.reason)
         self.assertEqual(
             "Decide whether to extend the 3-Run cap for the unchanged Goal.",
+            judgment.human_seat_return,
+        )
+
+    def test_cost_boundary_exhaustion_keeps_existing_cap_decision(self) -> None:
+        judgment = judge_continuation(
+            completed_result(),
+            context(cost_boundary_intact=NO),
+        )
+
+        self.assertEqual(SupervisorGate.CAP, judgment.gate)
+        self.assertEqual(DecisionRoute.HUMAN_SEAT, judgment.decision_route)
+        self.assertEqual(
+            "Decide whether to expand the authorized cost boundary.",
             judgment.human_seat_return,
         )
 

--- a/tests/test_compound_evidence_meter.py
+++ b/tests/test_compound_evidence_meter.py
@@ -274,7 +274,7 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
         self.assertIn(
-            "Preserve the exact temporal-evidence claim boundary",
+            "Preserve the exact BLOCK non-dilution claim boundary",
             payload["next_authorized_action"],
         )
         for relative_path in (
@@ -289,29 +289,44 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     maxsplit=1,
                 )[0]
                 self.assertIn(
-                    "V13 — Post V8-Derived Temporal Evidence Integration",
+                    "V13 — Decision Structure Transplant Integration / "
+                    "V6 Safety Non-Dilution",
                     current,
                 )
                 self.assertIn(
-                    "13-106 zero-declared-progress stop:\nINTEGRATED",
+                    "V6-derived Safety Non-Dilution:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
-                    "13-110 V8-derived temporal evidence invalidation:\n"
-                    "INTEGRATED only after this focused branch merges into main",
+                    "Existing BLOCK Human Seat failures cannot be diluted by "
+                    "earlier simultaneous\nHOLD/CAP failures.",
                     current,
                 )
                 self.assertIn(
-                    "13-108 repository-identity candidate:\n"
-                    "NONCANONICAL / NOT INTEGRATED",
+                    "every failed-condition identity is preserved in\n"
+                    "canonical condition order",
                     current,
                 )
                 self.assertIn(
-                    "strictly later approved Modify of that same declared path",
+                    "does not\nestablish a general Gate severity lattice",
                     current,
                 )
                 self.assertIn(
-                    "Field Note 132:\nunchanged / Verification pending",
+                    "V8-derived temporal evidence invalidation:\n"
+                    "unchanged / integrated",
+                    current,
+                )
+                self.assertIn(
+                    "V10 Protective Rescale:\n"
+                    "HOLD — Carrier observability missing",
+                    current,
+                )
+                self.assertIn(
+                    "13-108:\nNONCANONICAL",
+                    current,
+                )
+                self.assertIn(
+                    "Field Note 132:\nVerification pending",
                     current,
                 )
                 self.assertIn(


### PR DESCRIPTION
## What changed

- Evaluate all established `NOT_SATISFIED` Supervisor Human Seat conditions before commitment.
- Select the first canonical BLOCK condition whenever any simultaneous failed condition maps to BLOCK.
- Preserve every failed-condition identity, emit one deterministic Human Seat action, and dispatch no automatic continuation.
- Preserve existing first-match HOLD/CAP behavior when no BLOCK exists.
- Synchronize the bounded canonical state without changing the Compound Evidence Meter, V10 Protective Rescale, or Field Note 132.

## Why

An earlier HOLD or CAP could previously return before a later simultaneous BLOCK was evaluated, diluting an existing safety failure. This focused change closes only that ordering defect; it does not introduce a general Gate severity lattice.

## Validation

- Exact capability commit: `a1e66127ddd4db8219805e113a71700c88ef93b3`
- Exact branch head: `716043c86f469168f44e99c035202e91575724d2`
- Full suite: 1,469 tests passed, 15 skipped
- Supervisor/continuation/compound-loop regressions: 53 passed
- Canonical/parser tests: 40 passed
- Exhaustive BLOCK/no-BLOCK/UNKNOWN matrices passed
- Restart/replay remained hash-identical and dispatch-free
- `git diff --check` passed

## Existing timing sensitivity

The unchanged strict `<0.2s` lock-contention test remains load-sensitive. Paired target/parent repetitions each passed 24/25 and failed once at comparable values. Its threshold and implementation are unchanged and are not part of this remediation.