### PR TITLE
Integrate V11 selective reconnect edge

### DIFF
--- a/decision_os/companion/field_notes_reconnect.py
+++ b/decision_os/companion/field_notes_reconnect.py
@@ -217,6 +217,13 @@ class FieldNoteExactRead:
     relative_path: str
     field_note_id: str
     source_run_id: str
+    task_family: str
+    scope_sha256: str
+    entry_device: int
+    entry_inode: int
+    entry_size: int
+    entry_mtime_ns: int
+    entry_ctime_ns: int
     metadata_sha256: str
     metadata_byte_count: int
     note_sha256: str
@@ -238,6 +245,7 @@ class _FileIdentity:
     inode: int
     size: int
     mtime_ns: int
+    ctime_ns: int
 
 
 @dataclass(frozen=True)
@@ -276,6 +284,7 @@ def _identity(value: os.stat_result) -> _FileIdentity:
         inode=value.st_ino,
         size=value.st_size,
         mtime_ns=value.st_mtime_ns,
+        ctime_ns=value.st_ctime_ns,
     )
 
 
@@ -1029,6 +1038,15 @@ def read_exact_field_note(
             relative_path=relative_path,
             field_note_id=candidate.field_note_id,
             source_run_id=metadata["source_run_id"],
+            task_family=scope["task_family"],
+            scope_sha256=hashlib.sha256(
+                canonical_json(scope).encode("utf-8")
+            ).hexdigest(),
+            entry_device=expected.device,
+            entry_inode=expected.inode,
+            entry_size=expected.size,
+            entry_mtime_ns=expected.mtime_ns,
+            entry_ctime_ns=expected.ctime_ns,
             metadata_sha256=candidate.metadata_sha256,
             metadata_byte_count=consumed,
             note_sha256=hashlib.sha256(note).hexdigest(),

--- a/decision_os/companion/field_notes_selective_reconnect.py
+++ b/decision_os/companion/field_notes_selective_reconnect.py
@@ -1204,11 +1204,17 @@ def _parse_edges(data: bytes) -> tuple[SelectiveReconnectEdge, ...]:
                 object_pairs_hook=_strict_pairs,
                 parse_constant=_reject_constant,
             )
