### PR TITLE
V13: compact test output reference implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.test-logs/

--- a/docs/compact_test_output.md
+++ b/docs/compact_test_output.md
@@ -1,0 +1,38 @@
+# Compact test output
+
+`scripts/compact_test_output.py` is the V13-local output wrapper for the
+repository's existing `unittest` command. It does not select tests or add runner
+options. The command after `--` is passed to the operating system unchanged.
+
+Representative full-suite use:
+
+```console
+python3 scripts/compact_test_output.py \
+  --log .test-logs/full-suite.log \
+  -- python3 -B -m unittest discover -s tests
+```
+
+The wrapper sends the underlying process's complete combined stdout/stderr byte
+stream to the named log. On `OK`, the visible surface contains only the runner's
+`Ran` count, `OK` status, elapsed time, and absolute full-log path. On `FAILED`,
+the surface contains bounded failure identities and traceback context, the
+runner's final summary, the original exit result, and the full-log path.
+
+If output does not contain a recognizable final `unittest` summary, the wrapper
+reports the summary as `UNKNOWN`; it does not invent a test count. The wrapper
+still preserves the underlying process exit result. A signal result uses the
+shell-observable `128 + signal` exit convention and names both the signal and
+exit value.
+
+Generated logs default to `.test-logs/`, which is ignored by Git but is not
+deleted by the wrapper. Suppressed output therefore remains available for
+inspection until the caller intentionally removes it.
+
+## Value port contract
+
+For a later separately authorized Value port, the repository supplies its own
+test command; the wrapper captures its complete output; PASS returns a compact
+summary; FAIL returns bounded diagnostics; the full log remains recoverable;
+and the underlying exit semantics remain unchanged. This is the reusable
+contract only—no shared cross-repository implementation or Value change is part
+of this task.

