### PR TITLE
V13: close 13-42 and hand off to 13-43

### DIFF
--- a/docs/current_signal.md
+++ b/docs/current_signal.md
@@ -1,3 +1,108 @@
+# Current Signal — V13 13-42 Closure and 13-43 Handoff
+
+## Canonical Current State — 13-42 Closure Admission Candidate
+
+```text
+Canonical Reconstruction Base:
+5be89c84d1816a2b185cc2f6e85869a9f1e73d11
+
+Current Canonical Main:
+5be89c84d1816a2b185cc2f6e85869a9f1e73d11 at closure authorization; the admitted canonical main is the fetched merge descendant containing this exact block
+
+Current Layer:
+V13
+
+V12 State:
+PASS — 13-42 implementation, repair, measurement, canonical merge, trajectory reconstruction, and bounded handoff content are complete
+
+13-42 Closure:
+ADMITTED when this exact block is read from fetched origin/main; CANDIDATE on a branch or PR
+
+Completed Work:
+blindly reproduced P1/P2 security-authority repairs, Git authority isolation, current-state admission repair, and evidence-preserving Compact Test Output are integrated on canonical main
+
+Canonical Current Capability:
+the repaired V13 lineage through Compact Test Output is current; 13-42 adds closure and ownership transfer only
+
+Current Restart Point:
+validation/v13_13_42_closure_trajectory.md plus the 13-43 responsibility transfer in handoff/current_codex_handoff.md, read from fetched origin/main
+
+Active Branch:
+codex/13-42-closure-13-43-handoff before admission; none after this exact block is read from fetched origin/main
+
+Current Gate:
+HOLD — no automatic next loop and no invented GO for 13-43
+
+V13 Self-Repair / Research:
+HOLD — requires a fresh bounded selection and authority
+
+Article / Publication:
+BLOCK — preserve the admitted Compact current-state boundary and do not restart article work
+
+Value Port:
+EXTERNAL OWNERSHIP — Value-Locked side owns any later port; V13 and 13-43 must not run a parallel port
+
+Known Baseline Boundary:
+44 pre-existing creator-live fixed-identity errors remain unchanged and are not repair authority
+
+What 13-43 Now Owns:
+current V13 canonical state after admitted 13-42 closure, preservation of completed repair lineage and Gates, and only future V13 selection work that receives fresh bounded authority
+
+What Remains Parked:
+V13 self-repair and research, article/publication, Compact expansion, the 44-error repair, unrelated security work, and all Value-port execution
+
+What Must Not Be Inferred:
+handoff does not create GO, accept noncanonical branch state, authorize Value work, reopen article work, or start a new repair or research branch
+
+First One Action:
+13-43 fetches origin/main and reads the exact closure trajectory and handoff; if this block is absent or mismatched, HOLD and do not start work
+
+Do Not Continue Boundary:
+do not start 13-43 implementation, repair, research, Compact expansion, Value work, article work, or publication without a later fresh bounded selection
+
+Operational Cleanup:
+the executing closure AI owns validation, Git delivery, and post-authorized-merge read-back; routine cleanup must not be returned to Shin or 13-43
+
+Handoff Responsibility Transfer:
+Handoff is not complete until the receiving AI knows what it now owns.
+
+Completion Line:
+PASS when the trajectory and handoff are remotely reconstructable from fetched origin/main, the paired first blocks match, and 13-43 has the exact restart point
+
+Missing Closure:
+none when this exact block is read from fetched origin/main; on the candidate branch, commit, push, Human Seat merge, and remote read-back remain
+
+Next Authorized Action:
+candidate branch: complete closure delivery to the Human Seat boundary; fetched origin/main: 13-43 may accept the handoff by verifying the restart point, but no new work starts without fresh authority
+
+Next Actor:
+13-43 Receiving AI after canonical admission
+
+Not Authorized:
+automatic next loop; Value scan or port; article restart; Compact expansion; 44-error repair; unrelated security work; external publication
+
+Decision Owner:
+Shin
+
+Admission Joint:
+reader verifies this exact matched first block on fetched origin/main; branch and PR copies have no canonical restart authority
+
+Admission Evidence:
+presence of this exact first block on fetched origin/main plus the passing admission and handoff regressions
+
+Remote Read-Back:
+after Human Seat merge, the executing closure AI fetches origin/main and verifies both first blocks and commit ancestry before operational COMPLETE
+
+Older Material Below:
+HISTORICAL ONLY — older Gate, Next Authorized Action, branch, capability, and Completion Line grant no current authority
+```
+
+Everything below this boundary is preserved historical material. Its older
+`Current Gate`, `Next Authorized Action`, branch, capability, and `Completion
+Line` values cannot be inherited as current authority.
+
+<!-- current-state-history-boundary:v13-13-42-closure -->
+
 # Current Signal — V13 Compact Test Output Reference Implementation
 
 ## Canonical Current State — V13 Compact Test Output Admission Candidate

