### PR TITLE
V13 13-204: clarify public Gate definition precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,12 @@ A Compound Loop improves the condition from which the next loop begins.
 - CAP: valid only under fixed exposure limits
 - BLOCK: damages Aspire, Carrier, or re-entry capacity
 
+These are public-facing outcome dimensions, not standalone execution criteria.
+For executable decisions, `AGENTS.md` §3 (`V12 Completion Before V13 Gate`) is
+the controlling operational definition. `GO` is permitted only when evidence,
+scope, exit condition, touch surface, rollback, and debt risk are clear and
+bounded; `PASS` does not automatically mean `GO`.
+
 ## Practical Use
 
 - Start with [`USE_CASES.md`](USE_CASES.md) for common loop-governance scenarios.


### PR DESCRIPTION
## Authority

Implements only the Human Seat-approved `CA-01-R1` replacement after canonical admission of PRs #153 and #154.

## Change

- preserves the existing public-facing positive-EV, controllable, residue-producing, and Carrier-preserving GO dimensions
- preserves the existing HOLD/CAP/BLOCK public summaries
- adds the exact approved clarification that these are outcome dimensions, while `AGENTS.md` §3 controls executable Gate decisions

## Scope

- changed path: `README.md` only
- no Field Note lifecycle changes
- no `AGENTS.md`, current-state, template, schema, source, or test changes
- no additional Canon changes

## Verification

- exact CA-01-R1 text: PASS
- README-only path set: PASS
- `git diff --check`: PASS
- `python -B -m unittest tests.test_external_intelligence_onboarding`: 10/10 PASS
- protected surfaces unchanged from `origin/main`: PASS

## Gate

Stop at Human Seat merge decision. Do not merge automatically or begin another V13 loop.