### PR TITLE
V13 13-197: isolate Git repository authority

### DIFF
--- a/decision_os/acceleration/model.py
+++ b/decision_os/acceleration/model.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
 import subprocess
@@ -60,6 +61,7 @@ _GLOB_CHARACTERS = frozenset("*?[]{}")
 _SCP_REMOTE = re.compile(
     r"^(?:(?P<user>[^@/:]+)@)?(?P<host>[^/:]+):(?P<path>.+)$"
 )
+_GIT_IDENTITY_TIMEOUT_SECONDS = 10
 
 
 class AccelerationError(RuntimeError):
@@ -123,15 +125,58 @@ def hash_payload(payload: dict[str, Any]) -> str:
     return sha256_text(canonical_json(payload))
 
 
+def _isolated_git_environment() -> dict[str, str]:
+    """Build an environment with no ambient Git authority inputs."""
+
+    # Identity reads operate only on the explicitly supplied local repository;
+    # inherited Git context is unnecessary and can redirect that authority.
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+    environment.update(
+        {
+            "GIT_ATTR_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LANG": "C",
+            "LC_ALL": "C",
+        }
+    )
+    return environment
+
+
 def git_output(repository: Path, *arguments: str) -> str:
     """Run one read-only Git identity command."""
 
-    completed = subprocess.run(
-        ("git", "-C", str(repository), *arguments),
-        capture_output=True,
-        check=False,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            (
+                "git",
+                "--no-replace-objects",
+                "-c",
+                "core.useReplaceRefs=false",
+                "-C",
+                str(repository),
+                *arguments,
+            ),
+            capture_output=True,
+            check=False,
+            env=_isolated_git_environment(),
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=_GIT_IDENTITY_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RepositoryIdentityError(
+            "Git repository identity is unavailable."
+        ) from exc
     if completed.returncode != 0:
         raise RepositoryIdentityError(
             completed.stderr.strip() or "Git repository identity is unavailable."
@@ -189,17 +234,12 @@ def repository_id(repository: Path) -> str:
     """Derive a hashed repository identity without storing its raw name."""
 
     root = git_root(repository)
-    completed = subprocess.run(
-        ("git", "-C", str(root), "remote", "get-url", "origin"),
-        capture_output=True,
-        check=False,
-        text=True,
-    )
-    normalized_remote = (
-        _credential_free_remote(completed.stdout)
-        if completed.returncode == 0
-        else None
-    )
+    try:
+        remote = git_output(root, "remote", "get-url", "origin")
+    except RepositoryIdentityError:
+        normalized_remote = None
+    else:
+        normalized_remote = _credential_free_remote(remote)
     identity = normalized_remote or f"local:{root.as_posix()}"
     return f"repo:v1:{sha256_text(identity)}"
 

--- a/tests/test_acceleration_store.py
+++ b/tests/test_acceleration_store.py
@@ -10,6 +10,7 @@ import tempfile
 from threading import BrokenBarrierError
 import time
 import unittest
+from unittest.mock import patch
 
 from decision_os.acceleration.engine import AccelerationEngine
 from decision_os.acceleration.model import (
@@ -17,6 +18,7 @@ from decision_os.acceleration.model import (
     GENESIS_EVENT_HASH,
     ScopeError,
     derive_decision_identity,
+    git_output,
     normalize_scope,
     repository_id,
 )
@@ -364,6 +366,193 @@ class AccelerationStoreTest(unittest.TestCase):
             self.assertNotIn("secret", identity)
             self.assertNotIn("private", identity)
             self.assertNotIn("github", identity)
+
+    def test_ambient_git_control_plane_cannot_split_repository_authority(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository_a = create_repository(parent, "repository-a")
+            repository_b = create_repository(parent, "repository-b")
+            origin_a = "https://example.test/owner/repository-a.git"
+            origin_b = "https://example.test/owner/repository-b.git"
+            for repository, origin in (
+                (repository_a, origin_a),
+                (repository_b, origin_b),
+            ):
+                subprocess.run(
+                    (
+                        "git",
+                        "-C",
+                        str(repository),
+                        "remote",
+                        "add",
+                        "origin",
+                        origin,
+                    ),
+                    check=True,
+                    capture_output=True,
+                )
+
+            expected_a_id = repository_id(repository_a)
+            expected_b_id = repository_id(repository_b)
+            global_config = parent / "hostile-global-config"
+            system_config = parent / "hostile-system-config"
+            config_text = (
+                '[remote "origin"]\n'
+                f"\turl = {origin_b}\n"
+            )
+            global_config.write_text(config_text, encoding="utf-8")
+            system_config.write_text(config_text, encoding="utf-8")
+            hostile_environment = {
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(
+                    repository_b / ".git" / "objects"
+                ),
+                "GIT_COMMON_DIR": str(repository_b / ".git"),
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_GLOBAL": str(global_config),
+                "GIT_CONFIG_KEY_0": "remote.origin.url",
+                "GIT_CONFIG_NOSYSTEM": "0",
+                "GIT_CONFIG_SYSTEM": str(system_config),
+                "GIT_CONFIG_VALUE_0": origin_b,
+                "GIT_DIR": str(repository_b / ".git"),
+                "GIT_INDEX_FILE": str(repository_b / ".git" / "index"),
+                "GIT_OBJECT_DIRECTORY": str(
+                    repository_b / ".git" / "objects"
+                ),
+                "GIT_WORK_TREE": str(repository_a),
+            }
+
+            with patch.dict(os.environ, hostile_environment, clear=False):
+                observed_root = Path(
+                    git_output(repository_a, "rev-parse", "--show-toplevel")
+                ).resolve(strict=True)
+                git_dir = Path(
+                    git_output(repository_a, "rev-parse", "--git-dir")
+                )
+                common_dir = Path(
+                    git_output(repository_a, "rev-parse", "--git-common-dir")
+                )
+                observed_origin = git_output(
+                    repository_a,
+                    "remote",
+                    "get-url",
+                    "origin",
+                )
+                store = AccelerationStore(repository_a)
+
+            if not git_dir.is_absolute():
+                git_dir = repository_a / git_dir
+            if not common_dir.is_absolute():
+                common_dir = repository_a / common_dir
+            expected_git_dir = (repository_a / ".git").resolve(strict=True)
+            self.assertEqual(repository_a.resolve(strict=True), observed_root)
+            self.assertEqual(expected_git_dir, git_dir.resolve(strict=True))
+            self.assertEqual(expected_git_dir, common_dir.resolve(strict=True))
+            self.assertEqual(origin_a, observed_origin)
+            self.assertEqual(expected_a_id, store.repository_id)
+            self.assertNotEqual(expected_b_id, store.repository_id)
+            self.assertEqual(expected_git_dir, store.git_common_dir)
+            self.assertEqual(
+                expected_git_dir
+                / "decision-os"
+                / "acceleration"
+                / "v0.1",
+                store.state_dir,
+            )
+
+    def test_repository_default_cannot_cross_repositories_under_poisoned_git(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory)
+            repository_a = create_repository(parent, "repository-a")
+            repository_b = create_repository(parent, "repository-b")
+            for repository, origin in (
+                (repository_a, "https://example.test/owner/a.git"),
+                (repository_b, "https://example.test/owner/b.git"),
+            ):
+                (repository / "target.txt").write_text("one\n", encoding="utf-8")
+                subprocess.run(
+                    (
+                        "git",
+                        "-C",
+                        str(repository),
+                        "remote",
+                        "add",
+                        "origin",
+                        origin,
+                    ),
+                    check=True,
+                    capture_output=True,
+                )
+
+            engine_b = AccelerationEngine(repository_b)
+            default_b = engine_b.evaluate(
+                run_id="repository-b-default",
+                iteration=1,
+                decision_type=DecisionType.MODIFY_FILE,
+                requested_scope="target.txt",
+                source_interrupt_id="repository-b-default",
+                choice_provider=lambda _identity: "2",
+            )
+            b_events_before = engine_b.store.events_path.read_bytes()
+            choices_in_a: list[str] = []
+            hostile_environment = {
+                "GIT_COMMON_DIR": str(repository_b / ".git"),
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "remote.origin.url",
+                "GIT_CONFIG_VALUE_0": "https://example.test/owner/b.git",
+                "GIT_DIR": str(repository_b / ".git"),
+                "GIT_INDEX_FILE": str(repository_b / ".git" / "index"),
+                "GIT_OBJECT_DIRECTORY": str(
+                    repository_b / ".git" / "objects"
+                ),
+                "GIT_WORK_TREE": str(repository_a),
+            }
+
+            with patch.dict(os.environ, hostile_environment, clear=False):
+                engine_a = AccelerationEngine(repository_a)
+                denied_without_a_authority = engine_a.evaluate(
+                    run_id="repository-a-denied",
+                    iteration=1,
+                    decision_type=DecisionType.MODIFY_FILE,
+                    requested_scope="target.txt",
+                    source_interrupt_id="repository-a-denied",
+                    choice_provider=lambda _identity: (
+                        choices_in_a.append("asked") or None
+                    ),
+                )
+                created_in_a = engine_a.evaluate(
+                    run_id="repository-a-default",
+                    iteration=1,
+                    decision_type=DecisionType.MODIFY_FILE,
+                    requested_scope="target.txt",
+                    source_interrupt_id="repository-a-default",
+                    choice_provider=lambda _identity: "2",
+                )
+
+            self.assertEqual("HUMAN_DEFAULT_CREATED", default_b.status)
+            self.assertEqual("DENIED", denied_without_a_authority.status)
+            self.assertFalse(denied_without_a_authority.allowed)
+            self.assertEqual(["asked"], choices_in_a)
+            self.assertEqual("HUMAN_DEFAULT_CREATED", created_in_a.status)
+            self.assertEqual(
+                repository_id(repository_a),
+                engine_a.store.repository_id,
+            )
+            self.assertNotEqual(
+                default_b.identity.repository_id,
+                engine_a.store.repository_id,
+            )
+            self.assertEqual(
+                (repository_a / ".git").resolve(strict=True),
+                engine_a.store.git_common_dir,
+            )
+            self.assertEqual(
+                b_events_before,
+                engine_b.store.events_path.read_bytes(),
+            )
 
     def test_settings_are_validated_and_do_not_add_events(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- isolate acceleration Git identity reads from ambient Git control-plane variables
- bind origin, repository ID, Git common-dir, and state root to the supplied repository
- prove a Repository Default from B cannot authorize A under a poisoned environment

## Verification
- focused Git-authority RED to GREEN regressions
- acceleration model, store, engine, CLI, and Repository Default tests
- Claude and Codex authority suites
- mechanically protected path and concurrency regressions
- full-suite environmental failures confirmed outside the sandbox