--- a/handoff/current_codex_handoff.md
+++ b/handoff/current_codex_handoff.md
@@ -1,3 +1,181 @@
+# Current Codex Handoff — V13 13-42 Closure and 13-43 Transfer
+
+## Canonical Current State — 13-42 Closure Admission Candidate
+
+```text
+Canonical Reconstruction Base:
+5be89c84d1816a2b185cc2f6e85869a9f1e73d11
+
+Current Canonical Main:
+5be89c84d1816a2b185cc2f6e85869a9f1e73d11 at closure authorization; the admitted canonical main is the fetched merge descendant containing this exact block
+
+Current Layer:
+V13
+
+V12 State:
+PASS — 13-42 implementation, repair, measurement, canonical merge, trajectory reconstruction, and bounded handoff content are complete
+
+13-42 Closure:
+ADMITTED when this exact block is read from fetched origin/main; CANDIDATE on a branch or PR
+
+Completed Work:
+blindly reproduced P1/P2 security-authority repairs, Git authority isolation, current-state admission repair, and evidence-preserving Compact Test Output are integrated on canonical main
+
+Canonical Current Capability:
+the repaired V13 lineage through Compact Test Output is current; 13-42 adds closure and ownership transfer only
+
+Current Restart Point:
+validation/v13_13_42_closure_trajectory.md plus the 13-43 responsibility transfer in handoff/current_codex_handoff.md, read from fetched origin/main
+
+Active Branch:
+codex/13-42-closure-13-43-handoff before admission; none after this exact block is read from fetched origin/main
+
+Current Gate:
+HOLD — no automatic next loop and no invented GO for 13-43
+
+V13 Self-Repair / Research:
+HOLD — requires a fresh bounded selection and authority
+
+Article / Publication:
+BLOCK — preserve the admitted Compact current-state boundary and do not restart article work
+
+Value Port:
+EXTERNAL OWNERSHIP — Value-Locked side owns any later port; V13 and 13-43 must not run a parallel port
+
+Known Baseline Boundary:
+44 pre-existing creator-live fixed-identity errors remain unchanged and are not repair authority
+
+What 13-43 Now Owns:
+current V13 canonical state after admitted 13-42 closure, preservation of completed repair lineage and Gates, and only future V13 selection work that receives fresh bounded authority
+
+What Remains Parked:
+V13 self-repair and research, article/publication, Compact expansion, the 44-error repair, unrelated security work, and all Value-port execution
+
+What Must Not Be Inferred:
+handoff does not create GO, accept noncanonical branch state, authorize Value work, reopen article work, or start a new repair or research branch
+
+First One Action:
+13-43 fetches origin/main and reads the exact closure trajectory and handoff; if this block is absent or mismatched, HOLD and do not start work
+
+Do Not Continue Boundary:
+do not start 13-43 implementation, repair, research, Compact expansion, Value work, article work, or publication without a later fresh bounded selection
+
+Operational Cleanup:
+the executing closure AI owns validation, Git delivery, and post-authorized-merge read-back; routine cleanup must not be returned to Shin or 13-43
+
+Handoff Responsibility Transfer:
+Handoff is not complete until the receiving AI knows what it now owns.
+
+Completion Line:
+PASS when the trajectory and handoff are remotely reconstructable from fetched origin/main, the paired first blocks match, and 13-43 has the exact restart point
+
+Missing Closure:
+none when this exact block is read from fetched origin/main; on the candidate branch, commit, push, Human Seat merge, and remote read-back remain
+
+Next Authorized Action:
+candidate branch: complete closure delivery to the Human Seat boundary; fetched origin/main: 13-43 may accept the handoff by verifying the restart point, but no new work starts without fresh authority
+
+Next Actor:
+13-43 Receiving AI after canonical admission
+
+Not Authorized:
+automatic next loop; Value scan or port; article restart; Compact expansion; 44-error repair; unrelated security work; external publication
+
+Decision Owner:
+Shin
+
+Admission Joint:
+reader verifies this exact matched first block on fetched origin/main; branch and PR copies have no canonical restart authority
+
+Admission Evidence:
+presence of this exact first block on fetched origin/main plus the passing admission and handoff regressions
+
+Remote Read-Back:
+after Human Seat merge, the executing closure AI fetches origin/main and verifies both first blocks and commit ancestry before operational COMPLETE
+
+Older Material Below:
+HISTORICAL ONLY — older Gate, Next Authorized Action, branch, capability, and Completion Line grant no current authority
+```
+
+## 13-43 Responsibility Transfer
+
+```text
+Target Layer:
+V13
+
+Repo Root:
+shin4141/decision-os-v13-loopkit
+
+Current State:
+13-42 repair and Compact Test Output work are integrated through canonical main
+5be89c84; this closure and handoff become current only after their matched first
+blocks are read from fetched origin/main
+
+Current Gate:
+HOLD — no automatic next loop
+
+Active Branch:
+none after canonical admission
+
+Next Authorized Action:
+verify fetched origin/main, read validation/v13_13_42_closure_trajectory.md and
+this responsibility transfer, then remain on HOLD unless a fresh bounded V13
+selection is supplied
+
+Completion Line:
+13-42 trajectory and handoff are remotely reconstructable and 13-43 has a clear
+restart point without the 13-42 conversation
+
+Missing Closure:
+none after canonical admission; before admission, merge and remote read-back
+
+Next Owner:
+13-43 Receiving AI
+
+What the Receiving AI Now Owns:
+the current V13 canonical state, preservation of completed repair lineage and
+Gates, and later V13 self-repair or research only after fresh bounded selection
+
+First One Action:
+fetch origin/main and verify the exact restart point; HOLD on any mismatch
+
+Do Not Continue Boundary:
+do not begin implementation, repair, research, Value work, article work,
+Compact expansion, 44-error repair, or publication from this handoff
+
+What must not be inferred:
+handoff does not create GO, approve Value work, reopen the article, or make a
+branch or PR canonical
+
+Work already completed:
+blind reproduction and confirmed P1/P2 repairs; Git authority isolation;
+current-state admission repair; Compact Test Output implementation,
+measurement, and PR #150 canonical merge
+
+Work remaining parked:
+future V13 self-repair/research; article/publication; Compact expansion;
+44-error repair; unrelated security work; all Value port work
+
+Value port:
+owned by the Value-Locked side, not 13-43; no parallel V13 port
+
+Article:
+BLOCK — do not silently restart
+
+Operational cleanup that must not be returned to Shin:
+routine repository verification, branch cleanup, and future bounded execution
+cleanup belong to the executing AI; only genuine Human Seat decisions return
+to Shin
+
+Handoff is not complete until the receiving AI knows what it now owns.
+```
+
+Everything below this boundary is preserved historical material. Its older
+`Current Gate`, `Next Authorized Action`, branch, capability, and `Completion
+Line` values cannot be inherited as current authority.
+
+<!-- current-state-history-boundary:v13-13-42-closure -->
+
 # Current Codex Handoff — V13 Compact Test Output Reference Implementation
 
 ## Canonical Current State — V13 Compact Test Output Admission Candidate

