### PR TITLE
Integrate compound authority preflight before Default reuse

### DIFF
--- a/decision_os/acceleration/engine.py
+++ b/decision_os/acceleration/engine.py
@@ -13,6 +13,7 @@ from .store import AccelerationStore
 
 
 ChoiceProvider = Callable[[DecisionIdentity], str | None]
+MutationAuthorityPreflight = Callable[[DecisionIdentity], bool]
 
 
 @dataclass(frozen=True)
@@ -48,11 +49,13 @@ class AccelerationEngine:
         store: AccelerationStore | None = None,
         adapter: str = "core",
         adapter_version: str = "v0.1",
+        mutation_authority_preflight: MutationAuthorityPreflight | None = None,
     ) -> None:
         self.repository = Path(repository)
         self.store = store or AccelerationStore(self.repository)
         self.adapter = adapter
         self.adapter_version = adapter_version
+        self.mutation_authority_preflight = mutation_authority_preflight
 
     @staticmethod
     def new_run_id() -> str:
@@ -85,6 +88,26 @@ class AccelerationEngine:
             status="CHECKED",
             source_interrupt_id=source_interrupt_id,
         )
+        if (
+            identity.decision_type
+            in {DecisionType.CREATE_FILE, DecisionType.MODIFY_FILE}
+            and self.mutation_authority_preflight is not None
+        ):
+            try:
+                authority_allowed = (
+                    self.mutation_authority_preflight(identity) is True
+                )
+            except Exception:
+                authority_allowed = False
+            if not authority_allowed:
+                return DecisionOutcome(
+                    identity,
+                    run_id,
+                    iteration,
+                    False,
+                    "DENIED",
+                    source_interrupt_id,
+                )
         active = self.store.active_default(identity.decision_key)
         if active is not None:
             if active.rule_hash != identity.rule_hash:

--- a/decision_os/companion/controller.py
+++ b/decision_os/companion/controller.py
@@ -31,7 +31,10 @@ from decision_os.acceleration.codex_adapter import (
 )
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.acceleration.model import (
+    DecisionIdentity,
+    DecisionType,
     RepositoryIdentityError,
+    ScopeError,
     git_root,
     normalize_scope,
 )
