### PR TITLE
Canonicalize F-04 v3 authority witness validation

### DIFF
--- a/decision_os/checks.py
+++ b/decision_os/checks.py
@@ -53,6 +53,8 @@ AUTHORITY_MATCH_TEXT_WITNESSES = (
     ("required_authority", ("Required Authority",)),
     ("authority_held", ("Authority Held",)),
 )
+AUTHORITY_HELD_SUFFIX = " / HELD"
+AUTHORITY_DENIAL_LEXEMES = frozenset({"DENIED", "REVOKED", "WITHHELD"})
 AUTHORITY_MATCH_BOOLEAN_WITNESSES = (
     (
         "operational_effect",
@@ -216,26 +218,57 @@ def _same_alias_conflicts(
     return (sources,)
 
 
-def _authority_is_held(value: str | None) -> bool:
-    if not _is_resolved_evidence(value):
+def _authority_is_held(
+    required_authority: str | None,
+    authority_held: str | None,
+) -> bool:
+    if not (
+        _is_resolved_evidence(required_authority)
+        and _is_resolved_evidence(authority_held)
+    ):
         return False
-    assert value is not None
+    assert required_authority is not None
+    assert authority_held is not None
+    if _authority_is_explicitly_denied(required_authority):
+        return False
+    return authority_held == "GRANTED" or authority_held == (
+        required_authority + AUTHORITY_HELD_SUFFIX
+    )
+
+
+def _authority_is_explicitly_denied(value: str) -> bool:
     words = tuple(re.findall(r"[A-Z0-9]+", value.upper()))
     joined = " ".join(words)
-    return not (
+    return (
         words == ("NO",)
-        or "DENIED" in words
-        or "REVOKED" in words
-        or "NONE" in words
-        or "MISSING" in words
-        or "NO AUTHORITY" in joined
-        or "NOT AUTHORIZED" in joined
-        or "NOT GRANTED" in joined
-        or "INSUFFICIENT" in words
-        or "UNKNOWN" in words
-        or "PENDING" in words
-        or "TBD" in words
+        or not AUTHORITY_DENIAL_LEXEMES.isdisjoint(words)
+        or re.search(
+            r"\bNO(?: [A-Z0-9]+)* (?:AUTHORITY|GRANTED|HELD)\b",
+            joined,
+        )
+        is not None
+        or re.search(
+            r"\b(?:NOT|NEVER)(?: [A-Z0-9]+)* (?:AUTHORIZED|GRANTED|HELD)\b",
+            joined,
+        )
+        is not None
     )
+
+
+def _nonaffirmative_authority_witnesses(
+    required_authority: str,
+    authority_held: str,
+) -> tuple[str, ...]:
+    if _authority_is_explicitly_denied(required_authority):
+        return ("required_authority",)
+    if _authority_is_held(required_authority, authority_held):
+        return ()
+    if _authority_is_explicitly_denied(authority_held):
+        return ("authority_held",)
+    held_scope = authority_held.removesuffix(AUTHORITY_HELD_SUFFIX)
+    if held_scope and held_scope != authority_held:
+        return ("required_authority",)
+    return ("authority_held",)
 
 
 def _is_resolved_evidence(value: str | None) -> bool:
@@ -459,12 +492,21 @@ def _current_state(
     missing_match_witnesses: list[str] = []
     negative_match_witnesses: list[str] = []
     if explicit_authority_match == "YES":
+        text_witness_values: dict[str, str] = {}
         for name, aliases in AUTHORITY_MATCH_TEXT_WITNESSES:
             value = first_value(surfaces, aliases)
             if not _is_resolved_evidence(value):
                 missing_match_witnesses.append(name)
-            elif not _authority_is_held(value):
-                negative_match_witnesses.append(name)
+            else:
+                assert value is not None
+                text_witness_values[name] = value
+        if len(text_witness_values) == len(AUTHORITY_MATCH_TEXT_WITNESSES):
+            negative_match_witnesses.extend(
+                _nonaffirmative_authority_witnesses(
+                    text_witness_values["required_authority"],
+                    text_witness_values["authority_held"],
+                )
+            )
         for name, aliases in AUTHORITY_MATCH_BOOLEAN_WITNESSES:
             value = first_value(surfaces, aliases)
             token, valid = _parse_token(value, ("YES", "NO"))

--- a/decision_os/checks.py
+++ b/decision_os/checks.py
@@ -54,7 +54,7 @@ AUTHORITY_MATCH_TEXT_WITNESSES = (
     ("authority_held", ("Authority Held",)),
 )
 AUTHORITY_HELD_SUFFIX = " / HELD"
-AUTHORITY_DENIAL_LEXEMES = frozenset({"DENIED", "REVOKED", "WITHHELD"})
+SUPPORTED_REQUIRED_AUTHORITY_SCOPES = frozenset({"REPOSITORY-LOCAL TEST"})
 AUTHORITY_MATCH_BOOLEAN_WITNESSES = (
     (
         "operational_effect",
@@ -218,56 +218,21 @@ def _same_alias_conflicts(
     return (sources,)
 
 
-def _authority_is_held(
-    required_authority: str | None,
-    authority_held: str | None,
-) -> bool:
-    if not (
-        _is_resolved_evidence(required_authority)
-        and _is_resolved_evidence(authority_held)
-    ):
-        return False
-    assert required_authority is not None
-    assert authority_held is not None
-    if _authority_is_explicitly_denied(required_authority):
-        return False
-    return authority_held == "GRANTED" or authority_held == (
-        required_authority + AUTHORITY_HELD_SUFFIX
-    )
-
-
-def _authority_is_explicitly_denied(value: str) -> bool:
-    words = tuple(re.findall(r"[A-Z0-9]+", value.upper()))
-    joined = " ".join(words)
-    return (
-        words == ("NO",)
-        or not AUTHORITY_DENIAL_LEXEMES.isdisjoint(words)
-        or re.search(
-            r"\bNO(?: [A-Z0-9]+)* (?:AUTHORITY|GRANTED|HELD)\b",
-            joined,
-        )
-        is not None
-        or re.search(
-            r"\b(?:NOT|NEVER)(?: [A-Z0-9]+)* (?:AUTHORIZED|GRANTED|HELD)\b",
-            joined,
-        )
-        is not None
-    )
+def _is_required_authority_scope(value: str) -> bool:
+    return value in SUPPORTED_REQUIRED_AUTHORITY_SCOPES
 
 
 def _nonaffirmative_authority_witnesses(
     required_authority: str,
     authority_held: str,
 ) -> tuple[str, ...]:
-    if _authority_is_explicitly_denied(required_authority):
+    if not _is_required_authority_scope(required_authority):
         return ("required_authority",)
-    if _authority_is_held(required_authority, authority_held):
+    if authority_held in {
+        required_authority,
+        required_authority + AUTHORITY_HELD_SUFFIX,
+    }:
         return ()
-    if _authority_is_explicitly_denied(authority_held):
-        return ("authority_held",)
-    held_scope = authority_held.removesuffix(AUTHORITY_HELD_SUFFIX)
-    if held_scope and held_scope != authority_held:
-        return ("required_authority",)
     return ("authority_held",)
 
 

--- a/decision_os/checks.py
+++ b/decision_os/checks.py
@@ -224,9 +224,13 @@ def _authority_is_held(value: str | None) -> bool:
     joined = " ".join(words)
     return not (
         words == ("NO",)
+        or "DENIED" in words
+        or "REVOKED" in words
         or "NONE" in words
         or "MISSING" in words
+        or "NO AUTHORITY" in joined
         or "NOT AUTHORIZED" in joined
+        or "NOT GRANTED" in joined
         or "INSUFFICIENT" in words
         or "UNKNOWN" in words
         or "PENDING" in words

--- a/tests/test_decision_os_checks.py
+++ b/tests/test_decision_os_checks.py
@@ -401,6 +401,65 @@ PASS
             self.assertEqual(EXIT_CONTRADICTION, exit_code)
             self.assertTrue(payload["human_seat_required"])
 
+    def test_explicit_negative_authority_text_witnesses_fail_closed(self) -> None:
+        text_witnesses = (
+            (
+                "required_authority",
+                "Required Authority:\nREPOSITORY-LOCAL TEST",
+                "Required Authority",
+            ),
+            (
+                "authority_held",
+                "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
+                "Authority Held",
+            ),
+        )
+        negative_values = ("DENIED", "NO AUTHORITY", "REVOKED", "NOT GRANTED")
+
+        for witness_name, old, field_name in text_witnesses:
+            for negative_value in negative_values:
+                with self.subTest(
+                    witness=witness_name,
+                    negative_value=negative_value,
+                ):
+                    with tempfile.TemporaryDirectory() as directory:
+                        repository = create_repository(Path(directory), "complete")
+                        replace_in_state_surfaces(
+                            repository,
+                            old,
+                            f"{field_name}:\n{negative_value}",
+                        )
+
+                        payload, exit_code = inspect_repository(repository)
+
+                        self.assertEqual(EXIT_CONTRADICTION, exit_code)
+                        self.assertTrue(payload["human_seat_required"])
+                        witness_evidence = next(
+                            item
+                            for item in payload["evidence"]
+                            if item["check"] == "state.authority_match_witnesses"
+                        )
+                        self.assertEqual("FAIL", witness_evidence["status"])
+                        self.assertEqual(
+                            [witness_name],
+                            witness_evidence["detail"]["negative_or_invalid"],
+                        )
+
+    def test_affirmative_authority_text_witness_remains_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory), "complete")
+            replace_in_state_surfaces(
+                repository,
+                "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
+                "Authority Held:\nGRANTED",
+            )
+
+            payload, exit_code = inspect_repository(repository)
+
+            self.assertEqual(EXIT_OK, exit_code)
+            self.assertEqual("YES", payload["authority_match"])
+            self.assertFalse(payload["human_seat_required"])
+
     def test_authority_match_yes_conflicts_with_human_seat_yes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory), "complete")

--- a/tests/test_decision_os_checks.py
+++ b/tests/test_decision_os_checks.py
@@ -26,6 +26,7 @@ MANDATORY_NEGATIVE_AUTHORITY_VALUES = (
     "NOT HELD",
     "WITHHELD",
     "NEVER GRANTED",
+    "NO LONGER AUTHORIZED",
 )
 ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES = (
     "REPOSITORY-LOCAL TEST / DENIED BY OWNER",
@@ -38,6 +39,36 @@ ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES = (
     "REPOSITORY-LOCAL TEST / AUTHORITY WAS NEVER FORMALLY GRANTED",
     "REPOSITORY-LOCAL TEST / HELD / REVOKED",
     "GRANTED / REVOKED",
+)
+NEGATIVE_AUTHORITY_VARIANTS = (
+    " denied! ",
+    "No,   Authority!",
+    "reVoked.",
+    "not-granted",
+    "NOT   HELD!",
+    "withheld.",
+    "never\tgranted.",
+    "no   longer authorized.",
+)
+MALFORMED_REQUIRED_AUTHORITY_VALUES = (
+    "GRANTED",
+    "HELD",
+    "YES",
+    "NO",
+    "AUTHORIZED",
+    "REVOKED",
+    "DENIED",
+    "REPOSITORY-LOCAL TEST / HELD",
+    "REPOSITORY-LOCAL TEST/HELD",
+    "APPROVED",
+    "ALLOWED",
+    "PERMITTED",
+    "ACTIVE",
+    "TRUE",
+    "CURRENT",
+    "VALID",
+    "UNAUTHORIZED",
+    "DIFFERENT AUTHORITY",
 )
 
 
@@ -438,6 +469,7 @@ PASS
         negative_families = (
             ("mandatory", MANDATORY_NEGATIVE_AUTHORITY_VALUES),
             ("adversarial", ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES),
+            ("variants", NEGATIVE_AUTHORITY_VARIANTS),
         )
 
         for witness_name, old, field_name in text_witnesses:
@@ -476,10 +508,15 @@ PASS
         negative_values = (
             *MANDATORY_NEGATIVE_AUTHORITY_VALUES,
             *ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES,
+            *NEGATIVE_AUTHORITY_VARIANTS,
         )
 
         for negative_value in negative_values:
-            held_values = ("GRANTED", f"{negative_value} / HELD")
+            held_values = (
+                "GRANTED",
+                negative_value,
+                f"{negative_value} / HELD",
+            )
             for held_value in held_values:
                 with self.subTest(
                     required_authority=negative_value,
@@ -514,37 +551,107 @@ PASS
                             witness_evidence["detail"]["negative_or_invalid"],
                         )
 
+    def test_status_shaped_required_authority_cannot_manufacture_authority(
+        self,
+    ) -> None:
+        status_values = (
+            *MALFORMED_REQUIRED_AUTHORITY_VALUES,
+            " gRaNtEd! ",
+            "YeS.",
+            "authorized?",
+            "repository-local test / held!",
+            "G.R.A.N.T.E.D",
+            "D/E/N/I/E/D",
+            "A U T H O R I Z E D",
+            "Y.E.S",
+            "H-E-L-D",
+            "REPOSITORY-LOCAL TEST / H.E.L.D",
+        )
+
+        for required_authority in status_values:
+            held_values = (
+                "GRANTED",
+                required_authority,
+                f"{required_authority} / HELD",
+            )
+            for authority_held in held_values:
+                with self.subTest(
+                    required_authority=required_authority,
+                    authority_held=authority_held,
+                ):
+                    with tempfile.TemporaryDirectory() as directory:
+                        repository = create_repository(Path(directory), "complete")
+                        replace_in_state_surfaces(
+                            repository,
+                            "Required Authority:\nREPOSITORY-LOCAL TEST",
+                            f"Required Authority:\n{required_authority}",
+                        )
+                        replace_in_state_surfaces(
+                            repository,
+                            "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
+                            f"Authority Held:\n{authority_held}",
+                        )
+
+                        payload, exit_code = inspect_repository(repository)
+
+                        self.assertEqual(EXIT_CONTRADICTION, exit_code)
+                        self.assertTrue(payload["human_seat_required"])
+                        witness_evidence = next(
+                            item
+                            for item in payload["evidence"]
+                            if item["check"]
+                            == "state.authority_match_witnesses"
+                        )
+                        self.assertEqual("FAIL", witness_evidence["status"])
+                        self.assertEqual(
+                            ["required_authority"],
+                            witness_evidence["detail"]["negative_or_invalid"],
+                        )
+
     def test_held_authority_scope_must_match_required_authority(self) -> None:
+        invalid_held_values = (
+            "DIFFERENT AUTHORITY / HELD",
+            "DIFFERENT AUTHORITY",
+            "GRANTED",
+            "REPOSITORY-LOCAL TEST / HELD / HELD",
+            "REPOSITORY-LOCAL TEST / held",
+            "REPOSITORY-LOCAL TEST /  HELD",
+            "REPOSITORY-LOCAL TEST / HELD.",
+            "REPOSITORY-LOCAL TEST / H.E.L.D",
+        )
+
+        for authority_held in invalid_held_values:
+            with self.subTest(authority_held=authority_held):
+                with tempfile.TemporaryDirectory() as directory:
+                    repository = create_repository(Path(directory), "complete")
+                    replace_in_state_surfaces(
+                        repository,
+                        "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
+                        f"Authority Held:\n{authority_held}",
+                    )
+
+                    payload, exit_code = inspect_repository(repository)
+
+                    self.assertEqual(EXIT_CONTRADICTION, exit_code)
+                    self.assertTrue(payload["human_seat_required"])
+                    witness_evidence = next(
+                        item
+                        for item in payload["evidence"]
+                        if item["check"] == "state.authority_match_witnesses"
+                    )
+                    self.assertEqual("FAIL", witness_evidence["status"])
+                    self.assertEqual(
+                        ["authority_held"],
+                        witness_evidence["detail"]["negative_or_invalid"],
+                    )
+
+    def test_template_backed_unsuffixed_authority_list_remains_valid(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repository = create_repository(Path(directory), "complete")
             replace_in_state_surfaces(
                 repository,
                 "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
-                "Authority Held:\nDIFFERENT AUTHORITY / HELD",
-            )
-
-            payload, exit_code = inspect_repository(repository)
-
-            self.assertEqual(EXIT_CONTRADICTION, exit_code)
-            self.assertTrue(payload["human_seat_required"])
-            witness_evidence = next(
-                item
-                for item in payload["evidence"]
-                if item["check"] == "state.authority_match_witnesses"
-            )
-            self.assertEqual("FAIL", witness_evidence["status"])
-            self.assertEqual(
-                ["required_authority"],
-                witness_evidence["detail"]["negative_or_invalid"],
-            )
-
-    def test_affirmative_authority_text_witness_remains_valid(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            repository = create_repository(Path(directory), "complete")
-            replace_in_state_surfaces(
-                repository,
-                "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
-                "Authority Held:\nGRANTED",
+                "Authority Held:\nREPOSITORY-LOCAL TEST",
             )
 
             payload, exit_code = inspect_repository(repository)

--- a/tests/test_decision_os_checks.py
+++ b/tests/test_decision_os_checks.py
@@ -18,6 +18,27 @@ from decision_os.checks import (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = REPO_ROOT / "tests" / "fixtures" / "v13_runner_v0_1"
+MANDATORY_NEGATIVE_AUTHORITY_VALUES = (
+    "DENIED",
+    "NO AUTHORITY",
+    "REVOKED",
+    "NOT GRANTED",
+    "NOT HELD",
+    "WITHHELD",
+    "NEVER GRANTED",
+)
+ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES = (
+    "REPOSITORY-LOCAL TEST / DENIED BY OWNER",
+    "NO CURRENT REPOSITORY AUTHORITY",
+    "NO LONGER HELD",
+    "REPOSITORY-LOCAL TEST / GRANT REVOKED",
+    "REPOSITORY-LOCAL TEST / AUTHORITY NOT CURRENTLY GRANTED",
+    "repository-local test / not-held",
+    "REPOSITORY-LOCAL TEST / OWNER WITHHELD AUTHORITY",
+    "REPOSITORY-LOCAL TEST / AUTHORITY WAS NEVER FORMALLY GRANTED",
+    "REPOSITORY-LOCAL TEST / HELD / REVOKED",
+    "GRANTED / REVOKED",
+)
 
 
 def run_git(target: Path, *arguments: str) -> None:
@@ -414,20 +435,67 @@ PASS
                 "Authority Held",
             ),
         )
-        negative_values = ("DENIED", "NO AUTHORITY", "REVOKED", "NOT GRANTED")
+        negative_families = (
+            ("mandatory", MANDATORY_NEGATIVE_AUTHORITY_VALUES),
+            ("adversarial", ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES),
+        )
 
         for witness_name, old, field_name in text_witnesses:
-            for negative_value in negative_values:
+            for family, negative_values in negative_families:
+                for negative_value in negative_values:
+                    with self.subTest(
+                        witness=witness_name,
+                        family=family,
+                        negative_value=negative_value,
+                    ):
+                        with tempfile.TemporaryDirectory() as directory:
+                            repository = create_repository(Path(directory), "complete")
+                            replace_in_state_surfaces(
+                                repository,
+                                old,
+                                f"{field_name}:\n{negative_value}",
+                            )
+
+                            payload, exit_code = inspect_repository(repository)
+
+                            self.assertEqual(EXIT_CONTRADICTION, exit_code)
+                            self.assertTrue(payload["human_seat_required"])
+                            witness_evidence = next(
+                                item
+                                for item in payload["evidence"]
+                                if item["check"]
+                                == "state.authority_match_witnesses"
+                            )
+                            self.assertEqual("FAIL", witness_evidence["status"])
+                            self.assertEqual(
+                                [witness_name],
+                                witness_evidence["detail"]["negative_or_invalid"],
+                            )
+
+    def test_negative_required_authority_cannot_be_laundered(self) -> None:
+        negative_values = (
+            *MANDATORY_NEGATIVE_AUTHORITY_VALUES,
+            *ADVERSARIAL_NEGATIVE_AUTHORITY_VALUES,
+        )
+
+        for negative_value in negative_values:
+            held_values = ("GRANTED", f"{negative_value} / HELD")
+            for held_value in held_values:
                 with self.subTest(
-                    witness=witness_name,
-                    negative_value=negative_value,
+                    required_authority=negative_value,
+                    authority_held=held_value,
                 ):
                     with tempfile.TemporaryDirectory() as directory:
                         repository = create_repository(Path(directory), "complete")
                         replace_in_state_surfaces(
                             repository,
-                            old,
-                            f"{field_name}:\n{negative_value}",
+                            "Required Authority:\nREPOSITORY-LOCAL TEST",
+                            f"Required Authority:\n{negative_value}",
+                        )
+                        replace_in_state_surfaces(
+                            repository,
+                            "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
+                            f"Authority Held:\n{held_value}",
                         )
 
                         payload, exit_code = inspect_repository(repository)
@@ -437,13 +505,38 @@ PASS
                         witness_evidence = next(
                             item
                             for item in payload["evidence"]
-                            if item["check"] == "state.authority_match_witnesses"
+                            if item["check"]
+                            == "state.authority_match_witnesses"
                         )
                         self.assertEqual("FAIL", witness_evidence["status"])
                         self.assertEqual(
-                            [witness_name],
+                            ["required_authority"],
                             witness_evidence["detail"]["negative_or_invalid"],
                         )
+
+    def test_held_authority_scope_must_match_required_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = create_repository(Path(directory), "complete")
+            replace_in_state_surfaces(
+                repository,
+                "Authority Held:\nREPOSITORY-LOCAL TEST / HELD",
+                "Authority Held:\nDIFFERENT AUTHORITY / HELD",
+            )
+
+            payload, exit_code = inspect_repository(repository)
+
+            self.assertEqual(EXIT_CONTRADICTION, exit_code)
+            self.assertTrue(payload["human_seat_required"])
+            witness_evidence = next(
+                item
+                for item in payload["evidence"]
+                if item["check"] == "state.authority_match_witnesses"
+            )
+            self.assertEqual("FAIL", witness_evidence["status"])
+            self.assertEqual(
+                ["required_authority"],
+                witness_evidence["detail"]["negative_or_invalid"],
+            )
 
     def test_affirmative_authority_text_witness_remains_valid(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_decision_os_scan_cli.py
+++ b/tests/test_decision_os_scan_cli.py
@@ -53,7 +53,7 @@ PROTECTED_BLOBS = {
     ),
     "decision_os/checks.py": (
         "100644",
-        "4b7b1154d3af0a0847a0a1a588310e5877ea3f9e",
+        "fa304eb1361e09c0ee7213aa3a6899ec867507a6",
     ),
     "decision_os/state.py": (
         "100644",
@@ -98,7 +98,7 @@ PROTECTED_BLOBS = {
     ),
     "tests/test_decision_os_checks.py": (
         "100644",
-        "c4249c22d47a2da69d54d24e3cf265f827272b5a",
+        "e04f8e85fd2297e6c8a9d2b4711f13c97b6c67b2",
     ),
     "tests/test_decision_os_cli.py": (
         "100644",


### PR DESCRIPTION
## What changed

- Preserve the exact accepted F-04 lineage from `ef875cb8da7bbf37b1d76a8d78ccaead4dd32f2c` through `b58e8c66035599da0b9d4afd0753ba0e8d88c761`, including the incomplete and rejected repair iterations.
- Restrict positive authority text witnesses to the canonical `REPOSITORY-LOCAL TEST` grammar, optionally with ` / HELD` only for Authority Held.
- Fail closed for negative, malformed, status-shaped, mismatched, and self-laundered authority witness text.
- Re-anchor the protected-v0.1 hash pins for the two accepted F-04 blobs.

## Why

Previously, non-canonical authority witness text could satisfy a positive Authority Match. F-04 v3 binds the witnesses to the accepted bounded scope while preserving the F-02 retraction behavior.

## Scope boundary

F-04 only. No F-01, Stage B/C, Supervisor, Compound Evidence Meter, Field Note 132, release/publication behavior, product thesis, or unrelated protected identity changes are included.

## Validation

- F-04 focused: 6 tests, OK
- F-02 pinned non-regression: 1 test, OK
- checks/CLI: 39 tests, OK
- protected-v0.1 guard: 1 test, OK
- unrestricted full suite: 1499 tests, OK (skipped=15)
- `decision_os/checks.py`: `fa304eb1361e09c0ee7213aa3a6899ec867507a6`
- `tests/test_decision_os_checks.py`: `e04f8e85fd2297e6c8a9d2b4711f13c97b6c67b2`