--- a/tests/test_current_state_admission.py
+++ b/tests/test_current_state_admission.py
@@ -17,22 +17,23 @@ SURFACES = (
 )
 HISTORY_HEADERS = {
     "docs/current_signal.md": (
-        b"# Current Signal \xe2\x80\x94 Canonical Current-State Admission Joint Repair\n"
+        b"# Current Signal \xe2\x80\x94 V13 Compact Test Output Reference "
+        b"Implementation\n"
     ),
     "handoff/current_codex_handoff.md": (
-        b"# Current Codex Handoff \xe2\x80\x94 Canonical Current-State Admission "
-        b"Joint Repair\n"
+        b"# Current Codex Handoff \xe2\x80\x94 V13 Compact Test Output Reference "
+        b"Implementation\n"
     ),
 }
-PRE_COMPACT_OUTPUT_SHA256 = {
+PRE_13_42_CLOSURE_SHA256 = {
     "docs/current_signal.md": (
-        "ad1ecf79d33391242a3c74188a1ea6e84538394d0767d47d0e180aa167c8ed58"
+        "fc24d6ad23c5dc6895b5b8ad214c1765a5cac9434edf320e84df15c828da6089"
     ),
     "handoff/current_codex_handoff.md": (
-        "cfc6d8e95cf5e6653a75ae67d1e004d394f2f1228fd386a863eacf1d0d12c0a1"
+        "d3dfe6700bdf7d6cf9c083f674626ebe73b2ccb345f8504425e1cd5a5561e511"
     ),
 }
-RECONSTRUCTED_MAIN = "78e24aafc036e8af3148a33a1ac18e7e5e703e42"
+RECONSTRUCTED_MAIN = "5be89c84d1816a2b185cc2f6e85869a9f1e73d11"
 
 
 def current_block(relative_path: str) -> str:
@@ -63,17 +64,27 @@ class CurrentStateAdmissionTests(unittest.TestCase):
             "current_canonical_main",
             "current_layer",
             "v12_state",
+            "13_42_closure",
             "completed_work",
-            "known_baseline_boundary",
             "canonical_current_capability",
             "current_restart_point",
             "active_branch",
             "current_gate",
+            "v13_self_repair_research",
+            "article_publication",
             "value_port",
-            "framework_expansion",
+            "known_baseline_boundary",
+            "what_13_43_now_owns",
+            "what_remains_parked",
+            "what_must_not_be_inferred",
+            "first_one_action",
+            "do_not_continue_boundary",
+            "operational_cleanup",
+            "handoff_responsibility_transfer",
             "completion_line",
             "missing_closure",
             "next_authorized_action",
+            "next_actor",
             "not_authorized",
             "decision_owner",
             "admission_joint",
@@ -87,19 +98,19 @@ class CurrentStateAdmissionTests(unittest.TestCase):
             fields["canonical_reconstruction_base"][0],
         )
         self.assertTrue(fields["current_gate"][0].startswith("HOLD"))
