### PR TITLE
Integrate same-Run completion evidence invalidation

### DIFF
--- a/decision_os/companion/small_compound_loop.py
+++ b/decision_os/companion/small_compound_loop.py
@@ -461,7 +461,9 @@ def _requirement_temporal_state(
     invalidating_modifies = tuple(
         modify_run
         for modify_run in authorized_modifies
-        if any(read_run < modify_run for read_run in matching_reads)
+        # Persisted Run evidence does not order reads against file actions.
+        # A same-Run collision therefore cannot prove post-Modify support.
+        if any(read_run <= modify_run for read_run in matching_reads)
     )
     if not invalidating_modifies:
         return True, False

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,136 @@
+# Current Signal — Same-Run Completion Evidence Invalidation Integration
+
+## Canonical Current State — V13 Post Same-Run Temporal Evidence Integration
+
+```text
+Current Layer:
+V13 — Completion Integrity / Same-Run Temporal Evidence Integration
+
+V12 State:
+PASS
+
+13-124 Blank-Slate Highest-EV Round 2:
+PASS
+
+Selected capability:
+Same-Run approved-Modify completion-evidence invalidation
+
+Classification:
+CONTROL
+
+13-125:
+INTEGRATED locally pending remote canonicalization
+
+Bounded capability:
+same-Run matching completion read + approved exact-path Modify cannot establish
+current completion support.
+
+Temporal Rule:
+read_run <= modify_run invalidates.
+read_run > last_invalidation re-establishes support.
+
+Historical Evidence:
+The persisted matching read remains present as historical evidence. Only its
+eligibility as current completion support changes; "the file was read during
+this Run" is not rewritten.
+
+Conservative Boundary:
+Within-Run post-Modify reread cannot presently be proved from authoritative,
+restart-verifiable event ordering. Any same-Run matching-read / approved
+same-path-Modify collision therefore remains stale.
+
+Legacy Boundary:
+Pre-1.01 false-COMPLETE records fail closed as BLOCKED_CORRUPT / BLOCK. No
+silent migration, retrospective rewriting, or fabricated within-Run order is
+added.
+
+Bounded Claim:
+V13 no longer accepts a same-Run completion-matching read as current support
+when that Run also contains an approved Modify of the exact same evidence path.
+This prevents unsupported COMPLETE when post-mutation current identity is not
+proved.
+
+Claim Boundary:
+This does not establish within-Run event ordering, generic freshness, semantic
+equivalence, post-mutation content identity, transaction history, generic
+mutation dependency analysis, or full temporal reasoning.
+
+Compound Authority Preflight:
+INTEGRATED
+
+V11 Selective Reconnect:
+INTEGRATED
+
+V6 Safety Non-Dilution:
+INTEGRATED
+
+V8 Cross-Run Temporal Evidence Invalidation:
+INTEGRATED
+
+Zero-Declared-Progress Stop:
+INTEGRATED
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+Genesis Selection:
+HOLD — typed present-Goal comparison missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+5d937fb3f1a123efc6a5d04727547d9c137c63e3
+
+Canonical Starting Main:
+72219407008abd1aa9131cf79ec9f7c46ff1368a
+
+Canonicalization Condition:
+This block becomes remote canonical only when the exact capability commit and
+this synchronization delta are on main with Human Seat authorization.
+
+Active Branch:
+codex/13-126-same-run-invalidation-integration
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+Remote canonicalization only. Local review, integration, validation, and
+canonical synchronization are complete.
+
+Next Authorized Action:
+None. Stop at the remote publication Human Seat boundary. Do not push, open a
+PR, merge, begin another blank-slate diagnosis, generate candidates, start the
+forked stronger-intelligence audit experiment, or change V10, Genesis
+Selection, 13-108, Field Note 132, or the Compound Evidence Meter.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact 13-125 capability is reviewed and integrated locally, the
+same-Run collision now fails closed without erasing historical read evidence,
+clean and cross-Run behavior remain intact, and remote canonicalization awaits
+separate Human Seat authorization.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Signal — Compound Authority Preflight Integration
 
 ## Canonical Current State — V13 Post Compound Authority Preflight Integration

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,136 @@
+# Current Codex Handoff — Same-Run Completion Evidence Invalidation Integration
+
+## Canonical Current State — V13 Post Same-Run Temporal Evidence Integration
+
+```text
+Current Layer:
+V13 — Completion Integrity / Same-Run Temporal Evidence Integration
+
+V12 State:
+PASS
+
+13-124 Blank-Slate Highest-EV Round 2:
+PASS
+
+Selected capability:
+Same-Run approved-Modify completion-evidence invalidation
+
+Classification:
+CONTROL
+
+13-125:
+INTEGRATED locally pending remote canonicalization
+
+Bounded capability:
+same-Run matching completion read + approved exact-path Modify cannot establish
+current completion support.
+
+Temporal Rule:
+read_run <= modify_run invalidates.
+read_run > last_invalidation re-establishes support.
+
+Historical Evidence:
+The persisted matching read remains present as historical evidence. Only its
+eligibility as current completion support changes; "the file was read during
+this Run" is not rewritten.
+
+Conservative Boundary:
+Within-Run post-Modify reread cannot presently be proved from authoritative,
+restart-verifiable event ordering. Any same-Run matching-read / approved
+same-path-Modify collision therefore remains stale.
+
+Legacy Boundary:
+Pre-1.01 false-COMPLETE records fail closed as BLOCKED_CORRUPT / BLOCK. No
+silent migration, retrospective rewriting, or fabricated within-Run order is
+added.
+
+Bounded Claim:
+V13 no longer accepts a same-Run completion-matching read as current support
+when that Run also contains an approved Modify of the exact same evidence path.
+This prevents unsupported COMPLETE when post-mutation current identity is not
+proved.
+
+Claim Boundary:
+This does not establish within-Run event ordering, generic freshness, semantic
+equivalence, post-mutation content identity, transaction history, generic
+mutation dependency analysis, or full temporal reasoning.
+
+Compound Authority Preflight:
+INTEGRATED
+
+V11 Selective Reconnect:
+INTEGRATED
+
+V6 Safety Non-Dilution:
+INTEGRATED
+
+V8 Cross-Run Temporal Evidence Invalidation:
+INTEGRATED
+
+Zero-Declared-Progress Stop:
+INTEGRATED
+
+V10 Protective Rescale:
+HOLD — Carrier observability missing
+
+Genesis Selection:
+HOLD — typed present-Goal comparison missing
+
+13-108:
+NONCANONICAL
+
+Capability Commit:
+5d937fb3f1a123efc6a5d04727547d9c137c63e3
+
+Canonical Starting Main:
+72219407008abd1aa9131cf79ec9f7c46ff1368a
+
+Canonicalization Condition:
+This block becomes remote canonical only when the exact capability commit and
+this synchronization delta are on main with Human Seat authorization.
+
+Active Branch:
+codex/13-126-same-run-invalidation-integration
+
+Field Note 132:
+Verification pending
+
+Compound Evidence Meter:
+unchanged
+
+Current Missing Closure:
+Remote canonicalization only. Local review, integration, validation, and
+canonical synchronization are complete.
+
+Next Authorized Action:
+None. Stop at the remote publication Human Seat boundary. Do not push, open a
+PR, merge, begin another blank-slate diagnosis, generate candidates, start the
+forked stronger-intelligence audit experiment, or change V10, Genesis
+Selection, 13-108, Field Note 132, or the Compound Evidence Meter.
+
+Current Gate:
+HOLD — NO NEXT AUTHORITY
+
+Release Authority:
+NONE
+
+Publication Authority:
+NONE
+
+Decision Owner / Human Seat:
+Shin
+
+Completion Line:
+PASS — the exact 13-125 capability is reviewed and integrated locally, the
+same-Run collision now fails closed without erasing historical read evidence,
+clean and cross-Run behavior remain intact, and remote canonicalization awaits
+separate Human Seat authorization.
+```
+
+Everything below this boundary is preserved historical material byte-for-byte
+as of its own recorded state. Historical entries grant no present execution,
+merge, release, or publication authority.
+
 # Current Codex Handoff — Compound Authority Preflight Integration
 
 ## Canonical Current State — V13 Post Compound Authority Preflight Integration

--- a/tests/test_companion_small_compound_loop.py
+++ b/tests/test_companion_small_compound_loop.py
@@ -329,6 +329,167 @@ class StageCSmallCompoundLoopTest(unittest.TestCase):
                 controller.snapshot()["compound_loop"]["state"],
             )
 
+    def test_same_run_approved_modify_invalidates_current_read_support(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = create_repository(root)
+            factory = EvidenceFactory(
+                {
+                    "evidence": (1, 2, 3),
+                    "modifies": ("evidence-1.md",),
+                },
+                {"evidence": (1,)},
+            )
+            controller = self.make_controller(root, factory)
+            controller.select_repository(repository)
+            controller.start_small_compound_loop(
+                stage_c_request(
+                    allowed_mutation_paths=("evidence-1.md",),
+                )
+            )
+            chain = self.terminal(controller)["compound_loop"]
+
+            self.assertEqual("HOLD", chain["outcome"])
+            self.assertEqual(1, len(chain["runs"]))
+            self.assertEqual(
+                ["REQ-2", "REQ-3"],
+                chain["residues"][0]["established_requirement_ids"],
+            )
+            self.assertEqual(
+                ["REQ-1"],
+                chain["residues"][0]["remaining_requirement_ids"],
+            )
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                chain["supervisor_judgments"][0]["decision_route"],
+            )
+            self.assertEqual("HOLD", chain["governed_stop"]["gate"])
+            self.assertEqual(
+                "EVIDENCE-RECOVERY",
+                chain["governed_stop"]["route"],
+            )
+            self.assertEqual([], chain["automatic_tasks"])
+            self.assertEqual(0, chain["automatic_continuations_started"])
+            self.assertEqual(1, len(factory.prompts))
+            self.assertEqual(1, len(factory.plans))
+
+            matching_read = chain["runs"][0]["read_evidence"][0]
+            self.assertEqual(
+                {
+                    "path": "evidence-1.md",
+                    "bytes": 1,
+                    "sha256": "1" * 64,
+                    "repository_identity": "b" * 40,
+                    "status": "succeeded",
+                    "reason": None,
+                },
+                matching_read,
+            )
+            self.assertEqual(
+                {
+                    "action": "Modify",
+                    "path": "evidence-1.md",
+                    "access": "one-time",
+                    "status": "approved",
+                },
+                chain["runs"][0]["file_actions"][0],
+            )
+
+            restarted_factory = EvidenceFactory()
+            restarted = self.make_controller(root, restarted_factory)
+            replayed = restarted.snapshot()["compound_loop"]
+            self.assertEqual("HOLD", replayed["outcome"])
+            self.assertEqual(
+                chain["record_sha256"],
+                replayed["record_sha256"],
+            )
+            self.assertEqual(
+                chain["runs"][0]["read_evidence"],
+                replayed["runs"][0]["read_evidence"],
+            )
+            self.assertEqual(
+                ["REQ-1"],
+                replayed["residues"][0]["remaining_requirement_ids"],
+            )
+            self.assertEqual([], restarted_factory.prompts)
+
+    def test_same_run_collision_is_conservative_and_modify_specific(
+        self,
+    ) -> None:
+        collision = temporal_support_record(
+            {
+                "evidence": (1, 1, 2, 3),
+                "modifies": ("evidence-1.md",),
+            }
+        )
+        self.assertEqual(
+            ("REQ-2", "REQ-3"),
+            satisfied_requirement_ids(collision),
+        )
+        self.assertEqual(
+            ("REQ-1",),
+            tuple(
+                item["requirement_id"]
+                for item in remaining_requirements(collision)
+            ),
+        )
+        self.assertEqual(
+            2,
+            sum(
+                read["path"] == "evidence-1.md"
+                for read in collision["runs"][0]["read_evidence"]
+            ),
+        )
+
+        read_only = temporal_support_record({"evidence": (1, 2, 3)})
+        self.assertEqual(
+            ("REQ-1", "REQ-2", "REQ-3"),
+            satisfied_requirement_ids(read_only),
+        )
+
+        denied = temporal_support_record(
+            {
+                "evidence": (1, 2, 3),
+                "modifies": ("evidence-1.md",),
+            }
+        )
+        denied_action = denied["runs"][0]["file_actions"][0]
+        denied_action["access"] = "denied"
+        denied_action["status"] = "denied"
+        self.assertEqual(
+            ("REQ-1", "REQ-2", "REQ-3"),
+            satisfied_requirement_ids(denied),
+        )
+
+        created = temporal_support_record(
+            {
+                "evidence": (1, 2, 3),
+                "modifies": ("evidence-1.md",),
+            }
+        )
+        created["runs"][0]["file_actions"][0]["action"] = "Create"
+        self.assertEqual(
+            ("REQ-1", "REQ-2", "REQ-3"),
+            satisfied_requirement_ids(created),
+        )
+
+        different_path = temporal_support_record(
+            {
+                "evidence": (1, 2, 3),
+                "modifies": ("evidence-1.md",),
+            }
+        )
+        different_path["request"] = stage_c_request(
+            allowed_mutation_paths=("other.txt",),
+        ).as_dict()
+        different_path["runs"][0]["file_actions"][0]["path"] = "other.txt"
+        self.assertEqual(
+            ("REQ-1", "REQ-2", "REQ-3"),
+            satisfied_requirement_ids(different_path),
+        )
+
     def test_later_authorized_modify_invalidates_historical_read(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_compound_evidence_meter.py
+++ b/tests/test_compound_evidence_meter.py
@@ -274,7 +274,7 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
         self.assertIn(
-            "Preserve the exact compound-authority and acceleration boundary",
+            "Stop at the remote publication Human Seat boundary",
             payload["next_authorized_action"],
         )
         for relative_path in (
@@ -289,16 +289,17 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     maxsplit=1,
                 )[0]
                 self.assertIn(
-                    "V13 — Compound Loop / Authority Preflight Integration",
+                    "V13 — Completion Integrity / Same-Run Temporal Evidence "
+                    "Integration",
                     current,
                 )
                 self.assertIn(
-                    "13-121 Blank-Slate Highest-EV Selection:\nPASS",
+                    "13-124 Blank-Slate Highest-EV Round 2:\nPASS",
                     current,
                 )
                 self.assertIn(
-                    "Selected capability:\nCompound authority preflight before "
-                    "Repository Default reuse",
+                    "Selected capability:\nSame-Run approved-Modify "
+                    "completion-evidence invalidation",
                     current,
                 )
                 self.assertIn(
@@ -306,40 +307,61 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     current,
                 )
                 self.assertIn(
-                    "Selection basis:\nhighest current realizable EV, not "
-                    "category preference",
+                    "13-125:\nINTEGRATED locally pending remote "
+                    "canonicalization",
                     current,
                 )
                 self.assertIn(
-                    "13-122 Compound Authority Preflight:\nINTEGRATED",
+                    "same-Run matching completion read + approved exact-path "
+                    "Modify cannot establish\ncurrent completion support.",
                     current,
                 )
                 self.assertIn(
-                    "active Stage B/C Create/Modify authority is checked before "
-                    "Repository Default\nreuse can authorize the action.",
+                    "read_run <= modify_run invalidates.\n"
+                    "read_run > last_invalidation re-establishes support.",
                     current,
                 )
                 self.assertIn(
-                    "valid in-envelope and ordinary non-compound Default reuse "
-                    "remain intact.",
+                    "The persisted matching read remains present as historical "
+                    "evidence. Only its\neligibility as current completion "
+                    "support changes",
                     current,
                 )
                 self.assertIn(
-                    "V13 now preflights active Stage B/C Create/Modify proposals "
-                    "against the current\npersisted compound mutation envelope "
-                    "before Repository Default reuse can\nauthorize them.",
+                    "Within-Run post-Modify reread cannot presently be proved "
+                    "from authoritative,\nrestart-verifiable event ordering.",
                     current,
                 )
                 self.assertIn(
-                    "This prevents an older reusable Default from widening the\n"
-                    "current compound Run's file-mutation authority.",
+                    "Pre-1.01 false-COMPLETE records fail closed as "
+                    "BLOCKED_CORRUPT / BLOCK.",
                     current,
                 )
                 self.assertIn(
-                    "This does not establish a generic permission hierarchy; "
-                    "shell, network,\narbitrary-tool, publication, or release "
-                    "authority; generalized capability\nalgebra; or a full "
-                    "authority-system redesign.",
+                    "No\nsilent migration, retrospective rewriting, or "
+                    "fabricated within-Run order is\nadded.",
+                    current,
+                )
+                self.assertIn(
+                    "V13 no longer accepts a same-Run completion-matching read "
+                    "as current support\nwhen that Run also contains an "
+                    "approved Modify of the exact same evidence path.",
+                    current,
+                )
+                self.assertIn(
+                    "This prevents unsupported COMPLETE when post-mutation "
+                    "current identity is not\nproved.",
+                    current,
+                )
+                self.assertIn(
+                    "This does not establish within-Run event ordering, generic "
+                    "freshness, semantic\nequivalence, post-mutation content "
+                    "identity, transaction history, generic\nmutation "
+                    "dependency analysis, or full temporal reasoning.",
+                    current,
+                )
+                self.assertIn(
+                    "Compound Authority Preflight:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
@@ -351,7 +373,11 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                     current,
                 )
                 self.assertIn(
-                    "V8 Temporal Evidence Invalidation:\nINTEGRATED",
+                    "V8 Cross-Run Temporal Evidence Invalidation:\nINTEGRATED",
+                    current,
+                )
+                self.assertIn(
+                    "Zero-Declared-Progress Stop:\nINTEGRATED",
                     current,
                 )
                 self.assertIn(
@@ -370,12 +396,17 @@ class CompoundEvidenceMeterCanonicalSurfaceTests(unittest.TestCase):
                 )
                 self.assertIn(
                     "Capability Commit:\n"
-                    "8425b6e04a25f469687d8ca54b76258771a69027",
+                    "5d937fb3f1a123efc6a5d04727547d9c137c63e3",
                     current,
                 )
                 self.assertIn(
                     "Canonical Starting Main:\n"
-                    "b1131284854501a0364fb09984f1a4ea56eed531",
+                    "72219407008abd1aa9131cf79ec9f7c46ff1368a",
+                    current,
+                )
+                self.assertIn(
+                    "Active Branch:\n"
+                    "codex/13-126-same-run-invalidation-integration",
                     current,
                 )
                 self.assertIn(


### PR DESCRIPTION
## What changed

- Change Stage C temporal invalidation from `read_run < modify_run` to `read_run <= modify_run` for an approved `Modify` of the exact completion-evidence path.
- Preserve the historical matching read while withholding it as current completion support.
- Add focused same-Run collision, conservative reread, restart/replay, and unaffected-boundary coverage.
- Synchronize the current canonical signal and handoff surfaces without changing the Compound Evidence Meter.

## Why

Persisted Stage C evidence does not authoritatively order reads against file actions within one Run. A same-Run matching read plus approved same-path Modify therefore cannot prove post-mutation current identity. The previous rule could incorrectly produce `COMPLETE / STOP`; the reviewed rule produces `HOLD / EVIDENCE-RECOVERY` with zero automatic continuation.

## Boundaries

- Clean read-only completion remains unchanged.
- Different-path and denied Modify actions remain non-invalidating.
- Existing cross-Run V8 invalidation and strictly later-Run re-establishment remain unchanged.
- Historical read evidence remains present.
- No within-Run ordering, automatic reread/recovery, migration, or generalized temporal redesign is added.
- Pre-1.01 false-COMPLETE records fail closed as `BLOCKED_CORRUPT / BLOCK`.

## Exact reviewed range

- Base: `72219407008abd1aa9131cf79ec9f7c46ff1368a`
- Capability: `5d937fb3f1a123efc6a5d04727547d9c137c63e3`
- Head: `e8b61455086483fbf6708a1b4d5cb839bb3a6058`

## Validation

- Exact commit/parent/path review: PASS.
- Focused integration matrix: 97/97 passed.
- Canonical-surface tests: 12/12 passed.
- Repository-wide discovery: 1,494 tests; the 46 sandbox-only socket/Chrome failures were rerun in the implicated four modules with required permissions, where 155/155 passed (9 skipped).
- `git diff --check`: PASS.