--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,81 @@
+# Current Signal — V13 Compact Test Output Reference Implementation
+
+## Canonical Current State — V13 Compact Test Output Admission Candidate
+
+```text
+Canonical Reconstruction Base:
+78e24aafc036e8af3148a33a1ac18e7e5e703e42
+
+Current Canonical Main:
+78e24aafc036e8af3148a33a1ac18e7e5e703e42 at authorization; the admitted canonical main is the fetched merge descendant containing this exact block
+
+Current Layer:
+V13 — Development Efficiency / Evidence-Preserving Test Output
+
+V12 State:
+PASS — bounded implementation, focused validation, same-state A/B comparison, and controlled PASS/FAIL proofs are complete
+
+Completed Work:
+minimal repository-local unittest output wrapper, four bounded regression tests, measured validation record, and Value-port contract
+
+Known Baseline Boundary:
+the unchanged representative suite has 44 pre-existing creator-live fixed-identity errors on both A and B; the wrapper preserves exit 1 and every reported count
+
+Canonical Current Capability:
+V13 compact test output is admitted only when this exact block is read from fetched origin/main; branch and PR copies remain admission candidates
+
+Current Restart Point:
+validation/v13_compact_test_output_reference_implementation.md plus this exact matched first block as read from fetched origin/main
+
+Active Branch:
+codex/v13-compact-test-output-reference before admission; none after this exact block is read from fetched origin/main
+
+Current Gate:
+HOLD — no automatic next loop; candidate branch requires Human Seat merge, while admitted origin/main requires stop
+
+Value Port:
+BLOCK — separate Shin authority required
+
+Framework Expansion:
+BLOCK
+
+Article / Publication:
+BLOCK
+
+Completion Line:
+PASS when this exact matched block is observed on fetched origin/main; otherwise CONDITIONAL as an admission candidate
+
+Missing Closure:
+none when read from fetched origin/main; on the candidate branch, Human Seat merge and post-merge remote read-back remain
+
+Next Authorized Action:
+candidate branch: Human Seat merge decision; fetched origin/main: None. Stop.
+
+Not Authorized:
+automatic next loop; Value port; shared framework; article/publication; repair of the unrelated fixed-identity baseline
+
+Decision Owner:
+Shin
+
+Admission Joint:
+reader verifies this exact matched first block on fetched origin/main; other copies have no canonical restart authority
+
+Admission Evidence:
+presence of this exact first block on fetched origin/main plus the passing admission regression; a branch or PR copy is CANDIDATE only
+
+Remote Read-Back:
+executing AI fetches origin/main after Human Seat merge and verifies both first blocks and commit ancestry before operational COMPLETE
+
+Older Material Below:
+HISTORICAL ONLY — older Gate, Next Authorized Action, branch, capability, and Completion Line grant no current authority
+```
+
+Everything below this boundary is preserved historical material. Its older
+`Current Gate`, `Next Authorized Action`, branch, capability, and `Completion
+Line` values cannot be inherited as current authority.
+
+<!-- current-state-history-boundary:v13-compact-test-output -->
+
 # Current Signal — Canonical Current-State Admission Joint Repair
 
 ## Canonical Current State — V13 13-198 Post-Admission Steady State

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,81 @@
+# Current Codex Handoff — V13 Compact Test Output Reference Implementation
+
+## Canonical Current State — V13 Compact Test Output Admission Candidate
+
+```text
+Canonical Reconstruction Base:
+78e24aafc036e8af3148a33a1ac18e7e5e703e42
+
+Current Canonical Main:
+78e24aafc036e8af3148a33a1ac18e7e5e703e42 at authorization; the admitted canonical main is the fetched merge descendant containing this exact block
+
+Current Layer:
+V13 — Development Efficiency / Evidence-Preserving Test Output
+
+V12 State:
+PASS — bounded implementation, focused validation, same-state A/B comparison, and controlled PASS/FAIL proofs are complete
+
+Completed Work:
+minimal repository-local unittest output wrapper, four bounded regression tests, measured validation record, and Value-port contract
+
+Known Baseline Boundary:
+the unchanged representative suite has 44 pre-existing creator-live fixed-identity errors on both A and B; the wrapper preserves exit 1 and every reported count
+
+Canonical Current Capability:
+V13 compact test output is admitted only when this exact block is read from fetched origin/main; branch and PR copies remain admission candidates
+
+Current Restart Point:
+validation/v13_compact_test_output_reference_implementation.md plus this exact matched first block as read from fetched origin/main
+
+Active Branch:
+codex/v13-compact-test-output-reference before admission; none after this exact block is read from fetched origin/main
+
+Current Gate:
+HOLD — no automatic next loop; candidate branch requires Human Seat merge, while admitted origin/main requires stop
+
+Value Port:
+BLOCK — separate Shin authority required
+
+Framework Expansion:
+BLOCK
+
+Article / Publication:
+BLOCK
+
+Completion Line:
+PASS when this exact matched block is observed on fetched origin/main; otherwise CONDITIONAL as an admission candidate
+
+Missing Closure:
+none when read from fetched origin/main; on the candidate branch, Human Seat merge and post-merge remote read-back remain
+
+Next Authorized Action:
+candidate branch: Human Seat merge decision; fetched origin/main: None. Stop.
+
+Not Authorized:
+automatic next loop; Value port; shared framework; article/publication; repair of the unrelated fixed-identity baseline
+
+Decision Owner:
+Shin
+
+Admission Joint:
+reader verifies this exact matched first block on fetched origin/main; other copies have no canonical restart authority
+
+Admission Evidence:
+presence of this exact first block on fetched origin/main plus the passing admission regression; a branch or PR copy is CANDIDATE only
+
+Remote Read-Back:
+executing AI fetches origin/main after Human Seat merge and verifies both first blocks and commit ancestry before operational COMPLETE
+
+Older Material Below:
+HISTORICAL ONLY — older Gate, Next Authorized Action, branch, capability, and Completion Line grant no current authority
+```
+
+Everything below this boundary is preserved historical material. Its older
+`Current Gate`, `Next Authorized Action`, branch, capability, and `Completion
+Line` values cannot be inherited as current authority.
+
+<!-- current-state-history-boundary:v13-compact-test-output -->
+
 # Current Codex Handoff — Canonical Current-State Admission Joint Repair
 
 ## Canonical Current State — V13 13-198 Post-Admission Steady State