-        self.assertIn("Human Seat merge decision", fields["next_authorized_action"][0])
-        self.assertTrue(fields["value_port"][0].startswith("BLOCK"))
+        self.assertIn("13-43", fields["next_authorized_action"][0])
+        self.assertTrue(fields["value_port"][0].startswith("EXTERNAL OWNERSHIP"))
         self.assertEqual("Shin", fields["decision_owner"][0])
-        self.assertIn("44 pre-existing creator-live fixed-identity errors", signal_block)
-        self.assertIn("codex/v13-compact-test-output-reference", signal_block)
-        self.assertIn("Value port", signal_block)
+        self.assertIn("Handoff is not complete until the receiving AI knows what it now owns.", signal_block)
+        self.assertIn("codex/13-42-closure-13-43-handoff", signal_block)
+        self.assertIn("Value-Locked side", signal_block)
 
     def test_repository_check_reads_only_the_new_current_authority(self) -> None:
         payload, exit_code = inspect_repository(REPO_ROOT)
         self.assertEqual(EXIT_OK, exit_code)
         self.assertEqual("PASS", payload["v12_state"])
         self.assertEqual("HOLD", payload["v13_gate"])
-        self.assertIn("None. Stop.", payload["next_authorized_action"])
+        self.assertIn("13-43", payload["next_authorized_action"])
 
     def test_reconstruction_base_is_real_and_ancestral(self) -> None:
         completed = subprocess.run(
@@ -115,7 +126,7 @@ class CurrentStateAdmissionTests(unittest.TestCase):
             check=True,
             text=True,
         ).stdout.strip()