@@ -53,6 +56,7 @@ from decision_os.companion.guided_intake import (
 )
 from decision_os.companion.continuation import (
     ContinuationIntegrityError,
+    STAGE_B_SCHEMA,
     StageBContinuationRequest,
     StageBContinuationStore,
     automatic_task_from_persisted_run,
@@ -140,6 +144,16 @@ PickerRunner = Callable[[Path], str | None]
 
 _TERMINAL_STATES = frozenset(
     {"completed", "denied", "unsupported", "needs_attention"}
+)
+_ACTIVE_COMPOUND_STATES = frozenset(
+    {
+        "RUN_1_ACTIVE",
+        "RUN_1_COMPLETE",
+        "RUN_2_ACTIVE",
+        "RUN_2_COMPLETE",
+        "RUN_3_ACTIVE",
+        "RUN_3_COMPLETE",
+    }
 )
 _INTELLIGENCE_TRANSPLANT_EVIDENCE_TYPES = frozenset(
     {
@@ -386,15 +400,7 @@ class CompanionController:
             self._compound_loop = value
             self._compound_recovery_required = bool(
                 value is not None
-                and value.get("state")
-                in {
-                    "RUN_1_ACTIVE",
-                    "RUN_1_COMPLETE",
-                    "RUN_2_ACTIVE",
-                    "RUN_2_COMPLETE",
-                    "RUN_3_ACTIVE",
-                    "RUN_3_COMPLETE",
-                }
+                and value.get("state") in _ACTIVE_COMPOUND_STATES
             )
         except (ContinuationIntegrityError, OSError):
             if self._continuation_store.schema_hint() == STAGE_C_SCHEMA:
@@ -1307,12 +1313,6 @@ class CompanionController:
         with self._condition:
             if self._run["state"] != "running":
                 return "3"
-            if (
-                self._compound_active
-                and approval.normalized_scope
-                not in self._compound_allowed_mutation_paths
-            ):
-                return "3"
             self._run["approval"] = {
                 "repository": approval.repository_name,
                 "action": approval.action,
@@ -1332,6 +1332,139 @@ class CompanionController:
             self._approval_choice = None
             self._condition.notify_all()
             return choice
+
+    def _compound_mutation_preflight(
+        self,
+        identity: DecisionIdentity,
+    ) -> bool:
+        """Constrain file authority to one exact active compound envelope."""
+
+        if (
+            not isinstance(identity, DecisionIdentity)
+            or identity.decision_type
+            not in {DecisionType.CREATE_FILE, DecisionType.MODIFY_FILE}
+        ):
+            return False
+        with self._condition:
+            active_record = bool(
+                isinstance(self._compound_loop, dict)
+                and self._compound_loop.get("state")
+                in _ACTIVE_COMPOUND_STATES
+            )
+            if not self._compound_active:
+                return bool(
+                    not self._compound_recovery_required
+                    and not active_record
+                    and self._compound_allowed_mutation_paths == ()
+                    and self._run.get("continuation") is None
+                )
+            if self._compound_recovery_required:
+                return False
+            repository = self._repository
+            continuation = self._run.get("continuation")
+            if (
+                repository is None
+                or self._run.get("run_type") != "bounded_task"
+                or self._run.get("task_mode") != "contract"
+                or self._run.get("state") != "running"
+                or not isinstance(continuation, dict)
+                or set(continuation)
+                != {
+                    "schema",
+                    "chain_id",
+                    "run_number",
+                    "automatic",
+                    "source_run_id",
+                    "source_evidence_sha256",
+                    "task_sha256",
+                }
+                or continuation.get("schema")
+                != "decision-os-bounded-run-continuation-v0.1"
+            ):
+                return False
+            try:
+                record = self._continuation_store.load_required()
+                if record != self._compound_loop:
+                    return False
+                schema = record.get("schema")
+                if schema == STAGE_B_SCHEMA:
+                    request = StageBContinuationRequest.from_dict(
+                        record.get("request")
+                    )
+                    automatic_tasks = (
+                        []
+                        if record.get("automatic_task") is None
+                        else [record["automatic_task"]]
+                    )
+                    maximum_run = 2
+                elif schema == STAGE_C_SCHEMA:
+                    request = StageCContinuationRequest.from_dict(
+                        record.get("request")
+                    )
+                    automatic_tasks = record.get("automatic_tasks")
+                    maximum_run = 3
+                else:
+                    return False
+                run_number = continuation.get("run_number")
+                if (
+                    not isinstance(run_number, int)
+                    or isinstance(run_number, bool)
+                    or not 1 <= run_number <= maximum_run
+                    or record.get("state") != f"RUN_{run_number}_ACTIVE"
+                    or record.get("chain_id") != continuation.get("chain_id")
+                    or continuation.get("automatic") != (run_number > 1)
+                    or not isinstance(automatic_tasks, list)
+                ):
+                    return False
+                if run_number == 1:
+                    expected_source_run_id = None
+                    expected_source_evidence_sha256 = None
+                    expected_task_sha256 = hashlib.sha256(
+                        request.run_1_task.strip().encode("utf-8")
+                    ).hexdigest()
+                else:
+                    if len(automatic_tasks) < run_number - 1:
+                        return False
+                    automatic_task = automatic_tasks[run_number - 2]
+                    if not isinstance(automatic_task, dict):
+                        return False
+                    expected_source_run_id = automatic_task.get("source_run_id")
+                    expected_source_evidence_sha256 = automatic_task.get(
+                        "source_evidence_sha256"
+                    )
+                    expected_task_sha256 = automatic_task.get("task_sha256")
+                allowed_paths = tuple(request.allowed_mutation_paths)
+                if (
+                    identity.repository_id
+                    != AccelerationStore(repository).repository_id
+                    or record.get("repository_id") != identity.repository_id
+                    or tuple(
+                        normalize_scope(repository, path)
+                        for path in allowed_paths
+                    )
+                    != allowed_paths
+                    or self._compound_allowed_mutation_paths != allowed_paths
+                    or continuation.get("source_run_id")
+                    != expected_source_run_id
+                    or continuation.get("source_evidence_sha256")
+                    != expected_source_evidence_sha256
+                    or continuation.get("task_sha256")
+                    != expected_task_sha256
+                ):
+                    return False
+            except (
+                AttributeError,
+                ContinuationIntegrityError,
+                KeyError,
+                OSError,
+                RepositoryIdentityError,
+                ScopeError,
+                StateIntegrityError,
+                TypeError,
+                ValueError,
+            ):
+                return False
+            return identity.normalized_scope in allowed_paths
 
     def submit_approval(self, choice: str) -> dict[str, Any]:
         choices = {
@@ -1368,6 +1501,7 @@ class CompanionController:
             repository,
             adapter=ADAPTER_NAME,
             adapter_version=CODEX_CLI_VERSION,
+            mutation_authority_preflight=self._compound_mutation_preflight,
         )
         adapter = self.adapter_factory(
             engine,

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,116 @@
+# Current Signal — Compound Authority Preflight Integration
+
+## Canonical Current State — V13 Post Compound Authority Preflight Integration
+
+```text
+Current Layer:
+V13 — Compound Loop / Authority Preflight Integration
+
+V12 State:
+PASS
+
+13-121 Blank-Slate Highest-EV Selection:
+PASS
+
+Selected capability:
+Compound authority preflight before Repository Default reuse
+
+Classification:
+CONTROL
+
+Selection basis:
+highest current realizable EV, not category preference
+
+13-122 Compound Authority Preflight:
+INTEGRATED
+
+Bounded capability:
+active Stage B/C Create/Modify authority is checked before Repository Default
+reuse can authorize the action.
+
+Acceleration boundary:
+valid in-envelope and ordinary non-compound Default reuse remain intact.
+
+Bounded Claim:
+V13 now preflights active Stage B/C Create/Modify proposals against the current
+persisted compound mutation envelope before Repository Default reuse can
+authorize them. This prevents an older reusable Default from widening the
+current compound Run's file-mutation authority.
+
+Claim Boundary:
+This does not establish a generic permission hierarchy; shell, network,
+arbitrary-tool, publication, or release authority; generalized capability
+algebra; or a full authority-system redesign.
+
+V11 Selective Reconnect:
+INTEGRATED
+
+V6 Safety Non-Dilution:
+INTEGRATED
+
+V8 Temporal Evidence Invalidation:
+INTEGRATED
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+Genesis Selection:
+HOLD — typed present-Goal comparison missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+8425b6e04a25f469687d8ca54b76258771a69027
+
+Canonical Starting Main:
+b1131284854501a0364fb09984f1a4ea56eed531
+
+Canonicalization Condition:
+This block becomes canonical only when the exact capability commit and this
+synchronization delta are on main.
+
+Active Branch:
+main
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the exact capability commit and this canonical synchronization are
+on main.
+
+Next Authorized Action:
+None. Preserve the exact compound-authority and acceleration boundary. Do not
+start another blank-slate diagnosis, candidate selection, Decision transplant,
+release, publication, Meter change, Genesis Selection, V10 Protective Rescale,
+FN132, or 13-108 integration.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact 13-122 compound authority preflight is integrated before
+Repository Default reuse, valid in-envelope and ordinary non-compound Default
+acceleration remain available, and no next loop is authorized.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Signal — V11-Derived Selective Reconnect Edge Integration
 
 ## Canonical Current State — V13 Post Selective Reconnect Integration

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,116 @@
+# Current Codex Handoff — Compound Authority Preflight Integration
+
+## Canonical Current State — V13 Post Compound Authority Preflight Integration
+
+```text
+Current Layer:
+V13 — Compound Loop / Authority Preflight Integration
+
+V12 State:
+PASS
+
+13-121 Blank-Slate Highest-EV Selection:
+PASS
+
+Selected capability:
+Compound authority preflight before Repository Default reuse
+
+Classification:
+CONTROL
+
+Selection basis:
+highest current realizable EV, not category preference
+
+13-122 Compound Authority Preflight:
+INTEGRATED
+
+Bounded capability:
+active Stage B/C Create/Modify authority is checked before Repository Default
+reuse can authorize the action.
+
+Acceleration boundary:
+valid in-envelope and ordinary non-compound Default reuse remain intact.
+
+Bounded Claim:
+V13 now preflights active Stage B/C Create/Modify proposals against the current
+persisted compound mutation envelope before Repository Default reuse can
+authorize them. This prevents an older reusable Default from widening the
+current compound Run's file-mutation authority.
+
+Claim Boundary:
+This does not establish a generic permission hierarchy; shell, network,
+arbitrary-tool, publication, or release authority; generalized capability
+algebra; or a full authority-system redesign.
+
+V11 Selective Reconnect:
+INTEGRATED
+
+V6 Safety Non-Dilution:
+INTEGRATED
+
+V8 Temporal Evidence Invalidation:
+INTEGRATED
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+Genesis Selection:
+HOLD — typed present-Goal comparison missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+8425b6e04a25f469687d8ca54b76258771a69027
+
+Canonical Starting Main:
+b1131284854501a0364fb09984f1a4ea56eed531
+
+Canonicalization Condition:
+This block becomes canonical only when the exact capability commit and this
+synchronization delta are on main.
+
+Active Branch:
+main
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+None after the exact capability commit and this canonical synchronization are
+on main.
+
+Next Authorized Action:
+None. Preserve the exact compound-authority and acceleration boundary. Do not
+start another blank-slate diagnosis, candidate selection, Decision transplant,
+release, publication, Meter change, Genesis Selection, V10 Protective Rescale,
+FN132, or 13-108 integration.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact 13-122 compound authority preflight is integrated before
+Repository Default reuse, valid in-envelope and ordinary non-compound Default
+acceleration remain available, and no next loop is authorized.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Codex Handoff — V11-Derived Selective Reconnect Edge Integration
 
 ## Canonical Current State — V13 Post Selective Reconnect Integration

--- a/tests/test_acceleration_codex_adapter.py
+++ b/tests/test_acceleration_codex_adapter.py
@@ -32,6 +32,7 @@ from decision_os.acceleration.codex_adapter import (
     canonical_failure_diagnostic,
 )
 from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import DecisionType
 
 
 def create_repository(parent: Path) -> Path:
@@ -2959,6 +2960,172 @@ class CodexAdapterTest(unittest.IsolatedAsyncioTestCase):
                 for transport in factory.transports
             ]
             self.assertEqual(["thread-1", "thread-2"], turn_thread_ids)
+
+    async def test_compound_preflight_controls_wire_before_default_reuse(
+        self,
+    ) -> None:
+        cases = (
+            (DecisionType.MODIFY_FILE, "target.txt", "update"),
+            (DecisionType.CREATE_FILE, "created.txt", "add"),
+        )
+        for decision_type, path, kind in cases:
+            with self.subTest(decision_type=decision_type):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    ordinary = AccelerationEngine(
+                        repository,
+                        adapter=ADAPTER_NAME,
+                        adapter_version=CODEX_CLI_VERSION,
+                    )
+                    created = ordinary.evaluate(
+                        run_id="default-creation",
+                        iteration=1,
+                        decision_type=decision_type,
+                        requested_scope=path,
+                        source_interrupt_id="create-default",
+                        choice_provider=lambda _identity: "2",
+                    )
+                    default_before = ordinary.store.active_default(
+                        created.identity.decision_key
+                    )
+                    proposed_change = change(path=path, kind=kind)
+                    human_calls = []
+                    preflight_calls = []
+                    rejected_factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id="thread-rejected",
+                                turn_id="turn-rejected",
+                                item_id="item-rejected",
+                                file_changes=[proposed_change],
+                                item_status="declined",
+                            )
+                        ]
+                    )
+                    rejected_engine = AccelerationEngine(
+                        repository,
+                        adapter=ADAPTER_NAME,
+                        adapter_version=CODEX_CLI_VERSION,
+                        mutation_authority_preflight=lambda identity: (
+                            preflight_calls.append(identity) or False
+                        ),
+                    )
+                    rejected_adapter = CodexAdapter(
+                        rejected_engine,
+                        input_func=lambda: None,
+                        stdout=io.StringIO(),
+                        approval_provider=lambda approval: (
+                            human_calls.append(approval) or "1"
+                        ),
+                        transport_factory=rejected_factory,
+                    )
+
+                    rejected = await rejected_adapter.run(
+                        "out-of-envelope compound proposal"
+                    )
+
+                    rejected_decisions = [
+                        message["result"]["decision"]
+                        for message in rejected_factory.transports[0].sent
+                        if isinstance(message.get("result"), dict)
+                        and "decision" in message["result"]
+                    ]
+                    self.assertEqual(["decline"], rejected_decisions)
+                    self.assertEqual("DENIED", rejected.status)
+                    self.assertFalse(rejected.normal_terminal)
+                    self.assertEqual(1, len(preflight_calls))
+                    self.assertEqual(path, preflight_calls[0].normalized_scope)
+                    self.assertEqual([], human_calls)
+                    self.assertEqual(set(), rejected_adapter._accepted_items)
+                    self.assertEqual({}, rejected_adapter._approved_changes)
+                    self.assertFalse(
+                        any(
+                            action.status == "approved"
+                            or action.access == "reused"
+                            for action in rejected.file_actions
+                        )
+                    )
+                    self.assertEqual(
+                        default_before,
+                        rejected_engine.store.active_default(
+                            created.identity.decision_key
+                        ),
+                    )
+
+                    allowed_factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id="thread-allowed",
+                                turn_id="turn-allowed",
+                                item_id="item-allowed",
+                                file_changes=[proposed_change],
+                            )
+                        ]
+                    )
+                    allowed_engine = AccelerationEngine(
+                        repository,
+                        adapter=ADAPTER_NAME,
+                        adapter_version=CODEX_CLI_VERSION,
+                        mutation_authority_preflight=lambda _identity: True,
+                    )
+                    allowed_adapter = CodexAdapter(
+                        allowed_engine,
+                        input_func=lambda: None,
+                        stdout=io.StringIO(),
+                        approval_provider=lambda approval: (
+                            human_calls.append(approval) or "1"
+                        ),
+                        transport_factory=allowed_factory,
+                    )
+
+                    allowed = await allowed_adapter.run(
+                        "in-envelope compound proposal"
+                    )
+
+                    allowed_decisions = [
+                        message["result"]["decision"]
+                        for message in allowed_factory.transports[0].sent
+                        if isinstance(message.get("result"), dict)
+                        and "decision" in message["result"]
+                    ]
+                    self.assertEqual(["accept"], allowed_decisions)
+                    self.assertEqual("VERIFIED_SAVE", allowed.status)
+                    self.assertEqual(1, len(allowed.file_actions))
+                    self.assertEqual("reused", allowed.file_actions[0].access)
+                    self.assertEqual("approved", allowed.file_actions[0].status)
+                    self.assertEqual([], human_calls)
+
+                    ordinary_factory = FakeTransportFactory(
+                        [
+                            file_run_messages(
+                                repository,
+                                thread_id="thread-ordinary",
+                                turn_id="turn-ordinary",
+                                item_id="item-ordinary",
+                                file_changes=[proposed_change],
+                            )
+                        ]
+                    )
+                    ordinary_adapter = CodexAdapter(
+                        ordinary,
+                        input_func=lambda: self.fail(
+                            "ordinary matching Default must not ask again"
+                        ),
+                        stdout=io.StringIO(),
+                        transport_factory=ordinary_factory,
+                    )
+
+                    later_ordinary = await ordinary_adapter.run(
+                        "ordinary proposal after compound decline"
+                    )
+
+                    self.assertEqual("VERIFIED_REUSE", later_ordinary.status)
+                    self.assertEqual(
+                        "reused",
+                        later_ordinary.file_actions[0].access,
+                    )
 
     async def test_later_verified_reuse_keeps_final_reused_label(
         self,

--- a/tests/test_acceleration_engine.py
+++ b/tests/test_acceleration_engine.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from decision_os.acceleration.engine import AccelerationEngine, DeterministicAdapter
 from decision_os.acceleration.model import DecisionType
@@ -60,6 +61,215 @@ class AccelerationEngineTest(unittest.TestCase):
             self.assertEqual("VERIFIED_REUSE", third_checkpoint.status)
             self.assertTrue(third.allowed)
             self.assertEqual((1, 2), engine.store.counters())
+
+    def test_mutation_authority_preflight_precedes_matching_default(self) -> None:
+        cases = (
+            (DecisionType.MODIFY_FILE, "target.txt"),
+            (DecisionType.CREATE_FILE, "created.txt"),
+        )
+        for decision_type, path in cases:
+            with self.subTest(decision_type=decision_type):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    ordinary = self.make_engine(repository)
+                    created = ordinary.evaluate(
+                        run_id="default-creation",
+                        iteration=1,
+                        decision_type=decision_type,
+                        requested_scope=path,
+                        source_interrupt_id="create-default",
+                        choice_provider=lambda _identity: "2",
+                    )
+                    default_before = ordinary.store.active_default(
+                        created.identity.decision_key
+                    )
+                    preflight_calls = []
+                    human_calls = []
+                    guarded = AccelerationEngine(
+                        repository,
+                        adapter="deterministic-test",
+                        adapter_version="v0.1",
+                        mutation_authority_preflight=lambda identity: (
+                            preflight_calls.append(identity) or False
+                        ),
+                    )
+
+                    with patch.object(
+                        guarded.store,
+                        "active_default",
+                        wraps=guarded.store.active_default,
+                    ) as default_lookup:
+                        denied = guarded.evaluate(
+                            run_id="compound-out-of-envelope",
+                            iteration=1,
+                            decision_type=decision_type,
+                            requested_scope=path,
+                            source_interrupt_id="compound-proposal",
+                            choice_provider=lambda identity: (
+                                human_calls.append(identity) or "1"
+                            ),
+                        )
+
+                    self.assertEqual("DENIED", denied.status)
+                    self.assertFalse(denied.allowed)
+                    self.assertEqual([denied.identity], preflight_calls)
+                    self.assertEqual([], human_calls)
+                    default_lookup.assert_not_called()
+                    self.assertEqual(
+                        default_before,
+                        guarded.store.active_default(
+                            created.identity.decision_key
+                        ),
+                    )
+                    event_types = [
+                        event["event_type"]
+                        for event in guarded.store.read_events()
+                        if event["run_id"] == "compound-out-of-envelope"
+                    ]
+                    self.assertEqual(["DECISION_CHECK"], event_types)
+
+    def test_in_envelope_and_ordinary_default_acceleration_survive(self) -> None:
+        cases = (
+            (DecisionType.MODIFY_FILE, "target.txt"),
+            (DecisionType.CREATE_FILE, "created.txt"),
+        )
+        for decision_type, path in cases:
+            with self.subTest(decision_type=decision_type):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory))
+                    ordinary = self.make_engine(repository)
+                    created = ordinary.evaluate(
+                        run_id="default-creation",
+                        iteration=1,
+                        decision_type=decision_type,
+                        requested_scope=path,
+                        source_interrupt_id="create-default",
+                        choice_provider=lambda _identity: "2",
+                    )
+                    preflight_calls = []
+                    compound = AccelerationEngine(
+                        repository,
+                        adapter="deterministic-test",
+                        adapter_version="v0.1",
+                        mutation_authority_preflight=lambda identity: (
+                            preflight_calls.append(identity) or True
+                        ),
+                    )
+
+                    in_envelope = compound.evaluate(
+                        run_id="compound-in-envelope",
+                        iteration=1,
+                        decision_type=decision_type,
+                        requested_scope=path,
+                        source_interrupt_id="compound-proposal",
+                        choice_provider=lambda _identity: self.fail(
+                            "matching Default must not ask the Human Seat"
+                        ),
+                    )
+                    later_ordinary = ordinary.evaluate(
+                        run_id="later-ordinary",
+                        iteration=1,
+                        decision_type=decision_type,
+                        requested_scope=path,
+                        source_interrupt_id="ordinary-proposal",
+                        choice_provider=lambda _identity: self.fail(
+                            "ordinary matching Default must not ask again"
+                        ),
+                    )
+
+                    self.assertEqual("DEFAULT_MATCHED", in_envelope.status)
+                    self.assertTrue(in_envelope.allowed)
+                    self.assertEqual([in_envelope.identity], preflight_calls)
+                    self.assertEqual("DEFAULT_MATCHED", later_ordinary.status)
+                    self.assertTrue(later_ordinary.allowed)
+                    self.assertEqual(
+                        created.default_created_run_id,
+                        later_ordinary.default_created_run_id,
+                    )
+
+    def test_mutation_authority_preflight_fails_closed_and_normalizes_once(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory))
+            observed = []
+            engine = AccelerationEngine(
+                repository,
+                adapter="deterministic-test",
+                adapter_version="v0.1",
+                mutation_authority_preflight=lambda identity: (
+                    observed.append(identity.normalized_scope) or False
+                ),
+            )
+
+            first = engine.evaluate(
+                run_id="normalized-1",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="./target.txt",
+                source_interrupt_id="normalized-1",
+                choice_provider=lambda _identity: "1",
+            )
+            second = engine.evaluate(
+                run_id="normalized-2",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="nested/../target.txt",
+                source_interrupt_id="normalized-2",
+                choice_provider=lambda _identity: "1",
+            )
+
+            self.assertEqual("DENIED", first.status)
+            self.assertEqual("DENIED", second.status)
+            self.assertEqual(["target.txt", "target.txt"], observed)
+            self.assertEqual(first.identity, second.identity)
+
+            for result in (None, "allowed", 1):
+                with self.subTest(result=result):
+                    malformed = AccelerationEngine(
+                        repository,
+                        mutation_authority_preflight=lambda _identity: result,
+                    ).evaluate(
+                        run_id=f"malformed-{result!r}",
+                        iteration=1,
+                        decision_type=DecisionType.MODIFY_FILE,
+                        requested_scope="target.txt",
+                        source_interrupt_id="malformed",
+                        choice_provider=lambda _identity: "1",
+                    )
+                    self.assertEqual("DENIED", malformed.status)
+
+            raised = AccelerationEngine(
+                repository,
+                mutation_authority_preflight=lambda _identity: (_ for _ in ()).throw(
+                    RuntimeError("malformed compound authority")
+                ),
+            ).evaluate(
+                run_id="malformed-raised",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="malformed",
+                choice_provider=lambda _identity: "1",
+            )
+            self.assertEqual("DENIED", raised.status)
+
+            callback_calls = []
+            unrelated_surface = AccelerationEngine(
+                repository,
+                mutation_authority_preflight=lambda identity: (
+                    callback_calls.append(identity) or False
+                ),
+            ).evaluate(
+                run_id="unrelated-authority-surface",
+                iteration=1,
+                decision_type=DecisionType.ADD_TESTS,
+                requested_scope="target.txt",
+                source_interrupt_id="unrelated-authority-surface",
+                choice_provider=lambda _identity: "1",
+            )
+            self.assertEqual("ALLOW_ONCE", unrelated_surface.status)
+            self.assertEqual([], callback_calls)
 
     def test_allow_once_deny_timeout_and_same_run_are_excluded(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_companion_continuation.py
+++ b/tests/test_companion_continuation.py
@@ -9,11 +9,17 @@ import time
 import unittest
 from typing import Any
 
-from decision_os.acceleration.model import hash_payload
-from decision_os.acceleration.store import StateIntegrityError
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import (
+    DecisionType,
+    derive_decision_identity,
+    hash_payload,
+)
+from decision_os.acceleration.store import AccelerationStore, StateIntegrityError
 from decision_os.companion.continuation import (
     ContinuationIntegrityError,
     StageBContinuationRequest,
+    new_record,
 )
 from decision_os.companion.controller import (
     CompanionController,
@@ -237,6 +243,18 @@ class StageBContinuationTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             repository = create_repository(root)
+            ordinary = AccelerationEngine(repository)
+            created = ordinary.evaluate(
+                run_id="ordinary-default-creation",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="ordinary-default-creation",
+                choice_provider=lambda _identity: "2",
+            )
+            default_before = ordinary.store.active_default(
+                created.identity.decision_key
+            )
             factory = RecordingFactory("mutation", "read_only")
             controller = self.make_controller(root, factory)
             controller.select_repository(repository)
@@ -258,6 +276,133 @@ class StageBContinuationTest(unittest.TestCase):
             self.assertEqual("STOP", chain["supervisor"]["decision_route"])
             self.assertEqual(0, chain["automatic_continuations_started"])
             self.assertEqual(1, len(factory.prompts))
+            self.assertIsNone(chain["supervisor"]["human_seat_return"])
+            self.assertEqual(
+                default_before,
+                ordinary.store.active_default(created.identity.decision_key),
+            )
+            later = ordinary.evaluate(
+                run_id="later-ordinary-reuse",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="later-ordinary-proposal",
+                choice_provider=lambda _identity: self.fail(
+                    "preserved Default must remain reusable"
+                ),
+            )
+            self.assertEqual("DEFAULT_MATCHED", later.status)
+
+    def test_compound_preflight_binds_persisted_authority_and_replays_decline(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            controller = self.make_controller(root, RecordingFactory())
+            controller.select_repository(repository)
+            request = stage_b_request(allowed_mutation_paths=("target.txt",))
+            chain_id = "a" * 32
+            record = controller._continuation_store.save(
+                new_record(
+                    request,
+                    chain_id=chain_id,
+                    repository_id=AccelerationStore(repository).repository_id,
+                )
+            )
+            controller._compound_loop = record
+            controller._compound_active = True
+            controller._compound_recovery_required = False
+            controller._compound_allowed_mutation_paths = ("target.txt",)
+            controller._run["state"] = "running"
+            controller._run["task_mode"] = "contract"
+            controller._run["continuation"] = {
+                "schema": "decision-os-bounded-run-continuation-v0.1",
+                "chain_id": chain_id,
+                "run_number": 1,
+                "automatic": False,
+                "source_run_id": None,
+                "source_evidence_sha256": None,
+                "task_sha256": hashlib.sha256(
+                    request.run_1_task.encode("utf-8")
+                ).hexdigest(),
+            }
+            target = derive_decision_identity(
+                repository,
+                DecisionType.MODIFY_FILE,
+                "target.txt",
+            )
+            outside = derive_decision_identity(
+                repository,
+                DecisionType.MODIFY_FILE,
+                "other.txt",
+            )
+            foreign_repository = create_repository(root, name="foreign")
+            foreign = derive_decision_identity(
+                foreign_repository,
+                DecisionType.MODIFY_FILE,
+                "target.txt",
+            )
+
+            self.assertTrue(controller._compound_mutation_preflight(target))
+            self.assertFalse(controller._compound_mutation_preflight(outside))
+            self.assertFalse(controller._compound_mutation_preflight(foreign))
+
+            controller._compound_allowed_mutation_paths = ()
+            self.assertFalse(controller._compound_mutation_preflight(target))
+            controller._compound_allowed_mutation_paths = ("target.txt",)
+            controller._run["continuation"] = None
+            self.assertFalse(controller._compound_mutation_preflight(target))
+            controller._run["continuation"] = {
+                "schema": "decision-os-bounded-run-continuation-v0.1",
+                "chain_id": chain_id,
+                "run_number": 1,
+                "automatic": False,
+                "source_run_id": None,
+                "source_evidence_sha256": None,
+                "task_sha256": hashlib.sha256(
+                    request.run_1_task.encode("utf-8")
+                ).hexdigest(),
+            }
+
+            restarted = self.make_controller(root, RecordingFactory())
+            replayed = restarted.snapshot()["compound_loop"]
+            self.assertEqual(record["chain_id"], replayed["chain_id"])
+            self.assertEqual(record["record_sha256"], replayed["record_sha256"])
+            self.assertFalse(controller._compound_mutation_preflight(outside))
+            self.assertFalse(restarted._compound_mutation_preflight(outside))
+
+            ordinary = AccelerationEngine(repository)
+            ordinary.evaluate(
+                run_id="malformed-default-creation",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="malformed-default-creation",
+                choice_provider=lambda _identity: "2",
+            )
+            controller._compound_active = False
+            controller._compound_loop = None
+            controller._compound_allowed_mutation_paths = ()
+            malformed = AccelerationEngine(
+                repository,
+                mutation_authority_preflight=(
+                    controller._compound_mutation_preflight
+                ),
+            ).evaluate(
+                run_id="malformed-unbound-compound",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="malformed-unbound-compound",
+                choice_provider=lambda _identity: self.fail(
+                    "unbound compound state must not reach Human approval"
+                ),
+            )
+            self.assertEqual("DENIED", malformed.status)
+            controller._run["continuation"] = None
+            controller._compound_allowed_mutation_paths = []  # type: ignore[assignment]
+            self.assertFalse(controller._compound_mutation_preflight(target))
 
     def test_insufficient_run_1_evidence_never_starts_run_two(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_companion_small_compound_loop.py
+++ b/tests/test_companion_small_compound_loop.py
@@ -14,7 +14,8 @@ from decision_os.acceleration.codex_adapter import (
     CodexReadEvidence,
     CodexRunResult,
 )
-from decision_os.acceleration.model import hash_payload
+from decision_os.acceleration.engine import AccelerationEngine
+from decision_os.acceleration.model import DecisionType, hash_payload
 from decision_os.companion.controller import (
     CompanionController,
     RunConflictError,
@@ -698,6 +699,63 @@ class StageCSmallCompoundLoopTest(unittest.TestCase):
             )
             self.assertEqual(3, len(factory.prompts))
             self.assertEqual(1, len(factory.plans))
+
+    def test_stage_c_default_reuse_is_bounded_by_the_active_envelope(self) -> None:
+        cases = (
+            ("allowed.txt", "DENIED", "BLOCK", False),
+            ("target.txt", "VERIFIED_SAVE", "HOLD", True),
+        )
+        for allowed_path, run_status, outcome, approved in cases:
+            with self.subTest(allowed_path=allowed_path):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    repository = create_repository(root)
+                    ordinary = AccelerationEngine(repository)
+                    created = ordinary.evaluate(
+                        run_id="ordinary-default-creation",
+                        iteration=1,
+                        decision_type=DecisionType.MODIFY_FILE,
+                        requested_scope="target.txt",
+                        source_interrupt_id="ordinary-default-creation",
+                        choice_provider=lambda _identity: "2",
+                    )
+                    default_before = ordinary.store.active_default(
+                        created.identity.decision_key
+                    )
+                    factory = EvidenceFactory("mutation")
+                    controller = self.make_controller(root, factory)
+                    controller.select_repository(repository)
+
+                    controller.start_small_compound_loop(
+                        stage_c_request(
+                            allowed_mutation_paths=(allowed_path,),
+                        )
+                    )
+                    chain = self.terminal(controller)["compound_loop"]
+
+                    self.assertEqual(run_status, chain["runs"][0]["status"])
+                    self.assertEqual(outcome, chain["outcome"])
+                    approved_actions = [
+                        action
+                        for action in chain["runs"][0]["file_actions"]
+                        if action["status"] == "approved"
+                    ]
+                    self.assertEqual(approved, bool(approved_actions))
+                    if approved:
+                        self.assertEqual("reused", approved_actions[0]["access"])
+                    else:
+                        self.assertFalse(
+                            any(
+                                action["access"] == "reused"
+                                for action in chain["runs"][0]["file_actions"]
+                            )
+                        )
+                    self.assertEqual(
+                        default_before,
+                        ordinary.store.active_default(
+                            created.identity.decision_key
+                        ),
+                    )
 
     def test_rehashed_task_and_provenance_tampering_blocks_reconnect(self) -> None:
         def change_task_2(record: dict[str, Any]) -> None:

--- a/tests/test_compound_evidence_meter.py
+++ b/tests/test_compound_evidence_meter.py
@@ -274,7 +274,7 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
         self.assertIn(
-            "Preserve the exact addressability-only claim boundary",
+            "Preserve the exact compound-authority and acceleration boundary",
             payload["next_authorized_action"],
         )
         for relative_path in (
@@ -289,43 +289,61 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     maxsplit=1,
                 )[0]
                 self.assertIn(
-                    "V11 → V13 — Reconnectable Forgetting / Selective "
-                    "Reconnect Integration",
+                    "V13 — Compound Loop / Authority Preflight Integration",
                     current,
                 )
                 self.assertIn(
-                    "V11-derived Selective Reconnect Edge:\nINTEGRATED",
+                    "13-121 Blank-Slate Highest-EV Selection:\nPASS",
                     current,
                 )
                 self.assertIn(
-                    "Exact persisted Goal/gap → exact prior Field Note structure "
-                    "addressability, with\nfail-closed validation and no "
-                    "activation semantics.",
+                    "Selected capability:\nCompound authority preflight before "
+                    "Repository Default reuse",
                     current,
                 )
                 self.assertIn(
-                    "one bounded scale-addressable reconnect path from an exact "
-                    "current\nGoal/gap to one exact prior Field Note structure "
-                    "without broad historical scan",
+                    "Classification:\nCONTROL",
                     current,
                 )
                 self.assertIn(
-                    "Recall is addressability only. It does not establish "
-                    "present truth, usefulness,\nor validity",
+                    "Selection basis:\nhighest current realizable EV, not "
+                    "category preference",
                     current,
                 )
                 self.assertIn(
-                    "generalized Outcome-Masked Replay, or full V11 integration",
+                    "13-122 Compound Authority Preflight:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
-                    "already-recorded V11 source commit/path/blob identity "
-                    "matches the\nauthoritative "
-                    "`shin4141/decision-os-paper` repository",
+                    "active Stage B/C Create/Modify authority is checked before "
+                    "Repository Default\nreuse can authorize the action.",
                     current,
                 )
                 self.assertIn(
-                    "Fresh upstream PDF refetch / rehash:\nNOT PERFORMED",
+                    "valid in-envelope and ordinary non-compound Default reuse "
+                    "remain intact.",
+                    current,
+                )
+                self.assertIn(
+                    "V13 now preflights active Stage B/C Create/Modify proposals "
+                    "against the current\npersisted compound mutation envelope "
+                    "before Repository Default reuse can\nauthorize them.",
+                    current,
+                )
+                self.assertIn(
+                    "This prevents an older reusable Default from widening the\n"
+                    "current compound Run's file-mutation authority.",
+                    current,
+                )
+                self.assertIn(
+                    "This does not establish a generic permission hierarchy; "
+                    "shell, network,\narbitrary-tool, publication, or release "
+                    "authority; generalized capability\nalgebra; or a full "
+                    "authority-system redesign.",
+                    current,
+                )
+                self.assertIn(
+                    "V11 Selective Reconnect:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
@@ -348,6 +366,16 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                 )
                 self.assertIn(
                     "13-108:\nNONCANONICAL",
+                    current,
+                )
+                self.assertIn(
+                    "Capability Commit:\n"
+                    "8425b6e04a25f469687d8ca54b76258771a69027",
+                    current,
+                )
+                self.assertIn(
+                    "Canonical Starting Main:\n"
+                    "b1131284854501a0364fb09984f1a4ea56eed531",
                     current,
                 )
                 self.assertIn(


### PR DESCRIPTION
## Summary

- preflight active Stage B/C Create/Modify proposals against the persisted compound mutation envelope before Repository Default lookup or reuse can authorize them
- preserve valid in-envelope Default acceleration and ordinary non-compound Default reuse
- synchronize the canonical current signal and handoff at `HOLD — NO NEXT AUTHORITY`

## Root cause

A matching older Repository Default could bypass the active compound mutation envelope before the Stage C post-Run guard observed the out-of-envelope action.

## Exact scope

Base: `b1131284854501a0364fb09984f1a4ea56eed531`

Commits:
1. `8425b6e04a25f469687d8ca54b76258771a69027`
2. `4370f1c8c433ca9019d69473853aad40a27e6b39`

Exactly nine reviewed files; no Repository Default schema, generalized permission, V10, Genesis, 13-108, Field Note 132, Compound Evidence Meter, release, or publication-surface expansion.

## Validation

- original pre-authorization bypass reproduced on the exact base
- 114 affected engine/adapter/Stage B/C tests passed
- V6, V8, V11, restart/replay, zero-progress, ordinary Default, and canonical-surface regressions passed
- repository-wide suite: 1,492 tests passed, 15 skipped
- `git diff --check` passed