--- a/scripts/compact_test_output.py
+++ b/scripts/compact_test_output.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Run one command, retain its complete output, and compact unittest results."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+
+RUN_RE = re.compile(
+    r"^Ran (?P<count>\d+) tests? in (?P<seconds>\d+(?:\.\d+)?)s\s*$",
+    re.MULTILINE,
+)
+STATUS_RE = re.compile(
+    r"^(?P<status>OK|FAILED)(?: \((?P<details>[^\n]*)\))?\s*$",
+    re.MULTILINE,
+)
+FAILURE_HEADER_RE = re.compile(r"^(?:FAIL|ERROR): .+")
+MAX_IDENTITIES = 50
+MAX_CONTEXT_SECTIONS = 3
+MAX_CONTEXT_LINES = 30
+UNKNOWN_TAIL_LINES = 30
+
+
+@dataclass(frozen=True)
+class UnittestSummary:
+    tests_run: int
+    seconds: str
+    status: str
+    details: str | None
+
+    @property
+    def rendered_status(self) -> str:
+        if self.details:
+            return f"{self.status} ({self.details})"
+        return self.status
+
+
+def parse_unittest_summary(output: str) -> UnittestSummary | None:
+    """Return the runner's final summary, or ``None`` for unknown output."""
+
+    runs = list(RUN_RE.finditer(output))
+    if not runs:
+        return None
+    run = runs[-1]
+    statuses = [match for match in STATUS_RE.finditer(output, run.end())]
+    if not statuses:
+        return None
+    status = statuses[-1]
+    return UnittestSummary(
+        tests_run=int(run.group("count")),
+        seconds=run.group("seconds"),
+        status=status.group("status"),
+        details=status.group("details"),
+    )
+
+
+def _is_rule(line: str, character: str) -> bool:
+    stripped = line.strip()
+    return len(stripped) >= 20 and set(stripped) == {character}
+
+
+def failure_sections(output: str) -> list[list[str]]:
+    """Extract unittest FAIL/ERROR sections without unrelated success noise."""
+
+    lines = output.splitlines()
+    sections: list[list[str]] = []
+    index = 0
+    while index + 1 < len(lines):
+        if _is_rule(lines[index], "=") and FAILURE_HEADER_RE.match(
+            lines[index + 1].strip()
+        ):
+            end = index + 2
+            while end < len(lines):
+                if _is_rule(lines[end], "=") or RUN_RE.match(lines[end].strip()):
+                    break
+                end += 1
+            sections.append(lines[index + 1 : end])
+            index = end
+            continue
+        index += 1
+    return sections
+
+
+def default_log_path() -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path(".test-logs") / f"test-run-{timestamp}-{os.getpid()}.log"
+
+
+def shell_exit_result(returncode: int) -> tuple[int, str]:
+    """Map a subprocess result to the observable wrapper exit result."""
+
+    if returncode >= 0:
+        return returncode, f"exit {returncode}"
+    signal_number = -returncode
+    exit_code = 128 + signal_number
+    return exit_code, f"signal {signal_number} / exit {exit_code}"
+
+
+def _print_failure_diagnostics(output: str) -> None:
+    sections = failure_sections(output)
+    if sections:
+        identities = [section[0].strip() for section in sections]
+        print(f"Failure identities ({len(identities)}):")
+        for identity in identities[:MAX_IDENTITIES]:
+            print(identity)
+        omitted = max(0, len(identities) - MAX_IDENTITIES)
+        if omitted:
+            print(f"... {omitted} additional identities are in the full log")
+
+        print("Diagnostic context:")
+        for section in sections[:MAX_CONTEXT_SECTIONS]:
+            selected = section[:MAX_CONTEXT_LINES]
+            print("\n".join(selected))
+            if len(section) > MAX_CONTEXT_LINES:
+                print("... context clipped; complete section is in the full log")
+        remaining = max(0, len(sections) - MAX_CONTEXT_SECTIONS)
+        if remaining:
+            print(f"... {remaining} additional diagnostic sections are in the full log")
+        return
+
+    nonempty = [line for line in output.splitlines() if line.strip()]
+    if nonempty:
+        print("Diagnostic tail:")
+        for line in nonempty[-UNKNOWN_TAIL_LINES:]:
+            print(line)
+
+
+def render_result(output: str, returncode: int, log_path: Path) -> None:
+    exit_code, exit_text = shell_exit_result(returncode)
+    summary = parse_unittest_summary(output)
+
+    if returncode == 0 and summary is not None and summary.status == "OK":
+        print(
+            f"PASS: Ran {summary.tests_run} tests / "
+            f"{summary.rendered_status} / {summary.seconds}s"
+        )
+    elif returncode == 0:
+        print(f"RESULT: {exit_text} / unittest summary UNKNOWN")
+    else:
+        _print_failure_diagnostics(output)
+        if summary is None:
+            print(f"FAIL: unittest summary UNKNOWN / {exit_text}")
+        else:
+            print(
+                f"FAIL: Ran {summary.tests_run} tests / "
+                f"{summary.rendered_status} / {summary.seconds}s / {exit_text}"
+            )
+
+    print(f"Full log: {log_path}")
+
+
+def parse_arguments(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a command unchanged, retain complete combined stdout/stderr, "
+            "and compact Python unittest output."
+        )
+    )
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=None,
+        help="full-log path (default: .test-logs/test-run-<UTC>-<pid>.log)",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args(argv)
+    if arguments.command and arguments.command[0] == "--":
+        arguments.command = arguments.command[1:]
+    if not arguments.command:
+        parser.error("a command is required after --")
+    return arguments
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = parse_arguments(sys.argv[1:] if argv is None else argv)
+    log_path = (arguments.log or default_log_path()).resolve()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("wb") as full_log:
+            completed = subprocess.run(
+                arguments.command,
+                stdout=full_log,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        output = log_path.read_bytes().decode("utf-8", errors="replace")
+    except OSError as exc:
+        print(f"WRAPPER ERROR: {exc}", file=sys.stderr)
+        print(f"Full log: {log_path}", file=sys.stderr)
+        return 127
+
+    render_result(output, completed.returncode, log_path)
+    return shell_exit_result(completed.returncode)[0]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compact_test_output.py
+++ b/tests/test_compact_test_output.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts" / "compact_test_output.py"
+
+
+class CompactTestOutputTests(unittest.TestCase):
+    def run_wrapped(
+        self,
+        directory: Path,
+        source: str,
+        *arguments: str,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        log_path = directory / "full.log"
+        completed = subprocess.run(
+            (
+                sys.executable,
+                str(WRAPPER),
+                "--log",
+                str(log_path),
+                "--",
+                sys.executable,
+                "-c",
+                textwrap.dedent(source),
+                *arguments,
+            ),
+            cwd=ROOT,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        return completed, log_path
+
+    def test_success_is_compact_and_complete_log_retains_both_streams(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, log_path = self.run_wrapped(
+                Path(temporary),
+                """
+                import sys
+                print("suppressed successful stdout")
+                sys.stdout.flush()
+                print("retained stderr evidence", file=sys.stderr)
+                print("...", file=sys.stderr)
+                print("-" * 70, file=sys.stderr)
+                print("Ran 3 tests in 0.125s", file=sys.stderr)
+                print("", file=sys.stderr)
+                print("OK", file=sys.stderr)
+                """,
+            )
+            full_log = log_path.read_text(encoding="utf-8")
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertEqual(
+            [
+                "PASS: Ran 3 tests / OK / 0.125s",
+                f"Full log: {log_path.resolve()}",
+            ],
+            completed.stdout.splitlines(),
+        )
+        self.assertIn("suppressed successful stdout", full_log)
+        self.assertIn("retained stderr evidence", full_log)
+        self.assertNotIn("suppressed successful stdout", completed.stdout)
+
+    def test_failure_is_diagnostic_and_preserves_underlying_exit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, log_path = self.run_wrapped(
+                Path(temporary),
+                """
+                import sys
+                print("unrelated successful output")
+                print("=" * 70, file=sys.stderr)
+                print("FAIL: test_false (example.ExampleTest.test_false)", file=sys.stderr)
+                print("-" * 70, file=sys.stderr)
+                print("Traceback (most recent call last):", file=sys.stderr)
+                print('  File "example.py", line 7, in test_false', file=sys.stderr)
+                print("AssertionError: expected true", file=sys.stderr)
+                print("-" * 70, file=sys.stderr)
+                print("Ran 2 tests in 0.250s", file=sys.stderr)
+                print("", file=sys.stderr)
+                print("FAILED (failures=1)", file=sys.stderr)
+                raise SystemExit(7)
+                """,
+            )
+            full_log = log_path.read_text(encoding="utf-8")
+
+        self.assertEqual(7, completed.returncode)
+        self.assertIn(
+            "FAIL: test_false (example.ExampleTest.test_false)", completed.stdout
+        )
+        self.assertIn("Traceback (most recent call last):", completed.stdout)
+        self.assertIn("AssertionError: expected true", completed.stdout)
+        self.assertIn(
+            "FAIL: Ran 2 tests / FAILED (failures=1) / 0.250s / exit 7",
+            completed.stdout,
+        )
+        self.assertNotIn("additional identities", completed.stdout)
+        self.assertNotIn("additional diagnostic sections", completed.stdout)
+        self.assertIn(f"Full log: {log_path.resolve()}", completed.stdout)
+        self.assertNotIn("unrelated successful output", completed.stdout)
+        self.assertIn("unrelated successful output", full_log)
+
+    def test_unknown_success_output_does_not_invent_test_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            completed, log_path = self.run_wrapped(
+                Path(temporary),
+                """
+                print("custom runner completed")
+                """,
+            )
+            full_log = log_path.read_text(encoding="utf-8")
+
+        self.assertEqual(0, completed.returncode)
+        self.assertIn("RESULT: exit 0 / unittest summary UNKNOWN", completed.stdout)
+        self.assertNotIn("Ran ", completed.stdout)
+        self.assertNotIn("PASS:", completed.stdout)
+        self.assertEqual("custom runner completed\n", full_log)
+
+    def test_command_and_arguments_are_executed_without_test_set_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            marker = temporary_path / "executed.json"
+            expected_tests = ["test_alpha", "test_beta", "test_gamma"]
+            completed, _ = self.run_wrapped(
+                temporary_path,
+                """
+                import json
+                from pathlib import Path
+                import sys
+                Path(sys.argv[1]).write_text(json.dumps(sys.argv[2:]), encoding="utf-8")
+                print("." * len(sys.argv[2:]))
+                print("-" * 70)
+                print(f"Ran {len(sys.argv[2:])} tests in 0.001s")
+                print("")
+                print("OK")
+                """,
+                str(marker),
+                *expected_tests,
+            )
+
+            executed = json.loads(marker.read_text(encoding="utf-8"))
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertEqual(expected_tests, executed)
+        self.assertIn("PASS: Ran 3 tests / OK / 0.001s", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_current_state_admission.py
+++ b/tests/test_current_state_admission.py
@@ -17,22 +17,22 @@ SURFACES = (
 )
 HISTORY_HEADERS = {
     "docs/current_signal.md": (
-        b"# Current Signal \xe2\x80\x94 Same-Run Completion Evidence Invalidation Integration\n"
+        b"# Current Signal \xe2\x80\x94 Canonical Current-State Admission Joint Repair\n"
     ),
     "handoff/current_codex_handoff.md": (
-        b"# Current Codex Handoff \xe2\x80\x94 Same-Run Completion Evidence "
-        b"Invalidation Integration\n"
+        b"# Current Codex Handoff \xe2\x80\x94 Canonical Current-State Admission "
+        b"Joint Repair\n"
     ),
 }
-PRE_13_198_SHA256 = {
+PRE_COMPACT_OUTPUT_SHA256 = {
     "docs/current_signal.md": (
-        "8b4049f14d3d74f255ee0ebde522eac293d5a6bf241f79bf61bc8a3d83a47548"
+        "ad1ecf79d33391242a3c74188a1ea6e84538394d0767d47d0e180aa167c8ed58"
     ),
     "handoff/current_codex_handoff.md": (
-        "8a362d1261d13f4f43bfcf5b8f88047590062f1c7cc28f0ca4490adede78679d"
+        "cfc6d8e95cf5e6653a75ae67d1e004d394f2f1228fd386a863eacf1d0d12c0a1"
     ),
 }
-RECONSTRUCTED_MAIN = "fb89a07e31ebbf947f4f95d2bafdb1153dc08d29"
+RECONSTRUCTED_MAIN = "78e24aafc036e8af3148a33a1ac18e7e5e703e42"
 
 
 def current_block(relative_path: str) -> str:
@@ -60,13 +60,17 @@ class CurrentStateAdmissionTests(unittest.TestCase):
         fields = parse_fields(signal_block)
         required_fields = {
             "canonical_reconstruction_base",
+            "current_canonical_main",
             "current_layer",
             "v12_state",
-            "completed_canonical_frontier",
+            "completed_work",
+            "known_baseline_boundary",
             "canonical_current_capability",
             "current_restart_point",
             "active_branch",
             "current_gate",
+            "value_port",
+            "framework_expansion",
             "completion_line",
             "missing_closure",
             "next_authorized_action",
@@ -75,25 +79,20 @@ class CurrentStateAdmissionTests(unittest.TestCase):
             "admission_joint",
             "admission_evidence",
             "remote_read_back",
-            "13_198_p3_status",
             "older_material_below",
         }
         self.assertEqual(set(), required_fields.difference(fields))
-        self.assertNotIn("current_canonical_main", fields)
         self.assertEqual(
             RECONSTRUCTED_MAIN,
             fields["canonical_reconstruction_base"][0],
         )
         self.assertTrue(fields["current_gate"][0].startswith("HOLD"))
-        self.assertTrue(fields["next_authorized_action"][0].startswith("None. Stop."))
-        self.assertTrue(fields["13_198_p3_status"][0].startswith("CLOSED"))
+        self.assertIn("Human Seat merge decision", fields["next_authorized_action"][0])
+        self.assertTrue(fields["value_port"][0].startswith("BLOCK"))
         self.assertEqual("Shin", fields["decision_owner"][0])
-        self.assertIn("13-197", signal_block)
-        self.assertIn("PR #146", signal_block)
-        self.assertIn("13-198 Current-State Admission Repair", signal_block)
-        self.assertNotIn("5d937fb3f1a123efc6a5d04727547d9c137c63e3", signal_block)
-        self.assertNotIn("codex/13-126-same-run-invalidation-integration", signal_block)
-        self.assertNotIn("HOLD \xe2\x80\x94 NO NEXT AUTHORITY", signal_block)
+        self.assertIn("44 pre-existing creator-live fixed-identity errors", signal_block)
+        self.assertIn("codex/v13-compact-test-output-reference", signal_block)
+        self.assertIn("Value port", signal_block)
 
     def test_repository_check_reads_only_the_new_current_authority(self) -> None:
         payload, exit_code = inspect_repository(REPO_ROOT)
@@ -116,7 +115,7 @@ class CurrentStateAdmissionTests(unittest.TestCase):
             check=True,
             text=True,
         ).stdout.strip()
-        self.assertIn("13-197-git-authority-isolation-repair", title)
+        self.assertIn("Hidden Variable Time-Tube", title)
 
     def test_post_merge_reader_on_origin_main_recovers_steady_state(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -157,37 +156,40 @@ class CurrentStateAdmissionTests(unittest.TestCase):
         self.assertEqual(observed_blocks[0], observed_blocks[1])
         self.assertNotEqual(RECONSTRUCTED_MAIN, observed_head)
         fields = parse_fields(observed_blocks[0] or "")
-        self.assertNotIn("current_canonical_main", fields)
+        self.assertIn("current_canonical_main", fields)
         self.assertEqual(
             RECONSTRUCTED_MAIN,
             fields["canonical_reconstruction_base"][0],
         )
         self.assertTrue(fields["current_gate"][0].startswith("HOLD"))
-        self.assertTrue(fields["13_198_current_state_admission_repair"][0].startswith("COMPLETE"))
-        self.assertTrue(fields["13_198_p3_status"][0].startswith("CLOSED"))
-        self.assertNotIn("pending", fields["13_198_p3_status"][0].casefold())
+        self.assertTrue(
+            fields["canonical_current_capability"][0].startswith(
+                "V13 compact test output"
+            )
+        )
+        self.assertIn("fetched merge descendant", fields["current_canonical_main"][0])
         self.assertTrue(fields["missing_closure"][0].startswith("none"))
-        self.assertNotIn("merge", fields["missing_closure"][0].casefold())
-        self.assertNotIn("read-back", fields["missing_closure"][0].casefold())
-        self.assertNotIn("Draft PR", fields["next_authorized_action"][0])
-        self.assertNotIn("merge", fields["next_authorized_action"][0].casefold())
-        self.assertNotIn("read-back", fields["next_authorized_action"][0].casefold())
+        self.assertIn("fetched origin/main: None. Stop", fields["next_authorized_action"][0])
+        self.assertTrue(fields["completion_line"][0].startswith("PASS when"))
 
-    def test_pre_13_198_surfaces_remain_byte_preserved_history(self) -> None:
+    def test_pre_compact_output_surfaces_remain_byte_preserved_history(self) -> None:
         for relative_path in SURFACES:
             with self.subTest(relative_path=relative_path):
                 contents = (REPO_ROOT / relative_path).read_bytes()
-                boundary = b"<!-- current-state-history-boundary:13-198 -->\n"
+                boundary = (
+                    b"<!-- current-state-history-boundary:"
+                    b"v13-compact-test-output -->\n"
+                )
                 self.assertEqual(1, contents.count(boundary))
                 history_offset = contents.index(HISTORY_HEADERS[relative_path])
                 history = contents[history_offset:]
                 self.assertEqual(
-                    PRE_13_198_SHA256[relative_path],
+                    PRE_COMPACT_OUTPUT_SHA256[relative_path],
                     hashlib.sha256(history).hexdigest(),
                 )
                 disclaimer = contents[:history_offset]
                 self.assertIn(
-                    b"cannot be\ninherited as current authority",
+                    b"cannot be inherited as current authority",
                     disclaimer,
                 )
                 self.assertIn(b"Next Authorized Action:", history)

--- a/validation/v13_compact_test_output_reference_implementation.md
+++ b/validation/v13_compact_test_output_reference_implementation.md
@@ -1,0 +1,248 @@
+# V13 Compact Test Output Reference Implementation
+
+## Repository and command discovery
+
+- Canonical repository: `shin4141/decision-os-v13-loopkit`
+- Fetched base: `origin/main` at
+  `78e24aafc036e8af3148a33a1ac18e7e5e703e42`
+- Dedicated branch: `codex/v13-compact-test-output-reference`
+- Representative full suite:
+  `python3 -B -m unittest discover -s tests`
+- Framework: Python standard-library `unittest`
+- Existing structured result: none; the runner supplies a terminal
+  `Ran ... tests in ...s` line and `OK` or `FAILED (...)` line
+- Existing wrapper/helper suitable for reuse: none found under `scripts/`,
+  `bin/`, or the project entry points
+- Full-log location: ignored `.test-logs/`; the wrapper prints the absolute path
+  and never deletes the file
+
+The clean mainline suite discovered 1,535 tests before this implementation. In
+a localhost- and headless-Chrome-capable run it exited 1 with 44 errors and 15
+skips, all errors concentrated in the existing creator-live fixed-artifact
+identity checks. Current `AGENTS.md` does not match that older pinned identity.
+This task did not change those tests, the protected artifact logic, or
+`value-locked-repository-recovery`.
+
+## Same-state full-suite comparison
+
+Both measured runs used the same worktree state and the same underlying command.
+The four newly added wrapper tests account for the increase from the clean-main
+discovery count of 1,535 to the comparison count of 1,539.
+
+### BEFORE — unwrapped
+
+- Command: `python3 -B -m unittest discover -s tests`
+- Exit: `1`
+- Runner result: `Ran 1539 tests in 1006.982s`
+- Failures: `0` reported
+- Errors: `44`
+- Skipped: `15`
+- Passed: not separately reported by `unittest`; not inferred
+- AI-visible output: `707` lines / `95,513` bytes
+- Full log: `.test-logs/comparison-unwrapped.log`
+- Full-log SHA-256:
+  `6ec1d4d46edc4e50e91e7f2e5e44d445770fb674feacb6cfa6ddece2a7779f55`
+- Wall time: `1008.08s`
+
+### AFTER — wrapped
+
+- Wrapper command:
+  `python3 scripts/compact_test_output.py --log .test-logs/comparison-wrapped-full.log -- python3 -B -m unittest discover -s tests`
+- Underlying command: `python3 -B -m unittest discover -s tests`
+- Exit: `1`
+- Runner result: `Ran 1539 tests in 941.113s`
+- Failures: `0` reported
+- Errors: `44`
+- Skipped: `15`
+- Passed: not separately reported by `unittest`; not inferred
+- AI-visible output: `85` lines / `9,976` bytes
+- AI-visible SHA-256:
+  `402f866f1389fd5855bc1d53382e4bc2760c3e5c4c3f95f9917c60c2c2ae9e89`
+- Full log: `.test-logs/comparison-wrapped-full.log`
+- Full-log status: retained, Git-ignored, `702` lines / `93,331` bytes
+- Full-log SHA-256:
+  `26d1c0d85d341d64ad6b2fd31e0c24a208da296256749a5035b55b054bb61b15`
+- Wall time: `942.04s`
+
+### DELTA
+
+- Test count delta: `0`
+- Exit delta: `0`
+- Failure delta: `0`
+- Error delta: `0`
+- Skip delta: `0`
+- AI-visible line reduction: `622` lines
+- AI-visible byte reduction: `85,537` bytes
+- Token consumption: not measured; no token-saving percentage is claimed
+- Elapsed-time difference: observed but not attributed to the wrapper because
+  the suite has run-to-run timing variability
+
+The wrapper surfaced every available failure identity up to its bound, three
+traceback contexts, the complete terminal summary, exit 1, and the full-log
+path. It did not return unrelated successful output from the failing suite.
+
+## PASS proof
+
+A controlled successful command emitted suppressed detail and a real-shaped
+`unittest` summary. The wrapper exited 0 and returned exactly two lines:
+
+```text
+PASS: Ran 3 tests / OK / 0.125s
+Full log: /Users/sn/Documents/v13/13-compact-test-output-reference/.test-logs/success-proof-full.log
+```
+
+- AI-visible output: `2` lines / `133` bytes
+- Full log: `.test-logs/success-proof-full.log`
+- Full log contains the suppressed success detail: verified
+- Full-log SHA-256:
+  `d60c7bbeaa789c0ada10105b0fbc684ff843e2fb0c768c0ddd06d7707b5305de`
+
+## FAILURE PROOF
+
+The controlled command emitted one failing identity, traceback, assertion,
+terminal summary, and unrelated successful setup output, then exited 7. No
+canonical test or fixture was changed to create the failure.
+
+Observed wrapper output:
+
+```text
+Failure identities (1):
+FAIL: test_controlled_failure (proof.ControlledFailure.test_controlled_failure)
+Diagnostic context:
+FAIL: test_controlled_failure (proof.ControlledFailure.test_controlled_failure)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "proof.py", line 1, in test_controlled_failure
+AssertionError: controlled proof
+----------------------------------------------------------------------
+FAIL: Ran 2 tests / FAILED (failures=1) / 0.010s / exit 7
+Full log: /Users/sn/Documents/v13/13-compact-test-output-reference/.test-logs/failure-proof-full.log
+```
+
+- Observed wrapper exit: `7`
+- AI-visible output: `11` lines / `627` bytes
+- Full log recovery: PASS; `.test-logs/failure-proof-full.log` contains the
+  suppressed `unrelated successful setup` line, identity, traceback, assertion,
+  runner summary, stdout, and stderr
+- Full-log SHA-256:
+  `5bc02f63b92e267c3061a9c9d40f2d54791d922f1976c6a6e0a1b210862b1fda`
+
+## Wrapper regression validation
+
+Command:
+
+```console
+python3 -B -m unittest -v tests.test_compact_test_output
+```
+
+Result: `4/4 PASS`.
+
+The tests establish compact PASS, diagnostic FAIL, exit preservation, retained
+suppressed success output, retained stdout and stderr, UNKNOWN reporting without
+invented counts, and exact command-argument/test-set forwarding.
+
+Current-state admission validation:
+
+```console
+python3 -B -m unittest discover -s tests -p 'test_current_state_admission.py' -v
+```
+
+Result: `6/6 PASS`, including byte-identical first blocks, preserved historical
+surface hashes, and simulated fetched-remote read-back.
+
+Related wrapper, repository-check, and scan regressions:
+
+```console
+python3 -B -m unittest -q tests.test_compact_test_output tests.test_decision_os_checks tests.test_decision_os_scan_cli
+```
+
+Result: `48/48 PASS` in `109.730s`.
+
+## Value port contract
+
+The reusable contract is recorded in `docs/compact_test_output.md`: a repository
+supplies its own test command; the wrapper captures complete output; PASS returns
+a compact summary; FAIL returns bounded diagnostics; the full log remains
+recoverable; and underlying exit semantics remain unchanged. No Value or shared
+cross-repository code was created.
+
+## V12 completion report
+
+Created:
+- `scripts/compact_test_output.py`
+- `tests/test_compact_test_output.py`
+- `docs/compact_test_output.md`
+- `validation/v13_compact_test_output_reference_implementation.md`
+- `.gitignore` rule for `.test-logs/`
+
+Not created:
+- No service, daemon, plugin, dependency, shared framework, Value port, or
+  canonical failing test
+
+I inspected:
+- Canonical `origin/main`, `AGENTS.md`, test commands, test framework, scripts,
+  project metadata, current-state surfaces, admission regression, clean-main
+  baseline failures, full A/B logs, and controlled PASS/FAIL logs
+
+I did not inspect:
+- `value-locked-repository-recovery` contents; it was explicitly out of scope
+- Unrelated product behavior beyond the repository suite and wrapper boundary
+
+I inferred:
+- No passed-test count; `unittest` did not report one separately, so the record
+  preserves `Ran`, failure, error, and skip vocabulary instead
+
+I verified with files:
+- Wrapper source, focused tests, documentation, validation record, both full
+  comparison logs, both controlled full logs, their measured hashes, and both
+  matched canonical current-state surfaces
+
+I verified with rendered output:
+- Not applicable; this task creates no UI or layout-bearing document artifact
+
+Validation:
+- Focused wrapper suite `4/4 PASS`; same-state A/B full suites both ran 1,539
+  tests and preserved exit 1 / 44 errors / 15 skips; controlled PASS and exit-7
+  failure proofs passed; admission `6/6 PASS`; related regression set `48/48 PASS`
+
+Remaining unverified:
+- Canonical current-state admission on fetched `origin/main`, which requires the
+  Human Seat merge boundary and post-merge remote read-back
+
+Remaining UNKNOWN:
+- Resolution of the pre-existing 44 creator-live fixed-identity errors is outside
+  this task; token consumption was not measured
+
+Gate followed:
+- GO — V13 COMPACT TEST OUTPUT REFERENCE IMPLEMENTATION; stopped at this bounded
+  task with no automatic next loop
+
+Boundaries preserved:
+- Test command, discovery, assertions, failure semantics, full logs, protected
+  fixed-artifact logic, Value boundary, and unrelated production behavior
+
+Still HOLD / BLOCK:
+- HOLD — operational current-state completion until Human Seat merge and fetched
+  `origin/main` read-back
+- BLOCK — Value port, framework expansion, and article/publication work
+
+Next allowed action:
+- Human Seat merge decision for this dedicated branch; after merge, executing AI
+  fetches and verifies both canonical current-state surfaces
+
+Decision Owner:
+Shin
+
+Human screenshot/manual-check dependency:
+- None
+
+Can this be called complete? YES / NO / CONDITIONAL
+CONDITIONAL
+
+Reason:
+- Technical implementation and bounded evidence are complete; operational
+  current-state admission remains at the Human Seat merge boundary
+
+Completion Line:
+- CONDITIONAL — implementation evidence is complete; operational COMPLETE only
+  after canonical merge and fetched `origin/main` admission read-back


### PR DESCRIPTION
Implements the bounded V13 compact test output reference implementation. Preserves the underlying test command, counts, assertions, exit semantics, failure diagnostics, and full logs while reducing AI-visible output. Same-state comparison preserved 1,539 tests, exit 1, 44 errors, and 15 skips; visible output decreased from 707 lines / 95,513 bytes to 85 lines / 9,976 bytes. Value port and framework expansion remain out of scope.