### PR TITLE
V100: repair External Intelligence entrance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ reusable knowledge, and restart context outside one chat. A later AI retrieves
 only the prior structure that matters so it can make a better downstream
 decision—not merely store or summarize more text.
 
-This is not model self-training. The model weights do not update, one
-observation does not become a rule automatically, and more stored material is
-not automatically better. It is also not an everything-memory system, and a
-context compactor is not the interpretation anchor for this repository.
+This is not model self-training. The model weights do not update, and more
+stored material is not automatically better. It is also not an
+everything-memory system, and a context compactor is not the interpretation
+anchor for this repository.
+
+A saved observation is not automatically an active Rule. It remains
+[lifecycle-bounded](docs/field_note_lifecycle.md) and requires verification or
+repeated evidence before bounded promotion.
 
 ### What this repository supports
 
@@ -42,10 +46,56 @@ claim that External Intelligence caused cache or quota behavior.
 
 ### Try it in English — no fork required
 
-[Open and copy the English first-contact prompt](copy-paste/external-intelligence-first-contact.md),
-then paste it into a fresh ChatGPT, Claude, or Codex conversation. It tells the
-AI to inspect the actual public repository, disclose what it could access, and
-show the English Quest Board before recommending or changing anything.
+The source of truth is the [canonical English first-contact
+prompt](copy-paste/external-intelligence-first-contact.md). Copy the same prompt
+directly from here into a fresh ChatGPT, Claude, or Codex conversation:
+
+```text
+Inspect the actual public repository before explaining External Intelligence:
+
+https://github.com/shin4141/decision-os-v13-loopkit
+
+At minimum, inspect these public files:
+
+- README.md
+- AGENTS.md
+- docs/external_intelligence_onboarding.md
+- docs/ai_reading_order.md
+- docs/field_note_lifecycle.md
+
+Then respond in this order:
+
+1. Briefly state the recognizable problem this repository addresses and what
+   External Intelligence changes. Explain only mechanisms supported by the
+   repository files you actually inspected. Center selected past decisions,
+   failure boundaries, reusable knowledge, restart context, selective
+   retrieval, and changed downstream judgment—not context compaction.
+
+2. State exactly which requested files or surfaces you could access and which
+   you could not access. Do not infer unseen code, private implementation, or
+   unavailable behavior. Do not present creator-owned observations as
+   third-party certification, and do not claim cache or quota causality.
+
+3. Show the complete participant-facing section named
+   "English first-contact — External Intelligence Quest Board" from
+   docs/external_intelligence_onboarding.md.
+
+Until I select a Quest, do not fork or clone the repository, begin setup,
+modify files, create a handoff, save a Note, promote a Rule, recommend a
+specific Quest, or make External Intelligence depend on an optional Companion.
+
+After I select a Quest, inspect only the actual public files, rules, docs,
+relevant Field Notes, and implementation needed to explain that Quest. State
+any remaining evidence or availability boundary instead of guessing.
+```
+
+If the model cannot inspect GitHub, open the repository-relative [English
+Quest Board](docs/external_intelligence_onboarding.md#english-first-contact--external-intelligence-quest-board)
+and provide that section directly. Treat this as a fallback, not as evidence
+that the model inspected files it could not access.
+
+<details>
+<summary><strong>日本語のfirst-contact promptを開く — Fork不要</strong></summary>
 
 ### まず試してみる — Fork不要
 
@@ -99,6 +149,8 @@ Questを選んだ後は、
 GRADUATE`を含むfull Quest Boardを表示します。全Field Notesや全実装をfirst
 contactで読むのではなく、選択後に関係するevidenceだけを追加で読みます。
 
+</details>
+
 Do not adopt the whole repository at once. First explore the available
 External Intelligence Quests, then choose one structure that interests you or
 ask the AI what may fit. Add another structure only when actual use exposes
@@ -110,6 +162,13 @@ read upstream `docs/current_signal.md`, `handoff/current_codex_handoff.md`,
 `docs/trajectory/V13_TRAJECTORY.md`, or `validation/` as evidence of the
 fork's current state. Read them only when the user explicitly asks to resume
 or evaluate upstream work.
+
+## Beyond first contact — optional and deeper surfaces
+
+Everything below is optional depth. It may include the Full Experience
+fork/clone path, Completion and Loop Gate, Companion, the repository scanner,
+incident tooling, Audit surfaces, and other V13 structures. These surfaces have
+different maturity levels, and none is required to try External Intelligence.
 
 ### 🔓 Full Experience — Forkして体感する
 

--- a/README.md
+++ b/README.md
@@ -6,48 +6,46 @@
 ![Local read-only scan](https://img.shields.io/badge/scan-local%20read--only-blue)
 ![Human approval for changes](https://img.shields.io/badge/changes-human%20approval%20required-orange)
 
-## Stop after “done” long enough to decide what happens next
+## External intelligence for decisions that survive the chat
 
-Decision-OS V13 LoopKit is a no-install exit gate for AI coding work. It makes
-the agent separate two decisions that are easy to blur together:
+### The problem
 
-1. Is the current task actually complete and restartable?
-2. Should the next loop `GO`, `HOLD`, run under a `CAP`, or `BLOCK`?
+AI keeps rereading context. Old mistakes repeat. Previous decisions disappear.
+One agent says “done,” but the next cannot safely continue.
 
-Try it after your next AI-assisted task:
+### What External Intelligence changes
 
-```text
-Before starting another task, report:
-
-- Is the current task complete? PASS / DELAY / BLOCK / UNKNOWN
-- Should the next loop run? GO / HOLD / CAP / BLOCK
-- Why?
-- What is the one allowed next action?
-- What must not happen next?
-
-Do not start the next task automatically. Stop after the report.
-```
-
-That is the smallest trial: no install, fork, or repository change required.
-If it helps, use the full [Next-Action Confidence
-Check](copy-paste/next-action-confidence-check.md), then consider the
-[Fork + Codex Quickstart](docs/fork_codex_quickstart.md).
-
-## Build external intelligence for your own AI
-
-External intelligence keeps selected task memory, reusable lessons, operating
-boundaries, and restart points outside one chat so a later AI can retrieve
-them when they matter.
+External Intelligence preserves selected past decisions, failure boundaries,
+reusable knowledge, and restart context outside one chat. A later AI retrieves
+only the prior structure that matters so it can make a better downstream
+decision—not merely store or summarize more text.
 
 This is not model self-training. The model weights do not update, one
 observation does not become a rule automatically, and more stored material is
-not automatically better. The supported path is bounded:
+not automatically better. It is also not an everything-memory system, and a
+context compactor is not the interpretation anchor for this repository.
+
+### What this repository supports
+
+The public repository documents a bounded path from real work to later
+selective retrieval:
 
 ```text
 real work -> observation -> external memory -> reusable candidate
           -> verification or repeated evidence -> bounded promotion
           -> later selective retrieval -> a changed downstream decision
 ```
+
+Claims stay within the public files that were actually inspected. Creator-owned
+observations are not third-party certification, and this repository does not
+claim that External Intelligence caused cache or quota behavior.
+
+### Try it in English — no fork required
+
+[Open and copy the English first-contact prompt](copy-paste/external-intelligence-first-contact.md),
+then paste it into a fresh ChatGPT, Claude, or Codex conversation. It tells the
+AI to inspect the actual public repository, disclose what it could access, and
+show the English Quest Board before recommending or changing anything.
 
 ### まず試してみる — Fork不要
 
@@ -133,6 +131,33 @@ Forkで得られるのは、このpublic repositoryに含まれるsurfaceと、�
 Shin固有のprivate memory、public `main`に存在しないupstream internal trajectoryが
 自動的に使えるようになるわけではありません。The tiny `AGENTS.md` router opens
 the Quest Board on demand; unrelated tasks do not load the tutorial.
+
+## Next, if you need completion and loop gates
+
+Decision-OS V13 LoopKit can also act as a no-install exit gate for AI coding
+work. It makes the agent separate two decisions that are easy to blur together:
+
+1. Is the current task actually complete and restartable?
+2. Should the next loop `GO`, `HOLD`, run under a `CAP`, or `BLOCK`?
+
+Try it after your next AI-assisted task:
+
+```text
+Before starting another task, report:
+
+- Is the current task complete? PASS / DELAY / BLOCK / UNKNOWN
+- Should the next loop run? GO / HOLD / CAP / BLOCK
+- Why?
+- What is the one allowed next action?
+- What must not happen next?
+
+Do not start the next task automatically. Stop after the report.
+```
+
+That trial also requires no install, fork, or repository change. If it helps,
+use the full [Next-Action Confidence
+Check](copy-paste/next-action-confidence-check.md), then consider the
+[Fork + Codex Quickstart](docs/fork_codex_quickstart.md).
 
 ## Optional Companion: your coding agent asks once. The next Run remembers.
 

--- a/copy-paste/external-intelligence-first-contact.md
+++ b/copy-paste/external-intelligence-first-contact.md
@@ -1,0 +1,53 @@
+# External Intelligence First-Contact Prompt
+
+Use this read-only prompt to let ChatGPT, Claude, or Codex inspect the public
+repository before you decide whether any part of it is useful. No fork, clone,
+installation, account, repository attachment, or file change is required.
+
+## Copy-paste prompt
+
+```text
+Inspect the actual public repository before explaining External Intelligence:
+
+https://github.com/shin4141/decision-os-v13-loopkit
+
+At minimum, inspect these public files:
+
+- README.md
+- AGENTS.md
+- docs/external_intelligence_onboarding.md
+- docs/ai_reading_order.md
+- docs/field_note_lifecycle.md
+
+Then respond in this order:
+
+1. Briefly state the recognizable problem this repository addresses and what
+   External Intelligence changes. Explain only mechanisms supported by the
+   repository files you actually inspected. Center selected past decisions,
+   failure boundaries, reusable knowledge, restart context, selective
+   retrieval, and changed downstream judgment—not context compaction.
+
+2. State exactly which requested files or surfaces you could access and which
+   you could not access. Do not infer unseen code, private implementation, or
+   unavailable behavior. Do not present creator-owned observations as
+   third-party certification, and do not claim cache or quota causality.
+
+3. Show the complete participant-facing section named
+   "English first-contact — External Intelligence Quest Board" from
+   docs/external_intelligence_onboarding.md.
+
+Until I select a Quest, do not fork or clone the repository, begin setup,
+modify files, create a handoff, save a Note, promote a Rule, recommend a
+specific Quest, or make External Intelligence depend on an optional Companion.
+
+After I select a Quest, inspect only the actual public files, rules, docs,
+relevant Field Notes, and implementation needed to explain that Quest. State
+any remaining evidence or availability boundary instead of guessing.
+```
+
+## What to expect
+
+The first response should be a short repository-grounded orientation, a compact
+access disclosure, and the English Quest Board. Viewing or choosing a Quest does
+not authorize setup or file changes. Forking is a later, optional step only if
+you want to grow the public structures in your own workspace.

--- a/docs/ai_reading_order.md
+++ b/docs/ai_reading_order.md
@@ -5,9 +5,10 @@ actual public repository before showing the choice map.
 
 ```text
 Broad repository map
+  -> recognizable problem
+  -> External Intelligence core change
   -> compact access disclosure
-  -> short repo-grounded orientation
-  -> full Quest Board
+  -> matching English or Japanese Quest Board
   -> user selection
   -> Quest-specific deep read
 ```
@@ -39,9 +40,9 @@ claim only what the inspected public evidence establishes.
 
 3. `docs/external_intelligence_onboarding.md`
 
-   Follow the repo-first response order, full participant-facing Quest Board,
-   post-selection evidence rule, availability boundary, and post-interest
-   Fork CTA.
+   Follow the repo-first response order, the participant-facing English or
+   Japanese Quest Board that matches the user's language, post-selection
+   evidence rule, availability boundary, and post-interest Fork CTA.
 
 4. `docs/ai_reading_order.md`
 
@@ -61,30 +62,38 @@ set was inspected.
 
 Before the Quest Board, return only:
 
-1. a short explanation of the External Intelligence mechanisms actually
-   supported by the inspected repository surfaces;
-2. a compact access disclosure; and
-3. when setup, Companion, local apps, or platform requirements are part of the
+1. a short statement of the recognizable problem;
+2. an explanation of the External Intelligence mechanisms actually supported
+   by the inspected repository surfaces, centered on selected past decisions,
+   failure boundaries, reusable knowledge, restart context, selective
+   retrieval, and changed downstream judgment;
+3. a compact access disclosure; and
+4. when setup, Companion, local apps, or platform requirements are part of the
    user's question, one explicit boundary sentence stating that Companion is
    optional and separate from the core External Intelligence onboarding path.
 
 For example:
 
 ```text
-確認できたもの:
+Inspected / 確認できたもの:
 README / AGENTS / onboarding / reading order / Field Note lifecycle
 
-現在確認できないもの:
+Not accessible or not inspected / 現在確認できないもの:
 <none in the first-contact set, or exact unavailable surfaces>
 
-したがって、この案内では
+Therefore this orientation can explain / したがって、この案内では:
 <supported repository-evidence boundary>まで説明できます。
 ```
 
 Keep this to a few lines rather than producing a long audit report. Then show
-the entire `日本語first-contact — External Intelligence Quest Board` participant
-screen and wait. Do not recommend a Quest, request setup, or read all Field
-Notes before the user selects.
+the entire participant screen named `English first-contact — External
+Intelligence Quest Board` or `日本語first-contact — External Intelligence Quest
+Board`, matching the user's language, and wait. Do not recommend a Quest,
+request setup, or read all Field Notes before the user selects.
+
+Do not introduce the repository as a context compactor, completion checker,
+Handoff tool, or Gate system. Those remain available Quest-specific structures,
+but none replaces the External Intelligence core during first contact.
 
 ## User Evidence Gate
 
@@ -96,10 +105,13 @@ adoption.
 - If the user says `これはもうやっている` and the referent is not already
   clear from user-side evidence, ask one question that only identifies the
   referent. Do not deep-read a guessed Quest first.
+- Apply the same rule when an English-speaking user says `I already do some of
+  this` without identifying what `this` means.
 - If the user asks `自分なら何が合いそう？` and the current friction or
   existing user workflow is still unknown, ask one minimal question whose
   answer can change the recommendation. Do not prescribe `CONTINUE`, handoff,
   or another Quest from repository or audit metadata.
+- Apply the same evidence gate to `Which one might fit my current workflow?`.
 
 ## Quest-Specific Deep Read
 

--- a/docs/ai_reading_order.md
+++ b/docs/ai_reading_order.md
@@ -75,15 +75,19 @@ Before the Quest Board, return only:
 For example:
 
 ```text
-Inspected / 確認できたもの:
+Inspected:
 README / AGENTS / onboarding / reading order / Field Note lifecycle
 
-Not accessible or not inspected / 現在確認できないもの:
+Not accessible or not inspected:
 <none in the first-contact set, or exact unavailable surfaces>
 
-Therefore this orientation can explain / したがって、この案内では:
-<supported repository-evidence boundary>まで説明できます。
+Supported repository-evidence boundary:
+<what the inspected public surfaces establish>
 ```
+
+For Japanese first contact, use the equivalent Japanese disclosure template in
+`docs/external_intelligence_onboarding.md` rather than mixing both languages in
+one participant-facing response.
 
 Keep this to a few lines rather than producing a long audit report. Then show
 the entire participant screen named `English first-contact — External

--- a/docs/codex_tutorial_guide.md
+++ b/docs/codex_tutorial_guide.md
@@ -154,8 +154,9 @@ ChatGPT or install a plugin.
    evidence boundary. Do not infer missing implementation.
 3. The user does not need to adopt the whole system.
 4. Show the capability map before asking diagnostic questions, choosing a
-   starting structure, or recommending one. For Japanese first contact, use
-   `日本語first-contact — External Intelligence Quest Board` in
+   starting structure, or recommending one. Use the matching `English
+   first-contact — External Intelligence Quest Board` or `日本語first-contact —
+   External Intelligence Quest Board` in
    `docs/external_intelligence_onboarding.md`.
 5. Do not require a Fork, clone, repository attachment, Codex project, setup,
    or file change to view the Quest Board. Environment attachment comes only
@@ -178,6 +179,12 @@ ChatGPT or install a plugin.
    when the selected exercise closes or a real blocker ends the task.
 10. In a third-party fork, establish the fork's own Decision Owner. Do not
    inherit Shin merely because the upstream canonical repository names him.
+
+For English first contact, preserve the same seven visible areas, the Little
+OSI and Little Compactor entry names, evidence and availability boundaries,
+free-choice examples, and no-automatic-install statement in the English Quest
+Board. Do not replace it with the completion checker, Handoff, Compactor, or
+Gate system as the repository's primary interpretation.
 
 For Japanese first contact, do not replace the Quest Board with a preference
 question, a handoff exercise, or another preselected structure. Preserve the

--- a/docs/external_intelligence_onboarding.md
+++ b/docs/external_intelligence_onboarding.md
@@ -1,5 +1,159 @@
 # External Intelligence Onboarding
 
+This is a public showroom for seeing what kind of external intelligence an AI
+can use. Viewing it does not require a fork, clone, Codex project attachment,
+setup, file change, or understanding the whole V13 system.
+
+[Start in English](#english-first-contact--external-intelligence-quest-board)
+or [日本語で始める](#日本語first-contact--external-intelligence-quest-board).
+
+`DecisionOS Companion` is a separate optional prototype, not a prerequisite
+for this showroom, the later fork/clone path, Field Notes, Handoff, or V12/V13
+gates. Do not turn a Companion-specific platform limit into a requirement for
+External Intelligence as a whole.
+
+First contact is a showroom, not a prescription:
+
+```text
+Read the repository first. Show the map. Deep-read after selection.
+```
+
+## English first-contact — External Intelligence Quest Board
+
+For English onboarding, first inspect these minimum public surfaces:
+
+- `README.md`
+- `AGENTS.md`
+- `docs/external_intelligence_onboarding.md`
+- `docs/ai_reading_order.md`
+- `docs/field_note_lifecycle.md`
+
+Use only that inspected evidence to explain the repository briefly. Center the
+problem, then the mechanism: selected past decisions, failure boundaries,
+reusable knowledge, and restart context remain outside one chat so a later AI
+can retrieve only what matters and improve a downstream decision. This is not
+model self-training, everything-memory, or a context-compactor product.
+
+Before the board, give a compact access disclosure:
+
+```text
+Inspected:
+README / AGENTS / onboarding / reading order / Field Note lifecycle / <other surfaces actually inspected>
+
+Not accessible or not inspected:
+<exact surfaces, or "none within the first-contact set">
+
+Therefore this orientation can explain:
+<the boundary supported by the inspected repository evidence>
+```
+
+Do not fill inaccessible files, private or separate artifacts, or uninspected
+implementation with guesses. After that short orientation and disclosure,
+show the following participant-facing board in full.
+
+---
+
+# 🧠 External Intelligence — English Quest Board
+
+## Preserve what can change the next decision
+
+External Intelligence preserves selected memories, decisions, failure
+boundaries, reusable knowledge, and restart context outside one chat. ChatGPT,
+Claude, Codex, or another later AI reconnects only the relevant structure when
+it is needed.
+
+It does not automatically retrain the model, turn every observation into a
+permanent rule, or require you to understand or adopt the whole repository.
+
+### 🧠 MEMORY — Remember
+
+- Hand the next AI the state needed to continue — Handoff / Task Memory.
+- Preserve personal decision memory such as time, money, priorities, and
+  non-negotiable conditions.
+- Preserve why a decision was made — Decision Context.
+
+### 🌱 GROW — Develop reusable knowledge
+
+- Save a learning or failure as a Note; it does not begin as a universal Rule.
+- Let ChatGPT, Claude, or Codex surface at most one timely `External
+  Intelligence candidate` that may change a future decision.
+- Promote repeated or independently supported observations only through the
+  repository's evidence and approval boundaries.
+
+### 🪶 LIGHTEN — Retrieve selectively
+
+- Read only the past that matters — Selective Recall.
+- Keep always-loaded instructions small; move non-current knowledge behind
+  routes that are read only when triggered.
+- Explore Little Compactor only if instruction bloat is the selected problem.
+  It is an entry concept with a public research-candidate document, not the
+  core meaning or evidence of a complete shipped Compactor product.
+
+### 🔁 CONTINUE — Resume safely
+
+- Leave the minimum restart state a later AI needs — Little OSI.
+- Separate actual completion from “done” language — V12 Completion Integrity.
+- Decide whether another cycle is justified — V13 Loop Gate:
+  `GO / HOLD / CAP / BLOCK`.
+- A completed task does not automatically start the next loop.
+
+### 🛡️ PROTECT — Keep boundaries visible
+
+- Strengthen gates only when risk requires it: publication, APIs, external
+  repositories, money, credentials, or irreversible action.
+- Preserve time, attention, trust, and a restartable state instead of forcing
+  every visible next step.
+- Re-evaluate old success when current direction or conditions have changed.
+
+### 🔗 CONNECT — Reuse across AIs
+
+- Let ChatGPT, Claude, and Codex use the same external repository memory.
+- Return a candidate discovered by any AI to the user's own External
+  Intelligence surface.
+- Preserve source, evidence status, and authority instead of flattening them
+  into one unqualified memory store.
+
+### 🎓 GRADUATE — Choose the tutorial's future
+
+- **KEEP** — keep the tutorial entrance.
+- **MANUAL** — keep the tutorial but remove its always-on router.
+- **REMOVE** — remove only the approved tutorial entrance or tutorial-only
+  surfaces, not the memory, Notes, Handoff, Rules, or V12/V13 operation.
+- **NOT NOW** — change nothing.
+
+Graduation is the user's choice and does not happen automatically.
+
+## 🎮 Choose Your Quest
+
+Choose one area, browse without adopting anything, or ask freely:
+
+- “Give me a quick tour.”
+- “I already do some of this.”
+- “Which one might fit my current workflow?”
+- “What is Little OSI?”
+- “Show me Little Compactor.”
+- “I want my AI to remember decision criteria that matter to me.”
+- “I want ChatGPT and Codex to use the same external memory.”
+- “I want to graduate from the tutorial.”
+
+Viewing or choosing a Quest does not install or change anything.
+
+---
+
+Until the user selects, do not recommend a specific Quest, fork or clone the
+repository, begin setup, modify files, create a Handoff, save a Note, or promote
+a Rule. After selection, inspect only the actual public rules, docs, relevant
+Field Notes, and implementation needed for that Quest before explaining it.
+
+A Quest label is not proof of complete public implementation. State whether
+the inspected evidence is a concept, operating boundary, research candidate,
+public code/test, or unavailable/private surface. Offer the Full Experience
+fork/clone path only after a repository-grounded explanation or small trial and
+the user's explicit interest in growing these structures in their own
+workspace.
+
+## 日本語first-contact — External Intelligence Quest Board
+
 このページは、自分のAIにどんな外部知能を持たせられるかを見るための
 public showroomです。見るだけならFork、clone、Codex projectへの追加は
 必要ありません。V13全体を学ぶための必修カリキュラムでもありません。
@@ -13,12 +167,6 @@ onboardingとは分け、実際に確認できたpublic evidenceの範囲だけ�
 
 first contactは処方ではなくshowroomです。最初に何ができるかを見せ、
 ユーザーが選ぶまで開始構造を決めません。
-
-```text
-Read the repository first. Show the map. Deep-read after selection.
-```
-
-## 日本語first-contact — External Intelligence Quest Board
 
 日本語でExternal Intelligenceのtutorialや始め方を求められたら、まず同じ
 public repositoryにある次の最小surfaceを実際に確認します。

--- a/tests/test_external_intelligence_onboarding.py
+++ b/tests/test_external_intelligence_onboarding.py
@@ -10,6 +10,122 @@ def read(path: str) -> str:
 
 
 class RepoGroundedExternalIntelligenceOnboardingTests(unittest.TestCase):
+    def test_00_readme_first_contact_order_centers_external_intelligence(self) -> None:
+        readme = read("README.md")
+        markers = (
+            "### The problem",
+            "### What External Intelligence changes",
+            "### What this repository supports",
+            "### Try it in English — no fork required",
+            "### まず試してみる — Fork不要",
+            "## Next, if you need completion and loop gates",
+        )
+        positions = [readme.index(marker) for marker in markers]
+
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn(
+            "selected past decisions, failure boundaries,\n"
+            "reusable knowledge, and restart context outside one chat",
+            readme,
+        )
+        self.assertIn("later AI retrieves\nonly the prior structure that matters", readme)
+        self.assertLess(
+            readme.index("### What External Intelligence changes"),
+            readme.index("context compactor"),
+        )
+        prompt_path = "copy-paste/external-intelligence-first-contact.md"
+        self.assertIn(f"]({prompt_path})", readme)
+        self.assertTrue((ROOT / prompt_path).is_file())
+
+    def test_01_english_prompt_is_repo_first_read_only_and_no_fork(self) -> None:
+        prompt = read("copy-paste/external-intelligence-first-contact.md")
+        tutorial = read("docs/codex_tutorial_guide.md")
+
+        self.assertEqual(prompt.count("```text"), 1)
+        self.assertIn(
+            "https://github.com/shin4141/decision-os-v13-loopkit", prompt
+        )
+        for path in (
+            "README.md",
+            "AGENTS.md",
+            "docs/external_intelligence_onboarding.md",
+            "docs/ai_reading_order.md",
+            "docs/field_note_lifecycle.md",
+        ):
+            self.assertIn(f"- {path}", prompt)
+            self.assertTrue((ROOT / path).is_file())
+
+        for instruction in (
+            "Inspect the actual public repository",
+            "files you actually inspected",
+            "could access and which\n   you could not access",
+            "Do not infer unseen code, private implementation",
+            '"English first-contact — External Intelligence Quest Board"',
+            "do not fork or clone the repository",
+            "modify files",
+            "Until I select a Quest",
+        ):
+            self.assertIn(instruction, prompt)
+
+        self.assertIn(
+            "`English\n   first-contact — External Intelligence Quest Board`",
+            tutorial,
+        )
+        self.assertIn(
+            "Do not replace it with the completion checker, Handoff, Compactor, or\n"
+            "Gate system as the repository's primary interpretation.",
+            tutorial,
+        )
+
+    def test_02_english_and_japanese_boards_preserve_the_same_quest_boundaries(
+        self,
+    ) -> None:
+        onboarding = read("docs/external_intelligence_onboarding.md")
+        english = onboarding.split(
+            "## English first-contact — External Intelligence Quest Board", 1
+        )[1].split("## 日本語first-contact — External Intelligence Quest Board", 1)[0]
+        japanese = onboarding.split(
+            "## 日本語first-contact — External Intelligence Quest Board", 1
+        )[1]
+
+        english_markers = (
+            "### 🧠 MEMORY — Remember",
+            "### 🌱 GROW — Develop reusable knowledge",
+            "### 🪶 LIGHTEN — Retrieve selectively",
+            "### 🔁 CONTINUE — Resume safely",
+            "### 🛡️ PROTECT — Keep boundaries visible",
+            "### 🔗 CONNECT — Reuse across AIs",
+            "### 🎓 GRADUATE — Choose the tutorial's future",
+            "## 🎮 Choose Your Quest",
+        )
+        japanese_markers = (
+            "### 🧠 MEMORY — 覚える",
+            "### 🌱 GROW — 育てる",
+            "### 🪶 LIGHTEN — 軽くする",
+            "### 🔁 CONTINUE — 続ける・再開する",
+            "### 🛡️ PROTECT — 守る",
+            "### 🔗 CONNECT — AIをつなぐ",
+            "### 🎓 GRADUATE — Tutorialを卒業する",
+            "## 🎮 Choose Your Quest",
+        )
+
+        for board, markers in (
+            (english, english_markers),
+            (japanese, japanese_markers),
+        ):
+            positions = [board.index(marker) for marker in markers]
+            self.assertEqual(positions, sorted(positions))
+            for boundary in ("Fork", "clone", "file", "Handoff", "Note", "Rule"):
+                self.assertIn(boundary.lower(), board.lower())
+
+        english_lighten = english.split(
+            "### 🪶 LIGHTEN — Retrieve selectively", 1
+        )[1].split("### 🔁 CONTINUE — Resume safely", 1)[0]
+        self.assertIn("Little Compactor", english_lighten)
+        self.assertIn("not the\n  core meaning", english_lighten)
+        self.assertIn("not proof of complete public implementation", english)
+        self.assertIn("完全なimplementation", japanese)
+
     def test_a_primary_prompt_requires_repo_read_disclosure_and_full_board(self) -> None:
         readme = read("README.md")
         primary = readme.split("### まず試してみる — Fork不要", 1)[1].split(
@@ -43,6 +159,9 @@ class RepoGroundedExternalIntelligenceOnboardingTests(unittest.TestCase):
             self.assertIn(instruction, primary)
 
         onboarding = read("docs/external_intelligence_onboarding.md")
+        japanese_board = onboarding.split(
+            "## 日本語first-contact — External Intelligence Quest Board", 1
+        )[1]
         markers = (
             "# 🧠 External Intelligence",
             "### 🧠 MEMORY — 覚える",
@@ -54,7 +173,7 @@ class RepoGroundedExternalIntelligenceOnboardingTests(unittest.TestCase):
             "### 🎓 GRADUATE — Tutorialを卒業する",
             "## 🎮 Choose Your Quest",
         )
-        positions = [onboarding.index(marker) for marker in markers]
+        positions = [japanese_board.index(marker) for marker in markers]
         self.assertEqual(positions, sorted(positions))
         self.assertIn("確認できたもの:", onboarding)
         self.assertIn("現在確認できないもの:", onboarding)


### PR DESCRIPTION
## Scope

- put the English-first External Intelligence meaning before advanced V13 surfaces
- add an English no-fork self-service prompt and matching Quest Board
- preserve the Japanese path and evidence/availability boundaries
- apply the approved OPUS minor README entrance repairs

## Verification

- focused External Intelligence onboarding tests: 10/10 PASS
- relative Markdown links: PASS
- git diff --check: PASS
- expected delta: 6 files

## Boundary

No V13 redesign and no Reddit work.