-        self.assertIn("Hidden Variable Time-Tube", title)
+        self.assertIn("Merge pull request #150", title)
 
     def test_post_merge_reader_on_origin_main_recovers_steady_state(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -164,27 +175,27 @@ class CurrentStateAdmissionTests(unittest.TestCase):
         self.assertTrue(fields["current_gate"][0].startswith("HOLD"))
         self.assertTrue(
             fields["canonical_current_capability"][0].startswith(
-                "V13 compact test output"
+                "the repaired V13 lineage"
             )
         )
         self.assertIn("fetched merge descendant", fields["current_canonical_main"][0])
         self.assertTrue(fields["missing_closure"][0].startswith("none"))
-        self.assertIn("fetched origin/main: None. Stop", fields["next_authorized_action"][0])
+        self.assertIn("fetched origin/main: 13-43", fields["next_authorized_action"][0])
         self.assertTrue(fields["completion_line"][0].startswith("PASS when"))
 
-    def test_pre_compact_output_surfaces_remain_byte_preserved_history(self) -> None:
+    def test_pre_13_42_closure_surfaces_remain_byte_preserved_history(self) -> None:
         for relative_path in SURFACES:
             with self.subTest(relative_path=relative_path):
                 contents = (REPO_ROOT / relative_path).read_bytes()
                 boundary = (
                     b"<!-- current-state-history-boundary:"
-                    b"v13-compact-test-output -->\n"
+                    b"v13-13-42-closure -->\n"
                 )
                 self.assertEqual(1, contents.count(boundary))
                 history_offset = contents.index(HISTORY_HEADERS[relative_path])
                 history = contents[history_offset:]
                 self.assertEqual(
-                    PRE_COMPACT_OUTPUT_SHA256[relative_path],
+                    PRE_13_42_CLOSURE_SHA256[relative_path],
                     hashlib.sha256(history).hexdigest(),
                 )
                 disclaimer = contents[:history_offset]
@@ -193,6 +204,38 @@ class CurrentStateAdmissionTests(unittest.TestCase):
                     disclaimer,
                 )
                 self.assertIn(b"Next Authorized Action:", history)
+
+    def test_13_43_handoff_transfers_responsibility_without_starting_work(self) -> None:
+        handoff = (REPO_ROOT / "handoff/current_codex_handoff.md").read_text(
+            encoding="utf-8"
+        )
+        transfer = handoff.split("## 13-43 Responsibility Transfer", 1)[1].split(
+            "<!-- current-state-history-boundary:v13-13-42-closure -->", 1
+        )[0]
+        for required in (
+            "Target Layer:",
+            "Repo Root:",
+            "Current State:",
+            "Current Gate:",
+            "Completion Line:",
+            "Missing Closure:",
+            "Next Owner:",
+            "What the Receiving AI Now Owns:",
+            "First One Action:",
+            "Do Not Continue Boundary:",
+            "What must not be inferred:",
+            "Value port:",
+            "Article:",
+            "Operational cleanup that must not be returned to Shin:",
+        ):
+            self.assertIn(required, transfer)
+        self.assertIn(
+            "Handoff is not complete until the receiving AI knows what it now owns.",
+            transfer,
+        )
+        self.assertIn("HOLD", transfer)
+        self.assertIn("Value-Locked side", transfer)
+        self.assertIn("do not begin implementation", transfer)
 
     def test_agents_contract_blocks_complete_before_remote_admission(self) -> None:
         contract = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")