-        except (UnicodeDecodeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            if not isinstance(value, dict) or canonical_json(value) != text:
+                raise ValueError("Selective reconnect edge JSON is noncanonical.")
+            result.append(_edge_from_dict(value))
+        except (
+            UnicodeDecodeError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+            RecursionError,
+        ) as exc:
             raise ValueError("Selective reconnect edge JSON is invalid.") from exc
-        if not isinstance(value, dict) or canonical_json(value) != text:
-            raise ValueError("Selective reconnect edge JSON is noncanonical.")
-        result.append(_edge_from_dict(value))
     return tuple(result)
 
 

--- a/decision_os/companion/field_notes_selective_reconnect.py
+++ b/decision_os/companion/field_notes_selective_reconnect.py
@@ -1,0 +1,1554 @@
+"""One persisted, exact, addressability-only Field Note reconnect edge.
+
+This module deliberately does not integrate with Field Note selection,
+injection, serving, promotion, authority, or Worker dispatch.  It reads one
+fixed edge record, verifies one exact Note and byte-range binding, performs a
+separate current-applicability comparison, and returns the bound bytes or a
+fail-closed HOLD result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import secrets
+import stat
+from typing import Any, Literal, Mapping
+
+from decision_os.acceleration.model import (
+    RepositoryIdentityError,
+    git_output,
+    git_root,
+    repository_id,
+)
+from decision_os.companion.field_notes_model import canonical_json
+from decision_os.companion.field_notes_reconnect import (
+    FieldNoteExactRead,
+    FieldNoteExactReadError,
+    read_exact_field_note,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteServingPolicyBoundary,
+    FieldNoteStructureBinding,
+)
+
+
+SELECTIVE_RECONNECT_SCHEMA = "decision-os.selective-reconnect-edge.v1.01"
+SELECTIVE_RECONNECT_RECEIPT_SCHEMA = (
+    "decision-os.selective-reconnect-receipt.v1.01"
+)
+SELECTIVE_RECONNECT_SOURCE_EVIDENCE_SCHEMA = (
+    "decision-os.selective-reconnect-source-evidence.v1.01"
+)
+SELECTIVE_RECONNECT_EDGE_PATH = (
+    ".decision-os/selective-reconnect/edge-v1.jsonl"
+)
+MAX_EDGE_FILE_BYTES = 128 * 1024
+MAX_SOURCE_EVIDENCE_BYTES = 8 * 1024 * 1024
+
+V13Gate = Literal["GO", "HOLD", "CAP", "BLOCK"]
+SelectiveReconnectState = Literal["RECALLED", "DELAY_HOLD"]
+SelectiveReconnectFailure = Literal[
+    "ZERO_TARGETS",
+    "MULTIPLE_TARGETS",
+    "CORRUPTED_EDGE",
+    "GOAL_IDENTITY_MISMATCH",
+    "GAP_IDENTITY_MISMATCH",
+    "CURRENT_GATE_MISMATCH",
+    "PROTECTED_OBJECT_MISMATCH",
+    "AUTHORITY_BOUNDARY_MISMATCH",
+    "AS_OF_MISMATCH",
+    "TARGET_IDENTITY_MISMATCH",
+    "STALE_TARGET",
+    "SOURCE_IDENTITY_MISMATCH",
+    "SOURCE_EVIDENCE_FAILURE",
+    "SCOPE_MISMATCH",
+    "STALE_EVIDENCE",
+    "CURRENT_REPOSITORY_MISMATCH",
+    "UNSUPPORTED_APPLICABILITY_ROUTE",
+    "UNSTABLE_RECOVERY_WINDOW",
+]
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_RFC3339_RE = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+    r"[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?"
+    r"(?:Z|[+-][0-9]{2}:[0-9]{2})$"
+)
+_CURRENT_KEYS = frozenset(
+    {
+        "as_of",
+        "authority_boundary",
+        "binding_sha256",
+        "current_gate",
+        "goal",
+        "protected_object",
+        "repository_id",
+        "remaining_gap",
+        "as_of_commit",
+    }
+)
+_IDENTITY_KEYS = frozenset({"identity", "sha256"})
+_SOURCE_KEYS = frozenset(
+    {
+        "as_of",
+        "evidence_path",
+        "evidence_sha256",
+        "repository_id",
+        "source_blob",
+        "source_commit",
+        "source_path",
+        "source_sha256",
+    }
+)
+_NOTE_KEYS = frozenset(
+    {"field_note_id", "note_path", "note_sha256", "origin_run_id"}
+)
+_STRUCTURE_KEYS = frozenset(
+    {
+        "binding_sha256",
+        "end_byte",
+        "note",
+        "note_size",
+        "start_byte",
+        "structure_id",
+        "structure_sha256",
+    }
+)
+_TARGET_KEYS = frozenset(
+    {
+        "binding_sha256",
+        "recheck_conditions",
+        "reentry_path",
+        "scope",
+        "source",
+        "stop_conditions",
+        "structure",
+        "unresolved_delta",
+    }
+)
+_SERVING_POLICY_KEYS = frozenset(
+    {
+        "authority_precedence",
+        "automatic_derivation_supported",
+        "automatic_injection",
+        "complete_state_machine_implemented",
+        "delay_reason",
+        "derivation",
+        "forward_only_extension",
+        "note",
+    }
+)
+_APPLICABILITY_KEYS = frozenset(
+    {
+        "binding_sha256",
+        "current",
+        "evidence_stale",
+        "scope",
+        "serving_policy",
+        "source",
+        "target_binding_sha256",
+        "target_current_gate",
+        "target_status_as_of",
+    }
+)
+_EDGE_KEYS = frozenset(
+    {"applicability", "current", "edge_sha256", "schema", "target"}
+)
+
+
+class _DuplicateKey(ValueError):
+    pass
+
+
+class _ExactFileError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class _ExactRepositoryFileRead:
+    data: bytes
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+
+
+def _strict_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKey("Duplicate JSON key.")
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> None:
+    raise ValueError("Non-finite JSON constants are unsupported.")
+
+
+def _bounded_text(value: Any, label: str, *, maximum: int = 2048) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be text.")
+    normalized = value.strip()
+    if (
+        not normalized
+        or normalized != value
+        or len(normalized) > maximum
+        or "\x00" in normalized
+        or "\r" in normalized
+    ):
+        raise ValueError(f"{label} is outside its bounded schema.")
+    try:
+        normalized.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{label} is not valid UTF-8 text.") from exc
+    return normalized
+
+
+def _sha256(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest.")
+    return value
+
+
+def _as_of(value: Any) -> str:
+    normalized = _bounded_text(value, "As-of", maximum=64)
+    if _RFC3339_RE.fullmatch(normalized) is None:
+        raise ValueError("As-of must be strict RFC 3339.")
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("As-of must be RFC 3339.") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("As-of must be timezone-aware.")
+    return normalized
+
+
+def _relative_path(value: Any, label: str, *, maximum: int = 1024) -> str:
+    normalized = _bounded_text(value, label, maximum=maximum)
+    path = PurePosixPath(normalized)
+    if (
+        path.is_absolute()
+        or normalized.startswith("./")
+        or normalized.endswith("/")
+        or "\\" in normalized
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or path.as_posix() != normalized
+    ):
+        raise ValueError(f"{label} must be a canonical relative path.")
+    return normalized
+
+
+def _conditions(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, (tuple, list)) or not 1 <= len(value) <= 8:
+        raise ValueError(f"{label} must contain one to eight items.")
+    result = tuple(
+        _bounded_text(item, label, maximum=1024) for item in value
+    )
+    if len(set(result)) != len(result):
+        raise ValueError(f"{label} contains duplicates.")
+    return result
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def selective_reconnect_source_evidence_bytes(
+    *,
+    repository_id: str,
+    source_commit: str,
+    source_path: str,
+    source_blob: str,
+    source_sha256: str,
+    evidence_path: str,
+    as_of: str,
+) -> bytes:
+    """Build the narrow canonical evidence record bound to one source tuple."""
+
+    checked_repository = _bounded_text(
+        repository_id,
+        "Source repository",
+        maximum=512,
+    )
+    if not isinstance(source_commit, str) or _COMMIT_RE.fullmatch(source_commit) is None:
+        raise ValueError("Source commit must be a lowercase 40-character ID.")
+    if not isinstance(source_blob, str) or _COMMIT_RE.fullmatch(source_blob) is None:
+        raise ValueError("Source blob must be a lowercase 40-character ID.")
+    payload = {
+        "schema": SELECTIVE_RECONNECT_SOURCE_EVIDENCE_SCHEMA,
+        "repository_id": checked_repository,
+        "source_commit": source_commit,
+        "source_path": _relative_path(source_path, "Source artifact path"),
+        "source_blob": source_blob,
+        "source_sha256": _sha256(source_sha256, "Source artifact digest"),
+        "evidence_path": _relative_path(evidence_path, "Source-evidence path"),
+        "as_of": _as_of(as_of),
+    }
+    return canonical_json(payload).encode("utf-8") + b"\n"
+
+
+def _mapping(value: Any, keys: frozenset[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ValueError(f"{label} has an invalid shape.")
+    return value
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectIdentity:
+    """An exact named current or applicability identity."""
+
+    identity: str
+    sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "identity",
+            _bounded_text(self.identity, "Identity", maximum=512),
+        )
+        object.__setattr__(self, "sha256", _sha256(self.sha256, "Identity digest"))
+
+    def as_dict(self) -> dict[str, str]:
+        return {"identity": self.identity, "sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectCurrentBinding:
+    """The one exact current Goal/gap condition that may address the edge."""
+
+    goal: SelectiveReconnectIdentity
+    remaining_gap: SelectiveReconnectIdentity
+    current_gate: V13Gate
+    protected_object: SelectiveReconnectIdentity
+    authority_boundary: SelectiveReconnectIdentity
+    repository_id: str
+    as_of_commit: str
+    as_of: str
+
+    def __post_init__(self) -> None:
+        identities = (
+            self.goal,
+            self.remaining_gap,
+            self.protected_object,
+            self.authority_boundary,
+        )
+        if any(not isinstance(item, SelectiveReconnectIdentity) for item in identities):
+            raise ValueError("Current-side edge identities are invalid.")
+        if self.current_gate not in {"GO", "HOLD", "CAP", "BLOCK"}:
+            raise ValueError("Current Gate is invalid.")
+        object.__setattr__(
+            self,
+            "repository_id",
+            _bounded_text(self.repository_id, "Current repository", maximum=512),
+        )
+        if not isinstance(self.as_of_commit, str) or _COMMIT_RE.fullmatch(
+            self.as_of_commit
+        ) is None:
+            raise ValueError("Current As-of commit must be a lowercase commit ID.")
+        object.__setattr__(self, "as_of", _as_of(self.as_of))
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "goal": self.goal.as_dict(),
+            "remaining_gap": self.remaining_gap.as_dict(),
+            "current_gate": self.current_gate,
+            "protected_object": self.protected_object.as_dict(),
+            "authority_boundary": self.authority_boundary.as_dict(),
+            "repository_id": self.repository_id,
+            "as_of_commit": self.as_of_commit,
+            "as_of": self.as_of,
+        }
+
+    @property
+    def binding_sha256(self) -> str:
+        return _digest(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "binding_sha256": self.binding_sha256}
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectSourceAnchor:
+    """Exact source identity plus one locally verifiable evidence artifact."""
+
+    repository_id: str
+    source_commit: str
+    source_path: str
+    source_blob: str
+    source_sha256: str
+    evidence_path: str
+    evidence_sha256: str
+    as_of: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "repository_id",
+            _bounded_text(self.repository_id, "Source repository", maximum=512),
+        )
+        if not isinstance(self.source_commit, str) or _COMMIT_RE.fullmatch(
+            self.source_commit
+        ) is None:
+            raise ValueError("Source commit must be a lowercase 40-character ID.")
+        object.__setattr__(
+            self,
+            "source_path",
+            _relative_path(self.source_path, "Source artifact path"),
+        )
+        if not isinstance(self.source_blob, str) or _COMMIT_RE.fullmatch(
+            self.source_blob
+        ) is None:
+            raise ValueError("Source blob must be a lowercase 40-character ID.")
+        object.__setattr__(
+            self,
+            "source_sha256",
+            _sha256(self.source_sha256, "Source artifact digest"),
+        )
+        object.__setattr__(
+            self,
+            "evidence_path",
+            _relative_path(self.evidence_path, "Source-evidence path"),
+        )
+        object.__setattr__(
+            self,
+            "evidence_sha256",
+            _sha256(self.evidence_sha256, "Source-evidence digest"),
+        )
+        object.__setattr__(self, "as_of", _as_of(self.as_of))
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "repository_id": self.repository_id,
+            "source_commit": self.source_commit,
+            "source_path": self.source_path,
+            "source_blob": self.source_blob,
+            "source_sha256": self.source_sha256,
+            "evidence_path": self.evidence_path,
+            "evidence_sha256": self.evidence_sha256,
+            "as_of": self.as_of,
+        }
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectTargetBinding:
+    """One exact structure and the V11-critical facts needed for re-entry."""
+
+    structure: FieldNoteStructureBinding
+    source: SelectiveReconnectSourceAnchor
+    scope: SelectiveReconnectIdentity
+    stop_conditions: tuple[str, ...]
+    recheck_conditions: tuple[str, ...]
+    unresolved_delta: str
+    reentry_path: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.structure, FieldNoteStructureBinding):
+            raise ValueError("Reconnect target lacks an exact structure binding.")
+        if not isinstance(self.source, SelectiveReconnectSourceAnchor):
+            raise ValueError("Reconnect target lacks an exact source anchor.")
+        if not isinstance(self.scope, SelectiveReconnectIdentity):
+            raise ValueError("Reconnect target scope is invalid.")
+        object.__setattr__(
+            self,
+            "stop_conditions",
+            _conditions(self.stop_conditions, "Stop conditions"),
+        )
+        object.__setattr__(
+            self,
+            "recheck_conditions",
+            _conditions(self.recheck_conditions, "Recheck conditions"),
+        )
+        object.__setattr__(
+            self,
+            "unresolved_delta",
+            _bounded_text(self.unresolved_delta, "Unresolved delta"),
+        )
+        object.__setattr__(
+            self,
+            "reentry_path",
+            _relative_path(self.reentry_path, "Re-entry path"),
+        )
+        if self.reentry_path != self.structure.note.note_path:
+            raise ValueError("Re-entry path does not identify the bound Field Note.")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "structure": self.structure.as_dict(),
+            "source": self.source.as_dict(),
+            "scope": self.scope.as_dict(),
+            "stop_conditions": list(self.stop_conditions),
+            "recheck_conditions": list(self.recheck_conditions),
+            "unresolved_delta": self.unresolved_delta,
+            "reentry_path": self.reentry_path,
+        }
+
+    @property
+    def binding_sha256(self) -> str:
+        return _digest(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "binding_sha256": self.binding_sha256}
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectEdge:
+    """The only record admitted by Selective Reconnect Edge 1.01."""
+
+    current: SelectiveReconnectCurrentBinding
+    target: SelectiveReconnectTargetBinding
+    applicability: SelectiveReconnectApplicability
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.current, SelectiveReconnectCurrentBinding)
+            or not isinstance(self.target, SelectiveReconnectTargetBinding)
+            or not isinstance(
+                self.applicability,
+                SelectiveReconnectApplicability,
+            )
+        ):
+            raise ValueError("Selective reconnect edge is invalid.")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema": SELECTIVE_RECONNECT_SCHEMA,
+            "current": self.current.as_dict(),
+            "target": self.target.as_dict(),
+            "applicability": self.applicability.as_dict(),
+        }
+
+    @property
+    def edge_sha256(self) -> str:
+        return _digest(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "edge_sha256": self.edge_sha256}
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectApplicability:
+    """Persisted current-use evidence checked only after target recovery."""
+
+    current: SelectiveReconnectCurrentBinding
+    target_binding_sha256: str
+    source: SelectiveReconnectSourceAnchor
+    scope: SelectiveReconnectIdentity
+    target_current_gate: V13Gate
+    target_status_as_of: str
+    evidence_stale: bool
+    serving_policy: FieldNoteServingPolicyBoundary
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.current, SelectiveReconnectCurrentBinding):
+            raise ValueError("Applicability current binding is invalid.")
+        object.__setattr__(
+            self,
+            "target_binding_sha256",
+            _sha256(self.target_binding_sha256, "Applicability target digest"),
+        )
+        if not isinstance(self.source, SelectiveReconnectSourceAnchor):
+            raise ValueError("Applicability source is invalid.")
+        if not isinstance(self.scope, SelectiveReconnectIdentity):
+            raise ValueError("Applicability scope is invalid.")
+        if self.target_current_gate not in {"GO", "HOLD", "CAP", "BLOCK"}:
+            raise ValueError("Target current-use Gate is invalid.")
+        object.__setattr__(self, "target_status_as_of", _as_of(self.target_status_as_of))
+        if type(self.evidence_stale) is not bool:
+            raise ValueError("Applicability staleness must be Boolean.")
+        if not isinstance(self.serving_policy, FieldNoteServingPolicyBoundary):
+            raise ValueError("Applicability Serving Policy is invalid.")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "current": self.current.as_dict(),
+            "target_binding_sha256": self.target_binding_sha256,
+            "source": self.source.as_dict(),
+            "scope": self.scope.as_dict(),
+            "target_current_gate": self.target_current_gate,
+            "target_status_as_of": self.target_status_as_of,
+            "evidence_stale": self.evidence_stale,
+            "serving_policy": self.serving_policy.as_dict(),
+        }
+
+    @property
+    def binding_sha256(self) -> str:
+        return _digest(self._payload())
+
+    def as_dict(self) -> dict[str, Any]:
+        return {**self._payload(), "binding_sha256": self.binding_sha256}
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectReceipt:
+    """Replayable evidence for addressability without activation semantics."""
+
+    state: SelectiveReconnectState
+    failure_reason: SelectiveReconnectFailure | None
+    current_binding_sha256: str
+    applicability_gate: V13Gate
+    edge_records_seen: int = 0
+    edge_sha256: str | None = None
+    target_binding_sha256: str | None = None
+    structure_binding_sha256: str | None = None
+    target_note_path: str | None = None
+    target_field_note_id: str | None = None
+    target_note_sha256: str | None = None
+    edge_read_attempts: int = 0
+    source_evidence_read_attempts: int = 0
+    target_note_read_attempts: int = 0
+    target_note_bytes_validated: int = 0
+    structure_bytes_reopened: int = 0
+    field_note_directory_entries_seen: int = 0
+    unrelated_field_note_files_opened: int = 0
+    broad_scan_performed: Literal[False] = False
+    serving_policy_derivation: Literal["DELAY"] = "DELAY"
+    automatic_injection: None = None
+    serving_created: Literal[False] = False
+    selection_created: Literal[False] = False
+    promotion_created: Literal[False] = False
+    canon_created: Literal[False] = False
+    authority_granted: Literal[False] = False
+    worker_runs_dispatched: Literal[0] = 0
+    promotion_policy_status: Literal["UNSET"] = "UNSET"
+    authority_precedence: tuple[str, str] = (
+        "TOPMOST_CANONICAL",
+        "ADVISORY_FIELD_NOTE",
+    )
+
+    def __post_init__(self) -> None:
+        if self.state not in {"RECALLED", "DELAY_HOLD"}:
+            raise ValueError("Selective reconnect state is invalid.")
+        if self.applicability_gate not in {"GO", "HOLD", "CAP", "BLOCK"}:
+            raise ValueError("Applicability Gate is invalid.")
+        _sha256(self.current_binding_sha256, "Current binding digest")
+        counters = (
+            self.edge_records_seen,
+            self.edge_read_attempts,
+            self.source_evidence_read_attempts,
+            self.target_note_read_attempts,
+            self.target_note_bytes_validated,
+            self.structure_bytes_reopened,
+            self.field_note_directory_entries_seen,
+            self.unrelated_field_note_files_opened,
+        )
+        if any(type(item) is not int or item < 0 for item in counters):
+            raise ValueError("Selective reconnect counters are invalid.")
+        for value, label in (
+            (self.edge_sha256, "Edge digest"),
+            (self.target_binding_sha256, "Target binding digest"),
+            (self.structure_binding_sha256, "Structure binding digest"),
+            (self.target_note_sha256, "Target Note digest"),
+        ):
+            if value is not None:
+                _sha256(value, label)
+        fixed = (
+            self.broad_scan_performed is False
+            and self.field_note_directory_entries_seen == 0
+            and self.unrelated_field_note_files_opened == 0
+            and self.serving_policy_derivation == "DELAY"
+            and self.automatic_injection is None
+            and self.serving_created is False
+            and self.selection_created is False
+            and self.promotion_created is False
+            and self.canon_created is False
+            and self.authority_granted is False
+            and self.worker_runs_dispatched == 0
+            and self.promotion_policy_status == "UNSET"
+            and self.authority_precedence
+            == ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE")
+        )
+        if not fixed:
+            raise ValueError("Selective reconnect crossed an activation boundary.")
+        if self.state == "RECALLED":
+            required = (
+                self.edge_sha256,
+                self.target_binding_sha256,
+                self.structure_binding_sha256,
+                self.target_note_path,
+                self.target_field_note_id,
+                self.target_note_sha256,
+            )
+            if (
+                self.failure_reason is not None
+                or any(item is None for item in required)
+                or self.edge_records_seen != 1
+                or self.edge_read_attempts != 2
+                or self.source_evidence_read_attempts != 2
+                or self.target_note_read_attempts != 2
+                or self.target_note_bytes_validated <= 0
+                or self.structure_bytes_reopened <= 0
+            ):
+                raise ValueError("Recalled receipt lacks exact recovery evidence.")
+        elif self.failure_reason is None or self.applicability_gate != "HOLD":
+            raise ValueError("Failed reconnect must produce DELAY/HOLD.")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": SELECTIVE_RECONNECT_RECEIPT_SCHEMA,
+            "state": self.state,
+            "failure_reason": self.failure_reason,
+            "current_binding_sha256": self.current_binding_sha256,
+            "applicability_gate": self.applicability_gate,
+            "edge_records_seen": self.edge_records_seen,
+            "edge_sha256": self.edge_sha256,
+            "target_binding_sha256": self.target_binding_sha256,
+            "structure_binding_sha256": self.structure_binding_sha256,
+            "target_note_path": self.target_note_path,
+            "target_field_note_id": self.target_field_note_id,
+            "target_note_sha256": self.target_note_sha256,
+            "edge_read_attempts": self.edge_read_attempts,
+            "source_evidence_read_attempts": self.source_evidence_read_attempts,
+            "target_note_read_attempts": self.target_note_read_attempts,
+            "target_note_bytes_validated": self.target_note_bytes_validated,
+            "structure_bytes_reopened": self.structure_bytes_reopened,
+            "field_note_directory_entries_seen": self.field_note_directory_entries_seen,
+            "unrelated_field_note_files_opened": self.unrelated_field_note_files_opened,
+            "broad_scan_performed": self.broad_scan_performed,
+            "serving_policy_derivation": self.serving_policy_derivation,
+            "automatic_injection": self.automatic_injection,
+            "serving_created": self.serving_created,
+            "selection_created": self.selection_created,
+            "promotion_created": self.promotion_created,
+            "canon_created": self.canon_created,
+            "authority_granted": self.authority_granted,
+            "worker_runs_dispatched": self.worker_runs_dispatched,
+            "promotion_policy_status": self.promotion_policy_status,
+            "authority_precedence": list(self.authority_precedence),
+        }
+
+
+@dataclass(frozen=True)
+class SelectiveReconnectResult:
+    receipt: SelectiveReconnectReceipt
+    target: SelectiveReconnectTargetBinding | None = None
+    structure_bytes: bytes | None = None
+    envelope: str | None = None
+
+    def __post_init__(self) -> None:
+        recalled = self.receipt.state == "RECALLED"
+        payload_present = (
+            self.target is not None,
+            self.structure_bytes is not None,
+            self.envelope is not None,
+        )
+        if (recalled and not all(payload_present)) or (
+            not recalled and any(payload_present)
+        ):
+            raise ValueError("Selective reconnect payload disagrees with its receipt.")
+        if self.structure_bytes is not None and not self.structure_bytes:
+            raise ValueError("Selective reconnect structure bytes are empty.")
+
+
+def _identity_from_dict(value: Any) -> SelectiveReconnectIdentity:
+    data = _mapping(value, _IDENTITY_KEYS, "Selective reconnect identity")
+    return SelectiveReconnectIdentity(
+        identity=data["identity"],
+        sha256=data["sha256"],
+    )
+
+
+def _current_from_dict(value: Any) -> SelectiveReconnectCurrentBinding:
+    data = _mapping(value, _CURRENT_KEYS, "Current-side binding")
+    current = SelectiveReconnectCurrentBinding(
+        goal=_identity_from_dict(data["goal"]),
+        remaining_gap=_identity_from_dict(data["remaining_gap"]),
+        current_gate=data["current_gate"],
+        protected_object=_identity_from_dict(data["protected_object"]),
+        authority_boundary=_identity_from_dict(data["authority_boundary"]),
+        repository_id=data["repository_id"],
+        as_of_commit=data["as_of_commit"],
+        as_of=data["as_of"],
+    )
+    if current.binding_sha256 != _sha256(
+        data["binding_sha256"], "Stored current binding digest"
+    ):
+        raise ValueError("Current-side binding digest mismatch.")
+    return current
+
+
+def _source_from_dict(value: Any) -> SelectiveReconnectSourceAnchor:
+    data = _mapping(value, _SOURCE_KEYS, "Source anchor")
+    return SelectiveReconnectSourceAnchor(
+        repository_id=data["repository_id"],
+        source_commit=data["source_commit"],
+        source_path=data["source_path"],
+        source_blob=data["source_blob"],
+        source_sha256=data["source_sha256"],
+        evidence_path=data["evidence_path"],
+        evidence_sha256=data["evidence_sha256"],
+        as_of=data["as_of"],
+    )
+
+
+def _note_from_dict(value: Any) -> FieldNoteIdentity:
+    data = _mapping(value, _NOTE_KEYS, "Field Note identity")
+    return FieldNoteIdentity(
+        note_path=data["note_path"],
+        field_note_id=data["field_note_id"],
+        note_sha256=data["note_sha256"],
+        origin_run_id=data["origin_run_id"],
+    )
+
+
+def _structure_from_dict(value: Any) -> FieldNoteStructureBinding:
+    data = _mapping(value, _STRUCTURE_KEYS, "Field Note structure binding")
+    binding = FieldNoteStructureBinding(
+        note=_note_from_dict(data["note"]),
+        structure_id=data["structure_id"],
+        note_size=data["note_size"],
+        start_byte=data["start_byte"],
+        end_byte=data["end_byte"],
+        structure_sha256=data["structure_sha256"],
+    )
+    if binding.binding_sha256 != _sha256(
+        data["binding_sha256"], "Stored structure binding digest"
+    ):
+        raise ValueError("Structure binding digest mismatch.")
+    return binding
+
+
+def _target_from_dict(value: Any) -> SelectiveReconnectTargetBinding:
+    data = _mapping(value, _TARGET_KEYS, "Selective reconnect target")
+    target = SelectiveReconnectTargetBinding(
+        structure=_structure_from_dict(data["structure"]),
+        source=_source_from_dict(data["source"]),
+        scope=_identity_from_dict(data["scope"]),
+        stop_conditions=data["stop_conditions"],
+        recheck_conditions=data["recheck_conditions"],
+        unresolved_delta=data["unresolved_delta"],
+        reentry_path=data["reentry_path"],
+    )
+    if target.binding_sha256 != _sha256(
+        data["binding_sha256"], "Stored target binding digest"
+    ):
+        raise ValueError("Target binding digest mismatch.")
+    return target
+
+
+def _serving_policy_from_dict(value: Any) -> FieldNoteServingPolicyBoundary:
+    data = _mapping(value, _SERVING_POLICY_KEYS, "Serving Policy boundary")
+    precedence = data["authority_precedence"]
+    if not isinstance(precedence, list):
+        raise ValueError("Serving Policy authority precedence is invalid.")
+    return FieldNoteServingPolicyBoundary(
+        note=_note_from_dict(data["note"]),
+        derivation=data["derivation"],
+        automatic_derivation_supported=data["automatic_derivation_supported"],
+        automatic_injection=data["automatic_injection"],
+        complete_state_machine_implemented=data["complete_state_machine_implemented"],
+        forward_only_extension=data["forward_only_extension"],
+        authority_precedence=tuple(precedence),
+        delay_reason=data["delay_reason"],
+    )
+
+
+def _applicability_from_dict(value: Any) -> SelectiveReconnectApplicability:
+    data = _mapping(value, _APPLICABILITY_KEYS, "Current applicability evidence")
+    applicability = SelectiveReconnectApplicability(
+        current=_current_from_dict(data["current"]),
+        target_binding_sha256=data["target_binding_sha256"],
+        source=_source_from_dict(data["source"]),
+        scope=_identity_from_dict(data["scope"]),
+        target_current_gate=data["target_current_gate"],
+        target_status_as_of=data["target_status_as_of"],
+        evidence_stale=data["evidence_stale"],
+        serving_policy=_serving_policy_from_dict(data["serving_policy"]),
+    )
+    if applicability.binding_sha256 != _sha256(
+        data["binding_sha256"],
+        "Stored applicability binding digest",
+    ):
+        raise ValueError("Current applicability binding digest mismatch.")
+    return applicability
+
+
+def _edge_from_dict(value: Any) -> SelectiveReconnectEdge:
+    data = _mapping(value, _EDGE_KEYS, "Selective reconnect edge")
+    if data["schema"] != SELECTIVE_RECONNECT_SCHEMA:
+        raise ValueError("Selective reconnect schema is unsupported.")
+    edge = SelectiveReconnectEdge(
+        current=_current_from_dict(data["current"]),
+        target=_target_from_dict(data["target"]),
+        applicability=_applicability_from_dict(data["applicability"]),
+    )
+    if edge.edge_sha256 != _sha256(data["edge_sha256"], "Stored edge digest"):
+        raise ValueError("Selective reconnect edge digest mismatch.")
+    return edge
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _directory_flags() -> int:
+    if not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+        raise _ExactFileError("Safe directory flags unavailable.")
+    return os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY
+
+
+def _file_flags() -> int:
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise _ExactFileError("Safe file flags unavailable.")
+    return os.O_RDONLY | os.O_NOFOLLOW
+
+
+def _read_exact_repository_file(
+    repository: Path,
+    relative_path: str,
+    *,
+    maximum_bytes: int,
+    missing_ok: bool,
+) -> _ExactRepositoryFileRead | None:
+    """Read one exact relative file through no-follow descriptors; never scan."""
+
+    canonical = _relative_path(relative_path, "Exact repository file path")
+    segments = canonical.split("/")
+    descriptors: list[int] = []
+    directory_chain: list[
+        tuple[str | Path, int | None, int, tuple[int, int, int, int, int]]
+    ] = []
+    try:
+        try:
+            root_before = os.stat(repository, follow_symlinks=False)
+        except (OSError, TypeError, ValueError) as exc:
+            raise _ExactFileError("Repository root is unsafe.") from exc
+        if not stat.S_ISDIR(root_before.st_mode):
+            raise _ExactFileError("Repository root is unsafe.")
+        root_fd = os.open(repository, _directory_flags())
+        descriptors.append(root_fd)
+        root_identity = _file_identity(root_before)
+        if _file_identity(os.fstat(root_fd)) != root_identity:
+            raise _ExactFileError("Repository root changed during read.")
+        directory_chain.append((repository, None, root_fd, root_identity))
+        parent_fd = root_fd
+        for segment in segments[:-1]:
+            try:
+                before = os.stat(segment, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                if missing_ok:
+                    return None
+                raise _ExactFileError("Exact parent directory is missing.") from None
+            except OSError as exc:
+                raise _ExactFileError("Exact parent directory is unsafe.") from exc
+            if not stat.S_ISDIR(before.st_mode):
+                raise _ExactFileError("Exact parent directory is unsafe.")
+            child_fd = os.open(segment, _directory_flags(), dir_fd=parent_fd)
+            descriptors.append(child_fd)
+            identity = _file_identity(before)
+            if _file_identity(os.fstat(child_fd)) != identity:
+                raise _ExactFileError("Exact parent directory changed.")
+            directory_chain.append((segment, parent_fd, child_fd, identity))
+            parent_fd = child_fd
+        filename = segments[-1]
+        try:
+            before_file = os.stat(filename, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            if missing_ok:
+                return None
+            raise _ExactFileError("Exact file is missing.") from None
+        except OSError as exc:
+            raise _ExactFileError("Exact file is unsafe.") from exc
+        if not stat.S_ISREG(before_file.st_mode):
+            raise _ExactFileError("Exact file is unsafe.")
+        file_identity = _file_identity(before_file)
+        file_fd = os.open(filename, _file_flags(), dir_fd=parent_fd)
+        descriptors.append(file_fd)
+        if _file_identity(os.fstat(file_fd)) != file_identity:
+            raise _ExactFileError("Exact file changed during read.")
+        data = bytearray()
+        while True:
+            chunk = os.read(file_fd, min(65536, maximum_bytes + 1 - len(data)))
+            if not chunk:
+                break
+            data.extend(chunk)
+            if len(data) > maximum_bytes:
+                raise _ExactFileError("Exact file exceeds its bounded size.")
+        after_file = os.fstat(file_fd)
+        entry_after = os.stat(filename, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            _file_identity(after_file) != file_identity
+            or _file_identity(entry_after) != file_identity
+            or len(data) != file_identity[2]
+        ):
+            raise _ExactFileError("Exact file changed during read.")
+        for name, parent, descriptor, expected in reversed(directory_chain):
+            entry = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(entry.st_mode)
+                or _file_identity(entry) != expected
+                or _file_identity(os.fstat(descriptor)) != expected
+            ):
+                raise _ExactFileError("Exact directory changed during read.")
+        return _ExactRepositoryFileRead(
+            data=bytes(data),
+            device=file_identity[0],
+            inode=file_identity[1],
+            size=file_identity[2],
+            mtime_ns=file_identity[3],
+            ctime_ns=file_identity[4],
+        )
+    except _ExactFileError:
+        raise
+    except (OSError, TypeError, ValueError) as exc:
+        raise _ExactFileError("Exact file read failed safely.") from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _ensure_edge_directory(repository: Path) -> int:
+    root_before = os.stat(repository, follow_symlinks=False)
+    if not stat.S_ISDIR(root_before.st_mode):
+        raise ValueError("Repository root is unsafe.")
+    root_fd = os.open(repository, _directory_flags())
+    current_fd = root_fd
+    try:
+        for segment in (".decision-os", "selective-reconnect"):
+            try:
+                os.mkdir(segment, mode=0o700, dir_fd=current_fd)
+            except FileExistsError:
+                pass
+            before = os.stat(segment, dir_fd=current_fd, follow_symlinks=False)
+            if not stat.S_ISDIR(before.st_mode):
+                raise ValueError("Selective reconnect directory is unsafe.")
+            opened = os.open(segment, _directory_flags(), dir_fd=current_fd)
+            if _file_identity(os.fstat(opened)) != _file_identity(before):
+                os.close(opened)
+                raise ValueError("Selective reconnect directory changed.")
+            if current_fd != root_fd:
+                os.close(current_fd)
+            current_fd = opened
+        return current_fd
+    except Exception:
+        if current_fd != root_fd:
+            os.close(current_fd)
+        raise
+    finally:
+        os.close(root_fd)
+
+
+def _repository_identity(root: Path) -> tuple[str, str]:
+    try:
+        if git_root(root) != root.resolve(strict=True):
+            raise RepositoryIdentityError(
+                "Selective reconnect requires the exact Git worktree root."
+            )
+        return repository_id(root), git_output(root, "rev-parse", "HEAD")
+    except (OSError, RepositoryIdentityError) as exc:
+        raise _ExactFileError("Current repository identity is unavailable.") from exc
+
+
+def persist_selective_reconnect_edge(
+    repository: Path,
+    edge: SelectiveReconnectEdge,
+) -> Path:
+    """Persist exactly one canonical edge; never replace a different record."""
+
+    if not isinstance(edge, SelectiveReconnectEdge):
+        raise ValueError("Only a typed selective reconnect edge can be persisted.")
+    root = Path(repository)
+    try:
+        observed_repository, observed_commit = _repository_identity(root)
+    except _ExactFileError as exc:
+        raise ValueError("Current repository identity is unavailable.") from exc
+    if (
+        observed_repository != edge.current.repository_id
+        or observed_commit != edge.current.as_of_commit
+    ):
+        raise ValueError("Selective reconnect current repository identity mismatches.")
+    applicability_failure = _applicability_failure(
+        edge.current,
+        edge.target,
+        edge.applicability,
+    )
+    if applicability_failure is not None:
+        raise ValueError(
+            "Selective reconnect edge inputs are internally inconsistent."
+        )
+    try:
+        exact = read_exact_field_note(root, edge.target.reentry_path)
+    except FieldNoteExactReadError as exc:
+        raise ValueError("Selective reconnect target is not exact and current.") from exc
+    if _exact_target_failure(edge.target, exact) is not None:
+        raise ValueError("Selective reconnect target is not exact and current.")
+    expected_evidence = selective_reconnect_source_evidence_bytes(
+        repository_id=edge.target.source.repository_id,
+        source_commit=edge.target.source.source_commit,
+        source_path=edge.target.source.source_path,
+        source_blob=edge.target.source.source_blob,
+        source_sha256=edge.target.source.source_sha256,
+        evidence_path=edge.target.source.evidence_path,
+        as_of=edge.target.source.as_of,
+    )
+    try:
+        evidence = _read_exact_repository_file(
+            root,
+            edge.target.source.evidence_path,
+            maximum_bytes=MAX_SOURCE_EVIDENCE_BYTES,
+            missing_ok=False,
+        )
+    except _ExactFileError as exc:
+        raise ValueError("Selective reconnect source evidence is unavailable.") from exc
+    if (
+        evidence is None
+        or evidence.data != expected_evidence
+        or hashlib.sha256(evidence.data).hexdigest()
+        != edge.target.source.evidence_sha256
+    ):
+        raise ValueError("Selective reconnect source evidence is inconsistent.")
+    data = canonical_json(edge.as_dict()).encode("utf-8") + b"\n"
+    if len(data) > MAX_EDGE_FILE_BYTES:
+        raise ValueError("Selective reconnect edge exceeds its bounded size.")
+    target = root / SELECTIVE_RECONNECT_EDGE_PATH
+    directory_fd = _ensure_edge_directory(root)
+    temporary_name: str | None = None
+    descriptor: int | None = None
+    try:
+        for _attempt in range(16):
+            candidate = f".edge-v1-{secrets.token_hex(16)}.tmp"
+            try:
+                descriptor = os.open(
+                    candidate,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                    0o600,
+                    dir_fd=directory_fd,
+                )
+            except FileExistsError:
+                continue
+            temporary_name = candidate
+            break
+        if descriptor is None or temporary_name is None:
+            raise ValueError("Selective reconnect temporary slot is unavailable.")
+        view = memoryview(data)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise ValueError("Selective reconnect edge write failed.")
+            view = view[written:]
+        os.fsync(descriptor)
+        try:
+            os.link(
+                temporary_name,
+                "edge-v1.jsonl",
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileExistsError:
+            existing = _read_exact_repository_file(
+                root,
+                SELECTIVE_RECONNECT_EDGE_PATH,
+                maximum_bytes=MAX_EDGE_FILE_BYTES,
+                missing_ok=False,
+            )
+            if existing is None or existing.data != data:
+                raise ValueError(
+                    "The one Selective Reconnect Edge slot already differs."
+                )
+        os.fsync(directory_fd)
+        return target
+    except (OSError, _ExactFileError) as exc:
+        raise ValueError("Selective reconnect edge could not be persisted safely.") from exc
+    finally:
+        if temporary_name is not None and descriptor is not None:
+            try:
+                expected = _file_identity(os.fstat(descriptor))
+                observed = os.stat(
+                    temporary_name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                if _file_identity(observed) == expected:
+                    os.unlink(temporary_name, dir_fd=directory_fd)
+                    os.fsync(directory_fd)
+            except (FileNotFoundError, OSError):
+                pass
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(directory_fd)
+
+
+def _parse_edges(data: bytes) -> tuple[SelectiveReconnectEdge, ...]:
+    if not data:
+        return ()
+    if len(data) > MAX_EDGE_FILE_BYTES or not data.endswith(b"\n") or b"\r" in data:
+        raise ValueError("Selective reconnect edge file is not canonical JSONL.")
+    lines = data[:-1].split(b"\n")
+    if not lines or any(not line for line in lines):
+        raise ValueError("Selective reconnect edge file contains an empty record.")
+    result: list[SelectiveReconnectEdge] = []
+    for line in lines:
+        try:
+            text = line.decode("utf-8")
+            value = json.loads(
+                text,
+                object_pairs_hook=_strict_pairs,
+                parse_constant=_reject_constant,
+            )
+        except (UnicodeDecodeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ValueError("Selective reconnect edge JSON is invalid.") from exc
+        if not isinstance(value, dict) or canonical_json(value) != text:
+            raise ValueError("Selective reconnect edge JSON is noncanonical.")
+        result.append(_edge_from_dict(value))
+    return tuple(result)
+
+
+def _current_mismatch(
+    expected: SelectiveReconnectCurrentBinding,
+    observed: SelectiveReconnectCurrentBinding,
+) -> SelectiveReconnectFailure | None:
+    if expected.goal != observed.goal:
+        return "GOAL_IDENTITY_MISMATCH"
+    if expected.remaining_gap != observed.remaining_gap:
+        return "GAP_IDENTITY_MISMATCH"
+    if expected.current_gate != observed.current_gate:
+        return "CURRENT_GATE_MISMATCH"
+    if expected.protected_object != observed.protected_object:
+        return "PROTECTED_OBJECT_MISMATCH"
+    if expected.authority_boundary != observed.authority_boundary:
+        return "AUTHORITY_BOUNDARY_MISMATCH"
+    if expected.repository_id != observed.repository_id:
+        return "CURRENT_REPOSITORY_MISMATCH"
+    if expected.as_of_commit != observed.as_of_commit:
+        return "AS_OF_MISMATCH"
+    if expected.as_of != observed.as_of:
+        return "AS_OF_MISMATCH"
+    return None
+
+
+def _hold(
+    current: SelectiveReconnectCurrentBinding,
+    reason: SelectiveReconnectFailure,
+    *,
+    edge_records_seen: int = 0,
+    edge_read_attempts: int = 0,
+    edge: SelectiveReconnectEdge | None = None,
+    target_note_read_attempts: int = 0,
+    target_note_bytes_validated: int = 0,
+    source_evidence_read_attempts: int = 0,
+) -> SelectiveReconnectResult:
+    target = edge.target if edge is not None else None
+    structure = target.structure if target is not None else None
+    note = structure.note if structure is not None else None
+    return SelectiveReconnectResult(
+        receipt=SelectiveReconnectReceipt(
+            state="DELAY_HOLD",
+            failure_reason=reason,
+            current_binding_sha256=current.binding_sha256,
+            applicability_gate="HOLD",
+            edge_records_seen=edge_records_seen,
+            edge_sha256=edge.edge_sha256 if edge is not None else None,
+            target_binding_sha256=(target.binding_sha256 if target else None),
+            structure_binding_sha256=(
+                structure.binding_sha256 if structure else None
+            ),
+            target_note_path=note.note_path if note else None,
+            target_field_note_id=note.field_note_id if note else None,
+            target_note_sha256=note.note_sha256 if note else None,
+            edge_read_attempts=edge_read_attempts,
+            source_evidence_read_attempts=source_evidence_read_attempts,
+            target_note_read_attempts=target_note_read_attempts,
+            target_note_bytes_validated=target_note_bytes_validated,
+        )
+    )
+
+
+def _applicability_failure(
+    current: SelectiveReconnectCurrentBinding,
+    target: SelectiveReconnectTargetBinding,
+    applicability: SelectiveReconnectApplicability,
+) -> SelectiveReconnectFailure | None:
+    current_failure = _current_mismatch(current, applicability.current)
+    if current_failure is not None:
+        return current_failure
+    if target.source.as_of != current.as_of:
+        return "AS_OF_MISMATCH"
+    if applicability.target_binding_sha256 != target.binding_sha256:
+        return "TARGET_IDENTITY_MISMATCH"
+    if (
+        applicability.source.repository_id != target.source.repository_id
+        or applicability.source.source_commit != target.source.source_commit
+        or applicability.source.source_path != target.source.source_path
+        or applicability.source.source_blob != target.source.source_blob
+        or applicability.source.source_sha256 != target.source.source_sha256
+    ):
+        return "SOURCE_IDENTITY_MISMATCH"
+    if applicability.source.as_of != target.source.as_of:
+        return "AS_OF_MISMATCH"
+    if (
+        applicability.source.evidence_path != target.source.evidence_path
+        or applicability.source.evidence_sha256 != target.source.evidence_sha256
+    ):
+        return "SOURCE_EVIDENCE_FAILURE"
+    if applicability.scope != target.scope:
+        return "SCOPE_MISMATCH"
+    if applicability.target_status_as_of != current.as_of:
+        return "AS_OF_MISMATCH"
+    if applicability.evidence_stale:
+        return "STALE_EVIDENCE"
+    if applicability.target_current_gate != "HOLD":
+        return "UNSUPPORTED_APPLICABILITY_ROUTE"
+    if applicability.serving_policy.note != target.structure.note:
+        return "TARGET_IDENTITY_MISMATCH"
+    return None
+
+
+def _selective_envelope(
+    current: SelectiveReconnectCurrentBinding,
+    edge: SelectiveReconnectEdge,
+    structure_bytes: bytes,
+) -> str:
+    structure = edge.target.structure
+    applicability = edge.applicability
+    separator = "" if structure_bytes.endswith(b"\n") else "\n"
+    return (
+        "=== DECISION OS SELECTIVE RECONNECT / ADDRESSABILITY ONLY / BEGIN ===\n"
+        f"Edge SHA-256: {edge.edge_sha256}\n"
+        f"Current binding SHA-256: {current.binding_sha256}\n"
+        f"Target binding SHA-256: {edge.target.binding_sha256}\n"
+        f"Structure binding SHA-256: {structure.binding_sha256}\n"
+        f"Field Note path: {structure.note.note_path}\n"
+        f"Current Goal Gate: {current.current_gate}\n"
+        f"Target current-use Gate: {applicability.target_current_gate}\n\n"
+        "Boundary:\n"
+        "This block proves exact addressability only. Recall does not establish\n"
+        "current validity, serving, selection, promotion, Canon, authority, or\n"
+        "permission to continue. Existing topmost authority and HOLD conditions\n"
+        "remain controlling.\n\n"
+        "--- EXACT FIELD NOTE STRUCTURE UTF-8 BYTES BEGIN ---\n"
+        + structure_bytes.decode("utf-8")
+        + separator
+        + "--- EXACT FIELD NOTE STRUCTURE UTF-8 BYTES END ---\n"
+        "=== DECISION OS SELECTIVE RECONNECT / ADDRESSABILITY ONLY / END ===\n"
+    )
+
+
+def _exact_target_failure(
+    target: SelectiveReconnectTargetBinding,
+    exact: FieldNoteExactRead,
+) -> SelectiveReconnectFailure | None:
+    expected_note = target.structure.note
+    if (
+        exact.relative_path != expected_note.note_path
+        or exact.field_note_id != expected_note.field_note_id
+        or exact.source_run_id != expected_note.origin_run_id
+    ):
+        return "TARGET_IDENTITY_MISMATCH"
+    if (
+        exact.note_sha256 != expected_note.note_sha256
+        or len(exact.note_bytes) != target.structure.note_size
+        or not target.structure.verifies(expected_note, exact.note_bytes)
+    ):
+        return "STALE_TARGET"
+    if (
+        exact.task_family != target.scope.identity
+        or exact.scope_sha256 != target.scope.sha256
+    ):
+        return "SCOPE_MISMATCH"
+    return None
+
+
+def resolve_selective_reconnect(
+    repository: Path,
+    *,
+    current: SelectiveReconnectCurrentBinding,
+) -> SelectiveReconnectResult:
+    """Recover only one persisted exact target, or fail safely to HOLD."""
+
+    if not isinstance(current, SelectiveReconnectCurrentBinding):
+        raise ValueError("Selective reconnect input is not a typed current binding.")
+    root = Path(repository)
+    edge_read_attempts = 0
+    target_note_read_attempts = 0
+    source_evidence_read_attempts = 0
+    target_note_bytes_validated = 0
+    edge: SelectiveReconnectEdge | None = None
+
+    def hold(reason: SelectiveReconnectFailure, *, records: int = 0) -> SelectiveReconnectResult:
+        return _hold(
+            current,
+            reason,
+            edge_records_seen=records,
+            edge_read_attempts=edge_read_attempts,
+            edge=edge,
+            target_note_read_attempts=target_note_read_attempts,
+            target_note_bytes_validated=target_note_bytes_validated,
+            source_evidence_read_attempts=source_evidence_read_attempts,
+        )
+
+    try:
+        observed_repository, observed_commit = _repository_identity(root)
+    except _ExactFileError:
+        return hold("CURRENT_REPOSITORY_MISMATCH")
+    if observed_repository != current.repository_id:
+        return hold("CURRENT_REPOSITORY_MISMATCH")
+    if observed_commit != current.as_of_commit:
+        return hold("AS_OF_MISMATCH")
+
+    edge_read_attempts += 1
+    try:
+        edge_read = _read_exact_repository_file(
+            root,
+            SELECTIVE_RECONNECT_EDGE_PATH,
+            maximum_bytes=MAX_EDGE_FILE_BYTES,
+            missing_ok=True,
+        )
+    except _ExactFileError:
+        return hold("CORRUPTED_EDGE")
+    if edge_read is None or edge_read.data == b"":
+        return hold("ZERO_TARGETS")
+    try:
+        edges = _parse_edges(edge_read.data)
+    except (TypeError, ValueError):
+        return hold("CORRUPTED_EDGE")
+    if not edges:
+        return hold("ZERO_TARGETS")
+    if len(edges) != 1:
+        return hold("MULTIPLE_TARGETS", records=len(edges))
+    edge = edges[0]
+
+    mismatch = _current_mismatch(current, edge.current)
+    if mismatch is not None:
+        return hold(mismatch, records=1)
+
+    target = edge.target
+    applicability = edge.applicability
+    target_note_read_attempts += 1
+    try:
+        exact = read_exact_field_note(root, target.reentry_path)
+    except FieldNoteExactReadError:
+        return hold("STALE_TARGET", records=1)
+    target_failure = _exact_target_failure(target, exact)
+    if target_failure is not None:
+        return hold(target_failure, records=1)
+    target_note_bytes_validated += len(exact.note_bytes)
+
+    applicability_failure = _applicability_failure(
+        current,
+        target,
+        applicability,
+    )
+    if applicability_failure is not None:
+        return hold(applicability_failure, records=1)
+
+    expected_evidence = selective_reconnect_source_evidence_bytes(
+        repository_id=target.source.repository_id,
+        source_commit=target.source.source_commit,
+        source_path=target.source.source_path,
+        source_blob=target.source.source_blob,
+        source_sha256=target.source.source_sha256,
+        evidence_path=target.source.evidence_path,
+        as_of=target.source.as_of,
+    )
+    source_evidence_read_attempts += 1
+    try:
+        evidence_read = _read_exact_repository_file(
+            root,
+            target.source.evidence_path,
+            maximum_bytes=MAX_SOURCE_EVIDENCE_BYTES,
+            missing_ok=False,
+        )
+    except _ExactFileError:
+        evidence_read = None
+    evidence = evidence_read.data if evidence_read is not None else None
+    if (
+        evidence is None
+        or evidence != expected_evidence
+        or hashlib.sha256(evidence).hexdigest()
+        != target.source.evidence_sha256
+    ):
+        return hold("SOURCE_EVIDENCE_FAILURE", records=1)
+
+    # Re-read every persisted input before returning RECALLED.  This creates a
+    # bounded stable validation window and fails closed if a path is swapped
+    # between the independent exact reads.
+    edge_read_attempts += 1
+    try:
+        edge_read_after = _read_exact_repository_file(
+            root,
+            SELECTIVE_RECONNECT_EDGE_PATH,
+            maximum_bytes=MAX_EDGE_FILE_BYTES,
+            missing_ok=False,
+        )
+    except _ExactFileError:
+        edge_read_after = None
+    if edge_read_after != edge_read:
+        return hold("UNSTABLE_RECOVERY_WINDOW", records=1)
+
+    target_note_read_attempts += 1
+    try:
+        exact_after = read_exact_field_note(root, target.reentry_path)
+    except FieldNoteExactReadError:
+        return hold("UNSTABLE_RECOVERY_WINDOW", records=1)
+    if exact_after != exact or _exact_target_failure(target, exact_after) is not None:
+        return hold("UNSTABLE_RECOVERY_WINDOW", records=1)
+    target_note_bytes_validated += len(exact_after.note_bytes)
+
+    source_evidence_read_attempts += 1
+    try:
+        evidence_read_after = _read_exact_repository_file(
+            root,
+            target.source.evidence_path,
+            maximum_bytes=MAX_SOURCE_EVIDENCE_BYTES,
+            missing_ok=False,
+        )
+    except _ExactFileError:
+        evidence_read_after = None
+    if evidence_read_after != evidence_read:
+        return hold("UNSTABLE_RECOVERY_WINDOW", records=1)
+
+    try:
+        repository_after, commit_after = _repository_identity(root)
+    except _ExactFileError:
+        repository_after, commit_after = "", ""
+    if repository_after != current.repository_id:
+        return hold("CURRENT_REPOSITORY_MISMATCH", records=1)
+    if commit_after != current.as_of_commit:
+        return hold("AS_OF_MISMATCH", records=1)
+
+    expected_note = target.structure.note
+    structure_bytes = exact_after.note_bytes[
+        target.structure.start_byte : target.structure.end_byte
+    ]
+    return SelectiveReconnectResult(
+        receipt=SelectiveReconnectReceipt(
+            state="RECALLED",
+            failure_reason=None,
+            current_binding_sha256=current.binding_sha256,
+            applicability_gate=applicability.target_current_gate,
+            edge_records_seen=1,
+            edge_sha256=edge.edge_sha256,
+            target_binding_sha256=target.binding_sha256,
+            structure_binding_sha256=target.structure.binding_sha256,
+            target_note_path=expected_note.note_path,
+            target_field_note_id=expected_note.field_note_id,
+            target_note_sha256=expected_note.note_sha256,
+            edge_read_attempts=edge_read_attempts,
+            source_evidence_read_attempts=source_evidence_read_attempts,
+            target_note_read_attempts=target_note_read_attempts,
+            target_note_bytes_validated=target_note_bytes_validated,
+            structure_bytes_reopened=len(structure_bytes),
+        ),
+        target=target,
+        structure_bytes=structure_bytes,
+        envelope=_selective_envelope(current, edge, structure_bytes),
+    )

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,110 @@
+# Current Signal — V11-Derived Selective Reconnect Edge Integration
+
+## Canonical Current State — V13 Post Selective Reconnect Integration
+
+```text
+Current Layer:
+V11 → V13 — Reconnectable Forgetting / Selective Reconnect Integration
+
+V12 State:
+PASS
+
+V11-derived Selective Reconnect Edge:
+INTEGRATED
+
+Established Capability:
+Exact persisted Goal/gap → exact prior Field Note structure addressability, with
+fail-closed validation and no activation semantics.
+
+Bounded Claim:
+V13 now has one bounded scale-addressable reconnect path from an exact current
+Goal/gap to one exact prior Field Note structure without broad historical scan.
+
+Claim Boundary:
+Recall is addressability only. It does not establish present truth, usefulness,
+or validity; serving, injection, selection, promotion, or Canon; authority,
+Worker dispatch, or automatic continuation. It does not establish generic
+scalable memory, general semantic retrieval, RAG, autonomous memory management,
+generalized Outcome-Masked Replay, or full V11 integration.
+
+Source Validation:
+The already-recorded V11 source commit/path/blob identity matches the
+authoritative `shin4141/decision-os-paper` repository.
+
+Fresh upstream PDF refetch / rehash:
+NOT PERFORMED — the recorded PDF SHA-256 remains persisted lineage evidence,
+not a new independent source validation.
+
+V6 Safety Non-Dilution:
+INTEGRATED
+
+V8 Temporal Evidence Invalidation:
+INTEGRATED
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+Genesis Selection:
+HOLD — typed present-Goal comparison missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+4f8f95ec9d32672b80231294c8f1dddef55a7e74
+
+Guard Repair Commit:
+31a3ccb223cc7647f5557b8366e369f4e200a699
+
+Canonicalization Condition:
+This block becomes canonical only when the exact capability commit, guard repair
+commit, and this synchronization delta are on main.
+
+Canonical Starting Main:
+559ec0cd5bdc8af52fe0784bd3df2cd249212bcd
+
+Active Branch:
+main
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the exact capability, guard repair, and this canonical synchronization
+are on main.
+
+Next Authorized Action:
+None. Preserve the exact addressability-only claim boundary. Do not start another
+Decision transplant, release, publication, Meter change, Genesis Selection,
+V10 Protective Rescale, FN132, or 13-108 integration.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact V11-derived Selective Reconnect Edge is integrated as one
+bounded Goal/gap-to-structure addressability path with fail-closed validation,
+no broad historical scan, and no serving, selection, promotion, Canon,
+authority, Worker dispatch, or automatic-continuation semantics. No next
+Decision transplant is authorized.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Signal — V6 Safety Non-Dilution Integration
 
 ## Canonical Current State — V13 Post V6 Safety Non-Dilution Integration

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,110 @@
+# Current Codex Handoff — V11-Derived Selective Reconnect Edge Integration
+
+## Canonical Current State — V13 Post Selective Reconnect Integration
+
+```text
+Current Layer:
+V11 → V13 — Reconnectable Forgetting / Selective Reconnect Integration
+
+V12 State:
+PASS
+
+V11-derived Selective Reconnect Edge:
+INTEGRATED
+
+Established Capability:
+Exact persisted Goal/gap → exact prior Field Note structure addressability, with
+fail-closed validation and no activation semantics.
+
+Bounded Claim:
+V13 now has one bounded scale-addressable reconnect path from an exact current
+Goal/gap to one exact prior Field Note structure without broad historical scan.
+
+Claim Boundary:
+Recall is addressability only. It does not establish present truth, usefulness,
+or validity; serving, injection, selection, promotion, or Canon; authority,
+Worker dispatch, or automatic continuation. It does not establish generic
+scalable memory, general semantic retrieval, RAG, autonomous memory management,
+generalized Outcome-Masked Replay, or full V11 integration.
+
+Source Validation:
+The already-recorded V11 source commit/path/blob identity matches the
+authoritative `shin4141/decision-os-paper` repository.
+
+Fresh upstream PDF refetch / rehash:
+NOT PERFORMED — the recorded PDF SHA-256 remains persisted lineage evidence,
+not a new independent source validation.
+
+V6 Safety Non-Dilution:
+INTEGRATED
+
+V8 Temporal Evidence Invalidation:
+INTEGRATED
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+Genesis Selection:
+HOLD — typed present-Goal comparison missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+4f8f95ec9d32672b80231294c8f1dddef55a7e74
+
+Guard Repair Commit:
+31a3ccb223cc7647f5557b8366e369f4e200a699
+
+Canonicalization Condition:
+This block becomes canonical only when the exact capability commit, guard repair
+commit, and this synchronization delta are on main.
+
+Canonical Starting Main:
+559ec0cd5bdc8af52fe0784bd3df2cd249212bcd
+
+Active Branch:
+main
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the exact capability, guard repair, and this canonical synchronization
+are on main.
+
+Next Authorized Action:
+None. Preserve the exact addressability-only claim boundary. Do not start another
+Decision transplant, release, publication, Meter change, Genesis Selection,
+V10 Protective Rescale, FN132, or 13-108 integration.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact V11-derived Selective Reconnect Edge is integrated as one
+bounded Goal/gap-to-structure addressability path with fail-closed validation,
+no broad historical scan, and no serving, selection, promotion, Canon,
+authority, Worker dispatch, or automatic-continuation semantics. No next
+Decision transplant is authorized.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Codex Handoff — V6 Safety Non-Dilution Integration
 
 ## Canonical Current State — V13 Post V6 Safety Non-Dilution Integration

--- a/tests/test_compound_evidence_meter.py
+++ b/tests/test_compound_evidence_meter.py
@@ -274,7 +274,7 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
         self.assertIn(
-            "Preserve the exact BLOCK non-dilution claim boundary",
+            "Preserve the exact addressability-only claim boundary",
             payload["next_authorized_action"],
         )
         for relative_path in (
@@ -289,36 +289,61 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     maxsplit=1,
                 )[0]
                 self.assertIn(
-                    "V13 — Decision Structure Transplant Integration / "
-                    "V6 Safety Non-Dilution",
+                    "V11 → V13 — Reconnectable Forgetting / Selective "
+                    "Reconnect Integration",
                     current,
                 )
                 self.assertIn(
-                    "V6-derived Safety Non-Dilution:\nINTEGRATED",
+                    "V11-derived Selective Reconnect Edge:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
-                    "Existing BLOCK Human Seat failures cannot be diluted by "
-                    "earlier simultaneous\nHOLD/CAP failures.",
+                    "Exact persisted Goal/gap → exact prior Field Note structure "
+                    "addressability, with\nfail-closed validation and no "
+                    "activation semantics.",
                     current,
                 )
                 self.assertIn(
-                    "every failed-condition identity is preserved in\n"
-                    "canonical condition order",
+                    "one bounded scale-addressable reconnect path from an exact "
+                    "current\nGoal/gap to one exact prior Field Note structure "
+                    "without broad historical scan",
                     current,
                 )
                 self.assertIn(
-                    "does not\nestablish a general Gate severity lattice",
+                    "Recall is addressability only. It does not establish "
+                    "present truth, usefulness,\nor validity",
                     current,
                 )
                 self.assertIn(
-                    "V8-derived temporal evidence invalidation:\n"
-                    "unchanged / integrated",
+                    "generalized Outcome-Masked Replay, or full V11 integration",
+                    current,
+                )
+                self.assertIn(
+                    "already-recorded V11 source commit/path/blob identity "
+                    "matches the\nauthoritative "
+                    "`shin4141/decision-os-paper` repository",
+                    current,
+                )
+                self.assertIn(
+                    "Fresh upstream PDF refetch / rehash:\nNOT PERFORMED",
+                    current,
+                )
+                self.assertIn(
+                    "V6 Safety Non-Dilution:\nINTEGRATED",
+                    current,
+                )
+                self.assertIn(
+                    "V8 Temporal Evidence Invalidation:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
                     "V10 Protective Rescale:\n"
                     "HOLD — Carrier observability missing",
+                    current,
+                )
+                self.assertIn(
+                    "Genesis Selection:\n"
+                    "HOLD — typed present-Goal comparison missing",
                     current,
                 )
                 self.assertIn(

--- a/tests/test_field_notes_selective_reconnect.py
+++ b/tests/test_field_notes_selective_reconnect.py
@@ -287,6 +287,7 @@ class SelectiveReconnectFixtureTests(unittest.TestCase):
     def test_257_valid_notes_fail_broad_reconnect_but_edge_recalls_exact_target(
         self,
     ) -> None:
+        self.assertEqual(256, MAX_DIRECTORY_ENTRIES)
         for index in range(MAX_DIRECTORY_ENTRIES):
             write_note(
                 self.repository,
@@ -1051,6 +1052,7 @@ print(json.dumps({
             "traversal": canonical_json(traversal).encode("utf-8") + b"\n",
             "duplicate_key": duplicate.encode("utf-8") + b"\n",
             "mixed_valid_and_corrupt": valid_line + b"{\n",
+            "deeply_nested": b"[" * 1500 + b"0" + b"]" * 1500 + b"\n",
             "oversized": b"x" * (selective.MAX_EDGE_FILE_BYTES + 1),
         }
         for label, data in variants.items():
@@ -1065,6 +1067,24 @@ print(json.dumps({
                 self.assertEqual("DELAY_HOLD", result.receipt.state)
                 self.assertEqual("CORRUPTED_EDGE", result.receipt.failure_reason)
                 self.assertIsNone(result.structure_bytes)
+
+        self.edge_path.write_bytes(valid_line)
+        with (
+            patch.object(
+                selective.json,
+                "loads",
+                side_effect=RecursionError("decoder nesting limit"),
+            ),
+            patch.object(
+                selective,
+                "read_exact_field_note",
+                side_effect=AssertionError("target opened"),
+            ),
+        ):
+            recursive = self.resolve()
+        self.assertEqual("DELAY_HOLD", recursive.receipt.state)
+        self.assertEqual("CORRUPTED_EDGE", recursive.receipt.failure_reason)
+        self.assertIsNone(recursive.structure_bytes)
 
         outside = self.repository.parent / "outside-edge.jsonl"
         outside.write_bytes(valid_line)

--- a/tests/test_field_notes_selective_reconnect.py
+++ b/tests/test_field_notes_selective_reconnect.py
@@ -1,0 +1,1161 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from decision_os.acceleration.model import git_output, repository_id
+from decision_os.companion import field_notes_reconnect as broad_reconnect
+from decision_os.companion import field_notes_selective_reconnect as selective
+from decision_os.companion.field_notes_adapter import FieldNotesCodexAdapter
+from decision_os.companion.field_notes_controller import FieldNotesCompanionController
+from decision_os.companion.field_notes_model import canonical_json, compile_draft
+from decision_os.companion.field_notes_reconnect import (
+    MAX_DIRECTORY_ENTRIES,
+    prepare_field_note_reconnect,
+)
+from decision_os.companion.field_notes_reuse import (
+    FieldNoteIdentity,
+    FieldNoteServingPolicyBoundary,
+    bind_field_note_structure,
+    project_field_note_a3_status,
+    summarize_field_note_maturity,
+)
+from decision_os.companion.field_notes_selective_reconnect import (
+    SELECTIVE_RECONNECT_EDGE_PATH,
+    SELECTIVE_RECONNECT_SCHEMA,
+    SelectiveReconnectApplicability,
+    SelectiveReconnectCurrentBinding,
+    SelectiveReconnectEdge,
+    SelectiveReconnectIdentity,
+    SelectiveReconnectSourceAnchor,
+    SelectiveReconnectTargetBinding,
+    persist_selective_reconnect_edge,
+    resolve_selective_reconnect,
+)
+
+
+AS_OF = "2026-08-11T10:00:00+09:00"
+SOURCE_COMMIT = "07f20eb5bbea1e49d0b5f60fc4962c45ddcd3704"
+SOURCE_PATH = "notes/v11/Decision_OS_V11___Forget_for_Future.pdf"
+SOURCE_BLOB = "7939df5c03cad37c92cbbaab9418f7bf0ce0db7e"
+SOURCE_SHA256 = "58f089213c85553fe0451ce574a172a43c6cd5243ad716c784acf6a269268356"
+STRUCTURE_TEXT = "Preserve the exact causal guard and keep its route HOLD."
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def identity(value: str) -> SelectiveReconnectIdentity:
+    return SelectiveReconnectIdentity(
+        identity=value,
+        sha256=digest_bytes(value.encode("utf-8")),
+    )
+
+
+def proposal(
+    *,
+    title: str,
+    reusable_structure: str = STRUCTURE_TEXT,
+    trigger_terms: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "title": title,
+        "value_level": 1,
+        "source_model_class": "UNKNOWN",
+        "target_model_class": "UNKNOWN",
+        "trigger_terms": trigger_terms or ["selective reconnect", "scale edge"],
+        "scope": {
+            "task_family": "selective-reconnect-edge-1-01",
+            "path_prefixes": ["decision_os/companion"],
+            "exclude_terms": [],
+        },
+        "body": {
+            "trigger": "Use only for the exact bound Goal and remaining gap.",
+            "reusable_structure": reusable_structure,
+            "scope": "One current Goal/gap and one exact historical structure.",
+            "do_not_apply_when": "Do not apply after any identity becomes stale.",
+            "procedure": "Reopen the exact byte range, then check applicability.",
+            "acceptance": "Recall remains separate from serving and selection.",
+            "evidence": "One exact source anchor and one exact Note binding.",
+            "remaining_unknowns": "Current usefulness remains independently gated.",
+        },
+    }
+
+
+def write_note(
+    repository: Path,
+    *,
+    title: str,
+    field_note_id: str,
+    source_run_id: str,
+    reusable_structure: str = STRUCTURE_TEXT,
+    trigger_terms: list[str] | None = None,
+):
+    draft = compile_draft(
+        proposal(
+            title=title,
+            reusable_structure=reusable_structure,
+            trigger_terms=trigger_terms,
+        ),
+        source_run_id=source_run_id,
+        created_at="2026-08-10T12:00:00Z",
+        field_note_id=field_note_id,
+    )
+    path = repository / draft.relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(draft.markdown)
+    return draft
+
+
+def rehash_record(record: dict[str, object]) -> dict[str, object]:
+    payload = {key: value for key, value in record.items() if key != "edge_sha256"}
+    record["edge_sha256"] = digest_bytes(
+        canonical_json(payload).encode("utf-8")
+    )
+    return record
+
+
+class SelectiveReconnectFixtureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.repository = Path(self.temporary.name) / "repo"
+        self.repository.mkdir()
+        (self.repository / "seed.txt").write_text("seed\n", encoding="utf-8")
+        commands = (
+            ("git", "init", "-q", str(self.repository)),
+            ("git", "-C", str(self.repository), "add", "seed.txt"),
+            (
+                "git",
+                "-C",
+                str(self.repository),
+                "-c",
+                "user.name=Selective Reconnect Test",
+                "-c",
+                "user.email=selective-reconnect@example.invalid",
+                "commit",
+                "-qm",
+                "seed",
+            ),
+        )
+        for command in commands:
+            completed = subprocess.run(command, capture_output=True, text=True)
+            if completed.returncode != 0:
+                raise AssertionError(completed.stderr)
+        self.repository_id = repository_id(self.repository)
+        self.as_of_commit = git_output(self.repository, "rev-parse", "HEAD")
+        self.draft = write_note(
+            self.repository,
+            title="Selective reconnect scale target",
+            field_note_id="fn_selective_reconnect_scale_target",
+            source_run_id="run_historical_target",
+        )
+        self.note_path = self.repository / self.draft.relative_path
+        self.note = FieldNoteIdentity(
+            note_path=self.draft.relative_path,
+            field_note_id=self.draft.field_note_id,
+            note_sha256=self.draft.sha256,
+            origin_run_id=self.draft.source_run_id,
+        )
+        structure_bytes = STRUCTURE_TEXT.encode("utf-8")
+        start = self.draft.markdown.index(structure_bytes)
+        self.structure = bind_field_note_structure(
+            self.note,
+            self.draft.markdown,
+            structure_id="v11-selective-reconnect-causal-guard",
+            start_byte=start,
+            end_byte=start + len(structure_bytes),
+        )
+        self.current = SelectiveReconnectCurrentBinding(
+            goal=identity("goal:13-119-selective-reconnect"),
+            remaining_gap=identity("gap:scale-addressable-exact-reconnect"),
+            current_gate="GO",
+            protected_object=identity("protected:human-seat-and-current-gate"),
+            authority_boundary=identity("authority:shin-decision-owner"),
+            repository_id=self.repository_id,
+            as_of_commit=self.as_of_commit,
+            as_of=AS_OF,
+        )
+        evidence_path = "evidence/selective-reconnect-source-anchor.txt"
+        evidence = self.repository / evidence_path
+        evidence.parent.mkdir(parents=True)
+        evidence_bytes = selective.selective_reconnect_source_evidence_bytes(
+            repository_id="shin4141/decision-os-paper",
+            source_commit=SOURCE_COMMIT,
+            source_path=SOURCE_PATH,
+            source_blob=SOURCE_BLOB,
+            source_sha256=SOURCE_SHA256,
+            evidence_path=evidence_path,
+            as_of=AS_OF,
+        )
+        evidence.write_bytes(evidence_bytes)
+        self.source = SelectiveReconnectSourceAnchor(
+            repository_id="shin4141/decision-os-paper",
+            source_commit=SOURCE_COMMIT,
+            source_path=SOURCE_PATH,
+            source_blob=SOURCE_BLOB,
+            source_sha256=SOURCE_SHA256,
+            evidence_path=evidence_path,
+            evidence_sha256=digest_bytes(evidence_bytes),
+            as_of=AS_OF,
+        )
+        scope_payload = {
+            "task_family": self.draft.task_family,
+            "path_prefixes": list(self.draft.path_prefixes),
+            "exclude_terms": list(self.draft.exclude_terms),
+            "repository": "current",
+        }
+        self.scope = SelectiveReconnectIdentity(
+            identity=self.draft.task_family,
+            sha256=digest_bytes(canonical_json(scope_payload).encode("utf-8")),
+        )
+        self.target = SelectiveReconnectTargetBinding(
+            structure=self.structure,
+            source=self.source,
+            scope=self.scope,
+            stop_conditions=("Stop if any exact target identity changes.",),
+            recheck_conditions=("Recheck source evidence and current Gate.",),
+            unresolved_delta="Current applicability and usefulness remain separate.",
+            reentry_path=self.note.note_path,
+        )
+        self.serving_policy = FieldNoteServingPolicyBoundary(note=self.note)
+        self.applicability = SelectiveReconnectApplicability(
+            current=self.current,
+            target_binding_sha256=self.target.binding_sha256,
+            source=self.source,
+            scope=self.scope,
+            target_current_gate="HOLD",
+            target_status_as_of=AS_OF,
+            evidence_stale=False,
+            serving_policy=self.serving_policy,
+        )
+        self.edge = SelectiveReconnectEdge(
+            current=self.current,
+            target=self.target,
+            applicability=self.applicability,
+        )
+
+    @property
+    def edge_path(self) -> Path:
+        return self.repository / SELECTIVE_RECONNECT_EDGE_PATH
+
+    def persist(self, edge: SelectiveReconnectEdge | None = None) -> Path:
+        return persist_selective_reconnect_edge(
+            self.repository,
+            edge or self.edge,
+        )
+
+    def resolve(
+        self,
+        *,
+        current: SelectiveReconnectCurrentBinding | None = None,
+    ):
+        return resolve_selective_reconnect(
+            self.repository,
+            current=current or self.current,
+        )
+
+    def replace_persisted_edge(self, edge: SelectiveReconnectEdge) -> Path:
+        if self.edge_path.exists() or self.edge_path.is_symlink():
+            self.edge_path.unlink()
+        return self.persist(edge)
+
+    def write_edge_records(
+        self,
+        *edges: SelectiveReconnectEdge,
+    ) -> Path:
+        if self.edge_path.exists() or self.edge_path.is_symlink():
+            self.edge_path.unlink()
+        self.edge_path.parent.mkdir(parents=True, exist_ok=True)
+        self.edge_path.write_bytes(
+            b"".join(
+                canonical_json(edge.as_dict()).encode("utf-8") + b"\n"
+                for edge in edges
+            )
+        )
+        return self.edge_path
+
+    def test_257_valid_notes_fail_broad_reconnect_but_edge_recalls_exact_target(
+        self,
+    ) -> None:
+        for index in range(MAX_DIRECTORY_ENTRIES):
+            write_note(
+                self.repository,
+                title=f"Historical unrelated note {index:03d}",
+                field_note_id=f"fn_unrelated_{index:03d}",
+                source_run_id=f"run_unrelated_{index:03d}",
+                reusable_structure=f"Unrelated structure sentinel {index:03d}.",
+                trigger_terms=[f"unrelated {index:03d}", "historical only"],
+            )
+        store = self.repository / ".decision-os" / "field-notes"
+        self.assertEqual(MAX_DIRECTORY_ENTRIES + 1, len(list(store.iterdir())))
+        self.persist()
+        ordinary = prepare_field_note_reconnect(
+            self.repository,
+            "selective reconnect scale edge",
+            "run_scale_baseline",
+        )
+        self.assertEqual("NO_MATCH", ordinary.receipt.state)
+        self.assertEqual("directory_entry_limit", ordinary.receipt.failure_reason)
+        self.assertEqual(MAX_DIRECTORY_ENTRIES + 1, ordinary.receipt.metadata_entries_seen)
+        self.assertEqual(0, ordinary.receipt.metadata_bytes_read)
+        self.assertEqual(0, ordinary.receipt.full_note_bytes_read)
+        self.assertIsNone(ordinary.envelope)
+
+        opened: list[str] = []
+        exact_repository_files: list[str] = []
+        exact_read = selective.read_exact_field_note
+        exact_file_read = selective._read_exact_repository_file
+
+        def observe_exact_read(repository: Path, relative_path: str):
+            opened.append(relative_path)
+            return exact_read(repository, relative_path)
+
+        def observe_exact_file(repository: Path, relative_path: str, **kwargs):
+            exact_repository_files.append(relative_path)
+            return exact_file_read(repository, relative_path, **kwargs)
+
+        with (
+            patch.object(
+                broad_reconnect,
+                "_score",
+                side_effect=AssertionError("broad relevance score used"),
+            ),
+            patch.object(
+                broad_reconnect.os,
+                "scandir",
+                side_effect=AssertionError("broad Field Note scan used"),
+            ),
+            patch.object(
+                selective,
+                "read_exact_field_note",
+                side_effect=observe_exact_read,
+            ),
+            patch.object(
+                selective,
+                "_read_exact_repository_file",
+                side_effect=observe_exact_file,
+            ),
+            patch.object(
+                os,
+                "listdir",
+                side_effect=AssertionError("directory list used"),
+            ),
+            patch.object(
+                Path,
+                "iterdir",
+                side_effect=AssertionError("directory iteration used"),
+            ),
+            patch.object(
+                Path,
+                "glob",
+                side_effect=AssertionError("glob used"),
+            ),
+            patch.object(
+                Path,
+                "rglob",
+                side_effect=AssertionError("recursive glob used"),
+            ),
+        ):
+            recalled = self.resolve()
+
+        self.assertEqual("RECALLED", recalled.receipt.state)
+        self.assertEqual("HOLD", recalled.receipt.applicability_gate)
+        self.assertEqual(STRUCTURE_TEXT.encode("utf-8"), recalled.structure_bytes)
+        self.assertEqual(self.structure.binding_sha256, recalled.receipt.structure_binding_sha256)
+        self.assertEqual(self.edge.edge_sha256, recalled.receipt.edge_sha256)
+        self.assertEqual([self.note.note_path, self.note.note_path], opened)
+        self.assertEqual(
+            [
+                SELECTIVE_RECONNECT_EDGE_PATH,
+                self.source.evidence_path,
+                SELECTIVE_RECONNECT_EDGE_PATH,
+                self.source.evidence_path,
+            ],
+            exact_repository_files,
+        )
+        self.assertEqual(0, recalled.receipt.field_note_directory_entries_seen)
+        self.assertEqual(0, recalled.receipt.unrelated_field_note_files_opened)
+        self.assertFalse(recalled.receipt.broad_scan_performed)
+        self.assertNotIn("Unrelated structure sentinel", recalled.envelope or "")
+        self.assertNotIn("# Selective reconnect scale target", recalled.envelope or "")
+        self.assertNotIn("One current Goal/gap and one exact", recalled.envelope or "")
+        self.assertIn("Current Goal Gate: GO", recalled.envelope or "")
+        self.assertIn("Target current-use Gate: HOLD", recalled.envelope or "")
+
+    def test_target_and_edge_identity_are_deterministic(self) -> None:
+        self.persist()
+        first = self.resolve()
+        second = self.resolve()
+        self.assertEqual(first.receipt.as_dict(), second.receipt.as_dict())
+        self.assertEqual(first.structure_bytes, second.structure_bytes)
+        self.assertEqual(self.edge.edge_sha256, first.receipt.edge_sha256)
+        self.assertEqual(self.target.binding_sha256, first.receipt.target_binding_sha256)
+        self.assertEqual(self.structure.binding_sha256, first.receipt.structure_binding_sha256)
+        self.assertEqual(self.note.note_path, first.receipt.target_note_path)
+        self.assertEqual(self.note.field_note_id, first.receipt.target_field_note_id)
+        self.assertEqual(self.note.note_sha256, first.receipt.target_note_sha256)
+
+    def test_zero_matching_edge_holds_without_opening_a_target(self) -> None:
+        with patch.object(
+            selective,
+            "read_exact_field_note",
+            side_effect=AssertionError("target opened"),
+        ):
+            result = self.resolve()
+        self.assertEqual("DELAY_HOLD", result.receipt.state)
+        self.assertEqual("ZERO_TARGETS", result.receipt.failure_reason)
+        self.assertEqual("HOLD", result.receipt.applicability_gate)
+        self.assertIsNone(result.structure_bytes)
+        self.assertEqual(0, result.receipt.target_note_read_attempts)
+
+    def test_multiple_matching_edges_hold_without_ranking_or_target_read(self) -> None:
+        self.persist()
+        alternate_bytes = b"Recall remains separate from serving and selection."
+        alternate_start = self.draft.markdown.index(alternate_bytes)
+        alternate_structure = bind_field_note_structure(
+            self.note,
+            self.draft.markdown,
+            structure_id="alternate-current-gap-target",
+            start_byte=alternate_start,
+            end_byte=alternate_start + len(alternate_bytes),
+        )
+        alternate_target = replace(
+            self.target,
+            structure=alternate_structure,
+        )
+        alternate_applicability = replace(
+            self.applicability,
+            target_binding_sha256=alternate_target.binding_sha256,
+            serving_policy=FieldNoteServingPolicyBoundary(
+                note=alternate_target.structure.note
+            ),
+        )
+        alternate_edge = SelectiveReconnectEdge(
+            current=self.current,
+            target=alternate_target,
+            applicability=alternate_applicability,
+        )
+        self.assertNotEqual(self.edge.target.binding_sha256, alternate_target.binding_sha256)
+        lines = (
+            canonical_json(self.edge.as_dict()).encode("utf-8")
+            + b"\n"
+            + canonical_json(alternate_edge.as_dict()).encode("utf-8")
+            + b"\n"
+        )
+        self.edge_path.write_bytes(lines)
+        with (
+            patch.object(
+                broad_reconnect,
+                "_score",
+                side_effect=AssertionError("ranker used"),
+            ),
+            patch.object(
+                selective,
+                "read_exact_field_note",
+                side_effect=AssertionError("target opened"),
+            ),
+        ):
+            result = self.resolve()
+        self.assertEqual("DELAY_HOLD", result.receipt.state)
+        self.assertEqual("MULTIPLE_TARGETS", result.receipt.failure_reason)
+        self.assertEqual(2, result.receipt.edge_records_seen)
+        self.assertIsNone(result.structure_bytes)
+
+    def test_stale_target_and_stale_evidence_hold(self) -> None:
+        self.persist()
+        self.note_path.write_bytes(self.note_path.read_bytes() + b"\n")
+        stale_target = self.resolve()
+        self.assertEqual("DELAY_HOLD", stale_target.receipt.state)
+        self.assertEqual("STALE_TARGET", stale_target.receipt.failure_reason)
+        self.assertIsNone(stale_target.structure_bytes)
+
+        self.note_path.write_bytes(self.draft.markdown)
+        stale_applicability = replace(self.applicability, evidence_stale=True)
+        self.write_edge_records(
+            replace(self.edge, applicability=stale_applicability)
+        )
+        stale_evidence = self.resolve()
+        self.assertEqual("DELAY_HOLD", stale_evidence.receipt.state)
+        self.assertEqual("STALE_EVIDENCE", stale_evidence.receipt.failure_reason)
+        self.assertIsNone(stale_evidence.structure_bytes)
+
+    def test_source_identity_and_evidence_failure_hold(self) -> None:
+        self.persist()
+        evidence_path = self.repository / self.source.evidence_path
+        source_cases = {
+            "repository": replace(self.source, repository_id="different/source"),
+            "commit": replace(self.source, source_commit="0" * 40),
+            "source_path": replace(self.source, source_path="notes/v11/different.pdf"),
+            "source_blob": replace(self.source, source_blob="0" * 40),
+            "source_sha256": replace(self.source, source_sha256="0" * 64),
+        }
+        for label, wrong_source in source_cases.items():
+            with self.subTest(label=label):
+                self.write_edge_records(
+                    replace(
+                        self.edge,
+                        applicability=replace(
+                            self.applicability,
+                            source=wrong_source,
+                        ),
+                    )
+                )
+                mismatched = self.resolve()
+                self.assertEqual("DELAY_HOLD", mismatched.receipt.state)
+                self.assertEqual(
+                    "SOURCE_IDENTITY_MISMATCH",
+                    mismatched.receipt.failure_reason,
+                )
+                self.assertEqual(1, mismatched.receipt.target_note_read_attempts)
+
+        evidence_cases = {
+            "path": replace(self.source, evidence_path="evidence/different.txt"),
+            "digest": replace(self.source, evidence_sha256="0" * 64),
+        }
+        for label, wrong_source in evidence_cases.items():
+            with self.subTest(label=label):
+                self.write_edge_records(
+                    replace(
+                        self.edge,
+                        applicability=replace(
+                            self.applicability,
+                            source=wrong_source,
+                        ),
+                    )
+                )
+                mismatched = self.resolve()
+                self.assertEqual(
+                    "SOURCE_EVIDENCE_FAILURE",
+                    mismatched.receipt.failure_reason,
+                )
+
+        wrong_as_of = replace(
+            self.source,
+            as_of="2026-08-11T10:01:00+09:00",
+        )
+        self.write_edge_records(
+            replace(
+                self.edge,
+                applicability=replace(self.applicability, source=wrong_as_of),
+            )
+        )
+        as_of_result = self.resolve()
+        self.assertEqual("AS_OF_MISMATCH", as_of_result.receipt.failure_reason)
+
+        self.replace_persisted_edge(self.edge)
+        original = evidence_path.read_bytes()
+        outside = self.repository.parent / "outside-evidence.txt"
+        outside.write_bytes(original)
+        for case in ("changed", "missing", "symlink"):
+            with self.subTest(evidence_file=case):
+                if evidence_path.exists() or evidence_path.is_symlink():
+                    evidence_path.unlink()
+                evidence_path.write_bytes(original)
+                if case == "changed":
+                    evidence_path.write_bytes(b"changed source evidence\n")
+                elif case == "missing":
+                    evidence_path.unlink()
+                else:
+                    evidence_path.unlink()
+                    evidence_path.symlink_to(outside)
+                failed = self.resolve()
+                self.assertEqual("DELAY_HOLD", failed.receipt.state)
+                self.assertEqual(
+                    "SOURCE_EVIDENCE_FAILURE",
+                    failed.receipt.failure_reason,
+                )
+                self.assertIsNone(failed.structure_bytes)
+
+    def test_current_side_identity_mismatch_matrix_holds_before_target_read(self) -> None:
+        cases = {
+            "goal": (
+                replace(self.current, goal=identity("goal:different")),
+                "GOAL_IDENTITY_MISMATCH",
+            ),
+            "gap": (
+                replace(self.current, remaining_gap=identity("gap:different")),
+                "GAP_IDENTITY_MISMATCH",
+            ),
+            "gate": (
+                replace(self.current, current_gate="HOLD"),
+                "CURRENT_GATE_MISMATCH",
+            ),
+            "protected_object": (
+                replace(
+                    self.current,
+                    protected_object=identity("protected:different"),
+                ),
+                "PROTECTED_OBJECT_MISMATCH",
+            ),
+            "authority": (
+                replace(
+                    self.current,
+                    authority_boundary=identity("authority:different"),
+                ),
+                "AUTHORITY_BOUNDARY_MISMATCH",
+            ),
+            "as_of": (
+                replace(self.current, as_of="2026-08-11T10:01:00+09:00"),
+                "AS_OF_MISMATCH",
+            ),
+        }
+        for label, (edge_current, reason) in cases.items():
+            with self.subTest(label=label):
+                self.write_edge_records(
+                    replace(self.edge, current=edge_current)
+                )
+                with patch.object(
+                    selective,
+                    "read_exact_field_note",
+                    side_effect=AssertionError("target opened"),
+                ):
+                    result = self.resolve()
+                self.assertEqual("DELAY_HOLD", result.receipt.state)
+                self.assertEqual(reason, result.receipt.failure_reason)
+                self.assertEqual(0, result.receipt.target_note_read_attempts)
+
+    def test_current_repository_as_of_and_changed_during_read_hold(self) -> None:
+        self.persist()
+        wrong_repository = self.resolve(
+            current=replace(
+                self.current,
+                repository_id="repo:v1:" + "0" * 64,
+            )
+        )
+        self.assertEqual(
+            "CURRENT_REPOSITORY_MISMATCH",
+            wrong_repository.receipt.failure_reason,
+        )
+        self.assertEqual(0, wrong_repository.receipt.edge_read_attempts)
+
+        wrong_commit = self.resolve(
+            current=replace(self.current, as_of_commit="0" * 40)
+        )
+        self.assertEqual("AS_OF_MISMATCH", wrong_commit.receipt.failure_reason)
+        self.assertEqual(0, wrong_commit.receipt.edge_read_attempts)
+
+        with patch.object(
+            selective,
+            "_repository_identity",
+            side_effect=(
+                (self.repository_id, self.as_of_commit),
+                (self.repository_id, "0" * 40),
+            ),
+        ):
+            changed = self.resolve()
+        self.assertEqual("DELAY_HOLD", changed.receipt.state)
+        self.assertEqual("AS_OF_MISMATCH", changed.receipt.failure_reason)
+        self.assertEqual(2, changed.receipt.target_note_read_attempts)
+        self.assertEqual(2, changed.receipt.source_evidence_read_attempts)
+
+    def test_cross_read_swap_fails_closed_without_partial_payload(self) -> None:
+        self.persist()
+        evidence_path = self.repository / self.source.evidence_path
+        valid_evidence = evidence_path.read_bytes()
+        evidence_path.write_bytes(b"invalid before target read\n")
+        exact_read = selective.read_exact_field_note
+        calls = 0
+
+        def swap_after_first_target(repository: Path, relative_path: str):
+            nonlocal calls
+            exact = exact_read(repository, relative_path)
+            calls += 1
+            if calls == 1:
+                self.note_path.write_bytes(self.draft.markdown + b"\n")
+                evidence_path.write_bytes(valid_evidence)
+            return exact
+
+        with patch.object(
+            selective,
+            "read_exact_field_note",
+            side_effect=swap_after_first_target,
+        ):
+            result = self.resolve()
+        self.assertEqual("DELAY_HOLD", result.receipt.state)
+        self.assertEqual(
+            "UNSTABLE_RECOVERY_WINDOW",
+            result.receipt.failure_reason,
+        )
+        self.assertEqual(2, result.receipt.target_note_read_attempts)
+        self.assertIsNone(result.target)
+        self.assertIsNone(result.structure_bytes)
+        self.assertIsNone(result.envelope)
+        with self.assertRaises(ValueError):
+            selective.SelectiveReconnectResult(
+                receipt=result.receipt,
+                structure_bytes=b"partial payload must be rejected",
+            )
+
+    def test_alternating_note_and_evidence_versions_fail_closed(self) -> None:
+        self.persist()
+        evidence_path = self.repository / self.source.evidence_path
+        valid_evidence = evidence_path.read_bytes()
+        invalid_evidence = b"invalid alternating evidence\n"
+        evidence_path.write_bytes(invalid_evidence)
+        exact_note_read = selective.read_exact_field_note
+        exact_file_read = selective._read_exact_repository_file
+        edge_reads = 0
+
+        def flip_after_note(repository: Path, relative_path: str):
+            exact = exact_note_read(repository, relative_path)
+            self.note_path.write_bytes(self.draft.markdown + b"\n")
+            evidence_path.write_bytes(valid_evidence)
+            return exact
+
+        def flip_after_second_edge(
+            repository: Path,
+            relative_path: str,
+            **kwargs,
+        ):
+            nonlocal edge_reads
+            exact = exact_file_read(repository, relative_path, **kwargs)
+            if relative_path == SELECTIVE_RECONNECT_EDGE_PATH:
+                edge_reads += 1
+                if edge_reads == 2:
+                    self.note_path.write_bytes(self.draft.markdown)
+                    evidence_path.write_bytes(invalid_evidence)
+            return exact
+
+        with (
+            patch.object(
+                selective,
+                "read_exact_field_note",
+                side_effect=flip_after_note,
+            ),
+            patch.object(
+                selective,
+                "_read_exact_repository_file",
+                side_effect=flip_after_second_edge,
+            ),
+        ):
+            result = self.resolve()
+        self.assertEqual("DELAY_HOLD", result.receipt.state)
+        self.assertEqual(
+            "UNSTABLE_RECOVERY_WINDOW",
+            result.receipt.failure_reason,
+        )
+        self.assertIsNone(result.structure_bytes)
+
+    def test_source_evidence_record_binds_the_declared_source_tuple(self) -> None:
+        false_source = replace(self.source, source_commit="0" * 40)
+        false_target = replace(self.target, source=false_source)
+        false_applicability = replace(
+            self.applicability,
+            target_binding_sha256=false_target.binding_sha256,
+            source=false_source,
+        )
+        self.write_edge_records(
+            SelectiveReconnectEdge(
+                current=self.current,
+                target=false_target,
+                applicability=false_applicability,
+            )
+        )
+        result = self.resolve()
+        self.assertEqual("DELAY_HOLD", result.receipt.state)
+        self.assertEqual(
+            "SOURCE_EVIDENCE_FAILURE",
+            result.receipt.failure_reason,
+        )
+        self.assertIsNone(result.structure_bytes)
+
+    def test_applicability_scope_and_binding_mismatch_hold_after_recovery(self) -> None:
+        self.persist()
+        other_note = replace(
+            self.note,
+            field_note_id="fn_other_serving_identity",
+        )
+        cases = {
+            "scope": (
+                replace(self.applicability, scope=identity("scope:different")),
+                "SCOPE_MISMATCH",
+            ),
+            "target_binding": (
+                replace(self.applicability, target_binding_sha256="0" * 64),
+                "TARGET_IDENTITY_MISMATCH",
+            ),
+            "applicability_goal": (
+                replace(
+                    self.applicability,
+                    current=replace(
+                        self.current,
+                        goal=identity("goal:stale-applicability"),
+                    ),
+                ),
+                "GOAL_IDENTITY_MISMATCH",
+            ),
+            "applicability_gap": (
+                replace(
+                    self.applicability,
+                    current=replace(
+                        self.current,
+                        remaining_gap=identity("gap:stale-applicability"),
+                    ),
+                ),
+                "GAP_IDENTITY_MISMATCH",
+            ),
+            "applicability_gate": (
+                replace(
+                    self.applicability,
+                    current=replace(self.current, current_gate="HOLD"),
+                ),
+                "CURRENT_GATE_MISMATCH",
+            ),
+            "applicability_protected_object": (
+                replace(
+                    self.applicability,
+                    current=replace(
+                        self.current,
+                        protected_object=identity("protected:stale-applicability"),
+                    ),
+                ),
+                "PROTECTED_OBJECT_MISMATCH",
+            ),
+            "applicability_authority": (
+                replace(
+                    self.applicability,
+                    current=replace(
+                        self.current,
+                        authority_boundary=identity("authority:stale-applicability"),
+                    ),
+                ),
+                "AUTHORITY_BOUNDARY_MISMATCH",
+            ),
+            "applicability_repository": (
+                replace(
+                    self.applicability,
+                    current=replace(self.current, repository_id="repo:v1:" + "0" * 64),
+                ),
+                "CURRENT_REPOSITORY_MISMATCH",
+            ),
+            "applicability_commit": (
+                replace(
+                    self.applicability,
+                    current=replace(self.current, as_of_commit="0" * 40),
+                ),
+                "AS_OF_MISMATCH",
+            ),
+            "applicability_as_of": (
+                replace(
+                    self.applicability,
+                    current=replace(
+                        self.current,
+                        as_of="2026-08-11T10:01:00+09:00",
+                    ),
+                ),
+                "AS_OF_MISMATCH",
+            ),
+            "target_status_as_of": (
+                replace(
+                    self.applicability,
+                    target_status_as_of="2026-08-11T10:01:00+09:00",
+                ),
+                "AS_OF_MISMATCH",
+            ),
+            "serving_policy_note": (
+                replace(
+                    self.applicability,
+                    serving_policy=FieldNoteServingPolicyBoundary(note=other_note),
+                ),
+                "TARGET_IDENTITY_MISMATCH",
+            ),
+        }
+        for label, (applicability, reason) in cases.items():
+            with self.subTest(label=label):
+                self.write_edge_records(
+                    replace(self.edge, applicability=applicability)
+                )
+                result = self.resolve()
+                self.assertEqual("DELAY_HOLD", result.receipt.state)
+                self.assertEqual(reason, result.receipt.failure_reason)
+                self.assertEqual(1, result.receipt.target_note_read_attempts)
+                self.assertIsNone(result.structure_bytes)
+
+    def test_recalled_hold_target_preserves_all_non_activation_boundaries(self) -> None:
+        self.persist()
+        serving_before = self.serving_policy.as_dict()
+        maturity_before = project_field_note_a3_status(
+            summarize_field_note_maturity(self.note, (), ())
+        ).as_dict()
+
+        def repository_snapshot() -> dict[str, str]:
+            return {
+                path.relative_to(self.repository).as_posix(): digest_bytes(
+                    path.read_bytes()
+                )
+                for path in self.repository.rglob("*")
+                if path.is_file()
+            }
+
+        files_before = repository_snapshot()
+        with (
+            patch.object(
+                FieldNotesCompanionController,
+                "start_run",
+                side_effect=AssertionError("Worker dispatched"),
+            ),
+            patch.object(
+                FieldNotesCodexAdapter,
+                "run",
+                side_effect=AssertionError("adapter dispatched"),
+            ),
+        ):
+            result = self.resolve()
+        self.assertEqual("RECALLED", result.receipt.state)
+        self.assertNotEqual("SELECTED", result.receipt.state)
+        self.assertEqual("HOLD", result.receipt.applicability_gate)
+        self.assertEqual("HOLD", self.applicability.target_current_gate)
+        self.assertEqual(self.target, result.target)
+        self.assertEqual(serving_before, self.serving_policy.as_dict())
+        self.assertEqual(
+            maturity_before,
+            project_field_note_a3_status(
+                summarize_field_note_maturity(self.note, (), ())
+            ).as_dict(),
+        )
+        self.assertEqual(files_before, repository_snapshot())
+        self.assertEqual("DELAY", result.receipt.serving_policy_derivation)
+        self.assertIsNone(result.receipt.automatic_injection)
+        self.assertFalse(result.receipt.serving_created)
+        self.assertFalse(result.receipt.selection_created)
+        self.assertFalse(result.receipt.promotion_created)
+        self.assertFalse(result.receipt.canon_created)
+        self.assertFalse(result.receipt.authority_granted)
+        self.assertEqual(0, result.receipt.worker_runs_dispatched)
+        self.assertEqual("UNSET", result.receipt.promotion_policy_status)
+        self.assertEqual(
+            ("TOPMOST_CANONICAL", "ADVISORY_FIELD_NOTE"),
+            result.receipt.authority_precedence,
+        )
+        with self.assertRaises(TypeError):
+            resolve_selective_reconnect(
+                self.repository,
+                current=self.current,
+                applicability=replace(
+                    self.applicability,
+                    target_current_gate="GO",
+                ),
+            )
+        self.write_edge_records(
+            replace(
+                self.edge,
+                applicability=replace(
+                    self.applicability,
+                    target_current_gate="GO",
+                ),
+            )
+        )
+        unsupported_route = self.resolve()
+        self.assertEqual("DELAY_HOLD", unsupported_route.receipt.state)
+        self.assertEqual(
+            "UNSUPPORTED_APPLICABILITY_ROUTE",
+            unsupported_route.receipt.failure_reason,
+        )
+
+    def test_restart_replay_recovers_same_target_and_same_or_safer_route(self) -> None:
+        self.persist()
+        first = self.resolve()
+        payload = {
+            "repository": str(self.repository),
+            "current": self.current.as_dict(),
+        }
+        replay_script = r'''
+import hashlib
+import json
+from pathlib import Path
+import sys
+from decision_os.companion.field_notes_selective_reconnect import (
+    SelectiveReconnectCurrentBinding,
+    SelectiveReconnectIdentity,
+    resolve_selective_reconnect,
+)
+
+data = json.loads(sys.stdin.read())
+def exact(value):
+    return SelectiveReconnectIdentity(value["identity"], value["sha256"])
+current_data = data["current"]
+current = SelectiveReconnectCurrentBinding(
+    goal=exact(current_data["goal"]),
+    remaining_gap=exact(current_data["remaining_gap"]),
+    current_gate=current_data["current_gate"],
+    protected_object=exact(current_data["protected_object"]),
+    authority_boundary=exact(current_data["authority_boundary"]),
+    repository_id=current_data["repository_id"],
+    as_of_commit=current_data["as_of_commit"],
+    as_of=current_data["as_of"],
+)
+result = resolve_selective_reconnect(
+    Path(data["repository"]),
+    current=current,
+)
+print(json.dumps({
+    "receipt": result.receipt.as_dict(),
+    "target": result.target.as_dict() if result.target else None,
+    "structure_sha256": hashlib.sha256(result.structure_bytes or b"").hexdigest(),
+}, sort_keys=True, separators=(",", ":")))
+'''
+        completed = subprocess.run(
+            (sys.executable, "-c", replay_script),
+            input=canonical_json(payload),
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).resolve().parents[1],
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        replay = json.loads(completed.stdout)
+        self.assertEqual(first.receipt.as_dict(), replay["receipt"])
+        self.assertEqual(self.target.as_dict(), replay["target"])
+        self.assertEqual(
+            digest_bytes(first.structure_bytes or b""),
+            replay["structure_sha256"],
+        )
+        self.assertEqual("HOLD", replay["receipt"]["applicability_gate"])
+
+        self.note_path.write_bytes(self.note_path.read_bytes() + b"\n")
+        safer = self.resolve()
+        self.assertEqual("DELAY_HOLD", safer.receipt.state)
+        self.assertEqual("HOLD", safer.receipt.applicability_gate)
+
+    def test_corrupted_edge_variants_fail_safely_without_target_read(self) -> None:
+        self.persist()
+        valid = self.edge.as_dict()
+        bad_digest = dict(valid)
+        bad_digest["edge_sha256"] = "0" * 64
+        unknown = dict(valid)
+        unknown["unexpected"] = True
+        rehash_record(unknown)
+        bad_binding = json.loads(canonical_json(valid))
+        bad_binding["target"]["structure"]["binding_sha256"] = "0" * 64
+        rehash_record(bad_binding)
+        traversal = json.loads(canonical_json(valid))
+        traversal["target"]["source"]["evidence_path"] = "../outside"
+        rehash_record(traversal)
+        duplicate = canonical_json(valid)[:-1] + ',"schema":"duplicate"}'
+        valid_line = canonical_json(valid).encode("utf-8") + b"\n"
+        variants = {
+            "malformed": b"{\n",
+            "noncanonical": (json.dumps(valid) + "\n").encode("utf-8"),
+            "bad_edge_digest": canonical_json(bad_digest).encode("utf-8") + b"\n",
+            "unknown_key": canonical_json(unknown).encode("utf-8") + b"\n",
+            "bad_binding": canonical_json(bad_binding).encode("utf-8") + b"\n",
+            "traversal": canonical_json(traversal).encode("utf-8") + b"\n",
+            "duplicate_key": duplicate.encode("utf-8") + b"\n",
+            "mixed_valid_and_corrupt": valid_line + b"{\n",
+            "oversized": b"x" * (selective.MAX_EDGE_FILE_BYTES + 1),
+        }
+        for label, data in variants.items():
+            with self.subTest(label=label):
+                self.edge_path.write_bytes(data)
+                with patch.object(
+                    selective,
+                    "read_exact_field_note",
+                    side_effect=AssertionError("target opened"),
+                ):
+                    result = self.resolve()
+                self.assertEqual("DELAY_HOLD", result.receipt.state)
+                self.assertEqual("CORRUPTED_EDGE", result.receipt.failure_reason)
+                self.assertIsNone(result.structure_bytes)
+
+        outside = self.repository.parent / "outside-edge.jsonl"
+        outside.write_bytes(valid_line)
+        self.edge_path.unlink()
+        self.edge_path.symlink_to(outside)
+        with patch.object(
+            selective,
+            "read_exact_field_note",
+            side_effect=AssertionError("target opened"),
+        ):
+            symlinked = self.resolve()
+        self.assertEqual("DELAY_HOLD", symlinked.receipt.state)
+        self.assertEqual("CORRUPTED_EDGE", symlinked.receipt.failure_reason)
+
+    def test_persist_failure_does_not_wedge_the_single_edge_slot(self) -> None:
+        inconsistent = replace(
+            self.edge,
+            applicability=replace(
+                self.applicability,
+                target_binding_sha256="0" * 64,
+            ),
+        )
+        with self.assertRaises(ValueError):
+            self.persist(inconsistent)
+        self.assertFalse(self.edge_path.exists())
+
+        write = selective.os.write
+        writes = 0
+
+        def fail_after_one_byte(descriptor: int, data) -> int:
+            nonlocal writes
+            writes += 1
+            if writes == 1:
+                return write(descriptor, data[:1])
+            raise OSError("simulated partial edge write")
+
+        with (
+            patch.object(selective.os, "write", side_effect=fail_after_one_byte),
+            self.assertRaises(ValueError),
+        ):
+            self.persist()
+        self.assertFalse(self.edge_path.exists())
+        reconnect_directory = self.edge_path.parent
+        self.assertEqual(
+            [],
+            [
+                path.name
+                for path in reconnect_directory.iterdir()
+                if path.name.startswith(".edge-v1-")
+            ],
+        )
+
+        self.persist()
+        recalled = self.resolve()
+        self.assertEqual("RECALLED", recalled.receipt.state)
+
+    def test_persisted_schema_round_trip_contains_only_the_bounded_edge(self) -> None:
+        with self.assertRaises(ValueError):
+            replace(self.current, as_of="20260811T100000+09:00")
+        first_path = self.persist()
+        second_path = self.persist()
+        self.assertEqual(first_path, second_path)
+        raw = self.edge_path.read_bytes()
+        self.assertTrue(raw.endswith(b"\n"))
+        self.assertEqual(1, len(raw.splitlines()))
+        record = json.loads(raw)
+        self.assertEqual(SELECTIVE_RECONNECT_SCHEMA, record["schema"])
+        self.assertEqual(self.current.as_dict(), record["current"])
+        self.assertEqual(self.target.as_dict(), record["target"])
+        self.assertEqual(self.applicability.as_dict(), record["applicability"])
+        self.assertEqual(self.edge.edge_sha256, record["edge_sha256"])
+        self.assertEqual(canonical_json(record).encode("utf-8") + b"\n", raw)
+        recalled = self.resolve()
+        self.assertEqual(self.target, recalled.target)
+        self.assertEqual(
+            ("Stop if any exact target identity changes.",),
+            recalled.target.stop_conditions if recalled.target else (),
+        )
+        self.assertEqual(
+            ("Recheck source evidence and current Gate.",),
+            recalled.target.recheck_conditions if recalled.target else (),
+        )
+        self.assertEqual(
+            "Current applicability and usefulness remain separate.",
+            recalled.target.unresolved_delta if recalled.target else None,
+        )
+        self.assertEqual(
+            self.note.note_path,
+            recalled.target.reentry_path if recalled.target else None,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- integrates the exact reviewed Selective Reconnect capability commit `4f8f95ec9d32672b80231294c8f1dddef55a7e74`
- includes the separately reviewed Python 3.10 fail-closed repair `31a3ccb223cc7647f5557b8366e369f4e200a699`
- synchronizes the bounded canonical current-state surfaces in `d5048bc038537e8a0968078a7d756f58c99173ad`

## Why

At 257 valid direct Field Notes, ordinary reconnect preserves its 256-entry bound and returns `NO_MATCH / directory_entry_limit`. The selective edge provides one exact Goal/gap-to-structure addressability path without broad historical scanning or activation semantics.

Independent review also found that deeply nested corrupt JSON could raise `RecursionError` on supported Python 3.10. The repair normalizes that case to payload-free `DELAY_HOLD / CORRUPTED_EDGE`.

## Boundary

This does not create serving, selection, promotion, Canon, authority, Worker dispatch, automatic continuation, generic RAG, generalized memory, Genesis Selection, V10 Protective Rescale, 13-108, Field Note 132, or a Compound Evidence Meter change.

## Validation

- selective reconnect: 17/17 on Python 3.10
- selective reconnect: 17/17 on Python 3.14
- legacy reconnect/reuse and creator-live exact reconnect: 85 tests, 2 protected-local skips
- V6, V8, canonical-surface, and repository checks: 93/93
- isolated headless-browser reconnect receipt test: pass
- `git diff --check`: pass
- GitHub compare: base `559ec0c…`, head `d5048bc…`, exactly 3 commits ahead / 0 behind