--- a/validation/v13_13_42_closure_trajectory.md
+++ b/validation/v13_13_42_closure_trajectory.md
@@ -1,0 +1,203 @@
+# V13 13-42 Closure Trajectory
+
+## Identity and boundary
+
+```text
+Repository:
+shin4141/decision-os-v13-loopkit
+
+Decision Owner:
+Shin
+
+Closure layer:
+V13
+
+Fetched canonical main before closure:
+5be89c84d1816a2b185cc2f6e85869a9f1e73d11
+
+Canonical main delta from the supplied expectation:
+none
+
+Closure form:
+forward-only trajectory and 13-43 responsibility transfer
+```
+
+This record closes 13-42. It does not start 13-43 work, open another repair,
+rewrite prior trajectory, or create authority for a parked line.
+
+## Forward-only causal trajectory
+
+### 1. External security review became repository-grounded repair input
+
+An external security review supplied candidate authority/security findings. The
+repository did not admit those claims solely from the review. The defects were
+blindly reproduced against the repository, their severity was reclassified from
+the reproduced behavior, and only the confirmed P1/P2 findings entered the
+repair lineage.
+
+Canonical merge `9e6ab2a070731ff58874a02b82a1085b2524db0d` records the closure as:
+"blind reproduction and severity reclassification of the external security
+review." This distinction remains important: external review was discovery
+input; local reproduction and tests established the repair evidence.
+
+### 2. Confirmed P1/P2 authority and security defects were repaired
+
+The reproduced 13-192 through 13-195 lineage repaired four bounded surfaces:
+
+- `7d543dc` enforced one Claude mutation per run;
+- `3b982ff` serialized AccelerationStore event appends;
+- `848ba52` clarified the Repository Default authority boundary; and
+- `c402313` mechanically bound protected paths to compound authority.
+
+Merge `9e6ab2a` integrated the lineage with implementation and regression
+coverage. Prompt-injection qualification remained a separately bounded P3
+question under existing controls; no broader security guarantee or unrelated
+hardening claim was created.
+
+### 3. Git authority identity was isolated from caller-controlled identity
+
+The repair at `fc0e9be` separated repository Git authority in the acceleration
+model and added focused store witnesses. PR #146 merged that repair as
+`fb89a07e31ebbf947f4f95d2bafdb1153dc08d29`.
+
+The causal consequence was not a new execution grant. It removed an authority
+identity ambiguity so later continuation and repository evidence could fail
+closed against the actual repository boundary.
+
+### 4. Canonical current-state admission was repaired
+
+Commits `49afead` and `f84939f` introduced and settled the paired first-block
+admission joint. PR #147 merged the repair as
+`2120ea4ef3d94ea4c7c9d257e1e2f9c390da9ad8`.
+
+From that point, a local branch or pushed PR could prove delivery but not
+operational completion. Current Gate, restart point, Completion Line, and
+authority became inheritable only from matching first blocks read back from
+fetched `origin/main`, with older blocks preserved as historical evidence.
+
+### 5. Resource Justice and authority freshness remained research trajectory
+
+The session discussed Resource Justice and risk-bounded authority freshness as
+ways to avoid returning reconstruction, stale-authority, and routine cleanup
+burden to Shin. That discussion did not create a V13 `GO`, a production feature,
+or a new canonical authority rule in 13-42.
+
+Shin has separately transferred any later Compact Test Output port to the
+Value-Locked side. That ownership is external to 13-42 and 13-43. V13 must not
+scan Value, issue a second handoff, start the port, or run a parallel port.
+
+### 6. Compact Test Output preserved evidence while compressing the AI surface
+
+PR #150 merged the reference implementation as canonical main
+`5be89c84d1816a2b185cc2f6e85869a9f1e73d11`.
+
+The classification is:
+
+```text
+Evidence-preserving AI-visible output compression
+```
+
+The same representative suite and test state produced:
+
+| Measure | Unwrapped | Wrapped |
+|---|---:|---:|
+| Tests | 1,539 | 1,539 |
+| Exit | 1 | 1 |
+| Errors | 44 | 44 |
+| Skipped | 15 | 15 |
+| AI-visible lines | 707 | 85 |
+| AI-visible bytes | 95,513 | 9,976 |
+
+The full wrapped log remained recoverable. Test discovery, assertions, result
+counts, failure visibility, and exit semantics were not weakened. The 44
+pre-existing creator-live fixed-identity errors remained visible and unchanged;
+13-42 did not repair them. Token use was not measured, so no token-saving
+percentage is claimed.
+
+### 7. 13-42 closes at a transfer boundary, not an automatic next loop
+
+At the start of this closure, fetched `origin/main` exactly matched the supplied
+merged SHA `5be89c84d1816a2b185cc2f6e85869a9f1e73d11`; there was no unexpected main
+delta to reconcile.
+
+13-42 now adds only this forward closure record, the paired current-state
+candidate, and the 13-43 handoff. The canonical Gate remains `HOLD`. No 13-43
+self-repair, research, article, Compact expansion, Value port, security repair,
+or 44-error repair starts here.
+
+## Completed repair lineage carried forward
+
+- external security review candidates were independently reproduced before
+  confirmed P1/P2 repair admission;
+- 13-192 through 13-195 repairs are integrated on main;
+- 13-197 Git authority isolation is integrated on main;
+- 13-198 current-state admission repair is integrated on main;
+- Compact Test Output reference implementation and measured evidence are
+  integrated on main by PR #150; and
+- the Value-port ownership boundary is external to V13 and assigned to the
+  Value-Locked side by Shin.
+
+## Parked and prohibited lines at closure
+
+- V13 self-repair or research: `HOLD` until a fresh bounded selection and
+  authority exist;
+- article/publication: `BLOCK` under the admitted Compact current-state block;
+- Value port: external Value-Locked ownership, not 13-43;
+- Compact Test Output expansion or framework work: `BLOCK`;
+- the 44 pre-existing fixed-identity errors: known and unchanged, not authorized
+  for repair here;
+- unrelated security hardening and prompt-injection expansion: not authorized;
+  and
+- external publication: not authorized.
+
+## Closure validation
+
+The exact admission and handoff regression passed:
+
+```console
+python3 -B -m unittest discover -s tests -p 'test_current_state_admission.py' -v
+```
+
+Result: `7/7 PASS`. This includes matched first blocks, simulated fetched-remote
+read-back, preserved pre-closure surface hashes, required 13-43 ownership fields,
+the exact responsibility-transfer sentence, and the no-new-work boundary.
+
+Related state-surface consumers passed:
+
+```console
+python3 -B -m unittest -q tests.test_decision_os_checks tests.test_decision_os_scan_cli
+```
+
+Result: `44/44 PASS` in `150.864s`.
+
+The paired first fenced blocks are byte-identical at `4,271` UTF-8 bytes. The
+prior Compact-era surfaces remain below the new historical boundary with their
+complete pre-closure SHA-256 identities guarded by the admission test.
+
+The representative full suite was not rerun for this documentation/handoff-only
+closure. Its already canonical measured evidence remains 1,539 tests, exit 1,
+44 errors, 15 skips, and 707 → 85 AI-visible lines. This closure does not alter
+or reinterpret that evidence.
+
+## Closure state
+
+```text
+V12 State:
+PASS — 13-42 trajectory is reconstructed from canonical evidence and the
+handoff content is bounded
+
+Current Gate:
+HOLD — no automatic next loop
+
+Completion Line:
+13-42 trajectory and handoff are remotely reconstructable, both canonical
+current-state first blocks match on fetched origin/main, and 13-43 has a clear
+restart point without reading the 13-42 conversation
+
+Missing Closure:
+on the closure branch, commit, push, Human Seat merge, and canonical
+origin/main read-back; after admitted read-back, none for 13-42
+
+Next Actor:
+13-43 Receiving AI after canonical admission
+```


### PR DESCRIPTION
Closes 13-42 with one forward-only canonical trajectory record and an explicit 13-43 responsibility transfer. Preserves the admitted Compact Test Output measurements and unchanged 44-error boundary, assigns Value port ownership to the external Value-Locked side, keeps V13 and article work gated, and updates the paired current-state admission surfaces. Validation: current-state/handoff 7/7 PASS; related state consumers 44/44 PASS. No 13-43 implementation, Value scan/port, article work, Compact expansion, or error repair is included.